### PR TITLE
fix: graceful Ctrl+C shutdown for live, dictate, and record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,6 +2791,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 # Signal handling
-ctrlc = { version = "3", features = ["termination"] }
+ctrlc = "3"
 
 # HTTP client (for LLM API calls — no secrets in process args)
 ureq = { version = "3", features = ["json"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -686,13 +686,23 @@ fn cmd_record(
         }
     }
 
-    // Set up stop flag for signal handler
+    // Set up stop flag for signal handler (double Ctrl+C to force quit)
     let stop_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stop_clone = std::sync::Arc::clone(&stop_flag);
     ctrlc::set_handler(move || {
-        eprintln!("\nStopping recording...");
+        if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
+            eprintln!("\nForce quit.");
+            std::process::exit(1);
+        }
+        eprintln!("\nStopping recording... (Ctrl+C again to force quit)");
         stop_clone.store(true, std::sync::atomic::Ordering::Relaxed);
     })?;
+
+    // Ignore SIGTERM — `minutes stop` uses sentinel file for graceful shutdown
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGTERM, libc::SIG_IGN);
+    }
 
     // Record audio from default input device
     let wav_path = minutes_core::pid::current_wav_path();
@@ -2952,11 +2962,21 @@ fn cmd_dictate(stdout: bool, note_only: bool, config: &Config) -> Result<()> {
     let stop_flag = Arc::new(AtomicBool::new(false));
     let stop_clone = Arc::clone(&stop_flag);
 
-    // Handle Ctrl-C
+    // Handle Ctrl-C (double press to force quit)
     ctrlc::set_handler(move || {
-        eprintln!("\nStopping dictation...");
+        if stop_clone.load(Ordering::Relaxed) {
+            eprintln!("\nForce quit.");
+            std::process::exit(1);
+        }
+        eprintln!("\nStopping dictation... (Ctrl+C again to force quit)");
         stop_clone.store(true, Ordering::Relaxed);
     })?;
+
+    // Ignore SIGTERM — `minutes stop` uses sentinel file for graceful shutdown
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGTERM, libc::SIG_IGN);
+    }
 
     let mut config = config.clone();
     if stdout {
@@ -3538,11 +3558,22 @@ fn cmd_live(config: &Config) -> Result<()> {
     let stop = Arc::new(AtomicBool::new(false));
     let stop_clone = Arc::clone(&stop);
 
-    // Handle Ctrl-C
+    // Handle Ctrl-C (double press to force quit)
     ctrlc::set_handler(move || {
+        if stop_clone.load(Ordering::Relaxed) {
+            eprintln!("\nForce quit.");
+            std::process::exit(1);
+        }
+        eprintln!("\nStopping gracefully... (Ctrl+C again to force quit)");
         stop_clone.store(true, Ordering::Relaxed);
     })
     .ok();
+
+    // Ignore SIGTERM — `minutes stop` uses sentinel file for graceful shutdown
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGTERM, libc::SIG_IGN);
+    }
 
     // No sentinel watcher needed — run_inner already polls check_and_clear_sentinel
     // directly in its main loop, avoiding the thread-join and double-consume race.

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -28,7 +28,8 @@ pub fn audio_level() -> u32 {
 // ──────────────────────────────────────────────────────────────
 
 /// Start recording audio from the default input device.
-/// Blocks until `stop_flag` is set to true (via signal handler).
+/// Blocks until `stop_flag` is set to true (via signal handler) or a stop
+/// sentinel file is detected (from `minutes stop`).
 /// Writes raw PCM to a WAV file at the given path.
 /// If screen context is enabled, also captures periodic screenshots.
 pub fn record_to_wav(
@@ -37,6 +38,9 @@ pub fn record_to_wav(
     config: &Config,
 ) -> Result<(), CaptureError> {
     use cpal::traits::{DeviceTrait, StreamTrait};
+
+    // Clear any stale stop sentinel from a previous session
+    crate::pid::check_and_clear_sentinel();
 
     // Get the input device — prefer the macOS system default over cpal's default,
     // which can pick virtual devices (Descript Loopback, Zoom, etc.) over the real mic.
@@ -269,12 +273,17 @@ pub fn record_to_wav(
         None
     };
 
-    // Wait for stop signal
+    // Wait for stop signal (Ctrl+C sets stop_flag, `minutes stop` writes sentinel)
     while !stop_flag.load(Ordering::Relaxed) {
         std::thread::sleep(std::time::Duration::from_millis(100));
 
         if err_flag.load(Ordering::Relaxed) {
             tracing::error!("audio stream encountered an error, stopping");
+            break;
+        }
+
+        if crate::pid::check_and_clear_sentinel() {
+            tracing::info!("stop sentinel detected — stopping recording");
             break;
         }
     }


### PR DESCRIPTION
## Summary

Fixes #29 — `minutes live` and `minutes dictate` lose the last chunk of audio when stopped with Ctrl+C.

**Root cause**: The `ctrlc` crate's `"termination"` feature re-raises the signal with default disposition after the handler runs. This kills the process immediately — before the main loop can detect the `stop_flag` and flush the in-progress audio buffer to the transcript.

**Fix**:
- Remove `"termination"` feature from `ctrlc` — process continues after handler, main loop detects flag and finalizes normally
- Double Ctrl+C pattern — first press triggers graceful shutdown, second press force-quits (safety net if finalization hangs)
- Ignore SIGTERM on Unix — `minutes stop` now relies purely on the sentinel file for cross-platform graceful shutdown
- Add sentinel checking to `record_to_wav` — makes `minutes stop` work via sentinel instead of depending on the SIGTERM→ctrlc→stop_flag chain

All three modes (`record`, `live`, `dictate`) now flush their audio buffers and finalize output before exiting on Ctrl+C.

## Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | Remove `"termination"` feature from ctrlc |
| `crates/cli/src/main.rs` | Double Ctrl+C + SIGTERM ignore in `cmd_record`, `cmd_dictate`, `cmd_live` |
| `crates/core/src/capture.rs` | Sentinel checking in `record_to_wav` main loop + stale sentinel clearing |

## Test plan

- [x] `cargo clippy --all --no-default-features -- -D warnings` — clean
- [x] `cargo test -p minutes-core --no-default-features` — 198 pass
- [x] `cargo test -p minutes-cli` — 10 pass
- [ ] Manual: `minutes live` → speak → Ctrl+C → verify last utterance is in JSONL
- [ ] Manual: `minutes dictate` → speak → Ctrl+C → verify text copied to clipboard
- [ ] Manual: `minutes record` → Ctrl+C → verify WAV is finalized, pipeline runs
- [ ] Manual: `minutes live` → `minutes stop` (from another terminal) → clean shutdown
- [ ] Manual: Double Ctrl+C → immediate force quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)