### PR TITLE
add Parakeet ASR as opt-in transcription engine

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -74,8 +74,8 @@ The pipeline is the product, not the meeting. The same transcribe → summarize 
 │  ┌──────────┐  ├─▶│Transcribe │──▶│ Diarize   │──▶│ Summarize    │ │
 │  │ Watch     │  │  │           │   │ (optional)│   │              │ │
 │  │ Folder    │──┘  │whisper.cpp│   │ pyannote /│   │ Claude /     │ │
-│  │           │     │(local,    │   │ sherpa-   │   │ Ollama /     │ │
-│  │ Voice     │     │ Apple Si  │   │ onnx      │   │ OpenAI /     │ │
+│  │           │     │/ parakeet │   │ sherpa-   │   │ Ollama /     │ │
+│  │ Voice     │     │(local,    │   │ onnx      │   │ OpenAI /     │ │
 │  │ Memos,    │     │ optimized)│   │ (skip for │   │ any LLM      │ │
 │  │ any .m4a/ │     │           │   │  memos)   │   │ (pluggable)  │ │
 │  │ .wav file │     │           │   │           │   │              │ │
@@ -162,7 +162,7 @@ The pipeline is the product, not the meeting. The same transcribe → summarize 
 | Component | Technology | Rationale |
 |-----------|-----------|-----------|
 | **Audio engine** | Rust | Cross-platform, fast, memory-safe. Single binary. |
-| **Transcription** | whisper.cpp (via Rust bindings) | Local, Apple Silicon optimized, best open-source STT |
+| **Transcription** | whisper.cpp (default) or parakeet.cpp (opt-in) | Local, Apple Silicon optimized. Parakeet: lower WER, multilingual. |
 | **Diarization** | pyannote (subprocess) or sherpa-onnx (native) | Pluggable: pyannote for best quality, sherpa-onnx for no-Python mode |
 | **Menu bar app** | Tauri v2 | Rust backend + web frontend, ~10MB vs Electron's 150MB |
 | **CLI** | Rust (clap) | Same binary as engine, zero extra deps |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ minutes stop                  # Stop and transcribe
 Audio → Transcribe → Diarize → Summarize → Structured Markdown → Relationship Graph
          (local)     (local)     (LLM)       (decisions,            (people, commitments,
         whisper.cpp  pyannote   Claude/       action items,          topics, scores)
-                                Ollama/       people, entities)      SQLite index
+        /parakeet               Ollama/       people, entities)      SQLite index
                                 OpenAI
 ```
 
@@ -465,6 +465,11 @@ brew install ffmpeg           # macOS
 # Enable speaker diarization (optional, ~34MB ONNX models)
 minutes setup --diarization
 
+# Alternative: use Parakeet engine (opt-in, lower WER than Whisper)
+# Requires parakeet.cpp installed: https://github.com/Frikallo/parakeet.cpp
+minutes setup --parakeet                          # English model (tdt-ctc-110m, ~220MB)
+minutes setup --parakeet --parakeet-model tdt-600m  # Multilingual (25 EU languages, ~1.2GB)
+
 # Enroll your voice for automatic speaker identification
 minutes enroll              # Records 10s of your voice
 minutes voices              # View enrolled profiles
@@ -586,7 +591,10 @@ Optional — minutes works out of the box.
 # ~/.config/minutes/config.toml
 
 [transcription]
-model = "small"           # tiny (75MB), base, small (466MB), medium, large-v3 (3.1GB)
+engine = "whisper"        # "whisper" (default) or "parakeet" (opt-in, lower WER)
+model = "small"           # whisper: tiny (75MB), base, small (466MB), medium, large-v3 (3.1GB)
+# parakeet_model = "tdt-ctc-110m"  # parakeet: tdt-ctc-110m (English), tdt-600m (multilingual)
+# parakeet_binary = "parakeet"     # Path to parakeet.cpp binary (or name in PATH)
 
 [summarization]
 engine = "none"           # Default: Claude summarizes conversationally via MCP

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -212,6 +212,14 @@ enum Commands {
         /// Download speaker diarization models (~34 MB)
         #[arg(long)]
         diarization: bool,
+
+        /// Download parakeet.cpp model for alternative transcription engine
+        #[arg(long)]
+        parakeet: bool,
+
+        /// Parakeet model to download: tdt-ctc-110m, tdt-600m
+        #[arg(long, default_value = "tdt-ctc-110m")]
+        parakeet_model: String,
     },
 
     /// Inspect or register the meetings directory as a QMD collection
@@ -461,7 +469,15 @@ fn main() -> Result<()> {
             model,
             list,
             diarization,
-        } => cmd_setup(&model, list, diarization),
+            parakeet,
+            parakeet_model,
+        } => {
+            if parakeet {
+                cmd_setup_parakeet(&parakeet_model)
+            } else {
+                cmd_setup(&model, list, diarization)
+            }
+        }
         Commands::Qmd { action, collection } => cmd_qmd(&action, &collection, &config),
         Commands::Service { action } => {
             #[cfg(target_os = "macos")]
@@ -1359,6 +1375,10 @@ fn cmd_setup(model: &str, list: bool, diarization: bool) -> Result<()> {
         eprintln!();
         eprintln!("Speaker diarization:");
         eprintln!("  --diarization   34 MB   (pyannote-rs: segmentation + speaker embedding)");
+        eprintln!();
+        eprintln!("Parakeet models (alternative engine, --parakeet):");
+        eprintln!("  tdt-ctc-110m  ~220 MB   (English, fast, default)");
+        eprintln!("  tdt-600m      ~1.2 GB   (multilingual, 25 EU languages, best quality)");
         return Ok(());
     }
 
@@ -1475,6 +1495,88 @@ fn cmd_setup_diarization() -> Result<()> {
     eprintln!("\nTo enable speaker diarization, add to ~/.config/minutes/config.toml:");
     eprintln!("  [diarization]");
     eprintln!("  engine = \"pyannote-rs\"");
+
+    Ok(())
+}
+
+/// Download and set up a parakeet.cpp model for alternative transcription.
+fn cmd_setup_parakeet(model: &str) -> Result<()> {
+    let valid_models = ["tdt-ctc-110m", "tdt-600m"];
+    if !valid_models.contains(&model) {
+        anyhow::bail!(
+            "unknown parakeet model: {}. Available: {}",
+            model,
+            valid_models.join(", ")
+        );
+    }
+
+    let config = Config::default();
+    let model_dir = config.transcription.model_path.join("parakeet");
+    std::fs::create_dir_all(&model_dir)?;
+
+    let dest = model_dir.join(format!("{}.safetensors", model));
+    if dest.exists() {
+        let size = std::fs::metadata(&dest)?.len();
+        eprintln!(
+            "Model already downloaded: {} ({:.0} MB)",
+            dest.display(),
+            size as f64 / 1_048_576.0
+        );
+    } else {
+        // Map model name to HuggingFace repo
+        let hf_repo = match model {
+            "tdt-ctc-110m" => "nvidia/parakeet-tdt_ctc-110m",
+            "tdt-600m" => "nvidia/parakeet-tdt-0.6b-v3",
+            _ => unreachable!(),
+        };
+        let url = format!(
+            "https://huggingface.co/{}/resolve/main/model.safetensors",
+            hf_repo
+        );
+
+        eprintln!("Downloading parakeet model: {} ...", model);
+        eprintln!(
+            "Note: If a pre-converted safetensors is not available at this URL,"
+        );
+        eprintln!("you may need to download the .nemo file and convert it:");
+        eprintln!("  huggingface-cli download {} --include '*.nemo'", hf_repo);
+        eprintln!("  python scripts/convert_nemo.py <file>.nemo -o {}", dest.display());
+        eprintln!();
+
+        if let Err(e) = download_file(&url, &dest) {
+            eprintln!("Download failed: {}", e);
+            eprintln!("\nThe pre-converted safetensors may not be hosted yet.");
+            eprintln!("To convert manually, install parakeet.cpp and run:");
+            eprintln!("  python convert_nemo.py <model>.nemo -o {}", dest.display());
+            return Err(e);
+        }
+    }
+
+    // Verify parakeet binary is available
+    match std::process::Command::new("parakeet")
+        .arg("--help")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+    {
+        Ok(status) if status.success() => {
+            eprintln!("\nparakeet binary found in PATH.");
+        }
+        _ => {
+            eprintln!("\nWarning: `parakeet` binary not found in PATH.");
+            eprintln!("Install parakeet.cpp: https://github.com/Frikallo/parakeet.cpp");
+            eprintln!("Build from source:");
+            eprintln!("  git clone https://github.com/Frikallo/parakeet.cpp");
+            eprintln!("  cd parakeet.cpp && mkdir build && cd build");
+            eprintln!("  cmake .. && make -j");
+            eprintln!("  cp parakeet /usr/local/bin/");
+        }
+    }
+
+    eprintln!("\nTo use parakeet as your transcription engine, add to ~/.config/minutes/config.toml:");
+    eprintln!("  [transcription]");
+    eprintln!("  engine = \"parakeet\"");
+    eprintln!("  parakeet_model = \"{}\"", model);
 
     Ok(())
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["multimedia::audio", "command-line-utilities"]
 [features]
 default = ["whisper"]
 whisper = ["dep:whisper-rs"]
+parakeet = []  # subprocess-based, no native deps
 diarize = ["dep:pyannote-rs"]
 cuda = ["whisper-rs/cuda"]
 metal = ["whisper-rs/metal"]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -47,6 +47,8 @@ impl Default for VoiceConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TranscriptionConfig {
+    /// Transcription engine: "whisper" (default) or "parakeet".
+    pub engine: String,
     pub model: String,
     pub model_path: PathBuf,
     pub min_words: usize,
@@ -54,6 +56,10 @@ pub struct TranscriptionConfig {
     /// Silero VAD model name (resolved under model_path, e.g. "silero-v6.2.0" → ggml-silero-v6.2.0.bin).
     /// Set to empty string to disable VAD (falls back to energy-based silence stripping).
     pub vad_model: String,
+    /// Path or name of the parakeet.cpp binary (resolved via PATH if not absolute).
+    pub parakeet_binary: String,
+    /// Parakeet model type: "tdt-ctc-110m", "tdt-600m", "eou-120m", "nemotron-600m".
+    pub parakeet_model: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -275,11 +281,14 @@ impl Default for Config {
 impl Default for TranscriptionConfig {
     fn default() -> Self {
         Self {
+            engine: "whisper".into(),
             model: "small".into(),
             model_path: minutes_dir().join("models"),
             min_words: 3,
             language: None,
             vad_model: "silero-v6.2.0".into(),
+            parakeet_binary: "parakeet".into(),
+            parakeet_model: "tdt-ctc-110m".into(),
         }
     }
 }
@@ -468,8 +477,11 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         let config = Config::default();
+        assert_eq!(config.transcription.engine, "whisper");
         assert_eq!(config.transcription.model, "small");
         assert_eq!(config.transcription.min_words, 3);
+        assert_eq!(config.transcription.parakeet_binary, "parakeet");
+        assert_eq!(config.transcription.parakeet_model, "tdt-ctc-110m");
         assert_eq!(config.diarization.engine, "auto");
         assert_eq!(config.summarization.engine, "none");
         assert_eq!(config.search.engine, "builtin");
@@ -553,5 +565,47 @@ model = "tiny"
 
         let config = Config::load_from(&config_path);
         assert_eq!(config.transcription.model, "small");
+    }
+
+    #[test]
+    fn parakeet_config_from_toml() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[transcription]
+engine = "parakeet"
+parakeet_model = "tdt-600m"
+parakeet_binary = "/usr/local/bin/parakeet"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_from(&config_path);
+        assert_eq!(config.transcription.engine, "parakeet");
+        assert_eq!(config.transcription.parakeet_model, "tdt-600m");
+        assert_eq!(config.transcription.parakeet_binary, "/usr/local/bin/parakeet");
+        // Other fields should be defaults
+        assert_eq!(config.transcription.model, "small");
+        assert_eq!(config.transcription.min_words, 3);
+    }
+
+    #[test]
+    fn omitted_engine_defaults_to_whisper() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[transcription]
+model = "tiny"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_from(&config_path);
+        assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(config.transcription.parakeet_binary, "parakeet");
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -60,6 +60,15 @@ pub enum TranscribeError {
     #[error("transcription failed: {0}")]
     TranscriptionFailed(String),
 
+    #[error("engine '{0}' not compiled in — rebuild with: cargo build --features {0}")]
+    EngineNotAvailable(String),
+
+    #[error("parakeet binary not found. Install parakeet.cpp and ensure `parakeet` is in PATH.")]
+    ParakeetNotFound,
+
+    #[error("parakeet transcription failed: {0}")]
+    ParakeetFailed(String),
+
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::error::TranscribeError;
 use std::path::Path;
-#[cfg(feature = "whisper")]
+#[cfg(any(feature = "whisper", feature = "parakeet"))]
 use std::path::PathBuf;
 
 // ──────────────────────────────────────────────────────────────
@@ -9,22 +9,40 @@ use std::path::PathBuf;
 //
 //   Input audio (.wav, .m4a, .mp3, .ogg)
 //        │
-//        ├─ .wav ──────────────────────────────────▶ whisper-rs
+//        ├─ .wav ──────────────────────────────────▶ engine
 //        │
-//        └─ .m4a/.mp3/.ogg ─▶ symphonia decode ─▶ whisper-rs
+//        └─ .m4a/.mp3/.ogg ─▶ symphonia decode ─▶ engine
 //                              (to 16kHz mono PCM)
 //
-// whisper-rs wraps whisper.cpp, uses Apple Accelerate on M-series.
+// Engines:
+//   - whisper (default): whisper.cpp via whisper-rs, Apple Accelerate on M-series
+//   - parakeet (opt-in): parakeet.cpp via subprocess, Metal on Apple Silicon
+//
+// Engine is selected via config.transcription.engine ("whisper" or "parakeet").
 // Model must be downloaded first via `minutes setup`.
 // ──────────────────────────────────────────────────────────────
 
 /// Transcribe an audio file to text.
 ///
-/// With the `whisper` feature (default): uses whisper.cpp via whisper-rs.
-/// Without: returns a placeholder transcript (for testing without a model).
+/// Dispatches to the engine configured in `config.transcription.engine`:
+/// - `"whisper"` (default): whisper.cpp via whisper-rs
+/// - `"parakeet"`: parakeet.cpp via subprocess
 ///
 /// Handles format conversion (m4a/mp3/ogg → PCM) automatically via symphonia.
+/// Both engines produce identical output format: `[M:SS] text` lines.
 pub fn transcribe(audio_path: &Path, config: &Config) -> Result<String, TranscribeError> {
+    match config.transcription.engine.as_str() {
+        "parakeet" => transcribe_parakeet_dispatch(audio_path, config),
+        // Default: whisper (also handles "whisper" and any unrecognized value)
+        _ => transcribe_whisper_dispatch(audio_path, config),
+    }
+}
+
+/// Whisper transcription path (existing behavior).
+fn transcribe_whisper_dispatch(
+    audio_path: &Path,
+    config: &Config,
+) -> Result<String, TranscribeError> {
     // Step 1: Load audio as 16kHz mono f32 PCM samples
     let samples = load_audio_samples(audio_path)?;
 
@@ -73,6 +91,23 @@ pub fn transcribe(audio_path: &Path, config: &Config) -> Result<String, Transcri
             duration_secs,
             samples.len(),
         ))
+    }
+}
+
+/// Parakeet transcription path (subprocess-based).
+fn transcribe_parakeet_dispatch(
+    audio_path: &Path,
+    config: &Config,
+) -> Result<String, TranscribeError> {
+    #[cfg(feature = "parakeet")]
+    {
+        transcribe_with_parakeet(audio_path, config)
+    }
+
+    #[cfg(not(feature = "parakeet"))]
+    {
+        let _ = (audio_path, config);
+        Err(TranscribeError::EngineNotAvailable("parakeet".into()))
     }
 }
 
@@ -928,6 +963,316 @@ fn num_cpus() -> i32 {
         .min(8) // Cap at 8 — diminishing returns beyond that for whisper
 }
 
+// ──────────────────────────────────────────────────────────────
+// Parakeet engine (subprocess-based)
+//
+// Shells out to parakeet.cpp CLI, parses JSON output with
+// word-level timestamps, formats as [M:SS] lines to match
+// whisper output exactly. Pipeline/diarization/summarization
+// all work unchanged.
+// ──────────────────────────────────────────────────────────────
+
+/// Transcribe using parakeet.cpp as a subprocess.
+#[cfg(feature = "parakeet")]
+fn transcribe_with_parakeet(
+    audio_path: &Path,
+    config: &Config,
+) -> Result<String, TranscribeError> {
+    use std::process::Command;
+
+    // Step 1: Load audio and convert to 16kHz mono (reuse existing pipeline)
+    let samples = load_audio_samples(audio_path)?;
+    if samples.is_empty() {
+        return Err(TranscribeError::EmptyAudio);
+    }
+
+    // Strip silence (parakeet benefits from the same pre-processing)
+    let samples = strip_silence(&samples);
+    if samples.is_empty() {
+        return Err(TranscribeError::EmptyAudio);
+    }
+
+    // Step 2: Write samples to temp WAV for parakeet CLI
+    let tmp_wav = std::env::temp_dir().join(format!("minutes-parakeet-{}.wav", std::process::id()));
+    write_wav_16k_mono(&tmp_wav, &samples)?;
+
+    // Step 3: Resolve model path
+    let model_path = resolve_parakeet_model_path(config)?;
+
+    // Step 4: Run parakeet subprocess
+    let binary = &config.transcription.parakeet_binary;
+    tracing::info!(
+        binary = %binary,
+        model = %model_path.display(),
+        audio = %audio_path.display(),
+        "starting parakeet transcription"
+    );
+
+    let output = Command::new(binary)
+        .arg(model_path.to_str().unwrap_or(""))
+        .arg(tmp_wav.to_str().unwrap_or(""))
+        .args(["--model", &config.transcription.parakeet_model])
+        .args(["--output-format", "json"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                TranscribeError::ParakeetNotFound
+            } else {
+                TranscribeError::ParakeetFailed(format!("spawn error: {}", e))
+            }
+        });
+
+    // Clean up temp file regardless of outcome
+    let _ = std::fs::remove_file(&tmp_wav);
+
+    let output = output?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(TranscribeError::ParakeetFailed(
+            stderr
+                .lines()
+                .last()
+                .unwrap_or("unknown error")
+                .to_string(),
+        ));
+    }
+
+    // Step 5: Parse output and format as [M:SS] lines
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let transcript = parse_parakeet_output(&stdout, config)?;
+
+    let word_count = transcript.split_whitespace().count();
+    tracing::info!(words = word_count, "parakeet transcription complete");
+
+    Ok(transcript)
+}
+
+/// A single word from parakeet.cpp JSON output.
+#[cfg(feature = "parakeet")]
+#[derive(serde::Deserialize)]
+struct ParakeetWord {
+    #[serde(alias = "text")]
+    word: String,
+    start: f64,
+    end: f64,
+}
+
+/// Parakeet JSON output envelope — handles both array and object formats.
+#[cfg(feature = "parakeet")]
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum ParakeetOutput {
+    /// Array of word-level timestamps
+    Words(Vec<ParakeetWord>),
+    /// Object with a "words" or "timestamps" field
+    Object {
+        #[serde(default)]
+        words: Vec<ParakeetWord>,
+        #[serde(default)]
+        timestamps: Option<ParakeetTimestamps>,
+    },
+}
+
+#[cfg(feature = "parakeet")]
+#[derive(serde::Deserialize)]
+struct ParakeetTimestamps {
+    #[serde(default)]
+    words: Vec<ParakeetWord>,
+}
+
+/// Parse parakeet.cpp JSON output into `[M:SS] text` lines matching whisper format.
+///
+/// Groups consecutive words into segments at natural pause boundaries (>0.5s gap
+/// between words) or every ~30 words. Applies the same dedup_segments anti-hallucination
+/// filter used by whisper.
+#[cfg(feature = "parakeet")]
+fn parse_parakeet_output(raw_output: &str, config: &Config) -> Result<String, TranscribeError> {
+    let raw = raw_output.trim();
+
+    // Try JSON parsing first
+    let words: Vec<ParakeetWord> = if let Ok(output) = serde_json::from_str::<ParakeetOutput>(raw)
+    {
+        match output {
+            ParakeetOutput::Words(w) => w,
+            ParakeetOutput::Object { words, timestamps } => {
+                if !words.is_empty() {
+                    words
+                } else if let Some(ts) = timestamps {
+                    ts.words
+                } else {
+                    Vec::new()
+                }
+            }
+        }
+    } else {
+        // Fallback: try to parse line-based output like "[0.00 - 2.50] Hello world"
+        return parse_parakeet_text_output(raw, config);
+    };
+
+    if words.is_empty() {
+        return Err(TranscribeError::EmptyTranscript(
+            config.transcription.min_words,
+        ));
+    }
+
+    // Group words into segments at pause boundaries
+    let mut lines = Vec::new();
+    let mut current_words: Vec<&str> = Vec::new();
+    let mut segment_start: f64 = 0.0;
+
+    for (i, word) in words.iter().enumerate() {
+        if current_words.is_empty() {
+            segment_start = word.start;
+        }
+        let w = word.word.trim();
+        if !w.is_empty() {
+            current_words.push(w);
+        }
+
+        // Break segment at pauses > 0.5s or every ~30 words
+        let is_pause = if i + 1 < words.len() {
+            words[i + 1].start - word.end > 0.5
+        } else {
+            true // last word
+        };
+
+        if (is_pause || current_words.len() >= 30) && !current_words.is_empty() {
+            let mins = (segment_start / 60.0) as u64;
+            let secs = (segment_start % 60.0) as u64;
+            let text = current_words.join(" ");
+            lines.push(format!("[{}:{:02}] {}", mins, secs, text));
+            current_words.clear();
+        }
+    }
+
+    // Apply dedup (reuse existing anti-hallucination safety net)
+    let lines = dedup_segments(lines);
+
+    let transcript = lines.join("\n");
+    if transcript.is_empty() {
+        Ok(transcript)
+    } else {
+        Ok(format!("{}\n", transcript))
+    }
+}
+
+/// Fallback parser for parakeet.cpp text output (line-based with timestamps).
+///
+/// Handles output like:
+///   `[0.00 - 2.50] Hello world`
+///   `[2.80 - 5.10] How are you`
+#[cfg(feature = "parakeet")]
+fn parse_parakeet_text_output(
+    raw: &str,
+    config: &Config,
+) -> Result<String, TranscribeError> {
+    let mut lines = Vec::new();
+
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Try to parse "[start - end] text" format
+        if let Some(rest) = line.strip_prefix('[') {
+            if let Some(bracket_end) = rest.find(']') {
+                let timestamp_part = &rest[..bracket_end];
+                let text = rest[bracket_end + 1..].trim();
+
+                if let Some((start_str, _end_str)) = timestamp_part.split_once('-') {
+                    if let Ok(start_secs) = start_str.trim().parse::<f64>() {
+                        let mins = (start_secs / 60.0) as u64;
+                        let secs = (start_secs % 60.0) as u64;
+                        if !text.is_empty() {
+                            lines.push(format!("[{}:{:02}] {}", mins, secs, text));
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Unparseable line — include as-is if non-empty
+        if !line.is_empty() {
+            lines.push(format!("[0:00] {}", line));
+        }
+    }
+
+    if lines.is_empty() {
+        return Err(TranscribeError::EmptyTranscript(
+            config.transcription.min_words,
+        ));
+    }
+
+    let lines = dedup_segments(lines);
+    let transcript = lines.join("\n");
+    if transcript.is_empty() {
+        Ok(transcript)
+    } else {
+        Ok(format!("{}\n", transcript))
+    }
+}
+
+/// Write f32 samples as a 16kHz mono 16-bit WAV file.
+#[cfg(feature = "parakeet")]
+fn write_wav_16k_mono(path: &Path, samples: &[f32]) -> Result<(), TranscribeError> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: 16000,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)
+        .map_err(|e| TranscribeError::Io(std::io::Error::other(e.to_string())))?;
+    for &s in samples {
+        let sample = (s * 32767.0).clamp(-32768.0, 32767.0) as i16;
+        writer
+            .write_sample(sample)
+            .map_err(|e| TranscribeError::Io(std::io::Error::other(e.to_string())))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| TranscribeError::Io(std::io::Error::other(e.to_string())))?;
+    Ok(())
+}
+
+/// Resolve the parakeet model file path.
+///
+/// Looks for `.safetensors` files in `~/.minutes/models/parakeet/`.
+#[cfg(feature = "parakeet")]
+fn resolve_parakeet_model_path(config: &Config) -> Result<PathBuf, TranscribeError> {
+    let model_dir = config.transcription.model_path.join("parakeet");
+    let model_name = &config.transcription.parakeet_model;
+
+    let candidates = [
+        model_dir.join(format!("{}.safetensors", model_name)),
+        model_dir.join(format!("parakeet-{}.safetensors", model_name)),
+        model_dir.join("model.safetensors"),
+    ];
+
+    for candidate in &candidates {
+        if candidate.exists() {
+            return Ok(candidate.clone());
+        }
+    }
+
+    // Try as absolute path
+    let direct = PathBuf::from(model_name);
+    if direct.exists() {
+        return Ok(direct);
+    }
+
+    Err(TranscribeError::ModelNotFound(format!(
+        "Expected parakeet model \"{}\" in {}. Run: minutes setup --parakeet",
+        model_name,
+        model_dir.display(),
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -988,6 +1333,7 @@ mod tests {
                 min_words: 10,
                 language: Some("en".into()),
                 vad_model: String::new(),
+                ..crate::config::TranscriptionConfig::default()
             },
             ..Config::default()
         };
@@ -1233,5 +1579,202 @@ mod tests {
         assert_eq!(result.len(), 5); // first + marker + second + marker + normal
         assert!(result[1].contains("2 identical"));
         assert!(result[3].contains("3 identical"));
+    }
+
+    #[test]
+    fn engine_defaults_to_whisper_dispatch() {
+        // Verify that the default engine config takes the whisper path
+        let config = Config::default();
+        assert_eq!(config.transcription.engine, "whisper");
+    }
+
+    #[test]
+    fn engine_not_available_without_feature() {
+        // When parakeet feature is not compiled in, should return EngineNotAvailable
+        #[cfg(not(feature = "parakeet"))]
+        {
+            let config = Config {
+                transcription: crate::config::TranscriptionConfig {
+                    engine: "parakeet".into(),
+                    ..crate::config::TranscriptionConfig::default()
+                },
+                ..Config::default()
+            };
+            // Use a dummy path — it should fail at the engine check, not file check
+            let result = transcribe(Path::new("/nonexistent/test.wav"), &config);
+            assert!(result.is_err());
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("parakeet"),
+                "error should mention parakeet: {}",
+                err
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_json_basic() {
+        let json = r#"[
+            {"word": "Hello", "start": 0.0, "end": 0.5},
+            {"word": "world", "start": 0.6, "end": 1.0},
+            {"word": "how", "start": 1.2, "end": 1.4},
+            {"word": "are", "start": 1.5, "end": 1.7},
+            {"word": "you", "start": 1.8, "end": 2.0}
+        ]"#;
+        let config = Config::default();
+        let result = parse_parakeet_output(json, &config).unwrap();
+        // All words within 0.5s of each other → one segment
+        assert!(result.contains("[0:00]"), "should have timestamp: {}", result);
+        assert!(result.contains("Hello"), "should have Hello: {}", result);
+        assert!(result.contains("world"), "should have world: {}", result);
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_json_segments_at_pauses() {
+        let json = r#"[
+            {"word": "Hello", "start": 0.0, "end": 0.5},
+            {"word": "world", "start": 0.6, "end": 1.0},
+            {"word": "second", "start": 5.0, "end": 5.5},
+            {"word": "segment", "start": 5.6, "end": 6.0}
+        ]"#;
+        let config = Config::default();
+        let result = parse_parakeet_output(json, &config).unwrap();
+        // Gap of 4.0s between "world" and "second" → two segments
+        let lines: Vec<&str> = result.trim().lines().collect();
+        assert_eq!(lines.len(), 2, "should have 2 segments: {:?}", lines);
+        assert!(lines[0].contains("Hello world"), "first: {}", lines[0]);
+        assert!(
+            lines[1].contains("second segment"),
+            "second: {}",
+            lines[1]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_json_object_format() {
+        let json = r#"{"words": [
+            {"text": "Hello", "start": 0.0, "end": 0.5},
+            {"text": "world", "start": 0.6, "end": 1.0}
+        ]}"#;
+        let config = Config::default();
+        let result = parse_parakeet_output(json, &config).unwrap();
+        assert!(result.contains("Hello"), "should parse object format: {}", result);
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_json_timestamps_format() {
+        let json = r#"{"timestamps": {"words": [
+            {"word": "Hello", "start": 0.0, "end": 0.5},
+            {"word": "world", "start": 0.6, "end": 1.0}
+        ]}}"#;
+        let config = Config::default();
+        let result = parse_parakeet_output(json, &config).unwrap();
+        assert!(
+            result.contains("Hello"),
+            "should parse timestamps format: {}",
+            result
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_empty_output() {
+        let json = "[]";
+        let config = Config::default();
+        let result = parse_parakeet_output(json, &config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no text"));
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_malformed_json() {
+        // Completely empty input should fail
+        let bad = "";
+        let config = Config::default();
+        let result = parse_parakeet_output(bad, &config);
+        assert!(result.is_err(), "empty input should fail");
+
+        // Malformed JSON falls through to text parser, which captures it as-is
+        let bad = "this is not json {{{";
+        let result = parse_parakeet_output(bad, &config);
+        // Text fallback treats non-empty non-timestamp lines as [0:00] text
+        assert!(result.is_ok(), "text fallback should capture plain text");
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_text_fallback() {
+        let text = "[0.00 - 2.50] Hello world\n[3.00 - 5.10] How are you\n";
+        let config = Config::default();
+        let result = parse_parakeet_output(text, &config).unwrap();
+        let lines: Vec<&str> = result.trim().lines().collect();
+        assert_eq!(lines.len(), 2, "should have 2 lines: {:?}", lines);
+        assert!(lines[0].contains("[0:00] Hello world"), "first: {}", lines[0]);
+        assert!(lines[1].contains("[0:03] How are you"), "second: {}", lines[1]);
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn write_wav_roundtrip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.wav");
+
+        let samples: Vec<f32> = (0..16000)
+            .map(|i| 0.5 * (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16000.0).sin())
+            .collect();
+
+        write_wav_16k_mono(&path, &samples).unwrap();
+
+        // Read back with hound
+        let reader = hound::WavReader::open(&path).unwrap();
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.sample_rate, 16000);
+        assert_eq!(spec.bits_per_sample, 16);
+        let read_samples: Vec<i16> = reader.into_samples().filter_map(|s| s.ok()).collect();
+        assert_eq!(read_samples.len(), 16000);
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn resolve_parakeet_model_missing() {
+        let config = Config {
+            transcription: crate::config::TranscriptionConfig {
+                model_path: PathBuf::from("/tmp/no-such-dir"),
+                parakeet_model: "tdt-600m".into(),
+                ..crate::config::TranscriptionConfig::default()
+            },
+            ..Config::default()
+        };
+        let result = resolve_parakeet_model_path(&config);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("minutes setup --parakeet"),
+            "error should tell user how to fix it: {}",
+            err
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "parakeet")]
+    fn parse_parakeet_timestamp_formatting() {
+        // Verify that timestamps > 60s are formatted correctly
+        let json = r#"[
+            {"word": "late", "start": 125.0, "end": 125.5},
+            {"word": "segment", "start": 125.6, "end": 126.0}
+        ]"#;
+        let config = Config::default();
+        let result = parse_parakeet_output(json, &config).unwrap();
+        assert!(
+            result.contains("[2:05]"),
+            "125s should be [2:05]: {}",
+            result
+        );
     }
 }

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2756,6 +2756,7 @@ mod tests {
                 min_words: 3,
                 language: Some("en".into()),
                 vad_model: "silero-v6.2.0".into(),
+                ..minutes_core::config::TranscriptionConfig::default()
             },
             ..Config::default()
         };

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -17,6 +17,7 @@ fn test_config(output_dir: PathBuf) -> Config {
             min_words: 10,
             language: Some("en".into()),
             vad_model: "silero-v6.2.0".into(),
+            ..minutes_core::config::TranscriptionConfig::default()
         },
         ..Config::default()
     }


### PR DESCRIPTION
## Summary

- Add NVIDIA Parakeet (via parakeet.cpp) as a second transcription engine, selectable via `transcription.engine = "parakeet"` in config
- Whisper remains the default — this is purely additive
- Both engines produce identical downstream output (`[M:SS] text` lines), so diarization, summarization, and markdown writing work unchanged

## Motivation

- Parakeet V3 achieves lower WER than Whisper across standard benchmarks
- Native multilingual support (25 EU languages) without separate model variants
- ~110x RTF on Apple Silicon via Metal acceleration
- CC-BY-4.0 license, compatible with Minutes' MIT license

## Changes

- **Feature flag**: `parakeet = []` in `crates/core/Cargo.toml` (default off, subprocess-based, no native deps)
- **Config**: Add `engine`, `parakeet_binary`, `parakeet_model` fields to `TranscriptionConfig` (backward compatible — omitting `engine` defaults to whisper)
- **Errors**: Add `ParakeetNotFound`, `ParakeetFailed`, `EngineNotAvailable` variants to `TranscribeError`
- **Engine dispatch**: `transcribe()` matches on `config.transcription.engine` — `"parakeet"` invokes subprocess, `"whisper"`/default uses existing whisper-rs path. `pipeline.rs` is untouched.
- **Subprocess integration**: Shells out to `parakeet` CLI binary, parses JSON output with word-level timestamps, groups words into segments at pause boundaries (>0.5s gap), formats as `[M:SS] text` lines. Includes fallback text parser for non-JSON output formats.
- **CLI**: `minutes setup --parakeet [--parakeet-model tdt-600m]` downloads safetensors model to `~/.minutes/models/parakeet/`, verifies binary in PATH
- **Tests**: 13 new tests — 10 parakeet-specific (JSON parsing variants, text fallback, WAV roundtrip, model resolution, timestamp formatting) + 3 config tests (engine default, TOML parsing, backward compat)
- **Docs**: Updated README.md (config example, setup instructions, architecture diagram) and PLAN.md (tech stack table)
- **Style**: Applied `cargo fmt` across workspace

## Design decisions

- **Subprocess (Option B)** over FFI — matches existing pyannote diarization pattern, pragmatic while parakeet.cpp's C API matures
- **No trait** — simple match dispatch in `transcribe()`, consistent with how `diarize.rs` handles engine selection
- **pipeline.rs untouched** — public `transcribe() -> String` API unchanged, zero downstream modifications

## Test plan

- [x] `cargo test -p minutes-core --no-default-features` — 209 tests pass
- [x] `cargo test -p minutes-core --no-default-features --features parakeet` — 211 tests pass
- [x] `cargo test -p minutes-core --lib` — 202 unit tests pass with default features
- [x] `cargo build -p minutes-cli` — CLI builds successfully
- [x] `cargo fmt --all -- --check` — clean
- [x] Config without `engine` field defaults to whisper (backward compat verified by test)
- [x] Config with `engine = "parakeet"` without feature compiled returns clear `EngineNotAvailable` error

## Not in scope

- Sortformer diarization (parakeet.cpp bundles it, but we keep pyannote for now)
- Streaming/real-time transcription via Parakeet
- FFI bindings (future upgrade path from subprocess)
- Removing whisper.cpp support
