### PR TITLE
fix: force MACOSX_DEPLOYMENT_TARGET=11.0 to prevent Tauri build failure

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 # whisper.cpp's ggml uses std::filesystem which requires macOS 10.15+.
 # The cc crate defaults to 10.13 for some targets, causing build failures.
 # Setting this ensures the correct -mmacosx-version-min flag. (See #14)
-MACOSX_DEPLOYMENT_TARGET = { value = "11.0", force = false }
+MACOSX_DEPLOYMENT_TARGET = { value = "11.0", force = true }


### PR DESCRIPTION
## Summary

- Changes `force = false` → `force = true` in `.cargo/config.toml` for `MACOSX_DEPLOYMENT_TARGET`
- Tauri CLI sets its own deployment target (10.13) before invoking cargo, which silently overrode our config value
- On macOS 26 / Xcode 17, `std::filesystem::u8path` in whisper.cpp's `ggml-backend-reg.cpp` fails to compile when the target is below 10.15

## Root cause

The existing fix (#14) set `MACOSX_DEPLOYMENT_TARGET = { value = "11.0", force = false }`. The `force = false` means cargo respects any existing env var — but `cargo tauri build` sets `MACOSX_DEPLOYMENT_TARGET=10.13` internally before invoking the build, so our value was never applied.

## Test plan

- [ ] Run `cargo tauri build --bundles app` on macOS 26 / Xcode 17 — should compile successfully
- [ ] Confirm `Minutes.app` launches
- [ ] Confirm CLI build (`cargo build --release -p minutes-cli`) still works