### PR TITLE
fix: restore window size when exiting fullscreen with Recall panel open

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -5916,16 +5916,19 @@
     });
 
     // ── Restore window size when exiting fullscreen with recall panel open ──
+    // Track prior fullscreen state so the snap only fires on the actual
+    // fullscreen → windowed transition, not on every user drag-resize
+    // (which would also risk a resize loop since setSize triggers onResized).
+    let wasFullscreen = false;
     currentWindow.onResized(async () => {
-      if (!recallExpanded) return;
       const fs = await currentWindow.isFullscreen().catch(() => false);
-      if (!fs) {
-        // Just left fullscreen — snap the window to the expected expanded size.
+      if (wasFullscreen && !fs && recallExpanded) {
         await currentWindow.setSize(
           new window.__TAURI__.window.LogicalSize(EXPANDED_WIDTH, 640)
         ).catch(() => {});
         if (recallFitAddon) recallFitAddon.fit();
       }
+      wasFullscreen = fs;
     });
 
     // ── Button handlers ──


### PR DESCRIPTION
Fixes: #59 
When the user exits macOS fullscreen while the Recall panel is expanded, the window reverts to its pre-fullscreen size, squishing both panels together and hiding UI elements. Add an onResized listener that detects the fullscreen → windowed transition and snaps the window to EXPANDED_WIDTH × 640 so the side-by-side layout is preserved.