### PR TITLE
Add Google Meet settings toggle and safer browser probe UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,32 @@ The native hotkey uses macOS Input Monitoring, which is separate from Screen Rec
 
 Use `./scripts/install-dev-app.sh` first so you are testing the stable development app identity rather than a raw `target/` build. The helper intentionally launches the app through LaunchServices; direct shell execution of `Contents/MacOS/minutes-app --diagnose-hotkey` can misreport TCC status.
 
+### Updating
+
+```bash
+# macOS desktop app (Homebrew cask)
+brew upgrade --cask silverstein/tap/minutes
+
+# macOS CLI (Homebrew)
+brew upgrade silverstein/tap/minutes
+
+# From source (CLI)
+git pull && cargo install --path crates/cli
+
+# From source (desktop app)
+git pull
+export CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1"
+cargo tauri build --bundles app
+# Then replace /Applications/Minutes.app with the new build from
+# target/release/bundle/macos/Minutes.app
+
+# GitHub release (desktop app)
+# Download the latest .dmg from https://github.com/silverstein/minutes/releases
+# and drag Minutes.app to /Applications, replacing the old version
+```
+
+Check your current version with `minutes --version` (CLI) or the Settings gear in the desktop app.
+
 ## Configuration
 
 Optional — minutes works out of the box.
@@ -678,6 +704,17 @@ dictation_threshold_secs = 120      # Files shorter than this → memo (skip dia
 enabled = false           # Opt-in: capture screenshots during recording for LLM context
 interval_secs = 30        # How often to capture (seconds)
 keep_after_summary = false # Delete screenshots after summarization (default: clean up)
+
+[call_detection]
+enabled = true            # macOS-only today
+poll_interval_secs = 1
+cooldown_minutes = 5
+# Default apps stay conservative:
+# apps = ["zoom.us", "Microsoft Teams", "Webex"]
+#
+# Browser-based integrations such as Google Meet are opt-in on purpose.
+# If you want to dogfood browser detection, add the sentinel explicitly:
+# apps = ["zoom.us", "Microsoft Teams", "Webex", "google-meet"]
 
 [assistant]
 agent = "claude"          # CLI launched by the Tauri AI Assistant

--- a/tauri/src-tauri/src/call_detect.rs
+++ b/tauri/src-tauri/src/call_detect.rs
@@ -8,6 +8,7 @@
 //! `is_mic_in_use`) use CoreAudio and `ps`. Windows/Linux would need
 //! alternative implementations behind `cfg(target_os)` gates.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -44,6 +45,13 @@ pub struct CallDetector {
     /// but we also re-notify the same active app after a short interval so
     /// back-to-back meetings and sticky Zoom states don't go silent forever.
     active_call: Mutex<Option<ActiveCallState>>,
+    /// Browser tab probing is slower and lower-confidence than native app
+    /// detection, so keep it on its own cadence instead of every call-detect
+    /// poll when the mic is hot.
+    browser_probe_next_allowed_at: Mutex<Option<Instant>>,
+    /// Back off individual browsers after Apple Events / automation failures so
+    /// one denied path does not get retried every poll or suppress other browsers.
+    browser_probe_backoff_until: Mutex<HashMap<String, Instant>>,
 }
 
 /// Payload emitted to the frontend when a call is detected.
@@ -66,12 +74,16 @@ enum DetectionTransition {
 }
 
 const SAME_APP_REMINDER_SECS: u64 = 20;
+const BROWSER_PROBE_INTERVAL_SECS: u64 = 15;
+const BROWSER_PROBE_BACKOFF_SECS: u64 = 300;
 
 impl CallDetector {
     pub fn new(config: CallDetectionConfig) -> Self {
         Self {
             config,
             active_call: Mutex::new(None),
+            browser_probe_next_allowed_at: Mutex::new(None),
+            browser_probe_backoff_until: Mutex::new(HashMap::new()),
         }
     }
 
@@ -190,9 +202,16 @@ impl CallDetector {
             return None;
         }
 
+        let has_google_meet = self.config.apps.iter().any(|app| app == "google-meet");
+        let native_apps: Vec<&String> = self
+            .config
+            .apps
+            .iter()
+            .filter(|app| app.as_str() != "google-meet")
+            .collect();
         let running = running_process_names();
 
-        for config_app in &self.config.apps {
+        for config_app in native_apps {
             let config_lower = config_app.to_lowercase();
             // Substring match: "zoom.us" matches process "zoom.us",
             // "Microsoft Teams" matches "Microsoft Teams Helper", etc.
@@ -201,6 +220,13 @@ impl CallDetector {
             }) {
                 let display = display_name_for(config_app);
                 return Some((display, config_app.clone()));
+            }
+        }
+
+        if has_google_meet && self.browser_probe_due() {
+            self.schedule_next_browser_probe();
+            if self.detect_google_meet_in_browsers(&running) {
+                return Some(("Google Meet".into(), "google-meet".into()));
             }
         }
         None
@@ -241,9 +267,97 @@ impl CallDetector {
         let mut active = self.active_call.lock().unwrap();
         active.take().map(|state| state.process_name)
     }
+
+    fn browser_probe_due(&self) -> bool {
+        let mut next_probe = self.browser_probe_next_allowed_at.lock().unwrap();
+        match *next_probe {
+            Some(until) if Instant::now() < until => false,
+            Some(_) => {
+                *next_probe = None;
+                true
+            }
+            None => true,
+        }
+    }
+
+    fn schedule_next_browser_probe(&self) {
+        let mut next_probe = self.browser_probe_next_allowed_at.lock().unwrap();
+        *next_probe = Some(Instant::now() + Duration::from_secs(BROWSER_PROBE_INTERVAL_SECS));
+    }
+
+    fn browser_probe_allowed_for(&self, browser_app: &str) -> bool {
+        let mut backoff = self.browser_probe_backoff_until.lock().unwrap();
+        match backoff.get(browser_app).copied() {
+            Some(until) if Instant::now() < until => false,
+            Some(_) => {
+                backoff.remove(browser_app);
+                true
+            }
+            None => true,
+        }
+    }
+
+    fn defer_browser_probe_for(&self, browser_app: &str, reason: &str) {
+        let mut backoff = self.browser_probe_backoff_until.lock().unwrap();
+        backoff.insert(
+            browser_app.to_string(),
+            Instant::now() + Duration::from_secs(BROWSER_PROBE_BACKOFF_SECS),
+        );
+        log_call_detect_event(
+            "warn",
+            "browser_probe_backoff",
+            Some("Google Meet"),
+            Some(browser_app),
+            serde_json::json!({
+                "reason": reason,
+                "backoff_secs": BROWSER_PROBE_BACKOFF_SECS,
+            }),
+        );
+    }
+
+    fn detect_google_meet_in_browsers(&self, running: &[String]) -> bool {
+        let running_lower: Vec<String> = running.iter().map(|s| s.to_lowercase()).collect();
+
+        for (proc_fragment, app_name, kind) in &[
+            ("google chrome", "Google Chrome", BrowserKind::ChromeLike),
+            (
+                "chrome canary",
+                "Google Chrome Canary",
+                BrowserKind::ChromeLike,
+            ),
+            ("chromium", "Chromium", BrowserKind::ChromeLike),
+            ("safari", "Safari", BrowserKind::Safari),
+        ] {
+            if !running_lower.iter().any(|p| p.contains(proc_fragment)) {
+                continue;
+            }
+            if !self.browser_probe_allowed_for(app_name) {
+                continue;
+            }
+
+            match query_browser_urls(app_name, *kind) {
+                AppleScriptProbe::Urls(urls) => {
+                    if urls
+                        .iter()
+                        .any(|url| looks_like_google_meet_meeting_url(url))
+                    {
+                        return true;
+                    }
+                }
+                AppleScriptProbe::PermissionDenied => {
+                    self.defer_browser_probe_for(app_name, "apple_events_permission_denied");
+                }
+                AppleScriptProbe::Error => {
+                    self.defer_browser_probe_for(app_name, "browser_probe_error");
+                }
+            }
+        }
+
+        false
+    }
 }
 
-/// Friendly display name for a process name.
+/// Friendly display name for a process name or browser sentinel.
 fn display_name_for(process: &str) -> String {
     match process {
         "zoom.us" => "Zoom".into(),
@@ -251,8 +365,115 @@ fn display_name_for(process: &str) -> String {
         "FaceTime" => "FaceTime".into(),
         "Webex" => "Webex".into(),
         "Slack" => "Slack".into(),
+        "google-meet" => "Google Meet".into(),
         other => other.into(),
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BrowserKind {
+    ChromeLike,
+    Safari,
+}
+
+enum AppleScriptProbe {
+    Urls(Vec<String>),
+    PermissionDenied,
+    Error,
+}
+
+fn query_browser_urls(app_name: &str, kind: BrowserKind) -> AppleScriptProbe {
+    let script = match kind {
+        BrowserKind::ChromeLike => format!(
+            r#"tell application "{app_name}"
+set output to ""
+repeat with w in windows
+  repeat with t in tabs of w
+    set output to output & (URL of t as text) & linefeed
+  end repeat
+end repeat
+return output
+end tell"#
+        ),
+        BrowserKind::Safari => format!(
+            r#"tell application "{app_name}"
+set output to ""
+repeat with w in windows
+  repeat with t in tabs of w
+    set output to output & (URL of t as text) & linefeed
+  end repeat
+end repeat
+return output
+end tell"#
+        ),
+    };
+    run_applescript_urls(&script)
+}
+
+fn run_applescript_urls(script: &str) -> AppleScriptProbe {
+    let output = match std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => return AppleScriptProbe::Error,
+    };
+
+    if output.status.success() {
+        let urls = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect();
+        return AppleScriptProbe::Urls(urls);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    if stderr.contains("not authorized")
+        || stderr.contains("not permitted")
+        || stderr.contains("(-1743)")
+    {
+        AppleScriptProbe::PermissionDenied
+    } else {
+        AppleScriptProbe::Error
+    }
+}
+
+fn looks_like_google_meet_meeting_url(url: &str) -> bool {
+    let lower = url.trim().to_lowercase();
+    let without_scheme = lower
+        .strip_prefix("https://")
+        .or_else(|| lower.strip_prefix("http://"))
+        .unwrap_or(&lower);
+
+    let Some(rest) = without_scheme.strip_prefix("meet.google.com/") else {
+        return false;
+    };
+
+    let first_segment = rest
+        .split(['?', '#', '/'])
+        .next()
+        .unwrap_or_default()
+        .trim();
+
+    looks_like_google_meet_meeting_code(first_segment)
+}
+
+fn looks_like_google_meet_meeting_code(segment: &str) -> bool {
+    let parts: Vec<&str> = segment.split('-').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+
+    let expected_lengths = [3, 4, 3];
+    parts
+        .iter()
+        .zip(expected_lengths)
+        .all(|(part, expected_len)| {
+            part.len() == expected_len && part.chars().all(|ch| ch.is_ascii_lowercase())
+        })
 }
 
 // ── macOS-specific detection ──────────────────────────────────
@@ -384,7 +605,106 @@ mod tests {
         assert_eq!(display_name_for("zoom.us"), "Zoom");
         assert_eq!(display_name_for("Microsoft Teams"), "Teams");
         assert_eq!(display_name_for("FaceTime"), "FaceTime");
+        assert_eq!(display_name_for("google-meet"), "Google Meet");
         assert_eq!(display_name_for("SomeOtherApp"), "SomeOtherApp");
+    }
+
+    #[test]
+    fn google_meet_detection_is_opt_in_via_sentinel() {
+        let detector = CallDetector::new(CallDetectionConfig {
+            enabled: true,
+            poll_interval_secs: 1,
+            cooldown_minutes: 5,
+            apps: vec!["zoom.us".into(), "google-meet".into()],
+        });
+
+        assert!(detector.config.apps.iter().any(|app| app == "google-meet"));
+    }
+
+    #[test]
+    fn browser_probe_is_skipped_when_no_browser_processes_exist() {
+        let detector = CallDetector::new(CallDetectionConfig {
+            enabled: true,
+            poll_interval_secs: 1,
+            cooldown_minutes: 5,
+            apps: vec!["google-meet".into()],
+        });
+        let running: Vec<String> = vec!["Finder".into(), "launchd".into()];
+        assert!(!detector.detect_google_meet_in_browsers(&running));
+    }
+
+    #[test]
+    fn meet_url_requires_real_meeting_code() {
+        assert!(looks_like_google_meet_meeting_url(
+            "https://meet.google.com/abc-defg-hij"
+        ));
+        assert!(looks_like_google_meet_meeting_url(
+            "https://meet.google.com/abc-defg-hij?authuser=1"
+        ));
+        assert!(!looks_like_google_meet_meeting_url(
+            "https://meet.google.com/"
+        ));
+        assert!(!looks_like_google_meet_meeting_url(
+            "https://meet.google.com/new"
+        ));
+        assert!(!looks_like_google_meet_meeting_url(
+            "https://meet.google.com/landing"
+        ));
+        assert!(!looks_like_google_meet_meeting_url(
+            "https://example.com/abc-defg-hij"
+        ));
+    }
+
+    #[test]
+    fn malformed_applescript_fails_gracefully() {
+        assert!(matches!(
+            run_applescript_urls("this is not valid applescript @@@@"),
+            AppleScriptProbe::Error
+        ));
+    }
+
+    #[test]
+    fn browser_probe_backoff_resets_after_expiry() {
+        let detector = CallDetector::new(CallDetectionConfig {
+            enabled: true,
+            poll_interval_secs: 1,
+            cooldown_minutes: 5,
+            apps: vec!["google-meet".into()],
+        });
+
+        detector.defer_browser_probe_for("Google Chrome", "test");
+        assert!(!detector.browser_probe_allowed_for("Google Chrome"));
+        assert!(detector.browser_probe_allowed_for("Safari"));
+
+        {
+            let mut backoff = detector.browser_probe_backoff_until.lock().unwrap();
+            backoff.insert(
+                "Google Chrome".into(),
+                Instant::now() - Duration::from_secs(1),
+            );
+        }
+
+        assert!(detector.browser_probe_allowed_for("Google Chrome"));
+    }
+
+    #[test]
+    fn browser_probe_global_interval_resets_after_expiry() {
+        let detector = CallDetector::new(CallDetectionConfig {
+            enabled: true,
+            poll_interval_secs: 1,
+            cooldown_minutes: 5,
+            apps: vec!["google-meet".into()],
+        });
+
+        detector.schedule_next_browser_probe();
+        assert!(!detector.browser_probe_due());
+
+        {
+            let mut next_probe = detector.browser_probe_next_allowed_at.lock().unwrap();
+            *next_probe = Some(Instant::now() - Duration::from_secs(1));
+        }
+
+        assert!(detector.browser_probe_due());
     }
 
     #[test]

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -727,6 +727,17 @@ fn parse_optional_string_setting(value: &str) -> Option<String> {
     }
 }
 
+fn call_detection_has_sentinel(config: &Config, sentinel: &str) -> bool {
+    config.call_detection.apps.iter().any(|app| app == sentinel)
+}
+
+fn set_call_detection_sentinel(config: &mut Config, sentinel: &str, enabled: bool) {
+    config.call_detection.apps.retain(|app| app != sentinel);
+    if enabled {
+        config.call_detection.apps.push(sentinel.to_string());
+    }
+}
+
 #[cfg(test)]
 fn stage_label(stage: minutes_core::pipeline::PipelineStage, mode: CaptureMode) -> &'static str {
     match (stage, mode) {
@@ -3261,6 +3272,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "poll_interval_secs": config.call_detection.poll_interval_secs,
             "cooldown_minutes": config.call_detection.cooldown_minutes,
             "apps": config.call_detection.apps,
+            "google_meet_enabled": call_detection_has_sentinel(&config, "google-meet"),
         },
         "dictation": {
             "model": config.dictation.model,
@@ -3328,6 +3340,9 @@ pub fn cmd_set_setting(section: String, key: String, value: String) -> Result<St
             config.call_detection.cooldown_minutes = value
                 .parse()
                 .map_err(|_| "cooldown_minutes must be a number")?;
+        }
+        ("call_detection", "google_meet_enabled") => {
+            set_call_detection_sentinel(&mut config, "google-meet", value == "true");
         }
 
         // Dictation
@@ -3524,6 +3539,29 @@ mod tests {
             parse_optional_string_setting(" es "),
             Some("es".to_string())
         );
+    }
+
+    #[test]
+    fn call_detection_sentinel_toggle_is_idempotent() {
+        let mut config = Config::default();
+        assert!(!call_detection_has_sentinel(&config, "google-meet"));
+
+        set_call_detection_sentinel(&mut config, "google-meet", true);
+        assert!(call_detection_has_sentinel(&config, "google-meet"));
+
+        set_call_detection_sentinel(&mut config, "google-meet", true);
+        assert_eq!(
+            config
+                .call_detection
+                .apps
+                .iter()
+                .filter(|app| app.as_str() == "google-meet")
+                .count(),
+            1
+        );
+
+        set_call_detection_sentinel(&mut config, "google-meet", false);
+        assert!(!call_detection_has_sentinel(&config, "google-meet"));
     }
 
     #[test]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -2507,6 +2507,13 @@
             <input type="number" id="settings-call-detection-cooldown" min="0" style="margin-top: 6px; width: 100%; padding: 6px 8px; border-radius: 8px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1); color: var(--text); font-size: 13px;">
           </div>
         </div>
+        <div class="about-controls">
+          <div class="about-controls-group">
+            <div class="about-controls-copy">Google Meet detection (experimental)</div>
+            <div class="about-controls-meta">Opt-in browser integration for Meet in Chrome/Safari. Uses stronger meeting-URL matching, may require macOS browser automation permission, and backs off after failures instead of probing every second.</div>
+          </div>
+          <button class="btn btn-secondary btn-sm toggle-btn" id="settings-call-detection-google-meet">Off</button>
+        </div>
       </div>
 
       <!-- Privacy -->
@@ -4409,6 +4416,7 @@
           setSettingsToggle('settings-call-detection', s.call_detection.enabled);
           document.getElementById('settings-call-detection-polling-interval').value = String(s.call_detection.poll_interval_secs ?? 1);
           document.getElementById('settings-call-detection-cooldown').value = String(s.call_detection.cooldown_minutes ?? 5);
+          setSettingsToggle('settings-call-detection-google-meet', Boolean(s.call_detection.google_meet_enabled));
         }
         // Dictation settings
         if (s.dictation) {
@@ -4655,6 +4663,12 @@
     });
     document.getElementById('settings-call-detection-polling-interval').addEventListener('change', (e) => invoke('cmd_set_setting', {section:'call_detection',key:'poll_interval_secs',value:e.target.value}));
     document.getElementById('settings-call-detection-cooldown').addEventListener('change', (e) => invoke('cmd_set_setting', {section:'call_detection',key:'cooldown_minutes',value:e.target.value}));
+    document.getElementById('settings-call-detection-google-meet').addEventListener('click', async () => {
+      const s = await invoke('cmd_get_settings');
+      const next = !Boolean(s.call_detection.google_meet_enabled);
+      await invoke('cmd_set_setting', {section:'call_detection',key:'google_meet_enabled',value:String(next)});
+      setSettingsToggle('settings-call-detection-google-meet', next);
+    });
 
     // Dictation settings handlers
     document.getElementById('settings-dictation-shortcut').addEventListener('click', async () => {


### PR DESCRIPTION
Follow-up to #53.

## What this adds
- desktop Settings toggle for `Google Meet detection (experimental)` under Call Detection
- backend persistence for the opt-in `google-meet` sentinel without disturbing the conservative default app list
- small user-facing explanation that browser-based detection may require macOS browser automation permission
- idempotent backend test for toggling the sentinel on/off

## Why this follow-up exists
#53 made Google Meet detection safe enough to merge from a detection perspective. This PR finishes the product surface by making the opt-in path discoverable in the desktop UI instead of requiring users to edit config by hand.

## Verification
- `cargo fmt --manifest-path tauri/src-tauri/Cargo.toml`
- `CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1" cargo test --manifest-path tauri/src-tauri/Cargo.toml call_detect -- --test-threads=1`