### PR TITLE
style: rustfmt call_detect.rs browser tuple

### DIFF
--- a/tauri/src-tauri/src/call_detect.rs
+++ b/tauri/src-tauri/src/call_detect.rs
@@ -463,7 +463,12 @@ impl CallDetector {
         let mut saw_browser = false;
 
         for (proc_fragment, app_name, kind, exact) in &[
-            ("google chrome", "Google Chrome", BrowserKind::ChromeLike, false),
+            (
+                "google chrome",
+                "Google Chrome",
+                BrowserKind::ChromeLike,
+                false,
+            ),
             (
                 "chrome canary",
                 "Google Chrome Canary",


### PR DESCRIPTION
## Summary
- Fix CI failure on main after #120 merge: rustfmt wanted the `(proc_fragment, app_name, kind, exact)` tuple wrapped multi-line since it exceeds the line width.
- Pure `cargo fmt --all` output, no logic changes.

## Test plan
- [x] `cargo fmt --all -- --check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)