### PR TITLE
Fix broken release doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,8 +584,8 @@ The desktop app adds a system tray icon, recording controls, audio visualizer, R
 
 Release workflow details live in:
 
-- [docs/RELEASE-MACOS.md](/Users/silverbook/Sites/minutes/docs/RELEASE-MACOS.md)
-- [docs/RELEASE-WINDOWS.md](/Users/silverbook/Sites/minutes/docs/RELEASE-WINDOWS.md)
+- [docs/RELEASE-MACOS.md](docs/RELEASE-MACOS.md)
+- [docs/RELEASE-WINDOWS.md](docs/RELEASE-WINDOWS.md)
 
 For macOS development, use a dedicated signed dev app identity:
 


### PR DESCRIPTION
## Summary
The release documentation links in the README point to absolute local filesystem paths (`/Users/silverbook/Sites/minutes/docs/`) instead of relative paths. These links are broken for every user.

**Before:**
```markdown
- [docs/RELEASE-MACOS.md](/Users/silverbook/Sites/minutes/docs/RELEASE-MACOS.md)
- [docs/RELEASE-WINDOWS.md](/Users/silverbook/Sites/minutes/docs/RELEASE-WINDOWS.md)
```

**After:**
```markdown
- [docs/RELEASE-MACOS.md](docs/RELEASE-MACOS.md)
- [docs/RELEASE-WINDOWS.md](docs/RELEASE-WINDOWS.md)
```

2-line change. No functional impact beyond making the links work.