### PR TITLE
Fix path separator in isWithinDirectory for Windows

### DIFF
--- a/crates/mcp/src/paths.test.ts
+++ b/crates/mcp/src/paths.test.ts
@@ -3,7 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { expandHomeLikePath, validatePathInDirectory } from "./paths.js";
+import { expandHomeLikePath, isWithinDirectory, validatePathInDirectory } from "./paths.js";
 
 const tempRoots: string[] = [];
 
@@ -33,5 +33,19 @@ describe("path normalization", () => {
     const configuredRoot = `\${HOME}/${tempRoot.slice(homedir().length + 1)}/meetings`;
 
     expect(validatePathInDirectory(meetingPath, configuredRoot, [".md"])).toBe(meetingPath);
+  });
+});
+
+describe("isWithinDirectory", () => {
+  it("rejects paths that share a prefix but are not children", () => {
+    // ~/meetings-evil should NOT be within ~/meetings
+    expect(isWithinDirectory("/home/user/meetings-evil", "/home/user/meetings")).toBe(false);
+    expect(isWithinDirectory("/home/user/meetings-evil/file.md", "/home/user/meetings")).toBe(false);
+  });
+
+  it("accepts exact root match and direct children", () => {
+    expect(isWithinDirectory("/home/user/meetings", "/home/user/meetings")).toBe(true);
+    expect(isWithinDirectory("/home/user/meetings/file.md", "/home/user/meetings")).toBe(true);
+    expect(isWithinDirectory("/home/user/meetings/sub/file.md", "/home/user/meetings")).toBe(true);
   });
 });

--- a/crates/mcp/src/paths.ts
+++ b/crates/mcp/src/paths.ts
@@ -1,6 +1,6 @@
 import { existsSync, realpathSync } from "fs";
 import { homedir } from "os";
-import { extname, join, resolve } from "path";
+import { extname, join, resolve, sep } from "path";
 
 export function expandHomeLikePath(input: string): string {
   const home = homedir();
@@ -41,7 +41,9 @@ export function canonicalizeRoot(root: string): string {
 
 export function isWithinDirectory(candidate: string, root: string): boolean {
   // Ensure root ends with separator to prevent prefix attacks (e.g. ~/meetings-evil)
-  const rootWithSep = root.endsWith("/") ? root : root + "/";
+  // Use path.sep for cross-platform correctness — realpathSync returns OS-native
+  // separators, so on Windows the root will use backslashes.
+  const rootWithSep = root.endsWith(sep) ? root : root + sep;
   return candidate === root || candidate.startsWith(rootWithSep);
 }
 


### PR DESCRIPTION
## Summary
`isWithinDirectory` hardcodes `/` as the path separator when building the root prefix for the containment check. On Windows, `realpathSync` returns backslash-separated paths, so the prefix check never matches -- the directory guard is effectively bypassed.

## Fix
Import `sep` from `path` and use it instead of the hardcoded `/`. This matches the existing pattern in `expandHomeLikePath`, which already handles both `~/` and `~\`.

## Test coverage
Added two test cases to `paths.test.ts`:
- Prefix-attack rejection (`~/meetings-evil` is not within `~/meetings`)
- Direct child and exact-match acceptance

## Files changed
- `crates/mcp/src/paths.ts` -- use `path.sep` in `isWithinDirectory`
- `crates/mcp/src/paths.test.ts` -- added `isWithinDirectory` test suite