### PR TITLE
feat(call-detect): stop_when_call_ends auto-stop countdown

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -250,6 +250,14 @@ pub struct CallDetectionConfig {
     pub poll_interval_secs: u64,
     pub cooldown_minutes: u64,
     pub apps: Vec<String>,
+    /// When a call that the detector started a recording for ends, show a
+    /// countdown banner that auto-stops the recording. Default: false.
+    /// Named for the behavior (an assistive prompt, not a silent hard stop);
+    /// people often keep recording 30-90s past hangup for takeaways.
+    pub stop_when_call_ends: bool,
+    /// Seconds the user has to cancel auto-stop before it fires.
+    /// Only meaningful when `stop_when_call_ends` is true. Default: 30.
+    pub call_end_stop_countdown_secs: u64,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -531,6 +539,8 @@ impl Default for CallDetectionConfig {
             poll_interval_secs: 1,
             cooldown_minutes: 5,
             apps: vec!["zoom.us".into(), "Microsoft Teams".into(), "Webex".into()],
+            stop_when_call_ends: false,
+            call_end_stop_countdown_secs: 30,
         }
     }
 }
@@ -1151,6 +1161,56 @@ accumulate = false
 
         let config = Config::load_from(&config_path);
         assert!(!config.dictation.accumulate);
+    }
+
+    // ── Call detection: stop-when-call-ends opt-in ────────────
+
+    #[test]
+    fn stop_when_call_ends_is_off_by_default() {
+        let config = Config::default();
+        assert!(!config.call_detection.stop_when_call_ends);
+        assert_eq!(config.call_detection.call_end_stop_countdown_secs, 30);
+    }
+
+    #[test]
+    fn stop_when_call_ends_round_trips_through_toml() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[call_detection]
+enabled = true
+stop_when_call_ends = true
+call_end_stop_countdown_secs = 45
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_from(&config_path);
+        assert!(config.call_detection.stop_when_call_ends);
+        assert_eq!(config.call_detection.call_end_stop_countdown_secs, 45);
+        // Sibling fields still populated from defaults.
+        assert_eq!(config.call_detection.poll_interval_secs, 1);
+        assert!(!config.call_detection.apps.is_empty());
+    }
+
+    #[test]
+    fn stop_when_call_ends_omitted_keeps_default_off() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[call_detection]
+enabled = true
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_from(&config_path);
+        assert!(!config.call_detection.stop_when_call_ends);
+        assert_eq!(config.call_detection.call_end_stop_countdown_secs, 30);
     }
 
     // ── Palette config + upgrade migration ────────────────────

--- a/tauri/src-tauri/src/call_detect.rs
+++ b/tauri/src-tauri/src/call_detect.rs
@@ -69,10 +69,36 @@ pub struct CallDetectedPayload {
     pub is_reminder: bool,
 }
 
+/// Emitted when the call app that triggered the current recording is no
+/// longer detected. The frontend shows a countdown banner with Stop now /
+/// Keep recording, and the backend arms a cancellable auto-stop timer.
+#[derive(Clone, serde::Serialize)]
+pub struct CallEndedPayload {
+    pub app_name: String,
+    pub process_name: String,
+    pub countdown_secs: u64,
+}
+
+/// Handles shared with the desktop app state so this module can observe and
+/// arm the auto-stop countdown without having to reach into `commands::AppState`
+/// directly.
+#[derive(Clone)]
+pub struct CallEndAutoStopHandles {
+    pub recording_started_by_call_detect: Arc<AtomicBool>,
+    pub countdown_cancel: Arc<AtomicBool>,
+    pub countdown_active: Arc<AtomicBool>,
+    pub stop_flag: Arc<AtomicBool>,
+}
+
 #[derive(Clone)]
 struct ActiveCallState {
     process_name: String,
+    display_name: String,
     last_notified_at: Instant,
+    /// Set after `call:ended` has been emitted for the current session.
+    /// Keeps repeated "no longer detected" polls from re-arming the
+    /// countdown if the user hit "Keep recording".
+    call_end_fired: bool,
 }
 
 enum DetectionTransition {
@@ -134,6 +160,7 @@ impl CallDetector {
         app: tauri::AppHandle,
         recording: Arc<AtomicBool>,
         _processing: Arc<AtomicBool>,
+        auto_stop: CallEndAutoStopHandles,
     ) {
         let startup_config = self.current_config();
         let interval = Duration::from_secs(startup_config.poll_interval_secs.max(1));
@@ -178,8 +205,16 @@ impl CallDetector {
                 let interval = Duration::from_secs(config.poll_interval_secs.max(1));
                 std::thread::sleep(interval);
 
-                // Skip only while the mic is already in use.
-                if recording.load(Ordering::Relaxed) {
+                let is_recording = recording.load(Ordering::Relaxed);
+                let started_by_call_detect = auto_stop
+                    .recording_started_by_call_detect
+                    .load(Ordering::Relaxed);
+
+                // Default behavior preserved: when something else is recording
+                // (manual `minutes record`, hotkey, live transcript), skip detection
+                // entirely. Only observe calls when the detector's own banner
+                // launched this recording AND the user opted into auto-stop.
+                if is_recording && !(started_by_call_detect && config.stop_when_call_ends) {
                     continue;
                 }
 
@@ -188,7 +223,14 @@ impl CallDetector {
                         display_name,
                         process_name,
                     } => {
-                        match self.note_active_call(&process_name) {
+                        // Call came back (same app): if the previous call
+                        // already fired a countdown that the user dismissed
+                        // with "Keep recording", clear the latch so a later
+                        // call-end can re-arm the auto-stop prompt.
+                        if is_recording && started_by_call_detect {
+                            self.reset_call_end_latch();
+                        }
+                        match self.note_active_call(&process_name, &display_name) {
                             DetectionTransition::Noop => {}
                             transition => {
                                 let is_reminder =
@@ -253,7 +295,29 @@ impl CallDetector {
                         );
                     }
                     DetectActiveCallResult::None => {
-                        if let Some(previous) = self.clear_active_call() {
+                        // When a recording started via this detector is in
+                        // flight and the call has ended (app quit or mic
+                        // release), arm the auto-stop countdown — once per
+                        // session. The mark_call_end_fired guard keeps
+                        // repeat polls from re-firing if the user already
+                        // hit "Keep recording".
+                        if is_recording && started_by_call_detect && config.stop_when_call_ends {
+                            if let Some((process_name, display_name, already_fired)) =
+                                self.active_call_snapshot()
+                            {
+                                if !already_fired {
+                                    self.mark_call_end_fired();
+                                    self.arm_call_end_countdown(
+                                        &app,
+                                        &auto_stop,
+                                        &recording,
+                                        &display_name,
+                                        &process_name,
+                                        config.call_end_stop_countdown_secs,
+                                    );
+                                }
+                            }
+                        } else if let Some(previous) = self.clear_active_call() {
                             log_call_detect_event(
                                 "info",
                                 "cleared",
@@ -265,6 +329,114 @@ impl CallDetector {
                             );
                         }
                     }
+                }
+            }
+        });
+    }
+
+    /// Emit `call:ended` to the frontend and spawn a thread that auto-stops
+    /// the recording when the countdown elapses, unless the user cancels.
+    /// Returns immediately; the thread owns its own wakeup cadence.
+    fn arm_call_end_countdown(
+        &self,
+        app: &tauri::AppHandle,
+        auto_stop: &CallEndAutoStopHandles,
+        recording: &Arc<AtomicBool>,
+        display_name: &str,
+        process_name: &str,
+        countdown_secs: u64,
+    ) {
+        // Bail if another countdown is already in flight. The UI should only
+        // ever see one active banner per call-end transition.
+        if auto_stop
+            .countdown_active
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+        auto_stop.countdown_cancel.store(false, Ordering::Relaxed);
+
+        let secs = countdown_secs.max(1);
+        eprintln!(
+            "[call-detect] call ended: {} ({}). Auto-stop armed for {}s",
+            display_name, process_name, secs
+        );
+        log_call_detect_event(
+            "info",
+            "call_ended",
+            Some(display_name),
+            Some(process_name),
+            serde_json::json!({
+                "countdown_secs": secs,
+                "reason": "call app no longer detected while recording",
+            }),
+        );
+
+        app.emit(
+            "call:ended",
+            CallEndedPayload {
+                app_name: display_name.to_string(),
+                process_name: process_name.to_string(),
+                countdown_secs: secs,
+            },
+        )
+        .ok();
+
+        let app_for_thread = app.clone();
+        let cancel = auto_stop.countdown_cancel.clone();
+        let active = auto_stop.countdown_active.clone();
+        let started_by = auto_stop.recording_started_by_call_detect.clone();
+        let stop_flag = auto_stop.stop_flag.clone();
+        let recording_flag = recording.clone();
+        let display_for_thread = display_name.to_string();
+
+        std::thread::spawn(move || {
+            // Poll every 250ms so cancellation and external stops are snappy
+            // without busy-spinning.
+            let tick = Duration::from_millis(250);
+            let total = Duration::from_secs(secs);
+            let start = Instant::now();
+            loop {
+                std::thread::sleep(tick);
+
+                if cancel.load(Ordering::Relaxed) {
+                    eprintln!(
+                        "[call-detect] auto-stop cancelled for {}",
+                        display_for_thread
+                    );
+                    active.store(false, Ordering::Relaxed);
+                    app_for_thread.emit("call:end-countdown:cancelled", ()).ok();
+                    return;
+                }
+
+                if !recording_flag.load(Ordering::Relaxed) {
+                    eprintln!("[call-detect] auto-stop aborted — recording already stopped");
+                    active.store(false, Ordering::Relaxed);
+                    app_for_thread.emit("call:end-countdown:cancelled", ()).ok();
+                    return;
+                }
+
+                if start.elapsed() >= total {
+                    // Timer elapsed: fire stop via the same mechanism as the
+                    // "Stop" button. `request_stop` would require AppState;
+                    // the stop_flag is what the recording loop observes.
+                    eprintln!(
+                        "[call-detect] auto-stop firing stop for {}",
+                        display_for_thread
+                    );
+                    log_call_detect_event(
+                        "info",
+                        "call_end_auto_stop_fired",
+                        Some(&display_for_thread),
+                        None,
+                        serde_json::json!({ "countdown_secs": secs }),
+                    );
+                    stop_flag.store(true, Ordering::Relaxed);
+                    started_by.store(false, Ordering::Relaxed);
+                    active.store(false, Ordering::Relaxed);
+                    app_for_thread.emit("call:end-countdown:fired", ()).ok();
+                    return;
                 }
             }
         });
@@ -358,21 +530,25 @@ impl CallDetector {
         DetectActiveCallResult::None
     }
 
-    fn note_active_call(&self, process_name: &str) -> DetectionTransition {
+    fn note_active_call(&self, process_name: &str, display_name: &str) -> DetectionTransition {
         let mut active = self.active_call.lock().unwrap();
         let now = Instant::now();
         match active.as_mut() {
             None => {
                 *active = Some(ActiveCallState {
                     process_name: process_name.to_string(),
+                    display_name: display_name.to_string(),
                     last_notified_at: now,
+                    call_end_fired: false,
                 });
                 DetectionTransition::NewSession
             }
             Some(state) if state.process_name != process_name => {
                 *state = ActiveCallState {
                     process_name: process_name.to_string(),
+                    display_name: display_name.to_string(),
                     last_notified_at: now,
+                    call_end_fired: false,
                 };
                 DetectionTransition::NewSession
             }
@@ -386,6 +562,33 @@ impl CallDetector {
                     DetectionTransition::Noop
                 }
             }
+        }
+    }
+
+    /// Snapshot of the currently-active call session if any. Returns owned
+    /// strings so callers don't have to hold the lock.
+    fn active_call_snapshot(&self) -> Option<(String, String, bool)> {
+        self.active_call.lock().unwrap().as_ref().map(|state| {
+            (
+                state.process_name.clone(),
+                state.display_name.clone(),
+                state.call_end_fired,
+            )
+        })
+    }
+
+    fn mark_call_end_fired(&self) {
+        if let Some(state) = self.active_call.lock().unwrap().as_mut() {
+            state.call_end_fired = true;
+        }
+    }
+
+    /// Drop the "countdown already fired this session" latch. Used when a
+    /// new call session becomes active during an ongoing recording so
+    /// subsequent call-ends can re-arm the auto-stop prompt.
+    fn reset_call_end_latch(&self) {
+        if let Some(state) = self.active_call.lock().unwrap().as_mut() {
+            state.call_end_fired = false;
         }
     }
 
@@ -739,30 +942,36 @@ fn find_mic_check_binary() -> Option<std::path::PathBuf> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn call_session_rearms_when_process_changes_or_ends() {
-        let detector = CallDetector::new(CallDetectionConfig {
+    fn test_call_detection_config(apps: Vec<String>) -> CallDetectionConfig {
+        CallDetectionConfig {
             enabled: true,
             poll_interval_secs: 1,
             cooldown_minutes: 5,
-            apps: vec!["zoom.us".into()],
-        });
+            apps,
+            stop_when_call_ends: false,
+            call_end_stop_countdown_secs: 30,
+        }
+    }
+
+    #[test]
+    fn call_session_rearms_when_process_changes_or_ends() {
+        let detector = CallDetector::new(test_call_detection_config(vec!["zoom.us".into()]));
 
         assert!(matches!(
-            detector.note_active_call("zoom.us"),
+            detector.note_active_call("zoom.us", "Zoom"),
             DetectionTransition::NewSession
         ));
         assert!(matches!(
-            detector.note_active_call("zoom.us"),
+            detector.note_active_call("zoom.us", "Zoom"),
             DetectionTransition::Noop
         ));
         detector.clear_active_call();
         assert!(matches!(
-            detector.note_active_call("zoom.us"),
+            detector.note_active_call("zoom.us", "Zoom"),
             DetectionTransition::NewSession
         ));
         assert!(matches!(
-            detector.note_active_call("face.time"),
+            detector.note_active_call("face.time", "FaceTime"),
             DetectionTransition::NewSession
         ));
     }
@@ -778,12 +987,10 @@ mod tests {
 
     #[test]
     fn google_meet_detection_is_opt_in_via_sentinel() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["zoom.us".into(), "google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec![
+            "zoom.us".into(),
+            "google-meet".into(),
+        ]));
 
         assert!(detector
             .current_config()
@@ -794,12 +1001,7 @@ mod tests {
 
     #[test]
     fn browser_probe_is_skipped_when_no_browser_processes_exist() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec!["google-meet".into()]));
         let running: Vec<String> = vec!["Finder".into(), "launchd".into()];
         assert!(matches!(
             detector.detect_google_meet_in_browsers(&running),
@@ -839,12 +1041,7 @@ mod tests {
 
     #[test]
     fn browser_probe_backoff_resets_after_expiry() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec!["google-meet".into()]));
 
         detector.defer_browser_probe_for("Google Chrome", "test");
         assert!(!detector.browser_probe_allowed_for("Google Chrome"));
@@ -863,12 +1060,7 @@ mod tests {
 
     #[test]
     fn browser_probe_global_interval_resets_after_expiry() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec!["google-meet".into()]));
 
         detector.schedule_next_browser_probe();
         assert!(!detector.browser_probe_due());
@@ -883,12 +1075,10 @@ mod tests {
 
     #[test]
     fn sticky_google_meet_detection_survives_between_browser_probes() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["Slack".into(), "google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec![
+            "Slack".into(),
+            "google-meet".into(),
+        ]));
 
         detector.remember_google_meet_detection();
         assert!(detector.google_meet_detection_is_sticky());
@@ -903,12 +1093,10 @@ mod tests {
 
     #[test]
     fn native_app_detection_wins_before_browser_meet_probe() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["zoom.us".into(), "google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec![
+            "zoom.us".into(),
+            "google-meet".into(),
+        ]));
 
         let running = ["zoom.us".into(), "Safari".into()];
         let mic_live = true;
@@ -943,12 +1131,7 @@ mod tests {
 
     #[test]
     fn arc_exact_match_does_not_fire_on_system_processes() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec!["google-meet".into()]));
         // These macOS system processes contain "arc" as a substring but must
         // not be treated as the Arc browser.
         let running: Vec<String> = vec![
@@ -964,12 +1147,7 @@ mod tests {
 
     #[test]
     fn arc_exact_match_fires_on_arc_process() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec!["google-meet".into()]));
         // Defer the probe so `detect_google_meet_in_browsers` skips the real
         // AppleScript call to Arc but still records `saw_browser`.
         detector.defer_browser_probe_for("Arc", "test");
@@ -985,12 +1163,10 @@ mod tests {
 
     #[test]
     fn sticky_google_meet_still_wins_when_no_native_app_is_active() {
-        let detector = CallDetector::new(CallDetectionConfig {
-            enabled: true,
-            poll_interval_secs: 1,
-            cooldown_minutes: 5,
-            apps: vec!["zoom.us".into(), "google-meet".into()],
-        });
+        let detector = CallDetector::new(test_call_detection_config(vec![
+            "zoom.us".into(),
+            "google-meet".into(),
+        ]));
 
         detector.remember_google_meet_detection();
         let running = ["Safari".into()];
@@ -1027,5 +1203,59 @@ mod tests {
         // Just verify the function returns without crashing.
         // Will return false unless something is using the mic right now.
         let _result = is_mic_in_use();
+    }
+
+    #[test]
+    fn call_end_fires_once_per_session() {
+        let detector = CallDetector::new(test_call_detection_config(vec!["zoom.us".into()]));
+
+        assert!(matches!(
+            detector.note_active_call("zoom.us", "Zoom"),
+            DetectionTransition::NewSession
+        ));
+
+        let snap = detector.active_call_snapshot().unwrap();
+        assert_eq!(snap.0, "zoom.us");
+        assert_eq!(snap.1, "Zoom");
+        assert!(!snap.2, "call_end_fired should start false");
+
+        detector.mark_call_end_fired();
+        let snap = detector.active_call_snapshot().unwrap();
+        assert!(snap.2, "call_end_fired must flip to true");
+
+        detector.clear_active_call();
+        assert!(
+            detector.active_call_snapshot().is_none(),
+            "clearing the call must reset the snapshot"
+        );
+
+        assert!(matches!(
+            detector.note_active_call("zoom.us", "Zoom"),
+            DetectionTransition::NewSession
+        ));
+        let snap = detector.active_call_snapshot().unwrap();
+        assert!(!snap.2);
+    }
+
+    #[test]
+    fn new_session_after_process_change_resets_call_end_fired() {
+        // Ending Zoom, auto-stopping, then joining a Teams call must let the
+        // Teams session auto-stop too. The "already fired" flag is per-session,
+        // not per-detector.
+        let detector = CallDetector::new(test_call_detection_config(vec![
+            "zoom.us".into(),
+            "Microsoft Teams".into(),
+        ]));
+
+        detector.note_active_call("zoom.us", "Zoom");
+        detector.mark_call_end_fired();
+
+        assert!(matches!(
+            detector.note_active_call("Microsoft Teams", "Teams"),
+            DetectionTransition::NewSession
+        ));
+        let snap = detector.active_call_snapshot().unwrap();
+        assert_eq!(snap.0, "Microsoft Teams");
+        assert!(!snap.2, "new session must reset call_end_fired");
     }
 }

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -66,6 +66,17 @@ pub struct AppState {
     /// second prompt fires before the first overlay's JS has consumed its
     /// payload — see `show_meeting_prompt` in main.rs.
     pub pending_meeting_prompts: Arc<Mutex<HashMap<u64, MeetingPromptData>>>,
+    /// `true` iff the currently-active recording was started by a user click
+    /// on the call detection banner. Scopes `stop_when_call_ends` so manual
+    /// `cmd_start_recording` sessions are never auto-stopped.
+    pub recording_started_by_call_detect: Arc<AtomicBool>,
+    /// Set by the frontend's "Keep recording" button during an auto-stop
+    /// countdown. Read by the countdown thread in `call_detect.rs` to bail
+    /// out before calling stop.
+    pub call_end_countdown_cancel: Arc<AtomicBool>,
+    /// `true` while a call-end auto-stop countdown is running. Keeps repeat
+    /// call-end transitions from spawning parallel countdown threads.
+    pub call_end_countdown_active: Arc<AtomicBool>,
 }
 
 type ParakeetStatusView = minutes_core::transcription_coordinator::ParakeetBackendStatus;
@@ -3198,6 +3209,43 @@ fn scan_recovery_items(config: &Config) -> Vec<RecoveryItem> {
     found.into_iter().map(|(_, item)| item).collect()
 }
 
+/// Handles that `start_recording` clears at the end of a session. Keeps the
+/// auto-stop state tied to a single recording: if the user started this
+/// recording via the call detection banner, these flags live until the
+/// recording ends; after that, a subsequent manual `minutes record` must not
+/// be treated as call-detection-started.
+#[derive(Clone)]
+pub struct CallDetectSessionHandles {
+    pub started_by_call_detect: Arc<AtomicBool>,
+    pub countdown_active: Arc<AtomicBool>,
+    pub countdown_cancel: Arc<AtomicBool>,
+}
+
+/// RAII guard that clears the call-detect session flags when dropped.
+/// Used to keep every exit path in `start_recording` / `start_native_call_recording`
+/// (including early returns on capture failure) from leaving stale state.
+pub struct CallDetectSessionGuard {
+    handles: CallDetectSessionHandles,
+}
+
+impl CallDetectSessionGuard {
+    pub fn new(handles: CallDetectSessionHandles) -> Self {
+        Self { handles }
+    }
+}
+
+impl Drop for CallDetectSessionGuard {
+    fn drop(&mut self) {
+        self.handles
+            .started_by_call_detect
+            .store(false, Ordering::Relaxed);
+        self.handles
+            .countdown_active
+            .store(false, Ordering::Relaxed);
+        self.handles.countdown_cancel.store(true, Ordering::Relaxed);
+    }
+}
+
 /// Start recording in a background thread.
 #[allow(clippy::too_many_arguments)]
 pub fn start_recording(
@@ -3213,12 +3261,16 @@ pub fn start_recording(
     completion_notifications_enabled: Arc<AtomicBool>,
     hotkey_runtime: Option<Arc<Mutex<HotkeyRuntime>>>,
     discard_short_hotkey_capture: Option<Arc<AtomicBool>>,
+    call_detect_session: CallDetectSessionHandles,
     mode: CaptureMode,
     requested_intent: Option<RecordingIntent>,
     allow_degraded: bool,
     requested_title: Option<String>,
     language_override: Option<String>,
 ) {
+    // Drop on any exit path (early returns, panic, normal exit) clears the
+    // session flags so a subsequent manual recording isn't auto-stopped.
+    let _session_guard = CallDetectSessionGuard::new(call_detect_session);
     let mut config = Config::load();
     if let Some(language) = language_override {
         config.transcription.language = Some(language);
@@ -3517,6 +3569,11 @@ pub fn launch_recording(
     let activation_progress = state.activation_progress.clone();
     let call_capture_health = state.call_capture_health.clone();
     let completion_notifications_enabled = state.completion_notifications_enabled.clone();
+    let call_detect_session = CallDetectSessionHandles {
+        started_by_call_detect: state.recording_started_by_call_detect.clone(),
+        countdown_active: state.call_end_countdown_active.clone(),
+        countdown_cancel: state.call_end_countdown_cancel.clone(),
+    };
     let app_done = app.clone();
     mark_activation_first_recording_started(&activation_progress);
 
@@ -3534,6 +3591,7 @@ pub fn launch_recording(
             completion_notifications_enabled,
             hotkey_runtime,
             discard_short_hotkey_capture,
+            call_detect_session,
             mode,
             requested_intent,
             allow_degraded,
@@ -3831,6 +3889,7 @@ pub fn handle_dictation_shortcut_event(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_start_recording(
     app: tauri::AppHandle,
     state: tauri::State<AppState>,
@@ -3839,9 +3898,22 @@ pub fn cmd_start_recording(
     allow_degraded: Option<bool>,
     title: Option<String>,
     language: Option<String>,
+    source: Option<String>,
 ) -> Result<(), String> {
     let capture_mode = parse_capture_mode(mode.as_deref())?;
     let requested_intent = parse_recording_intent(intent.as_deref())?;
+
+    // Session-level flag that scopes the stop_when_call_ends auto-stop only
+    // to recordings started via the call detection banner. Manual starts
+    // never get auto-stopped, even when the config flag is on.
+    let from_call_detect = source.as_deref() == Some("call_detect");
+    state
+        .recording_started_by_call_detect
+        .store(from_call_detect, Ordering::Relaxed);
+    // Starting a fresh recording always cancels any in-flight countdown so
+    // the UI doesn't auto-stop a session the user has already moved past.
+    cancel_call_end_countdown(&state);
+
     launch_recording(
         app,
         &state,
@@ -3853,6 +3925,30 @@ pub fn cmd_start_recording(
         None,
         None,
     )
+}
+
+/// Clear countdown state — both the active flag and (as a no-op safety net)
+/// the cancel flag. Used when a new recording starts, when the countdown
+/// elapses, and when the user cancels via "Keep recording".
+pub fn cancel_call_end_countdown(state: &AppState) {
+    state
+        .call_end_countdown_cancel
+        .store(true, Ordering::Relaxed);
+    state
+        .call_end_countdown_active
+        .store(false, Ordering::Relaxed);
+}
+
+#[tauri::command]
+pub fn cmd_cancel_call_end_countdown(
+    app: tauri::AppHandle,
+    state: tauri::State<AppState>,
+) -> Result<(), String> {
+    cancel_call_end_countdown(&state);
+    // Tell the UI to hide the banner immediately; the countdown thread will
+    // observe the cancel flag on its next tick and exit without stopping.
+    app.emit("call:end-countdown:cancelled", ()).ok();
+    Ok(())
 }
 
 #[tauri::command]

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -816,6 +816,13 @@ fn main() {
     let recording_for_detector = recording.clone();
     let processing_clone = processing.clone();
     let stop_clone = stop_flag.clone();
+    let recording_started_by_call_detect = Arc::new(AtomicBool::new(false));
+    let call_end_countdown_cancel = Arc::new(AtomicBool::new(false));
+    let call_end_countdown_active = Arc::new(AtomicBool::new(false));
+    let started_by_call_detect_for_detector = recording_started_by_call_detect.clone();
+    let countdown_cancel_for_detector = call_end_countdown_cancel.clone();
+    let countdown_active_for_detector = call_end_countdown_active.clone();
+    let stop_for_detector = stop_flag.clone();
 
     tauri::Builder::default()
         .menu(build_app_menu)
@@ -1058,6 +1065,9 @@ fn main() {
             palette_lifecycle: palette_lifecycle.clone(),
             palette_reopen_pending: palette_reopen_pending.clone(),
             pending_meeting_prompts: Arc::new(Mutex::new(HashMap::new())),
+            recording_started_by_call_detect: recording_started_by_call_detect.clone(),
+            call_end_countdown_cancel: call_end_countdown_cancel.clone(),
+            call_end_countdown_active: call_end_countdown_active.clone(),
         })
         .manage(Arc::new(Mutex::new(
             shortcut_manager::ShortcutManager::new(),
@@ -1611,6 +1621,12 @@ fn main() {
                     app.handle().clone(),
                     recording_for_detector,
                     processing_clone,
+                    call_detect::CallEndAutoStopHandles {
+                        recording_started_by_call_detect: started_by_call_detect_for_detector,
+                        countdown_cancel: countdown_cancel_for_detector,
+                        countdown_active: countdown_active_for_detector,
+                        stop_flag: stop_for_detector,
+                    },
                 );
             }
 
@@ -1719,6 +1735,7 @@ fn main() {
             commands::cmd_add_note,
             commands::cmd_start_recording,
             commands::cmd_stop_recording,
+            commands::cmd_cancel_call_end_countdown,
             commands::cmd_extend_recording,
             commands::cmd_open_file,
             commands::cmd_read_text_file,

--- a/tauri/src-tauri/src/palette_dispatch.rs
+++ b/tauri/src-tauri/src/palette_dispatch.rs
@@ -346,7 +346,7 @@ fn dispatch_action(
             }
             // Palette launches with pipeline defaults — users who need flags
             // reach for the CLI or the existing tray menu.
-            cmd_start_recording(app, state, None, None, None, None, None)?;
+            cmd_start_recording(app, state, None, None, None, None, None, None)?;
             Ok(ActionResponse::Ok)
         }
         ActionId::StopRecording => {

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -3216,6 +3216,56 @@
       margin-top: 8px;
     }
 
+    /* ── Call ended countdown banner ── */
+    .call-ended {
+      display: none;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 12px 16px;
+      background: var(--red-bg);
+      border-bottom: 1px solid var(--red-border-strong);
+    }
+
+    .call-ended.active {
+      display: flex;
+    }
+
+    .call-ended-icon {
+      font-size: 16px;
+      flex-shrink: 0;
+    }
+
+    .call-ended-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .call-ended-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .call-ended-subtitle {
+      font-size: 11px;
+      color: var(--red);
+      font-weight: 600;
+      margin-top: 2px;
+    }
+
+    .call-ended-detail {
+      font-size: 11px;
+      color: var(--text-secondary);
+      margin-top: 6px;
+      line-height: 1.35;
+    }
+
+    .call-ended-actions {
+      display: flex;
+      gap: 6px;
+      align-items: flex-start;
+    }
+
     /* ── Update available banner ── */
     .update-banner {
       display: none;
@@ -3792,6 +3842,20 @@
       <div class="call-detected-actions">
         <button class="btn btn-primary btn-sm" id="btn-record-call">Record</button>
         <button class="btn btn-secondary btn-sm" id="btn-dismiss-call">Dismiss</button>
+      </div>
+    </div>
+
+    <!-- Call ended countdown banner -->
+    <div class="call-ended" id="call-ended-banner" role="alert" aria-live="polite">
+      <div class="call-ended-icon">⏲</div>
+      <div class="call-ended-info">
+        <div class="call-ended-title" id="call-ended-title">Call ended</div>
+        <div class="call-ended-subtitle" id="call-ended-subtitle">Stopping in 30s</div>
+        <div class="call-ended-detail" id="call-ended-detail">Keep recording if you're wrapping up notes or takeaways. Otherwise Minutes will stop and process this session.</div>
+      </div>
+      <div class="call-ended-actions">
+        <button class="btn btn-primary btn-sm" id="btn-call-end-stop">Stop now</button>
+        <button class="btn btn-secondary btn-sm" id="btn-call-end-keep">Keep recording</button>
       </div>
     </div>
 
@@ -8583,7 +8647,10 @@
 
     document.getElementById('btn-record-call').addEventListener('click', async () => {
       try {
-        await invoke('cmd_start_recording', { intent: 'call' });
+        // Mark the session as call-detection-initiated so stop_when_call_ends
+        // knows this recording is eligible for the auto-stop prompt when the
+        // call app exits. Manual `minutes record` / hotkey starts never set this.
+        await invoke('cmd_start_recording', { intent: 'call', source: 'call_detect' });
       } catch (e) {
         console.error('Call recording:', e);
       }
@@ -8592,6 +8659,90 @@
     document.getElementById('btn-dismiss-call').addEventListener('click', () => {
       if (activeCallSession) activeCallSession.dismissed = true;
       callBanner.classList.remove('active');
+    });
+
+    // ── Call-end auto-stop countdown ──
+    // Backend emits `call:ended` with { app_name, countdown_secs } when the
+    // call app that started this recording exits. Frontend ticks a local
+    // countdown (cosmetic); the backend thread is the authoritative timer.
+    const callEndedBanner = document.getElementById('call-ended-banner');
+    const callEndedTitle = document.getElementById('call-ended-title');
+    const callEndedSubtitle = document.getElementById('call-ended-subtitle');
+    const callEndedDetail = document.getElementById('call-ended-detail');
+    let callEndCountdownInterval = null;
+    let callEndCountdownDeadline = null;
+
+    function clearCallEndCountdown() {
+      if (callEndCountdownInterval) {
+        clearInterval(callEndCountdownInterval);
+        callEndCountdownInterval = null;
+      }
+      callEndCountdownDeadline = null;
+      callEndedBanner.classList.remove('active');
+    }
+
+    function tickCallEndCountdown() {
+      if (!callEndCountdownDeadline) return;
+      const remaining = Math.max(
+        0,
+        Math.round((callEndCountdownDeadline - Date.now()) / 1000)
+      );
+      callEndedSubtitle.textContent =
+        remaining > 0 ? `Stopping in ${remaining}s` : 'Stopping now...';
+      if (remaining <= 0) {
+        // Backend is about to fire stop; hide buttons visually.
+        clearInterval(callEndCountdownInterval);
+        callEndCountdownInterval = null;
+      }
+    }
+
+    currentWindow.listen('call:ended', (event) => {
+      const { app_name, countdown_secs } = event.payload || {};
+      const secs = Number.isFinite(countdown_secs) && countdown_secs > 0
+        ? countdown_secs
+        : 30;
+      callEndedTitle.textContent = `${app_name || 'Call'} ended`;
+      callEndedDetail.textContent =
+        'Keep recording if you\'re wrapping up notes or takeaways. Otherwise Minutes will stop and process this session.';
+      callEndCountdownDeadline = Date.now() + secs * 1000;
+      if (callEndCountdownInterval) clearInterval(callEndCountdownInterval);
+      callEndCountdownInterval = setInterval(tickCallEndCountdown, 250);
+      tickCallEndCountdown();
+      // Hide the "call detected" banner — we're past that now.
+      callBanner.classList.remove('active');
+      callEndedBanner.classList.add('active');
+    });
+
+    currentWindow.listen('call:end-countdown:cancelled', () => {
+      clearCallEndCountdown();
+    });
+
+    currentWindow.listen('call:end-countdown:fired', () => {
+      clearCallEndCountdown();
+    });
+
+    document.getElementById('btn-call-end-keep').addEventListener('click', async () => {
+      clearCallEndCountdown();
+      try {
+        await invoke('cmd_cancel_call_end_countdown');
+      } catch (e) {
+        console.error('cancel countdown:', e);
+      }
+    });
+
+    document.getElementById('btn-call-end-stop').addEventListener('click', async () => {
+      clearCallEndCountdown();
+      try {
+        // Cancel the backend timer first so Stop now doesn't double-fire.
+        await invoke('cmd_cancel_call_end_countdown');
+      } catch (e) {
+        console.error('cancel countdown before stop:', e);
+      }
+      try {
+        await invoke('cmd_stop_recording');
+      } catch (e) {
+        console.error('stop now:', e);
+      }
     });
 
     currentWindow.listen('dictation-hotkey:status', (event) => {


### PR DESCRIPTION
## Summary

Closes #129.

When a recording started via the call-detection banner is still running after the call app exits, Minutes shows a countdown prompt with **Stop now** / **Keep recording**. If the user does nothing, Minutes stops the recording and kicks off processing.

Behavior mirrors the design from the issue thread:

- **Opt-in.** Off by default, named for the behavior (assistive prompt, not silent hard stop).
- **Scoped.** Only fires for sessions the detector itself launched — a manual \`minutes record\`, hotkey-started capture, or live-transcript session is never auto-stopped, even with the flag on.
- **Cancellable.** Visible countdown; Stop now ends immediately, Keep recording dismisses the prompt. Starting a fresh recording also cancels a pending countdown.
- **Re-armable.** If the user clicks Keep recording and the call app disappears again later (e.g. Zoom meeting 1 ends -> Keep -> meeting 2 starts -> meeting 2 ends), the countdown fires again for meeting 2.

Config (default off):

\`\`\`toml
[call_detection]
enabled = true
stop_when_call_ends = true            # default false
call_end_stop_countdown_secs = 30     # default 30
\`\`\`

## Mechanics

- \`cmd_start_recording\` takes \`source=\"call_detect\"\` to tag the session. The frontend banner passes it; palette / hotkey / CLI starts don't.
- The detection loop now keeps polling during a call-detect-started recording (it previously skipped while recording) but only to observe the call-ending transition.
- \"Active call -> not detected\" emits \`call:ended\` and spawns a cancellable timer thread. Thread ticks every 250ms so cancel and external stops are snappy without busy-spinning. On elapse it flips \`stop_flag\`, which the existing capture loop already observes.
- \`CallDetectSessionGuard\` is an RAII drop guard that clears the provenance + countdown flags at any exit of \`start_recording\` so state can't leak into a subsequent session (including panic / early-return paths).

## UI

New red-tinted banner in the main window with the two buttons. The frontend ticks the visible countdown; the backend thread is authoritative. Follows DESIGN.md — reuses \`--red-bg\`, \`--red-border-strong\`, and existing button styles, no new colors, no gradients.

## Tests

- \`minutes-core\`: config round-trip for both new fields (default off, explicit on, omitted field).
- \`minutes-app\`: session latch fires once per session and resets on a new call. Existing call_detect tests updated for the extended \`note_active_call\` signature.

## Scope

- macOS-only (call detection itself is macOS-only). No-op on other platforms — the flag is still parseable, and a cross-platform detection loop can reuse the same state when it lands.
- No CLI surface: \`minutes record\` sessions are deliberately out of scope.
- Detection logic (how calls are detected) unchanged.

## Test plan

- [ ] \`cargo fmt --all -- --check\` (clean)
- [ ] \`cargo clippy --all --no-default-features -- -D warnings\` (clean)
- [ ] \`cargo test -p minutes-core --no-default-features --lib\` (444/444 locally)
- [ ] \`cargo test -p minutes-app\` (102 pass; the pre-existing \`parakeet_status_reports_ready_with_metadata\` failure is environmental, reproduces on main)
- [ ] Dev app built via \`./scripts/install-dev-app.sh\` (signed, installed to \`~/Applications/Minutes Dev.app\`, hotkey probe OK)
- [ ] Manual QA on \`~/Applications/Minutes Dev.app\`:
  - [ ] Set \`stop_when_call_ends = true\` in config.
  - [ ] Start Zoom, click Record on the detection banner.
  - [ ] Quit Zoom -> countdown banner appears.
  - [ ] Keep recording -> banner dismisses, recording continues.
  - [ ] Quit Zoom again or start a new meeting -> countdown re-fires as expected.
  - [ ] Stop now -> recording stops and processes.
  - [ ] Flag off (\`stop_when_call_ends = false\`) -> original behavior (no countdown).
  - [ ] Manual \`cmd_start_recording\` (no \`source\`) while config is on -> no countdown when call app exits.