### PR TITLE
feat: prompt for missing API key in CLI and GUI

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -756,6 +756,52 @@ fn cmd_note(text: &str, meeting: Option<&Path>, config: &Config) -> Result<()> {
     Ok(())
 }
 
+/// If the configured summarization engine requires an API key that isn't
+/// available (env var or config file), prompt the user interactively and
+/// persist it to the config file for future runs.
+fn ensure_api_key(config: &Config) -> Result<()> {
+    let env_var = match config.required_api_key_env() {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+
+    if config.resolve_api_key(env_var).is_some() {
+        return Ok(());
+    }
+
+    eprintln!(
+        "\nThe '{}' summarization engine requires {}.",
+        config.summarization.engine, env_var
+    );
+    eprint!("Enter your API key: ");
+
+    // Flush stderr so the prompt appears before we block on stdin
+    use std::io::Write;
+    std::io::stderr().flush().ok();
+
+    let mut key = String::new();
+    std::io::stdin().read_line(&mut key)?;
+    let key = key.trim().to_string();
+
+    if key.is_empty() {
+        anyhow::bail!(
+            "No API key provided. Re-run to try again or change [summarization] engine in ~/.config/minutes/config.toml."
+        );
+    }
+
+    // Persist to config file
+    let mut cfg = Config::load();
+    cfg.set_api_key(env_var, key.clone());
+    cfg.save()
+        .map_err(|e| anyhow::anyhow!("Failed to save config: {}", e))?;
+
+    // Make the key available to the current process immediately
+    std::env::set_var(env_var, &key);
+    eprintln!("API key saved to {}.", Config::config_path().display());
+
+    Ok(())
+}
+
 fn capture_mode_from_str(mode: &str) -> Result<CaptureMode> {
     match mode {
         "meeting" => Ok(CaptureMode::Meeting),
@@ -906,6 +952,10 @@ fn cmd_record(
     let wav_path = minutes_core::pid::current_wav_path();
     minutes_core::capture::record_to_wav(&wav_path, stop_flag, config)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    // Prompt for missing API key after recording, before processing
+    ensure_api_key(config)?;
+
     let recording_finished_at = Local::now();
     let user_notes = minutes_core::notes::read_notes();
     let pre_context = minutes_core::notes::read_context();
@@ -1928,6 +1978,7 @@ fn cmd_process(
         other => anyhow::bail!("unknown content type: {}. Use 'meeting' or 'memo'.", other),
     };
 
+    ensure_api_key(config)?;
     config.ensure_dirs()?;
     let result = minutes_core::process(path, ct, title, config)?;
     eprintln!("Saved: {}", result.path.display());
@@ -1943,6 +1994,7 @@ fn cmd_process(
 }
 
 fn cmd_watch(dir: Option<&Path>, config: &Config) -> Result<()> {
+    ensure_api_key(config)?;
     config.ensure_dirs()?;
 
     // Set up Ctrl-C to release the lock and exit cleanly

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -29,6 +29,18 @@ pub struct Config {
     pub voice: VoiceConfig,
     pub live_transcript: LiveTranscriptConfig,
     pub recording: RecordingConfig,
+    pub api_keys: ApiKeysConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ApiKeysConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anthropic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub openai: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mistral: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -369,6 +381,7 @@ impl Default for Config {
             voice: VoiceConfig::default(),
             live_transcript: LiveTranscriptConfig::default(),
             recording: RecordingConfig::default(),
+            api_keys: ApiKeysConfig::default(),
         }
     }
 }
@@ -564,6 +577,43 @@ impl Config {
     /// Path to the minutes state directory (~/.minutes/).
     pub fn minutes_dir() -> PathBuf {
         minutes_dir()
+    }
+
+    /// Resolve an API key by env var name: env var takes precedence, then config file.
+    pub fn resolve_api_key(&self, env_var: &str) -> Option<String> {
+        if let Ok(val) = std::env::var(env_var) {
+            if !val.is_empty() {
+                return Some(val);
+            }
+        }
+        match env_var {
+            "ANTHROPIC_API_KEY" => self.api_keys.anthropic.clone(),
+            "OPENAI_API_KEY" => self.api_keys.openai.clone(),
+            "MISTRAL_API_KEY" => self.api_keys.mistral.clone(),
+            _ => None,
+        }
+        .filter(|v| !v.is_empty())
+    }
+
+    /// Returns the required env var name for the configured summarization engine,
+    /// or None if the engine doesn't need an API key.
+    pub fn required_api_key_env(&self) -> Option<&'static str> {
+        match self.summarization.engine.as_str() {
+            "claude" => Some("ANTHROPIC_API_KEY"),
+            "openai" => Some("OPENAI_API_KEY"),
+            "mistral" => Some("MISTRAL_API_KEY"),
+            _ => None,
+        }
+    }
+
+    /// Store an API key in the config (by env var name).
+    pub fn set_api_key(&mut self, env_var: &str, value: String) {
+        match env_var {
+            "ANTHROPIC_API_KEY" => self.api_keys.anthropic = Some(value),
+            "OPENAI_API_KEY" => self.api_keys.openai = Some(value),
+            "MISTRAL_API_KEY" => self.api_keys.mistral = Some(value),
+            _ => {}
+        }
     }
 }
 

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -485,8 +485,9 @@ fn summarize_with_claude(
     screen_files: &[std::path::PathBuf],
     config: &Config,
 ) -> Result<Summary, Box<dyn std::error::Error>> {
-    let api_key = std::env::var("ANTHROPIC_API_KEY")
-        .map_err(|_| "ANTHROPIC_API_KEY not set. Export it or switch to engine = \"ollama\"")?;
+    let api_key = config
+        .resolve_api_key("ANTHROPIC_API_KEY")
+        .ok_or("ANTHROPIC_API_KEY not set. Set it via `minutes setup` or switch to engine = \"ollama\"")?;
 
     let chunks = build_prompt(transcript, config.summarization.chunk_max_tokens);
     let mut all_summaries = Vec::new();
@@ -603,8 +604,9 @@ fn summarize_with_openai(
     screen_files: &[std::path::PathBuf],
     config: &Config,
 ) -> Result<Summary, Box<dyn std::error::Error>> {
-    let api_key = std::env::var("OPENAI_API_KEY")
-        .map_err(|_| "OPENAI_API_KEY not set. Export it or switch to engine = \"ollama\"")?;
+    let api_key = config
+        .resolve_api_key("OPENAI_API_KEY")
+        .ok_or("OPENAI_API_KEY not set. Set it via `minutes setup` or switch to engine = \"ollama\"")?;
 
     let chunks = build_prompt(transcript, config.summarization.chunk_max_tokens);
     let mut all_text = String::new();
@@ -672,8 +674,9 @@ fn summarize_with_mistral(
     screen_files: &[std::path::PathBuf],
     config: &Config,
 ) -> Result<Summary, Box<dyn std::error::Error>> {
-    let api_key = std::env::var("MISTRAL_API_KEY")
-        .map_err(|_| "MISTRAL_API_KEY not set. Export it or switch to engine = \"ollama\"")?;
+    let api_key = config
+        .resolve_api_key("MISTRAL_API_KEY")
+        .ok_or("MISTRAL_API_KEY not set. Set it via `minutes setup` or switch to engine = \"ollama\"")?;
 
     let model = &config.summarization.mistral_model;
     let chunks = build_prompt(transcript, config.summarization.chunk_max_tokens);
@@ -1018,8 +1021,9 @@ fn run_speaker_mapping_prompt(
     match config.summarization.engine.as_str() {
         "agent" => run_speaker_mapping_via_agent(prompt, config),
         "claude" => {
-            let api_key =
-                std::env::var("ANTHROPIC_API_KEY").map_err(|_| "ANTHROPIC_API_KEY not set")?;
+            let api_key = config
+                .resolve_api_key("ANTHROPIC_API_KEY")
+                .ok_or("ANTHROPIC_API_KEY not set")?;
             let body = serde_json::json!({"model":"claude-sonnet-4-20250514","max_tokens":256,"messages":[{"role":"user","content":prompt}]});
             let resp: serde_json::Value = agent
                 .post("https://api.anthropic.com/v1/messages")
@@ -1035,7 +1039,9 @@ fn run_speaker_mapping_prompt(
                 .ok_or_else(|| "No text in response".into())
         }
         "openai" => {
-            let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| "OPENAI_API_KEY not set")?;
+            let api_key = config
+                .resolve_api_key("OPENAI_API_KEY")
+                .ok_or("OPENAI_API_KEY not set")?;
             let body = serde_json::json!({"model":"gpt-4o-mini","max_tokens":256,"messages":[{"role":"user","content":prompt}]});
             let resp: serde_json::Value = agent
                 .post("https://api.openai.com/v1/chat/completions")
@@ -1050,8 +1056,9 @@ fn run_speaker_mapping_prompt(
                 .ok_or_else(|| "No text in response".into())
         }
         "mistral" => {
-            let api_key =
-                std::env::var("MISTRAL_API_KEY").map_err(|_| "MISTRAL_API_KEY not set")?;
+            let api_key = config
+                .resolve_api_key("MISTRAL_API_KEY")
+                .ok_or("MISTRAL_API_KEY not set")?;
             let body = serde_json::json!({"model": &config.summarization.mistral_model, "max_tokens": 256, "messages":[{"role":"user","content":prompt}]});
             let resp: serde_json::Value = agent
                 .post("https://api.mistral.ai/v1/chat/completions")

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1756,6 +1756,22 @@ pub fn start_recording(
                     None
                 };
 
+                // Surface missing API key to the user before queuing the job
+                if let Some(env_var) = config.required_api_key_env() {
+                    if config.resolve_api_key(env_var).is_none() {
+                        let notice = OutputNotice {
+                            kind: "missing-api-key".into(),
+                            title: format!("{} required", env_var),
+                            path: wav_path.display().to_string(),
+                            detail: format!(
+                                "The '{}' summarization engine requires {}. Open Settings to configure it.",
+                                config.summarization.engine, env_var
+                            ),
+                        };
+                        set_latest_output(&latest_output, Some(notice));
+                    }
+                }
+
                 match minutes_core::jobs::queue_live_capture(
                     mode,
                     requested_title.clone(),
@@ -3184,9 +3200,10 @@ pub fn cmd_get_settings() -> serde_json::Value {
     let config = Config::load();
     let path = Config::config_path();
 
-    // Check env vars for API key status
-    let anthropic_key_set = std::env::var("ANTHROPIC_API_KEY").is_ok();
-    let openai_key_set = std::env::var("OPENAI_API_KEY").is_ok();
+    // Check API key availability (env var → config file)
+    let anthropic_key_set = config.resolve_api_key("ANTHROPIC_API_KEY").is_some();
+    let openai_key_set = config.resolve_api_key("OPENAI_API_KEY").is_some();
+    let mistral_key_set = config.resolve_api_key("MISTRAL_API_KEY").is_some();
 
     // Check Ollama reachability
     let ollama_reachable = ureq::Agent::new_with_config(
@@ -3235,6 +3252,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "ollama_url": config.summarization.ollama_url,
             "anthropic_key_set": anthropic_key_set,
             "openai_key_set": openai_key_set,
+            "mistral_key_set": mistral_key_set,
             "ollama_reachable": ollama_reachable,
         },
         "screen_context": {
@@ -3380,6 +3398,43 @@ pub fn cmd_set_autostart(app: tauri::AppHandle, enabled: bool) -> Result<(), Str
     } else {
         manager.disable().map_err(|e| e.to_string())
     }
+}
+
+#[tauri::command]
+pub fn cmd_set_api_key(env_var: String, value: String) -> Result<String, String> {
+    let mut config = Config::load();
+    config.set_api_key(&env_var, value.clone());
+    config
+        .save()
+        .map_err(|e| format!("Failed to save config: {}", e))?;
+
+    // Make key available to the current process immediately
+    std::env::set_var(&env_var, &value);
+
+    Ok(format!("{} saved", env_var))
+}
+
+#[tauri::command]
+pub fn cmd_check_api_key(engine: String) -> serde_json::Value {
+    let config = Config::load();
+    let env_var = match engine.as_str() {
+        "claude" => "ANTHROPIC_API_KEY",
+        "openai" => "OPENAI_API_KEY",
+        "mistral" => "MISTRAL_API_KEY",
+        _ => {
+            return serde_json::json!({
+                "needed": false,
+            });
+        }
+    };
+
+    let available = config.resolve_api_key(env_var).is_some();
+    serde_json::json!({
+        "needed": true,
+        "available": available,
+        "env_var": env_var,
+        "engine": engine,
+    })
 }
 
 #[tauri::command]

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1034,6 +1034,8 @@ fn main() {
             commands::cmd_set_setting,
             commands::cmd_get_autostart,
             commands::cmd_set_autostart,
+            commands::cmd_set_api_key,
+            commands::cmd_check_api_key,
             commands::cmd_get_storage_stats,
             commands::cmd_vault_status,
             commands::cmd_vault_setup,

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -2246,6 +2246,7 @@
               <option value="ollama">Ollama — local, free, runs on your machine</option>
               <option value="claude">Claude API — direct API key (legacy)</option>
               <option value="openai">OpenAI API — direct API key (legacy)</option>
+              <option value="mistral">Mistral API — direct API key</option>
             </select>
             <div class="about-controls-meta" id="settings-summarization-status"></div>
           </div>
@@ -2338,6 +2339,31 @@
 
       <div class="about-footer" style="font-size: 11px;">
         Config file: <span id="settings-config-path" style="font-family: var(--font-mono); opacity: 0.7;"></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- API Key Modal -->
+  <div class="about-overlay" id="apikey-overlay">
+    <div class="about-card" role="dialog" aria-modal="true" aria-labelledby="apikey-title" style="width: min(440px, 100%);">
+      <div class="about-top">
+        <h2 id="apikey-title" style="font-size: 18px; font-family: var(--font-display);">API Key Required</h2>
+        <button class="btn btn-secondary btn-sm" id="btn-apikey-cancel">Cancel</button>
+      </div>
+      <div style="padding: 0 4px;">
+        <p id="apikey-description" style="font-size: 13px; color: var(--text-secondary); margin-bottom: 16px;">
+          The selected summarization engine requires an API key.
+        </p>
+        <label for="apikey-input" style="font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary); display: block; margin-bottom: 6px;">
+          <span id="apikey-label">API Key</span>
+        </label>
+        <input type="password" id="apikey-input" autocomplete="off" spellcheck="false"
+          style="width: 100%; padding: 8px 10px; border-radius: 8px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.15); color: var(--text); font-size: 14px; font-family: var(--font-mono); box-sizing: border-box;"
+          placeholder="Paste your API key here" />
+        <div id="apikey-error" style="font-size: 12px; color: #f87171; margin-top: 6px; display: none;"></div>
+      </div>
+      <div style="display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px;">
+        <button class="btn btn-secondary btn-sm" id="btn-apikey-save">Save Key</button>
       </div>
     </div>
   </div>
@@ -3058,6 +3084,15 @@
       if (!notice) {
         outputNotice.classList.remove('active', 'capture');
         lastOutputKey = null;
+        return;
+      }
+
+      // Missing API key — open the modal so the user can enter it
+      if (notice.kind === 'missing-api-key') {
+        const envVar = notice.title.replace(' required', '');
+        const engineMatch = notice.detail.match(/The '(\w+)' summarization/);
+        const engine = engineMatch ? engineMatch[1] : '';
+        openApiKeyModal(envVar, engine);
         return;
       }
 
@@ -4072,6 +4107,59 @@
     // ⌘, keyboard shortcut
     document.addEventListener('keydown', (e) => { if (e.metaKey && e.key === ',') { e.preventDefault(); openSettings(); } });
 
+    // API Key modal
+    const apikeyOverlay = document.getElementById('apikey-overlay');
+    let apikeyEnvVar = '';
+    let apikeyEngine = '';
+
+    function openApiKeyModal(envVar, engine) {
+      apikeyEnvVar = envVar;
+      apikeyEngine = engine;
+      const labels = {
+        'ANTHROPIC_API_KEY': 'Anthropic API Key',
+        'OPENAI_API_KEY': 'OpenAI API Key',
+        'MISTRAL_API_KEY': 'Mistral API Key',
+      };
+      document.getElementById('apikey-label').textContent = labels[envVar] || envVar;
+      document.getElementById('apikey-description').textContent =
+        'The "' + engine + '" summarization engine requires ' + envVar + '. Enter it below and it will be saved to your config file.';
+      document.getElementById('apikey-input').value = '';
+      document.getElementById('apikey-error').style.display = 'none';
+      apikeyOverlay.classList.add('active');
+      setTimeout(() => document.getElementById('apikey-input').focus(), 100);
+    }
+
+    function closeApiKeyModal() {
+      apikeyOverlay.classList.remove('active');
+    }
+
+    document.getElementById('btn-apikey-cancel').addEventListener('click', closeApiKeyModal);
+    apikeyOverlay.addEventListener('click', (e) => { if (e.target === apikeyOverlay) closeApiKeyModal(); });
+
+    document.getElementById('btn-apikey-save').addEventListener('click', async () => {
+      const value = document.getElementById('apikey-input').value.trim();
+      const errorEl = document.getElementById('apikey-error');
+      if (!value) {
+        errorEl.textContent = 'Please enter an API key.';
+        errorEl.style.display = '';
+        return;
+      }
+      try {
+        await invoke('cmd_set_api_key', { envVar: apikeyEnvVar, value });
+        closeApiKeyModal();
+        const s = await invoke('cmd_get_settings');
+        updateSumStatus(s);
+      } catch (e) {
+        errorEl.textContent = 'Failed to save: ' + e;
+        errorEl.style.display = '';
+      }
+    });
+
+    document.getElementById('apikey-input').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') document.getElementById('btn-apikey-save').click();
+      if (e.key === 'Escape') closeApiKeyModal();
+    });
+
     async function loadSettings() {
       try {
         const s = await invoke('cmd_get_settings');
@@ -4266,8 +4354,21 @@
       if (s.summarization.engine === 'none') el.textContent = '';
       else if (s.summarization.engine === 'agent') el.textContent = 'Using: ' + (s.summarization.agent_command || 'claude') + ' — no API key needed, uses your existing subscription';
       else if (s.summarization.engine === 'ollama') el.textContent = s.summarization.ollama_reachable ? 'Ollama reachable (' + s.summarization.ollama_model + ')' : 'Ollama not reachable at ' + s.summarization.ollama_url;
-      else if (s.summarization.engine === 'claude') el.textContent = s.summarization.anthropic_key_set ? 'API key set' : 'ANTHROPIC_API_KEY not found in environment';
-      else if (s.summarization.engine === 'openai') el.textContent = s.summarization.openai_key_set ? 'API key set' : 'OPENAI_API_KEY not found in environment';
+      else if (s.summarization.engine === 'claude') el.textContent = s.summarization.anthropic_key_set ? 'API key set' : 'ANTHROPIC_API_KEY not set — click to configure';
+      else if (s.summarization.engine === 'openai') el.textContent = s.summarization.openai_key_set ? 'API key set' : 'OPENAI_API_KEY not set — click to configure';
+      else if (s.summarization.engine === 'mistral') el.textContent = s.summarization.mistral_key_set ? 'API key set' : 'MISTRAL_API_KEY not set — click to configure';
+
+      // Make the status clickable to open the API key modal when the key is missing
+      const engine = s.summarization.engine;
+      const keyMissing = (engine === 'claude' && !s.summarization.anthropic_key_set)
+        || (engine === 'openai' && !s.summarization.openai_key_set)
+        || (engine === 'mistral' && !s.summarization.mistral_key_set);
+      el.style.cursor = keyMissing ? 'pointer' : '';
+      el.style.textDecoration = keyMissing ? 'underline' : '';
+      el.onclick = keyMissing ? () => {
+        const envMap = { claude: 'ANTHROPIC_API_KEY', openai: 'OPENAI_API_KEY', mistral: 'MISTRAL_API_KEY' };
+        openApiKeyModal(envMap[engine], engine);
+      } : null;
     }
     async function loadStorageStats() {
       try {
@@ -4340,8 +4441,16 @@
       setSettingsToggle('settings-diarization', next!=='none');
     });
     document.getElementById('settings-summarization-engine').addEventListener('change', async (e) => {
-      await invoke('cmd_set_setting', {section:'summarization',key:'engine',value:e.target.value});
-      document.getElementById('settings-agent-command-row').style.display = e.target.value === 'agent' ? '' : 'none';
+      const engine = e.target.value;
+      await invoke('cmd_set_setting', {section:'summarization',key:'engine',value:engine});
+      document.getElementById('settings-agent-command-row').style.display = engine === 'agent' ? '' : 'none';
+
+      // Check if the selected engine needs an API key
+      const check = await invoke('cmd_check_api_key', { engine });
+      if (check.needed && !check.available) {
+        openApiKeyModal(check.env_var, engine);
+      }
+
       const s = await invoke('cmd_get_settings'); updateSumStatus(s);
     });
     document.getElementById('settings-agent-command').addEventListener('change', async (e) => {


### PR DESCRIPTION
## Summary

- When a summarization engine requires an API key and none is found, the user is now prompted instead of silently skipping summarization
- **CLI**: interactive prompt after recording finishes (before processing), key is persisted to config.toml
- **GUI**: modal dialog opens when selecting an engine in Settings, or as a notice after recording completes with a missing key

## Changes

- **config.rs** -- Add ApiKeysConfig struct with resolve/set helpers and env-var-first precedence
- **summarize.rs** -- Replace raw env var calls with config-aware key resolution
- **cli main.rs** -- Add ensure_api_key() prompt; called in cmd_record, cmd_process, cmd_watch
- **commands.rs** -- Add cmd_set_api_key and cmd_check_api_key Tauri commands; emit missing-api-key notice
- **tauri main.rs** -- Register new commands
- **index.html** -- API key modal, auto-opens on engine change or missing-key notice, add Mistral engine option

## Test plan

- [ ] CLI: set engine with no key, record, verify prompt appears and key is saved
- [ ] CLI: enter empty key at prompt, verify error message
- [ ] CLI: after saving key, re-run, verify no prompt
- [ ] CLI: set env var, verify env var takes precedence
- [ ] GUI: select engine in Settings, verify modal opens if key missing
- [ ] GUI: enter key in modal, verify status updates
- [ ] GUI: record with missing key, verify modal opens after recording

Made with [Cursor](https://cursor.com)