### PR TITLE
Wire up recorded_by filter in search

### DIFF
--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -750,6 +750,12 @@ fn process_file(
             return Ok(None);
         }
     }
+    if let Some(ref recorded_by) = filters.recorded_by {
+        let recorded = extract_field(frontmatter_str, "recorded_by").unwrap_or_default();
+        if !recorded.to_lowercase().contains(&recorded_by.to_lowercase()) {
+            return Ok(None);
+        }
+    }
 
     // Text search (case-insensitive)
     let body_lower = body.to_lowercase();
@@ -807,6 +813,15 @@ fn process_intent_file(
             .iter()
             .any(|name| name.to_lowercase().contains(&attendee_lower));
         if !attendee_match {
+            return Ok(vec![]);
+        }
+    }
+    if let Some(ref recorded_by) = filters.recorded_by {
+        let matches = frontmatter
+            .recorded_by
+            .as_ref()
+            .is_some_and(|r| r.to_lowercase().contains(&recorded_by.to_lowercase()));
+        if !matches {
             return Ok(vec![]);
         }
     }


### PR DESCRIPTION
## Summary
`SearchFilters.recorded_by` is defined and parsed but never checked during search execution. The `attendee`, `content_type`, and `since` filters are all wired up in `process_file` and `process_intent_file`, but `recorded_by` is silently ignored. This means filtering meetings by who recorded them has no effect.

## Fix
Added the `recorded_by` filter check to both search paths:
- `process_file` (text search): uses `extract_field` to read `recorded_by` from raw frontmatter, matching the `attendee` filter pattern
- `process_intent_file` (structured intents): uses the parsed `Frontmatter.recorded_by` field directly

Both use case-insensitive substring matching, consistent with how `attendee` filtering works.

## Files changed
- `crates/core/src/search.rs`