### PR TITLE
feat: add parakeet-coreml speech-to-text engine (macOS CoreML)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
- "walkdir",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["multimedia::audio", "command-line-utilities"]
 default = ["whisper"]
 whisper = ["dep:whisper-rs", "whisper-guard/whisper"]
 parakeet = ["dep:tempfile"]  # subprocess-based, uses tempfile for concurrent safety
+parakeet-coreml = ["dep:tempfile"]
 diarize = ["dep:pyannote-rs"]
 cuda = ["whisper-rs/cuda"]
 metal = ["whisper-rs/metal"]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -48,7 +48,7 @@ impl Default for VoiceConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TranscriptionConfig {
-    /// Transcription engine: "whisper" (default) or "parakeet".
+    /// Transcription engine: "whisper" (default), "parakeet", or "parakeet-coreml".
     pub engine: String,
     pub model: String,
     pub model_path: PathBuf,
@@ -66,6 +66,12 @@ pub struct TranscriptionConfig {
     pub parakeet_model: String,
     /// SentencePiece vocab filename (resolved under model_path/parakeet/, e.g. "vocab.txt").
     pub parakeet_vocab: String,
+    /// Path or name of the parakeet-coreml Swift helper binary.
+    /// Resolved via PATH if not absolute. Default: "parakeet-coreml"
+    pub parakeet_coreml_binary: String,
+    /// Directory containing the CoreML model (.mlmodelc).
+    /// Default: ~/.minutes/models/parakeet-coreml/
+    pub parakeet_coreml_model_dir: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -287,8 +293,39 @@ fn home_dir() -> PathBuf {
     dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"))
 }
 
+#[cfg(test)]
+std::thread_local! {
+    static TEST_MINUTES_DIR: std::cell::RefCell<Option<PathBuf>> = const { std::cell::RefCell::new(None) };
+}
+
 fn minutes_dir() -> PathBuf {
+    #[cfg(test)]
+    if let Some(path) = TEST_MINUTES_DIR.with(|slot| slot.borrow().clone()) {
+        return path;
+    }
+
     home_dir().join(".minutes")
+}
+
+#[cfg(test)]
+pub(crate) struct TestMinutesDirGuard {
+    previous: Option<PathBuf>,
+}
+
+#[cfg(test)]
+impl Drop for TestMinutesDirGuard {
+    fn drop(&mut self) {
+        TEST_MINUTES_DIR.with(|slot| {
+            slot.replace(self.previous.take());
+        });
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn override_test_minutes_dir(path: PathBuf) -> TestMinutesDirGuard {
+    std::fs::create_dir_all(&path).unwrap();
+    let previous = TEST_MINUTES_DIR.with(|slot| slot.replace(Some(path)));
+    TestMinutesDirGuard { previous }
 }
 
 impl Default for Config {
@@ -327,6 +364,8 @@ impl Default for TranscriptionConfig {
             parakeet_binary: "parakeet".into(),
             parakeet_model: "tdt-ctc-110m".into(),
             parakeet_vocab: "vocab.txt".into(),
+            parakeet_coreml_binary: "parakeet-coreml".into(),
+            parakeet_coreml_model_dir: minutes_dir().join("models").join("parakeet-coreml"),
         }
     }
 }

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -3,7 +3,7 @@ use crate::error::{DictationError, MinutesError, TranscribeError};
 use crate::markdown::{ContentType, Frontmatter, OutputStatus};
 use crate::pid;
 use crate::streaming::AudioStream;
-use crate::streaming_whisper::StreamingWhisper;
+use crate::streaming_engine::StreamingEngine;
 use crate::vad::Vad;
 use chrono::Local;
 use std::path::PathBuf;
@@ -213,173 +213,186 @@ where
     F: FnMut(DictationEvent),
     G: FnMut(DictationResult),
 {
-    // Try to use preloaded model, fall back to loading on demand
     #[cfg(feature = "whisper")]
-    let model_name = config.dictation.model.clone();
-    #[cfg(feature = "whisper")]
-    let whisper_ctx = if let Some(ctx) = take_cached_model(&model_name) {
-        tracing::info!(model = %model_name, "using preloaded whisper model");
-        ctx
+    let mut model_name = None;
+
+    let mut engine = if config.transcription.engine == "parakeet-coreml" {
+        StreamingEngine::new_for_dictation(config)?
     } else {
-        let model_path = crate::transcribe::resolve_model_path_for_dictation(config)?;
-        tracing::info!(model = %model_path.display(), "loading whisper model on demand");
-        let ctx = whisper_rs::WhisperContext::new_with_params(
-            model_path
-                .to_str()
-                .ok_or_else(|| TranscribeError::ModelLoadError("invalid path".into()))?,
-            whisper_rs::WhisperContextParameters::default(),
-        )
-        .map_err(|e| TranscribeError::ModelLoadError(format!("{}", e)))?;
-        tracing::info!("whisper model loaded for dictation session");
-        ctx
-    };
+        #[cfg(feature = "whisper")]
+        {
+            let whisper_model_name = config.dictation.model.clone();
+            model_name = Some(whisper_model_name.clone());
 
-    #[cfg(not(feature = "whisper"))]
-    return Err(
-        TranscribeError::ModelLoadError("dictation requires the whisper feature".into()).into(),
-    );
-
-    // Start audio stream
-    #[cfg(feature = "whisper")]
-    {
-        let stream = AudioStream::start()?;
-        tracing::info!(device = %stream.device_name, "dictation audio stream started");
-
-        let mut vad = Vad::new();
-        let mut streaming = StreamingWhisper::new(config.transcription.language.clone());
-        let mut was_speaking = false;
-        let mut has_spoken = false;
-        let mut total_silence_ms: u64 = 0;
-        let mut utterance_samples: usize = 0;
-        let max_utterance_samples = config.dictation.max_utterance_secs as usize * 16000;
-
-        on_event(DictationEvent::Listening);
-
-        loop {
-            // Check stop flag (Esc / Ctrl-C / MCP stop)
-            if stop_flag.load(Ordering::Relaxed) {
-                // Finalize any in-progress transcription before exiting
-                if utterance_samples > 0 {
-                    on_event(DictationEvent::Processing);
-                    if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                        let result = finish_utterance(&sr.text, sr.duration_secs, config);
-                        if let Some(result) = result {
-                            on_event(DictationEvent::Success);
-                            on_result(result);
-                        }
-                    }
-                }
-                on_event(DictationEvent::Cancelled);
-                break;
-            }
-
-            // Check if recording started (yield to recording)
-            if let Ok(Some(_)) = pid::check_recording() {
-                tracing::info!("recording started — yielding dictation");
-                if utterance_samples > 0 {
-                    on_event(DictationEvent::Processing);
-                    if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                        let result = finish_utterance(&sr.text, sr.duration_secs, config);
-                        if let Some(result) = result {
-                            on_event(DictationEvent::Success);
-                            on_result(result);
-                        }
-                    }
-                }
-                on_event(DictationEvent::Yielded);
-                break;
-            }
-
-            // Receive audio chunk (100ms timeout to allow stop checks)
-            let chunk = match stream
-                .receiver
-                .recv_timeout(std::time::Duration::from_millis(100))
-            {
-                Ok(chunk) => chunk,
-                Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
-                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+            let ctx = if let Some(ctx) = take_cached_model(&whisper_model_name) {
+                tracing::info!(model = %whisper_model_name, "using preloaded whisper model");
+                ctx
+            } else {
+                let model_path = crate::transcribe::resolve_model_path_for_dictation(config)?;
+                tracing::info!(model = %model_path.display(), "loading whisper model on demand");
+                let ctx = whisper_rs::WhisperContext::new_with_params(
+                    model_path
+                        .to_str()
+                        .ok_or_else(|| TranscribeError::ModelLoadError("invalid path".into()))?,
+                    whisper_rs::WhisperContextParameters::default(),
+                )
+                .map_err(|e| TranscribeError::ModelLoadError(format!("{}", e)))?;
+                tracing::info!("whisper model loaded for dictation session");
+                ctx
             };
 
-            let vad_result = vad.process(chunk.rms);
-
-            if vad_result.speaking {
-                if !was_speaking {
-                    on_event(DictationEvent::Accumulating);
-                    total_silence_ms = 0;
-                }
-                was_speaking = true;
-                has_spoken = true;
-                utterance_samples += chunk.samples.len();
-
-                // Feed to streaming whisper — may emit a partial result
-                if let Some(sr) = streaming.feed(&chunk.samples, &whisper_ctx) {
-                    on_event(DictationEvent::PartialText(sr.text));
-                }
-
-                // Force-finalize if max utterance reached
-                if utterance_samples >= max_utterance_samples {
-                    tracing::info!("max utterance duration reached, force-processing");
-                    on_event(DictationEvent::Processing);
-                    if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                        let result = finish_utterance(&sr.text, sr.duration_secs, config);
-                        if let Some(result) = result {
-                            on_event(DictationEvent::Success);
-                            on_result(result);
-                        }
-                    }
-                    streaming.reset();
-                    utterance_samples = 0;
-                    was_speaking = false;
-                    on_event(DictationEvent::Listening);
-                }
-            } else {
-                // Silence
-                if was_speaking && utterance_samples > 0 {
-                    // Speech just ended — finalize the streaming transcription
-                    on_event(DictationEvent::Processing);
-                    if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                        let result = finish_utterance(&sr.text, sr.duration_secs, config);
-                        if let Some(result) = result {
-                            on_event(DictationEvent::Success);
-                            on_result(result);
-                        }
-                    }
-                    streaming.reset();
-                    utterance_samples = 0;
-                    was_speaking = false;
-                    total_silence_ms = 0;
-                    on_event(DictationEvent::Listening);
-                }
-
-                total_silence_ms += 100;
-                if has_spoken
-                    && !was_speaking
-                    && total_silence_ms < config.dictation.silence_timeout_ms
-                {
-                    let remaining = config.dictation.silence_timeout_ms - total_silence_ms;
-                    on_event(DictationEvent::SilenceCountdown {
-                        total_ms: config.dictation.silence_timeout_ms,
-                        remaining_ms: remaining,
-                    });
-                }
-                if has_spoken
-                    && !was_speaking
-                    && total_silence_ms >= config.dictation.silence_timeout_ms
-                {
-                    tracing::info!(
-                        silence_ms = total_silence_ms,
-                        "silence timeout — ending dictation"
-                    );
-                    break;
-                }
+            StreamingEngine::Whisper {
+                ctx,
+                streamer: crate::streaming_whisper::StreamingWhisper::new(
+                    config.transcription.language.clone(),
+                ),
             }
         }
 
-        // Return model to cache for next session
-        return_model_to_cache(whisper_ctx, model_name);
+        #[cfg(not(feature = "whisper"))]
+        {
+            return Err(TranscribeError::EngineNotAvailable("whisper".into()).into());
+        }
+    };
 
-        Ok(())
+    let stream = AudioStream::start()?;
+    tracing::info!(device = %stream.device_name, "dictation audio stream started");
+
+    let mut vad = Vad::new();
+    let mut was_speaking = false;
+    let mut has_spoken = false;
+    let mut total_silence_ms: u64 = 0;
+    let mut utterance_samples: usize = 0;
+    let max_utterance_samples = config.dictation.max_utterance_secs as usize * 16000;
+
+    on_event(DictationEvent::Listening);
+
+    loop {
+        // Check stop flag (Esc / Ctrl-C / MCP stop)
+        if stop_flag.load(Ordering::Relaxed) {
+            // Finalize any in-progress transcription before exiting
+            if utterance_samples > 0 {
+                on_event(DictationEvent::Processing);
+                if let Some(sr) = engine.finalize() {
+                    let result = finish_utterance(&sr.text, sr.duration_secs, config);
+                    if let Some(result) = result {
+                        on_event(DictationEvent::Success);
+                        on_result(result);
+                    }
+                }
+            }
+            on_event(DictationEvent::Cancelled);
+            break;
+        }
+
+        // Check if recording started (yield to recording)
+        if let Ok(Some(_)) = pid::check_recording() {
+            tracing::info!("recording started — yielding dictation");
+            if utterance_samples > 0 {
+                on_event(DictationEvent::Processing);
+                if let Some(sr) = engine.finalize() {
+                    let result = finish_utterance(&sr.text, sr.duration_secs, config);
+                    if let Some(result) = result {
+                        on_event(DictationEvent::Success);
+                        on_result(result);
+                    }
+                }
+            }
+            on_event(DictationEvent::Yielded);
+            break;
+        }
+
+        // Receive audio chunk (100ms timeout to allow stop checks)
+        let chunk = match stream
+            .receiver
+            .recv_timeout(std::time::Duration::from_millis(100))
+        {
+            Ok(chunk) => chunk,
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+        };
+
+        let vad_result = vad.process(chunk.rms);
+
+        if vad_result.speaking {
+            if !was_speaking {
+                on_event(DictationEvent::Accumulating);
+                total_silence_ms = 0;
+            }
+            was_speaking = true;
+            has_spoken = true;
+            utterance_samples += chunk.samples.len();
+
+            // Feed to the streaming engine — may emit a partial result
+            if let Some(sr) = engine.feed(&chunk.samples) {
+                on_event(DictationEvent::PartialText(sr.text));
+            }
+
+            // Force-finalize if max utterance reached
+            if utterance_samples >= max_utterance_samples {
+                tracing::info!("max utterance duration reached, force-processing");
+                on_event(DictationEvent::Processing);
+                if let Some(sr) = engine.finalize() {
+                    let result = finish_utterance(&sr.text, sr.duration_secs, config);
+                    if let Some(result) = result {
+                        on_event(DictationEvent::Success);
+                        on_result(result);
+                    }
+                }
+                engine.reset();
+                utterance_samples = 0;
+                was_speaking = false;
+                on_event(DictationEvent::Listening);
+            }
+        } else {
+            // Silence
+            if was_speaking && utterance_samples > 0 {
+                // Speech just ended — finalize the streaming transcription
+                on_event(DictationEvent::Processing);
+                if let Some(sr) = engine.finalize() {
+                    let result = finish_utterance(&sr.text, sr.duration_secs, config);
+                    if let Some(result) = result {
+                        on_event(DictationEvent::Success);
+                        on_result(result);
+                    }
+                }
+                engine.reset();
+                utterance_samples = 0;
+                was_speaking = false;
+                total_silence_ms = 0;
+                on_event(DictationEvent::Listening);
+            }
+
+            total_silence_ms += 100;
+            if has_spoken && !was_speaking && total_silence_ms < config.dictation.silence_timeout_ms
+            {
+                let remaining = config.dictation.silence_timeout_ms - total_silence_ms;
+                on_event(DictationEvent::SilenceCountdown {
+                    total_ms: config.dictation.silence_timeout_ms,
+                    remaining_ms: remaining,
+                });
+            }
+            if has_spoken
+                && !was_speaking
+                && total_silence_ms >= config.dictation.silence_timeout_ms
+            {
+                tracing::info!(
+                    silence_ms = total_silence_ms,
+                    "silence timeout — ending dictation"
+                );
+                break;
+            }
+        }
     }
+
+    #[cfg(feature = "whisper")]
+    if let Some(model_name) = model_name {
+        if let Some(ctx) = engine.take_whisper_ctx() {
+            return_model_to_cache(ctx, model_name);
+        }
+    }
+
+    Ok(())
 }
 
 /// Finish a transcribed utterance: write to clipboard, file, daily note.
@@ -609,6 +622,7 @@ fn append_dictation_to_daily_note(text: &str, config: &Config) {
 }
 
 /// Save failed audio to disk for recovery.
+#[cfg(feature = "whisper")]
 fn save_failed_audio(samples: &[f32]) {
     let failed_dir = crate::config::Config::minutes_dir().join("dictation-failed");
     if std::fs::create_dir_all(&failed_dir).is_err() {
@@ -643,6 +657,7 @@ fn first_words(text: &str, n: usize) -> String {
     }
 }
 
+#[cfg(feature = "whisper")]
 fn num_cpus() -> i32 {
     whisper_guard::params::num_cpus()
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -69,6 +69,15 @@ pub enum TranscribeError {
     #[error("parakeet transcription failed: {0}")]
     ParakeetFailed(String),
 
+    #[error("parakeet-coreml helper not found. Run: minutes setup --parakeet-coreml")]
+    ParakeetCoremlNotFound,
+
+    #[error("parakeet-coreml requires macOS 14+ (Sonoma)")]
+    ParakeetCoremlUnsupported,
+
+    #[error("parakeet-coreml transcription failed: {0}")]
+    ParakeetCoremlFailed(String),
+
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -146,14 +146,10 @@ pub fn diarization_status(config: &Config) -> HealthItem {
         let installed = crate::diarize::models_installed(config);
         return HealthItem {
             label: "Speaker diarization".into(),
-            state: if installed {
+            state: if installed || is_auto {
                 "ready"
             } else {
-                if is_auto {
-                    "ready"
-                } else {
-                    "attention"
-                }
+                "attention"
             }
             .into(),
             detail: if installed {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,6 +30,18 @@ pub mod vad;
 #[cfg(feature = "streaming")]
 pub mod streaming_whisper;
 
+// Streaming parakeet-coreml (CoreML subprocess for real-time transcription)
+#[cfg(all(
+    feature = "streaming",
+    feature = "parakeet-coreml",
+    target_os = "macos"
+))]
+pub mod streaming_parakeet;
+
+// Unified streaming engine (wraps whisper or parakeet-coreml)
+#[cfg(feature = "streaming")]
+pub mod streaming_engine;
+
 // Dictation mode (requires streaming + whisper)
 #[cfg(feature = "streaming")]
 pub mod dictation;

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -1,15 +1,47 @@
 use crate::config::Config;
-use crate::error::{LiveTranscriptError, MinutesError, TranscribeError};
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
+use crate::error::LiveTranscriptError;
+use crate::error::MinutesError;
 use crate::pid;
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 use crate::streaming::AudioStream;
-use crate::streaming_whisper::StreamingWhisper;
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
+use crate::streaming_engine::StreamingEngine;
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 use crate::vad::Vad;
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
-use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::fs::File;
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader};
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
+use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 // ──────────────────────────────────────────────────────────────
@@ -68,6 +100,10 @@ pub struct SessionStatus {
 }
 
 /// Manages writing the JSONL and optional WAV file during a live session.
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 struct LiveTranscriptWriter {
     jsonl_writer: BufWriter<File>,
     wav_writer: Option<hound::WavWriter<BufWriter<File>>>,
@@ -89,6 +125,10 @@ pub struct LiveStatus {
     pub last_duration_ms: u64,
 }
 
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 impl LiveTranscriptWriter {
     fn new(config: &Config) -> Result<Self, MinutesError> {
         let jsonl_path = pid::live_transcript_jsonl_path();
@@ -236,7 +276,10 @@ impl LiveTranscriptWriter {
 ///
 /// Unlike dictation, there is NO silence timeout — the session runs
 /// until explicitly stopped via `minutes stop` or the stop_flag.
-#[cfg(feature = "whisper")]
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 pub fn run(
     stop_flag: Arc<AtomicBool>,
     config: &Config,
@@ -268,27 +311,15 @@ pub fn run(
     run_inner(stop_flag, config)
 }
 
-#[cfg(feature = "whisper")]
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 fn run_inner(
     stop_flag: Arc<AtomicBool>,
     config: &Config,
 ) -> Result<(usize, f64, PathBuf), MinutesError> {
-    // Load whisper model: use live_transcript.model if set, otherwise dictation.model
-    let whisper_ctx = {
-        let model_path = if config.live_transcript.model.is_empty() {
-            crate::transcribe::resolve_model_path_for_dictation(config)?
-        } else {
-            crate::transcribe::resolve_model_path_by_name(&config.live_transcript.model, config)?
-        };
-        tracing::info!(model = %model_path.display(), "loading whisper model for live transcript");
-        whisper_rs::WhisperContext::new_with_params(
-            model_path
-                .to_str()
-                .ok_or_else(|| TranscribeError::ModelLoadError("invalid path".into()))?,
-            whisper_rs::WhisperContextParameters::default(),
-        )
-        .map_err(|e| TranscribeError::ModelLoadError(format!("{}", e)))?
-    };
+    let mut engine = StreamingEngine::new_for_live(config)?;
 
     // Start audio stream FIRST — validate mic access before truncating any files
     let stream = AudioStream::start()?;
@@ -298,7 +329,6 @@ fn run_inner(
     let mut writer = LiveTranscriptWriter::new(config)?;
 
     let mut vad = Vad::new();
-    let mut streaming = StreamingWhisper::new(config.transcription.language.clone());
     let mut was_speaking = false;
     let mut utterance_samples: usize = 0;
     let max_utterance_secs = config.live_transcript.max_utterance_secs.max(5);
@@ -311,7 +341,7 @@ fn run_inner(
         if stop_flag.load(Ordering::Relaxed) {
             // Finalize any in-progress utterance
             if utterance_samples > 0 {
-                if let Some(sr) = streaming.finalize(&whisper_ctx) {
+                if let Some(sr) = engine.finalize() {
                     writer.write_utterance(&sr.text, sr.duration_secs);
                 }
             }
@@ -321,7 +351,7 @@ fn run_inner(
         // Check for stop sentinel (from `minutes stop`)
         if pid::check_and_clear_sentinel() {
             if utterance_samples > 0 {
-                if let Some(sr) = streaming.finalize(&whisper_ctx) {
+                if let Some(sr) = engine.finalize() {
                     writer.write_utterance(&sr.text, sr.duration_secs);
                 }
             }
@@ -338,7 +368,7 @@ fn run_inner(
             Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
                 tracing::warn!("audio stream disconnected");
                 if utterance_samples > 0 {
-                    if let Some(sr) = streaming.finalize(&whisper_ctx) {
+                    if let Some(sr) = engine.finalize() {
                         writer.write_utterance(&sr.text, sr.duration_secs);
                     }
                 }
@@ -355,15 +385,15 @@ fn run_inner(
             was_speaking = true;
             utterance_samples += chunk.samples.len();
 
-            // Feed to streaming whisper
-            if let Some(_sr) = streaming.feed(&chunk.samples, &whisper_ctx) {
+            // Feed to the streaming engine
+            if let Some(_sr) = engine.feed(&chunk.samples) {
                 // Partial result available — could emit event, but for now just continue
             }
 
             // Force-finalize if max utterance reached
             if utterance_samples >= max_utterance_samples {
                 tracing::info!("max utterance duration reached, force-finalizing");
-                if let Some(sr) = streaming.finalize(&whisper_ctx) {
+                if let Some(sr) = engine.finalize() {
                     if !writer.write_utterance(&sr.text, sr.duration_secs) {
                         tracing::error!(
                             "JSONL write failed — stopping session to prevent data loss"
@@ -371,19 +401,19 @@ fn run_inner(
                         break;
                     }
                 }
-                streaming.reset();
+                engine.reset();
                 utterance_samples = 0;
                 was_speaking = false;
             }
         } else if was_speaking && utterance_samples > 0 {
             // Speech just ended — finalize the utterance
-            if let Some(sr) = streaming.finalize(&whisper_ctx) {
+            if let Some(sr) = engine.finalize() {
                 if !writer.write_utterance(&sr.text, sr.duration_secs) {
                     tracing::error!("JSONL write failed — stopping session to prevent data loss");
                     break;
                 }
             }
-            streaming.reset();
+            engine.reset();
             utterance_samples = 0;
             was_speaking = false;
             // No silence timeout — keep running until stop
@@ -401,15 +431,18 @@ fn run_inner(
 }
 
 /// Stub when whisper feature is disabled.
-#[cfg(not(feature = "whisper"))]
+#[cfg(not(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+)))]
 pub fn run(
     _stop_flag: Arc<AtomicBool>,
     _config: &Config,
 ) -> Result<(usize, f64, PathBuf), MinutesError> {
-    Err(
-        TranscribeError::ModelLoadError("live transcript requires the whisper feature".into())
-            .into(),
+    Err(crate::error::TranscribeError::ModelLoadError(
+        "live transcript requires whisper or parakeet-coreml on macOS".into(),
     )
+    .into())
 }
 
 // ── Delta reader ────────────────────────────────────────────────
@@ -519,6 +552,10 @@ pub fn session_status() -> SessionStatus {
     }
 }
 
+#[cfg(any(
+    feature = "whisper",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 fn set_permissions_0600(path: &std::path::Path) {
     #[cfg(unix)]
     {

--- a/crates/core/src/pid.rs
+++ b/crates/core/src/pid.rs
@@ -269,7 +269,7 @@ pub fn create_pid_file(path: &Path) -> Result<(), PidError> {
 
     if let Some(old_pid) = read_locked_pid(&mut file)? {
         if old_pid != 0 && is_process_alive(old_pid) {
-            file.unlock().ok();
+            fs2::FileExt::unlock(&file).ok();
             return Err(PidError::AlreadyRecording(old_pid));
         }
     }
@@ -334,7 +334,7 @@ pub fn create_pid_guard(path: &Path) -> Result<PidGuard, PidError> {
 
     if let Some(old_pid) = read_locked_pid(&mut file)? {
         if old_pid != 0 && is_process_alive(old_pid) {
-            file.unlock().ok();
+            fs2::FileExt::unlock(&file).ok();
             return Err(PidError::AlreadyRecording(old_pid));
         }
     }
@@ -416,7 +416,7 @@ pub fn create() -> Result<(), PidError> {
     // We hold the lock. Check if there's a stale PID from a crashed process.
     if let Some(old_pid) = read_locked_pid(&mut file)? {
         if old_pid != 0 && is_process_alive(old_pid) {
-            file.unlock().ok();
+            fs2::FileExt::unlock(&file).ok();
             return Err(PidError::AlreadyRecording(old_pid));
         }
     }
@@ -580,12 +580,19 @@ mod tests {
     use super::*;
     use fs2::FileExt;
     use std::sync::{Mutex, MutexGuard, OnceLock};
+    use tempfile::TempDir;
 
     fn test_guard() -> MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn temp_minutes_dir() -> (TempDir, crate::config::TestMinutesDirGuard) {
+        let dir = TempDir::new().unwrap();
+        let guard = crate::config::override_test_minutes_dir(dir.path().join(".minutes"));
+        (dir, guard)
     }
 
     #[test]
@@ -604,6 +611,7 @@ mod tests {
     #[test]
     fn processing_status_round_trip() {
         let _guard = test_guard();
+        let (_tmp, _minutes_dir) = temp_minutes_dir();
         set_processing_status(Some("Transcribing audio"), Some(CaptureMode::QuickThought)).unwrap();
         let status = read_processing_status();
         assert!(status.processing);
@@ -616,6 +624,7 @@ mod tests {
     #[test]
     fn recording_metadata_round_trip() {
         let _guard = test_guard();
+        let (_tmp, _minutes_dir) = temp_minutes_dir();
         write_recording_metadata(CaptureMode::QuickThought).unwrap();
         let metadata = read_recording_metadata().unwrap();
         assert_eq!(metadata.mode, CaptureMode::QuickThought);
@@ -625,6 +634,7 @@ mod tests {
     #[test]
     fn sentinel_lifecycle() {
         let _guard = test_guard();
+        let (_tmp, _minutes_dir) = temp_minutes_dir();
         // Ensure clean state
         let _ = std::fs::remove_file(stop_sentinel_path());
         assert!(!stop_sentinel_path().exists());
@@ -644,6 +654,7 @@ mod tests {
     #[test]
     fn sentinel_write_and_clear() {
         let _guard = test_guard();
+        let (_tmp, _minutes_dir) = temp_minutes_dir();
         // Write a sentinel and verify check_and_clear removes it
         write_stop_sentinel().unwrap();
         assert!(stop_sentinel_path().exists());
@@ -656,6 +667,7 @@ mod tests {
     #[test]
     fn check_and_clear_sentinel_returns_false_when_absent() {
         let _guard = test_guard();
+        let (_tmp, _minutes_dir) = temp_minutes_dir();
         // Ensure no sentinel exists
         let _ = std::fs::remove_file(stop_sentinel_path());
         assert!(!check_and_clear_sentinel());

--- a/crates/core/src/streaming_engine.rs
+++ b/crates/core/src/streaming_engine.rs
@@ -1,0 +1,199 @@
+use crate::config::Config;
+use crate::error::TranscribeError;
+use crate::streaming_whisper::StreamingResult;
+
+#[cfg(feature = "whisper")]
+use whisper_rs::{WhisperContext, WhisperContextParameters};
+
+pub enum StreamingEngine {
+    #[cfg(feature = "whisper")]
+    Whisper {
+        ctx: whisper_rs::WhisperContext,
+        streamer: crate::streaming_whisper::StreamingWhisper,
+    },
+    #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+    ParakeetCoreml {
+        streamer: crate::streaming_parakeet::StreamingParakeet,
+    },
+}
+
+impl StreamingEngine {
+    pub fn new_for_dictation(config: &Config) -> Result<Self, TranscribeError> {
+        if config.transcription.engine == "parakeet-coreml" {
+            #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+            {
+                return Ok(Self::ParakeetCoreml {
+                    streamer: crate::streaming_parakeet::StreamingParakeet::new(config)?,
+                });
+            }
+
+            #[cfg(not(all(feature = "parakeet-coreml", target_os = "macos")))]
+            {
+                return Err(TranscribeError::EngineNotAvailable(
+                    "parakeet-coreml".into(),
+                ));
+            }
+        }
+
+        #[cfg(feature = "whisper")]
+        {
+            let model_path = crate::transcribe::resolve_model_path_for_dictation(config)?;
+            let ctx = WhisperContext::new_with_params(
+                model_path
+                    .to_str()
+                    .ok_or_else(|| TranscribeError::ModelLoadError("invalid path".into()))?,
+                WhisperContextParameters::default(),
+            )
+            .map_err(|e| TranscribeError::ModelLoadError(format!("{}", e)))?;
+            let streamer = crate::streaming_whisper::StreamingWhisper::new(
+                config.transcription.language.clone(),
+            );
+            Ok(Self::Whisper { ctx, streamer })
+        }
+
+        #[cfg(not(feature = "whisper"))]
+        {
+            let _ = config;
+            Err(TranscribeError::EngineNotAvailable("whisper".into()))
+        }
+    }
+
+    pub fn new_for_live(config: &Config) -> Result<Self, TranscribeError> {
+        if config.transcription.engine == "parakeet-coreml" {
+            #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+            {
+                return Ok(Self::ParakeetCoreml {
+                    streamer: crate::streaming_parakeet::StreamingParakeet::new(config)?,
+                });
+            }
+
+            #[cfg(not(all(feature = "parakeet-coreml", target_os = "macos")))]
+            {
+                return Err(TranscribeError::EngineNotAvailable(
+                    "parakeet-coreml".into(),
+                ));
+            }
+        }
+
+        #[cfg(feature = "whisper")]
+        {
+            let model_path = if config.live_transcript.model.is_empty() {
+                crate::transcribe::resolve_model_path_for_dictation(config)?
+            } else {
+                crate::transcribe::resolve_model_path_by_name(
+                    &config.live_transcript.model,
+                    config,
+                )?
+            };
+            let ctx = WhisperContext::new_with_params(
+                model_path
+                    .to_str()
+                    .ok_or_else(|| TranscribeError::ModelLoadError("invalid path".into()))?,
+                WhisperContextParameters::default(),
+            )
+            .map_err(|e| TranscribeError::ModelLoadError(format!("{}", e)))?;
+            let streamer = crate::streaming_whisper::StreamingWhisper::new(
+                config.transcription.language.clone(),
+            );
+            Ok(Self::Whisper { ctx, streamer })
+        }
+
+        #[cfg(not(feature = "whisper"))]
+        {
+            let _ = config;
+            Err(TranscribeError::EngineNotAvailable("whisper".into()))
+        }
+    }
+
+    #[cfg(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    ))]
+    pub fn feed(&mut self, samples: &[f32]) -> Option<StreamingResult> {
+        match self {
+            #[cfg(feature = "whisper")]
+            Self::Whisper { ctx, streamer } => streamer.feed(samples, ctx),
+            #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+            Self::ParakeetCoreml { streamer } => streamer.feed(samples),
+        }
+    }
+
+    #[cfg(not(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    )))]
+    pub fn feed(&mut self, samples: &[f32]) -> Option<StreamingResult> {
+        let _ = samples;
+        None
+    }
+
+    #[cfg(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    ))]
+    pub fn finalize(&mut self) -> Option<StreamingResult> {
+        match self {
+            #[cfg(feature = "whisper")]
+            Self::Whisper { ctx, streamer } => streamer.finalize(ctx),
+            #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+            Self::ParakeetCoreml { streamer } => streamer.finalize(),
+        }
+    }
+
+    #[cfg(not(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    )))]
+    pub fn finalize(&mut self) -> Option<StreamingResult> {
+        None
+    }
+
+    #[cfg(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    ))]
+    pub fn reset(&mut self) {
+        match self {
+            #[cfg(feature = "whisper")]
+            Self::Whisper { streamer, .. } => streamer.reset(),
+            #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+            Self::ParakeetCoreml { streamer } => streamer.reset(),
+        }
+    }
+
+    #[cfg(not(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    )))]
+    pub fn reset(&mut self) {}
+
+    #[cfg(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    ))]
+    pub fn duration_secs(&self) -> f64 {
+        match self {
+            #[cfg(feature = "whisper")]
+            Self::Whisper { streamer, .. } => streamer.duration_secs(),
+            #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+            Self::ParakeetCoreml { streamer } => streamer.duration_secs(),
+        }
+    }
+
+    #[cfg(not(any(
+        feature = "whisper",
+        all(feature = "parakeet-coreml", target_os = "macos")
+    )))]
+    pub fn duration_secs(&self) -> f64 {
+        0.0
+    }
+
+    #[cfg(feature = "whisper")]
+    pub fn take_whisper_ctx(self) -> Option<WhisperContext> {
+        match self {
+            Self::Whisper { ctx, .. } => Some(ctx),
+            #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+            Self::ParakeetCoreml { .. } => None,
+        }
+    }
+}

--- a/crates/core/src/streaming_parakeet.rs
+++ b/crates/core/src/streaming_parakeet.rs
@@ -1,0 +1,238 @@
+use crate::config::Config;
+use crate::error::TranscribeError;
+use crate::streaming_whisper::StreamingResult;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+const PARTIAL_INTERVAL_SAMPLES: usize = 16000 * 2;
+const MIN_TRANSCRIBE_SAMPLES: usize = 16000;
+const CHUNK_SIZE: usize = 1600;
+
+#[derive(Debug, Deserialize)]
+struct HelperResponse {
+    #[serde(rename = "type")]
+    response_type: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    duration_secs: Option<f64>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+pub struct StreamingParakeet {
+    child: Child,
+    stdin: BufWriter<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+    buffer_samples: usize,
+    samples_since_partial: usize,
+    last_partial: String,
+}
+
+impl StreamingParakeet {
+    pub fn new(config: &Config) -> Result<Self, TranscribeError> {
+        let binary = crate::transcribe::resolve_parakeet_coreml_binary(config)?;
+        let model_dir = &config.transcription.parakeet_coreml_model_dir;
+
+        let mut cmd = Command::new(&binary);
+        cmd.arg("--stream").arg("--model-dir").arg(model_dir);
+        if let Some(language) = config.transcription.language.as_deref() {
+            cmd.arg("--language").arg(language);
+        }
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+
+        let mut child = cmd.spawn().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                TranscribeError::ParakeetCoremlNotFound
+            } else {
+                TranscribeError::ParakeetCoremlFailed(format!("spawn error: {}", e))
+            }
+        })?;
+
+        let stdin = child.stdin.take().ok_or_else(|| {
+            TranscribeError::ParakeetCoremlFailed("failed to capture helper stdin".into())
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            TranscribeError::ParakeetCoremlFailed("failed to capture helper stdout".into())
+        })?;
+
+        tracing::info!(
+            binary = %binary.display(),
+            model_dir = %model_dir.display(),
+            "started parakeet-coreml streaming helper"
+        );
+
+        Ok(Self {
+            child,
+            stdin: BufWriter::new(stdin),
+            stdout: BufReader::new(stdout),
+            buffer_samples: 0,
+            samples_since_partial: 0,
+            last_partial: String::new(),
+        })
+    }
+
+    pub fn feed(&mut self, samples: &[f32]) -> Option<StreamingResult> {
+        for chunk in samples.chunks(CHUNK_SIZE) {
+            if let Err(e) = self.write_command(&serde_json::json!({
+                "cmd": "audio",
+                "samples": chunk,
+            })) {
+                tracing::warn!("parakeet-coreml audio write failed: {}", e);
+                return None;
+            }
+            self.buffer_samples += chunk.len();
+            self.samples_since_partial += chunk.len();
+        }
+
+        if self.samples_since_partial < PARTIAL_INTERVAL_SAMPLES
+            || self.buffer_samples < MIN_TRANSCRIBE_SAMPLES
+        {
+            return None;
+        }
+
+        if let Err(e) = self.write_command(&serde_json::json!({ "cmd": "transcribe" })) {
+            tracing::warn!("parakeet-coreml transcribe command failed: {}", e);
+            return None;
+        }
+        self.samples_since_partial = 0;
+
+        match self.read_response() {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::warn!("parakeet-coreml partial read failed: {}", e);
+                None
+            }
+        }
+    }
+
+    pub fn finalize(&mut self) -> Option<StreamingResult> {
+        if self.buffer_samples < MIN_TRANSCRIBE_SAMPLES {
+            return None;
+        }
+
+        if let Err(e) = self.write_command(&serde_json::json!({ "cmd": "finalize" })) {
+            tracing::warn!("parakeet-coreml finalize command failed: {}", e);
+            return None;
+        }
+
+        match self.read_response() {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::warn!("parakeet-coreml final read failed: {}", e);
+                None
+            }
+        }
+    }
+
+    pub fn reset(&mut self) {
+        if let Err(e) = self.write_command(&serde_json::json!({ "cmd": "reset" })) {
+            tracing::warn!("parakeet-coreml reset command failed: {}", e);
+        }
+        self.buffer_samples = 0;
+        self.samples_since_partial = 0;
+        self.last_partial.clear();
+    }
+
+    pub fn duration_secs(&self) -> f64 {
+        self.buffer_samples as f64 / 16000.0
+    }
+
+    fn write_command(&mut self, value: &serde_json::Value) -> Result<(), TranscribeError> {
+        serde_json::to_writer(&mut self.stdin, value)
+            .map_err(|e| TranscribeError::ParakeetCoremlFailed(format!("encode error: {}", e)))?;
+        self.stdin.write_all(b"\n").map_err(TranscribeError::Io)?;
+        self.stdin.flush().map_err(TranscribeError::Io)
+    }
+
+    fn read_response(&mut self) -> Result<Option<StreamingResult>, TranscribeError> {
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let read = self
+                .stdout
+                .read_line(&mut line)
+                .map_err(TranscribeError::Io)?;
+            if read == 0 {
+                return Err(TranscribeError::ParakeetCoremlFailed(
+                    "helper exited before sending a response".into(),
+                ));
+            }
+
+            let raw = line.trim();
+            if raw.is_empty() {
+                continue;
+            }
+
+            let response: HelperResponse = match serde_json::from_str(raw) {
+                Ok(response) => response,
+                Err(e) => {
+                    tracing::debug!(
+                        line = raw,
+                        error = %e,
+                        "skipping non-JSON parakeet-coreml helper output"
+                    );
+                    continue;
+                }
+            };
+
+            if response.response_type == "error" {
+                let message = response
+                    .message
+                    .or({
+                        if response.text.is_empty() {
+                            None
+                        } else {
+                            Some(response.text)
+                        }
+                    })
+                    .unwrap_or_else(|| raw.to_string());
+                return Err(TranscribeError::ParakeetCoremlFailed(message));
+            }
+
+            if response.response_type != "partial" && response.response_type != "final" {
+                tracing::debug!(
+                    response_type = %response.response_type,
+                    "skipping unexpected parakeet-coreml response"
+                );
+                continue;
+            }
+
+            let text = response.text.trim().to_string();
+            if text.is_empty() {
+                return Ok(None);
+            }
+
+            let is_final = response.response_type == "final";
+            if !is_final && text == self.last_partial {
+                return Ok(None);
+            }
+
+            let duration_secs = response
+                .duration_secs
+                .unwrap_or_else(|| self.duration_secs());
+            self.last_partial = text.clone();
+
+            return Ok(Some(StreamingResult {
+                text,
+                is_final,
+                duration_secs,
+            }));
+        }
+    }
+}
+
+impl Drop for StreamingParakeet {
+    fn drop(&mut self) {
+        let _ = self.write_command(&serde_json::json!({ "cmd": "quit" }));
+
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}

--- a/crates/core/src/streaming_whisper.rs
+++ b/crates/core/src/streaming_whisper.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "whisper")]
 use crate::transcribe::streaming_whisper_params;
+#[cfg(feature = "whisper")]
 use whisper_rs::WhisperContext;
 
 // ──────────────────────────────────────────────────────────────
@@ -39,9 +41,11 @@ use whisper_rs::WhisperContext;
 // ──────────────────────────────────────────────────────────────
 
 /// How often to run partial transcription (in audio samples at 16kHz).
+#[cfg(feature = "whisper")]
 const PARTIAL_INTERVAL_SAMPLES: usize = 16000 * 2; // Every 2 seconds
 
 /// Minimum audio length to attempt transcription (avoid noise-only runs).
+#[cfg(feature = "whisper")]
 const MIN_TRANSCRIBE_SAMPLES: usize = 16000; // 1 second
 
 /// Result from a streaming transcription pass.
@@ -57,6 +61,7 @@ pub struct StreamingResult {
 
 /// Streaming whisper transcriber. Holds the accumulated audio buffer
 /// and runs partial transcriptions at intervals.
+#[cfg(feature = "whisper")]
 pub struct StreamingWhisper {
     /// All audio samples accumulated so far (16kHz mono f32).
     audio_buffer: Vec<f32>,
@@ -72,6 +77,7 @@ pub struct StreamingWhisper {
     has_created_state: bool,
 }
 
+#[cfg(feature = "whisper")]
 impl StreamingWhisper {
     /// Create a new streaming transcriber.
     pub fn new(language: Option<String>) -> Self {
@@ -196,6 +202,7 @@ impl StreamingWhisper {
 }
 
 /// Temporarily suppress stderr (whisper C code prints noisy init logs).
+#[cfg(feature = "whisper")]
 fn suppress_stderr<T>(f: impl FnOnce() -> T) -> T {
     #[cfg(unix)]
     {
@@ -219,11 +226,12 @@ fn suppress_stderr<T>(f: impl FnOnce() -> T) -> T {
     f()
 }
 
+#[cfg(feature = "whisper")]
 fn num_cpus() -> i32 {
     whisper_guard::params::num_cpus()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "whisper"))]
 mod tests {
     use super::*;
 

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -23,8 +23,10 @@ pub use whisper_guard::segments::{clean_transcript, CleanStats};
 // Engines:
 //   - whisper (default): whisper.cpp via whisper-rs, Apple Accelerate on M-series
 //   - parakeet (opt-in): parakeet.cpp via subprocess, Metal on Apple Silicon
+//   - parakeet-coreml (opt-in, macOS-only): Swift helper subprocess via CoreML
 //
-// Engine is selected via config.transcription.engine ("whisper" or "parakeet").
+// Engine is selected via config.transcription.engine
+// ("whisper", "parakeet", or "parakeet-coreml").
 // Model must be downloaded first via `minutes setup`.
 // ──────────────────────────────────────────────────────────────
 
@@ -33,6 +35,7 @@ pub use whisper_guard::segments::{clean_transcript, CleanStats};
 /// Dispatches to the engine configured in `config.transcription.engine`:
 /// - `"whisper"` (default): whisper.cpp via whisper-rs
 /// - `"parakeet"`: parakeet.cpp via subprocess
+/// - `"parakeet-coreml"`: Swift helper subprocess on macOS
 ///
 /// Handles format conversion (m4a/mp3/ogg → PCM) automatically via symphonia.
 /// Both engines produce identical output format: `[M:SS] text` lines.
@@ -40,6 +43,7 @@ pub fn transcribe(audio_path: &Path, config: &Config) -> Result<String, Transcri
     match config.transcription.engine.as_str() {
         "whisper" => transcribe_whisper_dispatch(audio_path, config),
         "parakeet" => transcribe_parakeet_dispatch(audio_path, config),
+        "parakeet-coreml" => transcribe_parakeet_coreml_dispatch(audio_path, config),
         other => {
             tracing::warn!(
                 engine = other,
@@ -128,6 +132,28 @@ fn transcribe_parakeet_dispatch(
     {
         let _ = (audio_path, config);
         Err(TranscribeError::EngineNotAvailable("parakeet".into()))
+    }
+}
+
+/// Parakeet CoreML transcription path (macOS-only, Swift helper subprocess).
+fn transcribe_parakeet_coreml_dispatch(
+    audio_path: &Path,
+    config: &Config,
+) -> Result<String, TranscribeError> {
+    #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+    {
+        transcribe_with_parakeet_coreml(audio_path, config)
+    }
+
+    #[cfg(not(all(feature = "parakeet-coreml", target_os = "macos")))]
+    {
+        let _ = (audio_path, config);
+        #[cfg(not(target_os = "macos"))]
+        return Err(TranscribeError::ParakeetCoremlUnsupported);
+        #[cfg(target_os = "macos")]
+        return Err(TranscribeError::EngineNotAvailable(
+            "parakeet-coreml".into(),
+        ));
     }
 }
 
@@ -546,15 +572,39 @@ fn decode_with_symphonia(path: &Path) -> Result<Vec<f32>, TranscribeError> {
 // They are re-exported as pub use at the top of this file for API compatibility.
 // The private wrappers below delegate to whisper-guard so internal callers
 // (transcribe_with_whisper) continue working without path changes.
+#[cfg(any(
+    test,
+    feature = "whisper",
+    feature = "parakeet",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 use whisper_guard::segments as wg_segments;
 
 // Thin delegates to whisper-guard (used by whisper, parakeet, and tests)
+#[cfg(any(
+    test,
+    feature = "whisper",
+    feature = "parakeet",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 fn dedup_segments(lines: Vec<String>) -> Vec<String> {
     wg_segments::dedup_segments(&lines)
 }
+#[cfg(any(
+    test,
+    feature = "whisper",
+    feature = "parakeet",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 fn dedup_interleaved(lines: Vec<String>) -> Vec<String> {
     wg_segments::dedup_interleaved(&lines)
 }
+#[cfg(any(
+    test,
+    feature = "whisper",
+    feature = "parakeet",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 fn trim_trailing_noise(lines: Vec<String>) -> Vec<String> {
     wg_segments::trim_trailing_noise(&lines)
 }
@@ -980,8 +1030,192 @@ fn parse_parakeet_output(raw_output: &str, config: &Config) -> Result<String, Tr
     Ok(format!("{}\n", transcript))
 }
 
+#[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+fn transcribe_with_parakeet_coreml(
+    audio_path: &Path,
+    config: &Config,
+) -> Result<String, TranscribeError> {
+    use std::process::Command;
+
+    let samples = load_audio_samples(audio_path)?;
+    if samples.is_empty() {
+        return Err(TranscribeError::EmptyAudio);
+    }
+
+    let samples = strip_silence(&samples, 16000);
+    if samples.is_empty() {
+        return Err(TranscribeError::EmptyAudio);
+    }
+
+    let tmp_wav = tempfile::Builder::new()
+        .prefix("minutes-parakeet-coreml-")
+        .suffix(".wav")
+        .tempfile()
+        .map_err(TranscribeError::Io)?;
+    write_wav_16k_mono(tmp_wav.path(), &samples)?;
+
+    let binary = resolve_parakeet_coreml_binary(config)?;
+    let model_dir = &config.transcription.parakeet_coreml_model_dir;
+
+    tracing::info!(
+        binary = %binary.display(),
+        model_dir = %model_dir.display(),
+        audio = %audio_path.display(),
+        "starting parakeet-coreml transcription"
+    );
+
+    let wav_str = tmp_wav.path().to_str().ok_or_else(|| {
+        TranscribeError::ParakeetCoremlFailed("temp WAV path is not valid UTF-8".into())
+    })?;
+    let model_dir_str = model_dir.to_str().ok_or_else(|| {
+        TranscribeError::ParakeetCoremlFailed("model dir path is not valid UTF-8".into())
+    })?;
+
+    let mut cmd = Command::new(&binary);
+    cmd.arg("--batch")
+        .arg(wav_str)
+        .arg("--model-dir")
+        .arg(model_dir_str);
+    if let Some(ref lang) = config.transcription.language {
+        cmd.arg("--language").arg(lang);
+    }
+    cmd.stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let output = cmd.output().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            TranscribeError::ParakeetCoremlNotFound
+        } else {
+            TranscribeError::ParakeetCoremlFailed(format!("spawn error: {}", e))
+        }
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(TranscribeError::ParakeetCoremlFailed(format!(
+            "exit code {}: {}",
+            output.status.code().unwrap_or(-1),
+            stderr.trim()
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let transcript = parse_parakeet_coreml_output(&stdout, config)?;
+
+    let word_count = transcript.split_whitespace().count();
+    tracing::info!(words = word_count, "parakeet-coreml transcription complete");
+
+    Ok(transcript)
+}
+
+#[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+fn parse_parakeet_coreml_output(raw: &str, config: &Config) -> Result<String, TranscribeError> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(TranscribeError::EmptyTranscript(
+            config.transcription.min_words,
+        ));
+    }
+
+    let mut lines: Vec<String> = Vec::new();
+    let mut has_timestamps = false;
+
+    for raw_line in raw.lines() {
+        let raw_line = raw_line.trim();
+        if raw_line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = raw_line.strip_prefix('[') {
+            if let Some(bracket_end) = rest.find(']') {
+                let timestamp_part = &rest[..bracket_end];
+                let text = rest[bracket_end + 1..].trim();
+                if text.is_empty() {
+                    continue;
+                }
+                if let Some(dash_pos) = timestamp_part.find('-') {
+                    let start_str = timestamp_part[..dash_pos].trim();
+                    if let Ok(start_secs) = start_str.parse::<f64>() {
+                        let total_secs = start_secs as u64;
+                        let mins = total_secs / 60;
+                        let secs = total_secs % 60;
+                        has_timestamps = true;
+                        lines.push(format!("[{}:{:02}] {}", mins, secs, text));
+                        continue;
+                    }
+                }
+            }
+        }
+        tracing::debug!(line = raw_line, "skipping unparseable parakeet-coreml line");
+    }
+
+    if lines.is_empty() {
+        if !has_timestamps {
+            let preview: String = raw.chars().take(200).collect();
+            return Err(TranscribeError::ParakeetCoremlFailed(format!(
+                "could not parse parakeet-coreml output (no [start - end] timestamps found). \
+                 First 200 chars: {}",
+                preview
+            )));
+        }
+        return Err(TranscribeError::EmptyTranscript(
+            config.transcription.min_words,
+        ));
+    }
+
+    let lines = dedup_segments(lines);
+    let lines = dedup_interleaved(lines);
+    let lines = trim_trailing_noise(lines);
+
+    let transcript = lines.join("\n");
+    if transcript.is_empty() {
+        return Err(TranscribeError::EmptyTranscript(
+            config.transcription.min_words,
+        ));
+    }
+    Ok(format!("{}\n", transcript))
+}
+
+#[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+pub(crate) fn resolve_parakeet_coreml_binary(
+    config: &Config,
+) -> Result<std::path::PathBuf, TranscribeError> {
+    let binary_name = &config.transcription.parakeet_coreml_binary;
+    let path = std::path::PathBuf::from(binary_name);
+    if path.is_absolute() {
+        if path.exists() {
+            return Ok(path);
+        }
+        return Err(TranscribeError::ParakeetCoremlNotFound);
+    }
+    let candidates = [
+        dirs::home_dir().map(|h| h.join(".local").join("bin").join(binary_name)),
+        Some(std::path::PathBuf::from("/opt/homebrew/bin").join(binary_name)),
+        Some(std::path::PathBuf::from("/usr/local/bin").join(binary_name)),
+    ];
+    for candidate in candidates.iter().flatten() {
+        if candidate.exists() {
+            return Ok(candidate.clone());
+        }
+    }
+    if let Ok(output) = std::process::Command::new("which")
+        .arg(binary_name)
+        .output()
+    {
+        if output.status.success() {
+            let p = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !p.is_empty() {
+                return Ok(std::path::PathBuf::from(p));
+            }
+        }
+    }
+    Err(TranscribeError::ParakeetCoremlNotFound)
+}
+
 /// Write f32 samples as a 16kHz mono 16-bit WAV file.
-#[cfg(feature = "parakeet")]
+#[cfg(any(
+    feature = "parakeet",
+    all(feature = "parakeet-coreml", target_os = "macos")
+))]
 fn write_wav_16k_mono(path: &Path, samples: &[f32]) -> Result<(), TranscribeError> {
     let spec = hound::WavSpec {
         channels: 1,
@@ -1456,6 +1690,47 @@ mod tests {
             "should reject invalid model: {}",
             err
         );
+    }
+
+    #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+    #[test]
+    fn parse_parakeet_coreml_basic() {
+        let config = Config::default();
+        let output = "[0.00 - 2.45] Hello world\n[2.50 - 5.10] How are you\n";
+        let result = parse_parakeet_coreml_output(output, &config).unwrap();
+        assert!(result.contains("[0:00] Hello world"));
+        assert!(result.contains("[0:02] How are you"));
+    }
+
+    #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+    #[test]
+    fn parse_parakeet_coreml_empty() {
+        let config = Config::default();
+        let result = parse_parakeet_coreml_output("", &config);
+        assert!(result.is_err());
+    }
+
+    #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+    #[test]
+    fn parse_parakeet_coreml_plain_text_rejected() {
+        let config = Config::default();
+        let result = parse_parakeet_coreml_output("plain text without timestamps", &config);
+        assert!(result.is_err(), "plain text without timestamps should fail");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("no [start - end] timestamps"),
+            "error should explain the issue: {}",
+            err
+        );
+    }
+
+    #[cfg(all(feature = "parakeet-coreml", target_os = "macos"))]
+    #[test]
+    fn parse_parakeet_coreml_over_minute() {
+        let config = Config::default();
+        let output = "[65.00 - 70.00] After a minute\n";
+        let result = parse_parakeet_coreml_output(output, &config).unwrap();
+        assert!(result.contains("[1:05] After a minute"));
     }
 
     #[test]

--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -544,6 +544,12 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn temp_minutes_dir() -> (TempDir, crate::config::TestMinutesDirGuard) {
+        let dir = TempDir::new().unwrap();
+        let guard = crate::config::override_test_minutes_dir(dir.path().join(".minutes"));
+        (dir, guard)
+    }
+
     #[test]
     fn has_valid_extension_matches_configured_types() {
         let config = Config::default();
@@ -637,6 +643,7 @@ mod tests {
 
     #[test]
     fn lock_acquire_and_release() {
+        let (_tmp, _minutes_dir) = temp_minutes_dir();
         // Clean up any existing lock
         release_lock();
 

--- a/helpers/parakeet-coreml/Package.swift
+++ b/helpers/parakeet-coreml/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "parakeet-coreml",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .executable(
+            name: "parakeet-coreml",
+            targets: ["parakeet-coreml"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", branch: "main"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "parakeet-coreml",
+            dependencies: [
+                .product(name: "FluidAudio", package: "FluidAudio"),
+            ],
+            path: "Sources"
+        ),
+    ]
+)

--- a/helpers/parakeet-coreml/README.md
+++ b/helpers/parakeet-coreml/README.md
@@ -1,0 +1,68 @@
+# parakeet-coreml
+
+`parakeet-coreml` is a small Swift CLI helper that wraps the `FluidAudio` framework to run Parakeet CoreML speech-to-text on macOS.
+
+## Requirements
+
+- macOS 14 or newer
+- A local Parakeet CoreML model directory
+- Xcode / Swift toolchain with Swift Package Manager support
+
+Default model lookup starts from `~/.minutes/models/parakeet-coreml/` and resolves the matching FluidAudio Parakeet model bundle from there.
+
+## Build
+
+```bash
+cd helpers/parakeet-coreml
+swift build -c release
+```
+
+From the repo root, build and install the helper into `~/.local/bin/parakeet-coreml`:
+
+```bash
+./scripts/build-parakeet-helper.sh
+```
+
+## Batch Mode
+
+Transcribe a WAV file and print timestamped transcript lines:
+
+```bash
+./.build/release/parakeet-coreml --batch meeting.wav
+./.build/release/parakeet-coreml --batch meeting.wav --model-dir ~/.minutes/models/parakeet-coreml --language en
+```
+
+Output format:
+
+```text
+[0.00 - 2.45] Hello, how are you doing today?
+```
+
+## Stream Mode
+
+Run the helper as a JSON-lines process that keeps the model loaded:
+
+```bash
+./.build/release/parakeet-coreml --stream
+```
+
+Example commands:
+
+```json
+{"cmd":"audio","samples":[0.1,-0.2,0.05]}
+{"cmd":"transcribe"}
+{"cmd":"finalize"}
+{"cmd":"reset"}
+{"cmd":"quit"}
+```
+
+Protocol notes:
+
+- `audio` appends 16 kHz mono PCM samples and does not emit a response on success.
+- `transcribe` emits a partial response: `{"type":"partial","text":"...","duration_secs":1.23}`
+- `finalize` emits a final response: `{"type":"final","text":"...","duration_secs":1.23}`
+- `reset` clears buffered audio for the next utterance while keeping the loaded model in memory.
+- `quit` exits the process.
+- Malformed input emits an error response: `{"type":"error","message":"..."}`
+
+Responses are written as JSON lines, and stdout is flushed after every emitted JSON line.

--- a/helpers/parakeet-coreml/Sources/main.swift
+++ b/helpers/parakeet-coreml/Sources/main.swift
@@ -1,0 +1,517 @@
+import Darwin
+import FluidAudio
+import Foundation
+
+private let defaultModelDirectory = "~/.minutes/models/parakeet-coreml/"
+private let samplesPerSecond: Double = 16_000
+private let minimumTranscribableSamples = 16_000
+private let pauseSplitThreshold: TimeInterval = 0.75
+private let maxSegmentCharacters = 120
+private let posixLocale = Locale(identifier: "en_US_POSIX")
+
+private struct CLIError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
+private enum CLIControl: Error {
+    case help(String)
+}
+
+private struct BatchSegment {
+    let start: TimeInterval
+    let end: TimeInterval
+    let text: String
+}
+
+private struct ResolvedModelDirectory {
+    let directory: URL
+    let version: AsrModelVersion
+}
+
+private enum LanguagePreference {
+    case automatic
+    case english
+    case other(String)
+}
+
+private enum Mode {
+    case batch(audioPath: String)
+    case stream
+}
+
+private struct CLIOptions {
+    let mode: Mode
+    let modelDirectory: String
+    let language: String?
+}
+
+private final class Transcriber {
+    private let manager: AsrManager
+
+    private init(manager: AsrManager) {
+        self.manager = manager
+    }
+
+    static func load(modelDirectory: String, language: String?) async throws -> Transcriber {
+        let resolved = try resolveModelDirectory(basePath: modelDirectory, language: language)
+        let models = try await AsrModels.load(from: resolved.directory, version: resolved.version)
+        let manager = AsrManager(config: .default)
+        try await manager.initialize(models: models)
+        return Transcriber(manager: manager)
+    }
+
+    func transcribeFile(at url: URL) async throws -> ASRResult {
+        try await manager.transcribe(url, source: .system)
+    }
+
+    func transcribeSamples(_ samples: [Float]) async throws -> ASRResult {
+        try await manager.transcribe(samples, source: .microphone)
+    }
+
+    private static func resolveModelDirectory(basePath: String, language: String?) throws -> ResolvedModelDirectory {
+        let baseURL = expandedURL(for: basePath)
+        let preference = languagePreference(from: language)
+        let versions = preferredVersions(for: preference)
+        let v2Folder = AsrModels.defaultCacheDirectory(for: .v2).lastPathComponent
+        let v3Folder = AsrModels.defaultCacheDirectory(for: .v3).lastPathComponent
+
+        var triedPaths: [String] = []
+
+        for version in versions {
+            let folderName: String
+            switch version {
+            case .v2:
+                folderName = v2Folder
+            case .v3:
+                folderName = v3Folder
+            }
+            for candidate in candidateDirectories(baseURL: baseURL, folderName: folderName) {
+                triedPaths.append(candidate.path)
+                if AsrModels.modelsExist(at: candidate, version: version) {
+                    return ResolvedModelDirectory(directory: candidate, version: version)
+                }
+            }
+        }
+
+        let languageHelp: String
+        switch preference {
+        case .automatic:
+            languageHelp = "No compatible Parakeet CoreML model directory was found."
+        case .english:
+            languageHelp = "No English-capable Parakeet CoreML model directory was found."
+        case .other(let language):
+            languageHelp = "No multilingual Parakeet CoreML model directory was found for language '\(language)'."
+        }
+
+        throw CLIError(
+            message: """
+            \(languageHelp)
+            Checked:
+            \(triedPaths.map { "  - \($0)" }.joined(separator: "\n"))
+            """
+        )
+    }
+
+    private static func candidateDirectories(baseURL: URL, folderName: String) -> [URL] {
+        let candidates = [
+            baseURL,
+            baseURL.appendingPathComponent(folderName, isDirectory: true),
+            baseURL.deletingLastPathComponent().appendingPathComponent(folderName, isDirectory: true),
+        ]
+
+        var unique: [URL] = []
+        var seen = Set<String>()
+
+        for candidate in candidates {
+            let standardized = candidate.standardizedFileURL
+            if seen.insert(standardized.path).inserted {
+                unique.append(standardized)
+            }
+        }
+
+        return unique
+    }
+
+    private static func preferredVersions(for preference: LanguagePreference) -> [AsrModelVersion] {
+        switch preference {
+        case .automatic:
+            return [.v3, .v2]
+        case .english:
+            return [.v2, .v3]
+        case .other:
+            return [.v3]
+        }
+    }
+
+    private static func languagePreference(from language: String?) -> LanguagePreference {
+        guard let language else {
+            return .automatic
+        }
+
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .automatic
+        }
+
+        let normalized = trimmed.lowercased()
+        if normalized == "auto" {
+            return .automatic
+        }
+
+        let englishHints = ["en", "en-us", "en-gb", "english"]
+        if englishHints.contains(normalized) {
+            return .english
+        }
+
+        // TODO: Verify whether future FluidAudio releases expose explicit per-request language selection.
+        return .other(trimmed)
+    }
+
+    private static func expandedURL(for path: String) -> URL {
+        URL(fileURLWithPath: (path as NSString).expandingTildeInPath).standardizedFileURL
+    }
+}
+
+private enum BatchFormatter {
+    static func lines(for result: ASRResult) -> [String] {
+        segments(for: result).map { segment in
+            "[\(formatSeconds(segment.start)) - \(formatSeconds(segment.end))] \(segment.text)"
+        }
+    }
+
+    private static func segments(for result: ASRResult) -> [BatchSegment] {
+        if let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty {
+            let fromTimings = segments(from: tokenTimings)
+            if !fromTimings.isEmpty {
+                return fromTimings
+            }
+        }
+
+        let text = normalizedText(result.text)
+        guard !text.isEmpty else {
+            return []
+        }
+
+        return [
+            BatchSegment(
+                start: 0,
+                end: max(result.duration, 0),
+                text: text
+            )
+        ]
+    }
+
+    private static func segments(from tokenTimings: [TokenTiming]) -> [BatchSegment] {
+        var segments: [BatchSegment] = []
+        var currentStart: TimeInterval?
+        var currentEnd: TimeInterval = 0
+        var currentText = ""
+
+        func flushCurrentSegment() {
+            let text = normalizedText(currentText)
+            guard let start = currentStart, !text.isEmpty else {
+                currentStart = nil
+                currentEnd = 0
+                currentText = ""
+                return
+            }
+
+            segments.append(BatchSegment(start: start, end: currentEnd, text: text))
+            currentStart = nil
+            currentEnd = 0
+            currentText = ""
+        }
+
+        for index in tokenTimings.indices {
+            let tokenTiming = tokenTimings[index]
+            let tokenText = tokenTiming.token
+
+            guard !normalizedText(tokenText).isEmpty else {
+                continue
+            }
+
+            if currentStart == nil {
+                currentStart = tokenTiming.startTime
+            }
+
+            currentText.append(tokenText)
+            currentEnd = tokenTiming.endTime
+
+            let isLast = index == tokenTimings.endIndex - 1
+            let gapToNext = isLast ? 0 : tokenTimings[index + 1].startTime - tokenTiming.endTime
+            let shouldSplit =
+                tokenEndsSentence(tokenText) ||
+                gapToNext > pauseSplitThreshold ||
+                normalizedText(currentText).count >= maxSegmentCharacters
+
+            if shouldSplit {
+                flushCurrentSegment()
+            }
+        }
+
+        flushCurrentSegment()
+        return segments
+    }
+
+    private static func tokenEndsSentence(_ token: String) -> Bool {
+        guard let lastCharacter = normalizedText(token).last else {
+            return false
+        }
+
+        return ".?!".contains(lastCharacter)
+    }
+
+    private static func normalizedText(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func formatSeconds(_ seconds: TimeInterval) -> String {
+        String(format: "%.2f", locale: posixLocale, seconds)
+    }
+}
+
+private final class StreamSession {
+    private let transcriber: Transcriber
+    private var samples: [Float] = []
+
+    init(transcriber: Transcriber) {
+        self.transcriber = transcriber
+    }
+
+    func run() async -> Int32 {
+        while let line = readLine(strippingNewline: true) {
+            if line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                continue
+            }
+
+            do {
+                let shouldQuit = try await handle(line: line)
+                if shouldQuit {
+                    return 0
+                }
+            } catch {
+                emitStreamError(error.localizedDescription, logToStandardError: true)
+            }
+        }
+
+        return 0
+    }
+
+    private func handle(line: String) async throws -> Bool {
+        guard let data = line.data(using: .utf8) else {
+            throw CLIError(message: "Input line was not valid UTF-8.")
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data)
+        guard let object = json as? [String: Any] else {
+            throw CLIError(message: "Input line must be a JSON object.")
+        }
+
+        guard let command = object["cmd"] as? String else {
+            throw CLIError(message: "Input object is missing a string 'cmd' field.")
+        }
+
+        switch command {
+        case "audio":
+            try appendSamples(from: object)
+        case "transcribe":
+            try await emitTranscription(type: "partial")
+        case "finalize":
+            try await emitTranscription(type: "final")
+        case "reset":
+            samples.removeAll(keepingCapacity: true)
+        case "quit":
+            return true
+        default:
+            throw CLIError(message: "Unknown command '\(command)'.")
+        }
+
+        return false
+    }
+
+    private func appendSamples(from object: [String: Any]) throws {
+        guard let rawSamples = object["samples"] as? [Any] else {
+            throw CLIError(message: "The 'audio' command requires a numeric 'samples' array.")
+        }
+
+        // Validate the whole payload before mutating the session buffer so malformed
+        // chunks do not partially leak into subsequent transcriptions.
+        var parsedSamples: [Float] = []
+        parsedSamples.reserveCapacity(rawSamples.count)
+        for value in rawSamples {
+            guard let number = value as? NSNumber else {
+                throw CLIError(message: "The 'samples' array must only contain numbers.")
+            }
+            if CFGetTypeID(number as CFTypeRef) == CFBooleanGetTypeID() {
+                throw CLIError(message: "The 'samples' array must only contain numbers.")
+            }
+            parsedSamples.append(number.floatValue)
+        }
+
+        samples.append(contentsOf: parsedSamples)
+    }
+
+    private func emitTranscription(type: String) async throws {
+        let duration = Double(samples.count) / samplesPerSecond
+        guard samples.count >= minimumTranscribableSamples else {
+            writeJSONObject(
+                [
+                    "type": type,
+                    "text": "",
+                    "duration_secs": duration,
+                ]
+            )
+            return
+        }
+
+        let result = try await transcriber.transcribeSamples(samples)
+        writeJSONObject(
+            [
+                "type": type,
+                "text": result.text,
+                "duration_secs": result.duration,
+            ]
+        )
+    }
+
+    private func emitStreamError(_ message: String, logToStandardError: Bool) {
+        if logToStandardError {
+            writeStandardError(message)
+        }
+
+        writeJSONObject(
+            [
+                "type": "error",
+                "message": message,
+            ]
+        )
+    }
+}
+
+@main
+struct ParakeetCoreMLCLI {
+    static func main() async {
+        let exitCode = await run()
+        Darwin.exit(exitCode)
+    }
+
+    private static func run() async -> Int32 {
+        do {
+            let options = try parseArguments(CommandLine.arguments)
+            let transcriber = try await Transcriber.load(
+                modelDirectory: options.modelDirectory,
+                language: options.language
+            )
+
+            switch options.mode {
+            case .batch(let audioPath):
+                let audioURL = expandedURL(for: audioPath)
+                let result = try await transcriber.transcribeFile(at: audioURL)
+                for line in BatchFormatter.lines(for: result) {
+                    writeStandardOutput(line)
+                }
+                return 0
+            case .stream:
+                return await StreamSession(transcriber: transcriber).run()
+            }
+        } catch CLIControl.help(let message) {
+            writeStandardOutput(message)
+            return 0
+        } catch {
+            writeStandardError(error.localizedDescription)
+            return 1
+        }
+    }
+
+    private static func parseArguments(_ arguments: [String]) throws -> CLIOptions {
+        var mode: Mode?
+        var modelDirectory = defaultModelDirectory
+        var language: String?
+
+        var index = 1
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--batch":
+                index += 1
+                guard index < arguments.count else {
+                    throw CLIError(message: usage("Missing path after --batch."))
+                }
+                guard mode == nil else {
+                    throw CLIError(message: usage("Choose either --batch or --stream, not both."))
+                }
+                mode = .batch(audioPath: arguments[index])
+            case "--stream":
+                guard mode == nil else {
+                    throw CLIError(message: usage("Choose either --batch or --stream, not both."))
+                }
+                mode = .stream
+            case "--model-dir":
+                index += 1
+                guard index < arguments.count else {
+                    throw CLIError(message: usage("Missing path after --model-dir."))
+                }
+                modelDirectory = arguments[index]
+            case "--language":
+                index += 1
+                guard index < arguments.count else {
+                    throw CLIError(message: usage("Missing language after --language."))
+                }
+                language = arguments[index]
+            case "--help", "-h":
+                throw CLIControl.help(usage(nil))
+            default:
+                throw CLIError(message: usage("Unknown argument '\(argument)'."))
+            }
+
+            index += 1
+        }
+
+        guard let mode else {
+            throw CLIError(message: usage("Specify exactly one of --batch or --stream."))
+        }
+
+        return CLIOptions(mode: mode, modelDirectory: modelDirectory, language: language)
+    }
+
+    private static func usage(_ error: String?) -> String {
+        let help = """
+        Usage:
+          parakeet-coreml --batch <audio.wav> [--model-dir <path>] [--language <lang>]
+          parakeet-coreml --stream [--model-dir <path>] [--language <lang>]
+        """
+
+        if let error {
+            return "\(error)\n\n\(help)"
+        }
+
+        return help
+    }
+
+    private static func expandedURL(for path: String) -> URL {
+        URL(fileURLWithPath: (path as NSString).expandingTildeInPath).standardizedFileURL
+    }
+}
+
+private func writeJSONObject(_ object: [String: Any]) {
+    do {
+        let data = try JSONSerialization.data(withJSONObject: object)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data([0x0A]))
+        fflush(stdout)
+    } catch {
+        writeStandardError("Failed to write JSON response: \(error.localizedDescription)")
+    }
+}
+
+private func writeStandardOutput(_ line: String) {
+    FileHandle.standardOutput.write(Data((line + "\n").utf8))
+}
+
+private func writeStandardError(_ line: String) {
+    FileHandle.standardError.write(Data((line + "\n").utf8))
+}

--- a/scripts/build-parakeet-helper.sh
+++ b/scripts/build-parakeet-helper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER_DIR="$ROOT_DIR/helpers/parakeet-coreml"
+TARGET_BIN="$HOME/.local/bin/parakeet-coreml"
+
+cd "$HELPER_DIR"
+swift build -c release
+
+mkdir -p "$HOME/.local/bin"
+cp -f .build/release/parakeet-coreml "$TARGET_BIN"
+
+echo "Installed parakeet-coreml to $TARGET_BIN"


### PR DESCRIPTION
## Summary

- Adds **parakeet-tdt-0.6b-v3-coreml** as an opt-in alternative STT engine alongside whisper.cpp
- ~2x better accuracy and ~15x faster inference than whisper-small on Apple Silicon (macOS 14+)
- Feature-flagged behind `parakeet-coreml` — whisper stays the default, zero behavior change unless opted in

### Architecture
- **Swift CLI helper** (`helpers/parakeet-coreml/`) wraps FluidAudio for batch and streaming modes via JSON-line protocol over stdin/stdout
- **StreamingParakeet** manages the long-lived subprocess for dictation/live transcript
- **StreamingEngine** enum unifies Whisper and ParakeetCoreml behind a common interface
- Batch transcription follows the existing parakeet.cpp subprocess pattern

### New files
- `helpers/parakeet-coreml/` — Swift Package (Package.swift, main.swift, README)
- `scripts/build-parakeet-helper.sh` — build + install script
- `crates/core/src/streaming_parakeet.rs` — subprocess wrapper
- `crates/core/src/streaming_engine.rs` — unified engine abstraction

### Modified files
- `Cargo.toml` — `parakeet-coreml` feature flag
- `config.rs` — `parakeet_coreml_binary` + `parakeet_coreml_model_dir` fields
- `error.rs` — 3 new error variants
- `transcribe.rs` — batch dispatch + output parser + binary resolver
- `dictation.rs` — uses StreamingEngine (preserves whisper model cache)
- `live_transcript.rs` — uses StreamingEngine
- `health.rs`, `pid.rs`, `watch.rs` — clippy fixes + test isolation

## Test plan

- [x] `cargo check -p minutes-core --no-default-features` — passes
- [x] `cargo clippy -p minutes-core --no-default-features -- -D warnings` — zero warnings
- [x] `cargo test -p minutes-core --no-default-features` — all 8 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [ ] End-to-end: `minutes setup --parakeet-coreml` + `minutes record` with `engine = "parakeet-coreml"`
- [ ] Streaming: `minutes dictate` and `minutes live` with parakeet-coreml engine
- [ ] Swift helper: `cd helpers/parakeet-coreml && swift build -c release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)