### PR TITLE
Add initial_prompt config for custom Whisper vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,9 @@ ollama_model = "llama3.2"
 [transcription]
 # vad_model = "silero-v6.2.0" # Silero VAD model (auto-downloaded by setup). Empty = disable.
                               # Prevents whisper hallucination loops on non-English/noisy audio.
+# initial_prompt = "Acme Corp, JIRA, OKRs, GraphQL, S3"  # Bias Whisper toward domain vocabulary.
+                              # Add company names, project acronyms, industry jargon, or proper nouns
+                              # that Whisper tends to misspell. Comma-separated list works well.
 
 [diarization]
 engine = "auto"           # "auto" (default — uses pyannote-rs if models downloaded, otherwise skips),

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -54,6 +54,9 @@ pub struct TranscriptionConfig {
     /// Silero VAD model name (resolved under model_path, e.g. "silero-v6.2.0" → ggml-silero-v6.2.0.bin).
     /// Set to empty string to disable VAD (falls back to energy-based silence stripping).
     pub vad_model: String,
+    /// Optional prompt to bias Whisper toward domain-specific vocabulary.
+    /// Useful for proper nouns, acronyms, and jargon that Whisper would otherwise misspell.
+    pub initial_prompt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -280,6 +283,7 @@ impl Default for TranscriptionConfig {
             min_words: 3,
             language: None,
             vad_model: "silero-v6.2.0".into(),
+            initial_prompt: None,
         }
     }
 }
@@ -543,6 +547,32 @@ model = "tiny"
 
         let config = Config::load_from(&config_path);
         assert_eq!(config.transcription.language, None);
+    }
+
+    #[test]
+    fn default_initial_prompt_is_none() {
+        let config = Config::default();
+        assert_eq!(config.transcription.initial_prompt, None);
+    }
+
+    #[test]
+    fn initial_prompt_round_trips_through_toml() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[transcription]
+initial_prompt = "Acme Corp, JIRA, OKRs, GraphQL"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_from(&config_path);
+        assert_eq!(
+            config.transcription.initial_prompt,
+            Some("Acme Corp, JIRA, OKRs, GraphQL".into())
+        );
     }
 
     #[test]

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -240,7 +240,10 @@ where
         tracing::info!(device = %stream.device_name, "dictation audio stream started");
 
         let mut vad = Vad::new();
-        let mut streaming = StreamingWhisper::new(config.transcription.language.clone());
+        let mut streaming = StreamingWhisper::new(
+            config.transcription.language.clone(),
+            config.transcription.initial_prompt.clone(),
+        );
         let mut was_speaking = false;
         let mut has_spoken = false;
         let mut total_silence_ms: u64 = 0;

--- a/crates/core/src/streaming_whisper.rs
+++ b/crates/core/src/streaming_whisper.rs
@@ -68,19 +68,22 @@ pub struct StreamingWhisper {
     n_threads: i32,
     /// Language hint (None = auto-detect).
     language: Option<String>,
+    /// Optional prompt to bias Whisper toward domain-specific vocabulary.
+    initial_prompt: Option<String>,
     /// Whether we've created a state before (suppress init noise on subsequent calls).
     has_created_state: bool,
 }
 
 impl StreamingWhisper {
     /// Create a new streaming transcriber.
-    pub fn new(language: Option<String>) -> Self {
+    pub fn new(language: Option<String>, initial_prompt: Option<String>) -> Self {
         Self {
             audio_buffer: Vec::with_capacity(16000 * 30), // pre-alloc 30s
             samples_since_partial: 0,
             last_partial: String::new(),
             n_threads: num_cpus(),
             language,
+            initial_prompt,
             has_created_state: false,
         }
     }
@@ -139,6 +142,9 @@ impl StreamingWhisper {
         let mut params = streaming_whisper_params();
         params.set_n_threads(self.n_threads);
         params.set_language(self.language.as_deref());
+        if let Some(ref prompt) = self.initial_prompt {
+            params.set_initial_prompt(prompt);
+        }
 
         let start = std::time::Instant::now();
 
@@ -231,14 +237,14 @@ mod tests {
 
     #[test]
     fn new_streaming_whisper_has_empty_buffer() {
-        let sw = StreamingWhisper::new(None);
+        let sw = StreamingWhisper::new(None, None);
         assert_eq!(sw.duration_secs(), 0.0);
         assert!(sw.audio_buffer.is_empty());
     }
 
     #[test]
     fn feed_below_interval_returns_none() {
-        let mut sw = StreamingWhisper::new(None);
+        let mut sw = StreamingWhisper::new(None, None);
         // Feed 1 second of silence (below 2s interval)
         let silence = vec![0.0f32; 16000];
         // We can't test with a real WhisperContext without a model,
@@ -251,7 +257,7 @@ mod tests {
 
     #[test]
     fn reset_clears_state() {
-        let mut sw = StreamingWhisper::new(Some("en".into()));
+        let mut sw = StreamingWhisper::new(Some("en".into()), None);
         sw.audio_buffer.extend_from_slice(&[0.0; 16000]);
         sw.samples_since_partial = 16000;
         sw.last_partial = "hello".into();

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -111,6 +111,9 @@ fn transcribe_with_whisper(
     let mut params = default_whisper_params(vad_path_str);
     params.set_n_threads(num_cpus());
     params.set_language(config.transcription.language.as_deref());
+    if let Some(ref prompt) = config.transcription.initial_prompt {
+        params.set_initial_prompt(prompt);
+    }
     params.set_token_timestamps(true);
 
     state
@@ -1277,6 +1280,7 @@ mod tests {
                 min_words: 10,
                 language: Some("en".into()),
                 vad_model: String::new(),
+                initial_prompt: None,
             },
             ..Config::default()
         };

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2758,6 +2758,7 @@ mod tests {
                 min_words: 3,
                 language: Some("en".into()),
                 vad_model: "silero-v6.2.0".into(),
+                initial_prompt: None,
             },
             ..Config::default()
         };

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -17,6 +17,7 @@ fn test_config(output_dir: PathBuf) -> Config {
             min_words: 10,
             language: Some("en".into()),
             vad_model: "silero-v6.2.0".into(),
+            initial_prompt: None,
         },
         ..Config::default()
     }


### PR DESCRIPTION
## Summary

Adds an optional `initial_prompt` field to `[transcription]` config that biases Whisper toward domain-specific vocabulary. This helps with proper nouns, acronyms, and jargon that Whisper tends to misspell.

- New `initial_prompt: Option<String>` in `TranscriptionConfig` with `None` default
- Passes through to `whisper-rs` `set_initial_prompt()` for both batch and streaming transcription
- Fully backward-compatible: existing configs without the field work unchanged via `#[serde(default)]`

### Example config

```toml
[transcription]
initial_prompt = "Acme Corp, JIRA, OKRs, GraphQL, S3"
```

## Files changed

| File | Change |
|------|--------|
| `crates/core/src/config.rs` | New field + Default + 2 unit tests |
| `crates/core/src/transcribe.rs` | Pass prompt to batch whisper params |
| `crates/core/src/streaming_whisper.rs` | Pass prompt to streaming whisper params |
| `crates/core/src/dictation.rs` | Thread config value to StreamingWhisper |
| `tauri/src-tauri/src/commands.rs` | Update test struct construction |
| `tests/integration/pipeline_test.rs` | Update test struct construction |
| `README.md` | Document the new config option |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p minutes-core -- -D warnings` — clean
- [x] `cargo test -p minutes-core --no-default-features` — 208 passed, 1 pre-existing failure (timezone test unrelated to this change)
- [x] New test: `default_initial_prompt_is_none` — verifies backward compat
- [x] New test: `initial_prompt_round_trips_through_toml` — verifies config serialization