### PR TITLE
Add desktop transcription language setting

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -718,6 +718,15 @@ fn parse_recording_intent(intent: Option<&str>) -> Result<Option<RecordingIntent
     }
 }
 
+fn parse_optional_string_setting(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 #[cfg(test)]
 fn stage_label(stage: minutes_core::pipeline::PipelineStage, mode: CaptureMode) -> &'static str {
     match (stage, mode) {
@@ -3224,6 +3233,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
         "transcription": {
             "model": config.transcription.model,
             "downloaded_models": downloaded_models,
+            "language": config.transcription.language,
         },
         "diarization": {
             "engine": config.diarization.engine,
@@ -3276,6 +3286,9 @@ pub fn cmd_set_setting(section: String, key: String, value: String) -> Result<St
     match (section.as_str(), key.as_str()) {
         // Transcription
         ("transcription", "model") => config.transcription.model = value.clone(),
+        ("transcription", "language") => {
+            config.transcription.language = parse_optional_string_setting(&value);
+        }
 
         // Diarization
         ("diarization", "engine") => config.diarization.engine = value.clone(),
@@ -3489,6 +3502,17 @@ mod tests {
                 CaptureMode::Meeting
             ),
             "Saving meeting"
+        );
+    }
+
+    #[test]
+    fn parse_optional_string_setting_preserves_auto_detect_state() {
+        assert_eq!(parse_optional_string_setting(""), None);
+        assert_eq!(parse_optional_string_setting("   "), None);
+        assert_eq!(parse_optional_string_setting("en"), Some("en".to_string()));
+        assert_eq!(
+            parse_optional_string_setting(" es "),
+            Some("es".to_string())
         );
     }
 

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -2345,6 +2345,115 @@
           </div>
         </div>
         <div class="about-controls">
+          <div class="about-controls-group">
+            <div class="about-controls-copy">Transcription language</div>
+            <div class="about-controls-meta">Leave this on Auto-detect for mixed or unknown audio. Pick a language only when Whisper is consistently guessing wrong.</div>
+            <select id="settings-whisper-language" style="margin-top: 6px; width: 100%; padding: 6px 8px; border-radius: 8px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1); color: var(--text); font-size: 13px;">
+              <option value="">Auto-detect</option>
+              <option value="af">Afrikaans</option>
+              <option value="am">Amharic</option>
+              <option value="ar">Arabic</option>
+              <option value="as">Assamese</option>
+              <option value="az">Azerbaijani</option>
+              <option value="ba">Bashkir</option>
+              <option value="be">Belarusian</option>
+              <option value="bg">Bulgarian</option>
+              <option value="bn">Bengali</option>
+              <option value="bo">Tibetan</option>
+              <option value="br">Breton</option>
+              <option value="bs">Bosnian</option>
+              <option value="ca">Catalan</option>
+              <option value="cs">Czech</option>
+              <option value="cy">Welsh</option>
+              <option value="da">Danish</option>
+              <option value="de">German</option>
+              <option value="el">Greek</option>
+              <option value="en">English</option>
+              <option value="es">Spanish</option>
+              <option value="et">Estonian</option>
+              <option value="eu">Basque</option>
+              <option value="fa">Persian</option>
+              <option value="fi">Finnish</option>
+              <option value="fo">Faroese</option>
+              <option value="fr">French</option>
+              <option value="gl">Galician</option>
+              <option value="gu">Gujarati</option>
+              <option value="ha">Hausa</option>
+              <option value="haw">Hawaiian</option>
+              <option value="he">Hebrew</option>
+              <option value="hi">Hindi</option>
+              <option value="hr">Croatian</option>
+              <option value="ht">Haitian Creole</option>
+              <option value="hu">Hungarian</option>
+              <option value="hy">Armenian</option>
+              <option value="id">Indonesian</option>
+              <option value="is">Icelandic</option>
+              <option value="it">Italian</option>
+              <option value="ja">Japanese</option>
+              <option value="jw">Javanese</option>
+              <option value="ka">Georgian</option>
+              <option value="kk">Kazakh</option>
+              <option value="km">Khmer</option>
+              <option value="kn">Kannada</option>
+              <option value="ko">Korean</option>
+              <option value="la">Latin</option>
+              <option value="lb">Luxembourgish</option>
+              <option value="ln">Lingala</option>
+              <option value="lo">Lao</option>
+              <option value="lt">Lithuanian</option>
+              <option value="lv">Latvian</option>
+              <option value="mg">Malagasy</option>
+              <option value="mi">Maori</option>
+              <option value="mk">Macedonian</option>
+              <option value="ml">Malayalam</option>
+              <option value="mn">Mongolian</option>
+              <option value="mr">Marathi</option>
+              <option value="ms">Malay</option>
+              <option value="mt">Maltese</option>
+              <option value="my">Myanmar</option>
+              <option value="ne">Nepali</option>
+              <option value="nl">Dutch</option>
+              <option value="nn">Norwegian Nynorsk</option>
+              <option value="no">Norwegian</option>
+              <option value="oc">Occitan</option>
+              <option value="pa">Punjabi</option>
+              <option value="pl">Polish</option>
+              <option value="ps">Pashto</option>
+              <option value="pt">Portuguese</option>
+              <option value="ro">Romanian</option>
+              <option value="ru">Russian</option>
+              <option value="sa">Sanskrit</option>
+              <option value="sd">Sindhi</option>
+              <option value="si">Sinhala</option>
+              <option value="sk">Slovak</option>
+              <option value="sl">Slovenian</option>
+              <option value="sn">Shona</option>
+              <option value="so">Somali</option>
+              <option value="sq">Albanian</option>
+              <option value="sr">Serbian</option>
+              <option value="su">Sundanese</option>
+              <option value="sv">Swedish</option>
+              <option value="sw">Swahili</option>
+              <option value="ta">Tamil</option>
+              <option value="te">Telugu</option>
+              <option value="tg">Tajik</option>
+              <option value="th">Thai</option>
+              <option value="tk">Turkmen</option>
+              <option value="tl">Tagalog</option>
+              <option value="tr">Turkish</option>
+              <option value="tt">Tatar</option>
+              <option value="uk">Ukrainian</option>
+              <option value="ur">Urdu</option>
+              <option value="uz">Uzbek</option>
+              <option value="vi">Vietnamese</option>
+              <option value="yi">Yiddish</option>
+              <option value="yo">Yoruba</option>
+              <option value="zh">Chinese</option>
+              <option value="yue">Cantonese</option>
+            </select>
+          </div>
+        </div>
+        <div class="about-controls">
           <div class="about-controls-copy">Speaker diarization (identify who said what)</div>
           <button class="btn btn-secondary btn-sm toggle-btn" id="settings-diarization">Off</button>
         </div>
@@ -4246,6 +4355,7 @@
           ? 'Downloaded: ' + dl.join(', ')
           : dl.length ? 'Downloaded: ' + dl.join(', ') + '  •  "' + selectedModel + '" not yet downloaded' : 'No models downloaded yet.';
         document.getElementById('btn-download-model').style.display = isDownloaded ? 'none' : '';
+        document.getElementById('settings-whisper-language').value = s.transcription.language || '';
         setSettingsToggle('settings-diarization', s.diarization.engine !== 'none'); // "auto" shows as On
         document.getElementById('settings-summarization-engine').value = s.summarization.engine;
         updateSumStatus(s);
@@ -4476,6 +4586,9 @@
       }
       btn.disabled = false;
       btn.textContent = 'Download';
+    });
+    document.getElementById('settings-whisper-language').addEventListener('change', async (e) => {
+      await invoke('cmd_set_setting', {section:'transcription',key:'language',value:e.target.value});
     });
     document.getElementById('settings-diarization').addEventListener('click', async () => {
       const s = await invoke('cmd_get_settings');


### PR DESCRIPTION
Fixes #48.

## What changed
- add a desktop Settings control for transcription language
- expose `transcription.language` through `cmd_get_settings`
- persist language changes through `cmd_set_setting`
- preserve the existing auto-detect behavior by mapping an empty value back to `None`
- add a narrow unit test for the auto-detect parsing path

## Why this branch exists
There is already an open PR for the desktop language setting, but this branch keeps the existing nullable config semantics intact. `transcription.language` is currently optional in config, so the desktop UI needs an explicit Auto-detect state rather than forcing every user into a concrete language code.

## Verification
- `cargo fmt --manifest-path tauri/src-tauri/Cargo.toml`
- `CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1" cargo test --manifest-path tauri/src-tauri/Cargo.toml parse_optional_string_setting_preserves_auto_detect_state -- --test-threads=1`