### PR TITLE
feat: actionable meeting prompt overlay before calendar meetings

### DIFF
--- a/crates/core/src/calendar.rs
+++ b/crates/core/src/calendar.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 // Also tries a compiled EventKit helper if available.
 // ──────────────────────────────────────────────────────────────
 
-/// A calendar event with title, start time, and attendees.
+/// A calendar event with title, start time, attendees, and optional meeting URL.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CalendarEvent {
     pub title: String,
@@ -18,6 +18,53 @@ pub struct CalendarEvent {
     pub minutes_until: i64,
     #[serde(default)]
     pub attendees: Vec<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// Extract a meeting URL (Zoom, Google Meet, Teams, Webex) from text.
+/// Searches for common video conferencing URL patterns and returns the first match.
+pub fn extract_meeting_url(text: &str) -> Option<String> {
+    let patterns = [
+        "https://zoom.us/j/",
+        "https://us02web.zoom.us/j/",
+        "https://us04web.zoom.us/j/",
+        "https://us05web.zoom.us/j/",
+        "https://us06web.zoom.us/j/",
+        "https://meet.google.com/",
+        "https://teams.microsoft.com/l/meetup-join/",
+        "https://teams.live.com/meet/",
+        "https://webex.com/meet/",
+        "https://facetime.apple.com/",
+    ];
+
+    for pattern in &patterns {
+        if let Some(start) = text.find(pattern) {
+            let url_text = &text[start..];
+            let end = url_text
+                .find(|c: char| c.is_whitespace() || c == '>' || c == '"' || c == ')')
+                .unwrap_or(url_text.len());
+            let url = &url_text[..end];
+            if url.len() > pattern.len() {
+                return Some(url.to_string());
+            }
+        }
+    }
+
+    // Fallback: look for any https:// URL containing common meeting keywords
+    for keyword in &["zoom.us", "meet.google", "teams.microsoft", "webex.com", "facetime.apple"] {
+        if let Some(https_pos) = text.find("https://") {
+            let url_text = &text[https_pos..];
+            if url_text.contains(keyword) {
+                let end = url_text
+                    .find(|c: char| c.is_whitespace() || c == '>' || c == '"' || c == ')')
+                    .unwrap_or(url_text.len());
+                return Some(url_text[..end].to_string());
+            }
+        }
+    }
+
+    None
 }
 
 /// Query upcoming calendar events within the next `lookahead_minutes`.
@@ -90,7 +137,12 @@ tell application "Calendar"
                             set attendeeNames to attendeeNames & (name of anAttendee)
                         end repeat
                     end try
-                    set output to output & t & unitSep & (s as string) & unitSep & mins & unitSep & attendeeNames & linefeed
+                    set loc to ""
+                    try
+                        set loc to location of evt
+                        if loc is missing value then set loc to ""
+                    end try
+                    set output to output & t & unitSep & (s as string) & unitSep & mins & unitSep & attendeeNames & unitSep & loc & linefeed
                 end if
             end repeat
         end try
@@ -111,7 +163,7 @@ return output"#;
         .lines()
         .filter(|l| !l.trim().is_empty())
         .filter_map(|line| {
-            let parts: Vec<&str> = line.splitn(4, unit_sep).collect();
+            let parts: Vec<&str> = line.splitn(5, unit_sep).collect();
             if parts.len() >= 3 {
                 let attendees = if parts.len() >= 4 && !parts[3].trim().is_empty() {
                     parts[3]
@@ -122,11 +174,15 @@ return output"#;
                 } else {
                     Vec::new()
                 };
+                let url = parts
+                    .get(4)
+                    .and_then(|loc| extract_meeting_url(loc.trim()));
                 Some(CalendarEvent {
                     title: parts[0].trim().to_string(),
                     start: parts[1].trim().to_string(),
                     minutes_until: parts[2].trim().parse().unwrap_or(0),
                     attendees,
+                    url,
                 })
             } else {
                 None
@@ -208,7 +264,12 @@ tell application "Calendar"
                 if s >= now and s <= horizon then
                     set t to summary of evt
                     set mins to ((s - now) / 60) as integer
-                    set output to output & t & (ASCII character 31) & (s as string) & (ASCII character 31) & mins & linefeed
+                    set loc to ""
+                    try
+                        set loc to location of evt
+                        if loc is missing value then set loc to ""
+                    end try
+                    set output to output & t & (ASCII character 31) & (s as string) & (ASCII character 31) & mins & (ASCII character 31) & loc & linefeed
                 end if
             end repeat
         end try
@@ -238,13 +299,17 @@ return output"#,
         .lines()
         .filter(|l| !l.trim().is_empty())
         .filter_map(|line| {
-            let parts: Vec<&str> = line.splitn(3, sep).collect();
+            let parts: Vec<&str> = line.splitn(4, sep).collect();
             if parts.len() >= 3 {
+                let url = parts
+                    .get(3)
+                    .and_then(|loc| extract_meeting_url(loc.trim()));
                 Some(CalendarEvent {
                     title: parts[0].trim().to_string(),
                     start: parts[1].trim().to_string(),
                     minutes_until: parts[2].trim().parse().unwrap_or(0),
                     attendees: Vec::new(),
+                    url,
                 })
             } else {
                 None
@@ -256,4 +321,61 @@ return output"#,
     events.sort_by_key(|e| (e.minutes_until, e.title.clone()));
     events.dedup_by(|a, b| a.title == b.title && a.minutes_until == b.minutes_until);
     events
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_zoom_url() {
+        let text = "https://zoom.us/j/1234567890?pwd=abc123";
+        assert_eq!(
+            extract_meeting_url(text),
+            Some("https://zoom.us/j/1234567890?pwd=abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_google_meet_url() {
+        let text = "Join: https://meet.google.com/abc-defg-hij";
+        assert_eq!(
+            extract_meeting_url(text),
+            Some("https://meet.google.com/abc-defg-hij".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_teams_url() {
+        let text = "https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc";
+        assert_eq!(
+            extract_meeting_url(text),
+            Some("https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_no_url() {
+        assert_eq!(extract_meeting_url("Conference Room B"), None);
+        assert_eq!(extract_meeting_url(""), None);
+        assert_eq!(extract_meeting_url("https://docs.google.com/doc/123"), None);
+    }
+
+    #[test]
+    fn extract_url_from_mixed_text() {
+        let text = "Location: Building 4, Room 201\nhttps://zoom.us/j/999 (backup link)";
+        assert_eq!(
+            extract_meeting_url(text),
+            Some("https://zoom.us/j/999".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_zoom_subdomain_url() {
+        let text = "https://us02web.zoom.us/j/8765432?pwd=xyz";
+        assert_eq!(
+            extract_meeting_url(text),
+            Some("https://us02web.zoom.us/j/8765432?pwd=xyz".to_string())
+        );
+    }
 }

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2138,6 +2138,15 @@ pub fn cmd_get_storage_stats() -> serde_json::Value {
     })
 }
 
+#[tauri::command]
+pub fn cmd_open_meeting_url(url: String) -> Result<(), String> {
+    std::process::Command::new("open")
+        .arg(&url)
+        .spawn()
+        .map_err(|e| format!("Failed to open URL: {}", e))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -107,7 +107,7 @@ pub fn update_tray_state(app: &tauri::AppHandle, is_recording: bool) {
 const MAX_CALENDAR_ITEMS: usize = 3;
 const CALENDAR_REFRESH_SECS: u64 = 60;
 const CALENDAR_LOOKAHEAD_MINUTES: u32 = 240; // 4 hours
-const MEETING_NOTIFY_MINUTES: i64 = 2; // Notify this many minutes before
+const MEETING_NOTIFY_MINUTES: i64 = 3; // Show prompt this many minutes before
 
 struct CalendarMenuState {
     items: Vec<MenuItem<tauri::Wry>>,
@@ -132,6 +132,75 @@ fn format_calendar_label(event: &minutes_core::calendar::CalendarEvent) -> Strin
     } else {
         format!("{} · in {} min", event.title, event.minutes_until)
     }
+}
+
+/// Show a floating overlay prompt for an upcoming meeting.
+/// The overlay has "Join & Record" (if URL) or "Record" + "Dismiss" buttons.
+fn show_meeting_prompt(app: &tauri::AppHandle, event: &minutes_core::calendar::CalendarEvent) {
+    // Don't show if already recording
+    if let Some(state) = app.try_state::<commands::AppState>() {
+        if state.recording.load(Ordering::Relaxed) || state.processing.load(Ordering::Relaxed) {
+            return;
+        }
+    }
+
+    // Close any existing prompt window
+    if let Some(win) = app.get_webview_window("meeting-prompt") {
+        win.close().ok();
+    }
+
+    // Encode event data in URL fragment: title|minutesUntil|url
+    let url_part = event.url.as_deref().unwrap_or("");
+    let fragment = format!(
+        "{}|{}|{}",
+        event.title.replace('|', " "),
+        event.minutes_until,
+        url_part
+    );
+    let encoded = fragment
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || "-._~ |/".contains(c) {
+                c.to_string()
+            } else {
+                format!("%{:02X}", c as u32)
+            }
+        })
+        .collect::<String>();
+    let url = format!("meeting-prompt.html#{}", encoded);
+
+    // Position: top-right of main screen, below menu bar
+    let (pos_x, pos_y) = get_top_right_position(340.0, 140.0);
+
+    match WebviewWindowBuilder::new(app, "meeting-prompt", WebviewUrl::App(url.into()))
+        .title("Upcoming Meeting")
+        .inner_size(340.0, 140.0)
+        .position(pos_x, pos_y)
+        .resizable(false)
+        .decorations(false)
+        .always_on_top(true)
+        .focused(true)
+        .skip_taskbar(true)
+        .build()
+    {
+        Ok(_) => eprintln!("[calendar] meeting prompt shown for: {}", event.title),
+        Err(e) => eprintln!("[calendar] failed to show meeting prompt: {}", e),
+    }
+}
+
+/// Calculate position for top-right placement, 16px from screen edge.
+fn get_top_right_position(width: f64, height: f64) -> (f64, f64) {
+    let _ = height;
+    // Default to a reasonable position; Tauri doesn't expose screen size easily
+    // from a non-window context, so we use a heuristic for common displays.
+    // The window will be placed at x=screen_width - window_width - 16, y=38 (below menu bar).
+    // For a 1440px-wide MacBook display at 2x: logical width ~1440
+    // For a 1920px-wide external: logical width ~1920
+    // We'll use 1440 as a safe default — the window stays visible on any Mac screen.
+    let screen_width = 1440.0;
+    let x = screen_width - width - 16.0;
+    let y = 38.0; // Below the macOS menu bar
+    (x, y)
 }
 
 fn refresh_calendar_items(
@@ -162,26 +231,16 @@ fn refresh_calendar_items(
     for e in &all_events {
         eprintln!("[calendar]   {} — in {} min", e.title, e.minutes_until);
     }
-    // Notify for meetings starting in ≤ MEETING_NOTIFY_MINUTES (once per event)
+    // Show meeting prompt overlay for meetings starting in ≤ MEETING_NOTIFY_MINUTES (once per event)
     for e in &all_events {
         if e.minutes_until >= 0
             && e.minutes_until <= MEETING_NOTIFY_MINUTES
             && !state.notified.contains(&e.title)
         {
-            let body = if e.minutes_until == 0 {
-                format!("{} is starting now. Click to record.", e.title)
-            } else if e.minutes_until == 1 {
-                format!("{} starts in 1 minute. Click to record.", e.title)
-            } else {
-                format!(
-                    "{} starts in {} minutes. Click to record.",
-                    e.title, e.minutes_until
-                )
-            };
-            crate::commands::show_user_notification("Upcoming Meeting", &body);
+            show_meeting_prompt(app, e);
             state.notified.insert(e.title.clone());
             eprintln!(
-                "[calendar] notified: {} (in {} min)",
+                "[calendar] prompted: {} (in {} min)",
                 e.title, e.minutes_until
             );
         }
@@ -693,6 +752,7 @@ fn main() {
             commands::cmd_vault_status,
             commands::cmd_vault_setup,
             commands::cmd_vault_unlink,
+            commands::cmd_open_meeting_url,
         ])
         .run(tauri::generate_context!())
         .expect("error while running minutes app");

--- a/tauri/src/meeting-prompt.html
+++ b/tauri/src/meeting-prompt.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Upcoming Meeting</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', sans-serif;
+      background: #1c1c1e;
+      color: #f5f5f7;
+      padding: 20px;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      -webkit-user-select: none;
+      user-select: none;
+      border: 1px solid #38383a;
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .meeting-info {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      min-width: 0;
+      flex: 1;
+    }
+
+    .calendar-icon {
+      font-size: 16px;
+      line-height: 1.3;
+      flex-shrink: 0;
+    }
+
+    .meeting-text {
+      min-width: 0;
+    }
+
+    .meeting-title {
+      font-size: 15px;
+      font-weight: 600;
+      color: #f5f5f7;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: 1.3;
+    }
+
+    .meeting-countdown {
+      font-size: 13px;
+      color: #0a84ff;
+      margin-top: 2px;
+    }
+
+    .meeting-countdown.urgent {
+      color: #ff453a;
+    }
+
+    .close-btn {
+      padding: 2px 8px;
+      border-radius: 6px;
+      border: none;
+      background: transparent;
+      color: #636366;
+      font-size: 14px;
+      cursor: pointer;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+
+    .close-btn:hover { color: #86868b; background: #38383a; }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+    }
+
+    .btn {
+      padding: 8px 16px;
+      border-radius: 6px;
+      border: none;
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.12s ease;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .btn-primary {
+      background: #0a84ff;
+      color: #fff;
+      flex: 1;
+    }
+
+    .btn-primary:hover { background: #409cff; }
+    .btn-primary:active { background: #0071e3; transform: scale(0.97); }
+    .btn-primary:disabled { background: #38383a; color: #636366; cursor: default; transform: none; }
+
+    .btn-secondary {
+      background: transparent;
+      color: #86868b;
+      border: 1px solid #38383a;
+    }
+
+    .btn-secondary:hover { background: #38383a; color: #f5f5f7; }
+    .btn-secondary:active { transform: scale(0.97); }
+
+    .error-text {
+      font-size: 12px;
+      color: #ff453a;
+      margin-top: 8px;
+      display: none;
+    }
+
+    .toast {
+      position: fixed;
+      bottom: 12px;
+      left: 50%;
+      transform: translateX(-50%) translateY(30px);
+      background: #30d158;
+      color: #000;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 6px 14px;
+      border-radius: 20px;
+      opacity: 0;
+      transition: all 0.25s ease;
+      pointer-events: none;
+      white-space: nowrap;
+    }
+
+    .toast.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Slide-in animation */
+    @keyframes slideIn {
+      from { opacity: 0; transform: translateY(-12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    body {
+      animation: slideIn 300ms ease-out;
+    }
+  </style>
+</head>
+<body role="alertdialog" aria-label="Upcoming meeting">
+  <div class="header">
+    <div class="meeting-info">
+      <span class="calendar-icon">📅</span>
+      <div class="meeting-text">
+        <div class="meeting-title" id="title"></div>
+        <div class="meeting-countdown" id="countdown"></div>
+      </div>
+    </div>
+    <button class="close-btn" id="close-btn" aria-label="Dismiss">✕</button>
+  </div>
+  <div class="actions">
+    <button class="btn btn-primary" id="primary-btn" autofocus></button>
+    <button class="btn btn-secondary" id="dismiss-btn">Dismiss</button>
+  </div>
+  <div class="error-text" id="error-text"></div>
+  <div class="toast" id="toast">Recording started ✓</div>
+
+  <script>
+    const { invoke } = window.__TAURI__.core;
+    const { getCurrentWebviewWindow } = window.__TAURI__.webviewWindow;
+
+    // Parse event data from URL fragment: title|minutesUntil|url
+    const fragment = decodeURIComponent(window.location.hash.slice(1));
+    const [title, minutesStr, meetingUrl] = fragment.split('|');
+    const minutesUntil = parseInt(minutesStr, 10) || 0;
+    const hasUrl = meetingUrl && meetingUrl.length > 0 && meetingUrl !== 'undefined';
+
+    // Set content
+    const titleEl = document.getElementById('title');
+    const countdownEl = document.getElementById('countdown');
+    const primaryBtn = document.getElementById('primary-btn');
+    const errorEl = document.getElementById('error-text');
+    const toast = document.getElementById('toast');
+
+    titleEl.textContent = title || 'Meeting';
+    titleEl.title = title || 'Meeting'; // full text on hover
+
+    if (minutesUntil <= 0) {
+      countdownEl.textContent = 'starting now';
+      countdownEl.classList.add('urgent');
+    } else if (minutesUntil === 1) {
+      countdownEl.textContent = 'in 1 minute';
+    } else {
+      countdownEl.textContent = `in ${minutesUntil} minutes`;
+    }
+
+    primaryBtn.textContent = hasUrl ? 'Join & Record' : 'Record';
+
+    // Auto-focus primary button
+    primaryBtn.focus();
+
+    // Actions
+    async function startRecording() {
+      primaryBtn.disabled = true;
+      primaryBtn.textContent = 'Starting...';
+
+      try {
+        // Open meeting URL first if available
+        if (hasUrl) {
+          await invoke('cmd_open_meeting_url', { url: meetingUrl });
+        }
+
+        // Start recording
+        await invoke('cmd_start_recording');
+
+        // Success toast
+        toast.classList.add('show');
+        setTimeout(() => {
+          toast.classList.remove('show');
+          setTimeout(() => getCurrentWebviewWindow().close(), 200);
+        }, 600);
+      } catch (e) {
+        primaryBtn.disabled = false;
+        primaryBtn.textContent = hasUrl ? 'Join & Record' : 'Record';
+        errorEl.textContent = String(e);
+        errorEl.style.display = 'block';
+      }
+    }
+
+    function dismiss() {
+      getCurrentWebviewWindow().close();
+    }
+
+    primaryBtn.addEventListener('click', startRecording);
+    document.getElementById('dismiss-btn').addEventListener('click', dismiss);
+    document.getElementById('close-btn').addEventListener('click', dismiss);
+
+    // Keyboard: Escape to dismiss
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') dismiss();
+    });
+
+    // Auto-dismiss after 60 seconds
+    setTimeout(() => {
+      document.body.style.transition = 'opacity 300ms ease-out';
+      document.body.style.opacity = '0';
+      setTimeout(() => getCurrentWebviewWindow().close(), 300);
+    }, 60000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace plain AppleScript notifications with a floating overlay window that appears 3 minutes before calendar meetings
- "Join & Record" button opens the meeting URL and starts recording simultaneously (Granola-style UX)
- "Record" button for meetings without URLs, "Dismiss" to skip
- Extract meeting URLs (Zoom, Meet, Teams, Webex, FaceTime) from calendar event locations
- Auto-dismiss after 60s, keyboard accessible (`role=alertdialog`, auto-focus, Escape)
- Success toast + fade-out on recording start, inline error on failure

## Why overlay instead of notifications
Tauri's notification plugin Actions API is [mobile-only on macOS](https://github.com/tauri-apps/plugins-workspace/issues/2150) — click events for desktop notifications are unimplemented since 2022. A floating `WebviewWindow` is actually better: works regardless of notification permissions, survives Do Not Disturb, has real buttons.

## Test Coverage
- 6 new unit tests for URL extraction (Zoom, Meet, Teams, no-URL, mixed text, subdomains)
- 20 existing Tauri app tests pass (no regressions)
- All 26 tests green

## Pre-Landing Review
Eng review (CLEAR) + Design review (5/10 → 9/10) completed in this session. Key decisions:
- Floating overlay (not notification plugin) — Tauri actions are mobile-only
- Join + Record as combined action (Granola-style)
- Top-right positioning, 340x140px, matches existing dark theme
- Red "starting now" urgency state, green toast success confirmation
- Single-line title with ellipsis truncation

## Test plan
- [ ] Verify overlay appears ~3 min before a calendar meeting
- [ ] Click "Join & Record" with a Zoom URL → opens Zoom + starts recording
- [ ] Click "Record" (no URL meeting) → starts recording
- [ ] Click "Dismiss" → overlay closes, no action
- [ ] Overlay auto-dismisses after 60s
- [ ] Overlay does NOT appear when already recording
- [ ] Long meeting titles truncate with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)