### PR TITLE
feat(settings): expose stop_when_call_ends in the desktop UI

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -5732,6 +5732,8 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "cooldown_minutes": config.call_detection.cooldown_minutes,
             "apps": config.call_detection.apps,
             "google_meet_enabled": call_detection_has_sentinel(&config, "google-meet"),
+            "stop_when_call_ends": config.call_detection.stop_when_call_ends,
+            "call_end_stop_countdown_secs": config.call_detection.call_end_stop_countdown_secs,
         },
         "dictation": {
             "model": config.dictation.model,
@@ -5872,6 +5874,21 @@ pub fn cmd_set_setting(section: String, key: String, value: String) -> Result<St
         }
         ("call_detection", "google_meet_enabled") => {
             set_call_detection_sentinel(&mut config, "google-meet", value == "true");
+        }
+        ("call_detection", "stop_when_call_ends") => {
+            config.call_detection.stop_when_call_ends = value == "true";
+        }
+        ("call_detection", "call_end_stop_countdown_secs") => {
+            let parsed: u64 = value
+                .parse()
+                .map_err(|_| "call_end_stop_countdown_secs must be a number")?;
+            // 1s minimum: the detector clamps with max(1) anyway, but reject 0
+            // at the settings boundary so a misclick in the UI doesn't persist
+            // a nonsensical "0s" countdown.
+            if parsed == 0 {
+                return Err("call_end_stop_countdown_secs must be at least 1".into());
+            }
+            config.call_detection.call_end_stop_countdown_secs = parsed;
         }
 
         // Dictation

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -4503,6 +4503,21 @@
           </div>
           <button class="btn btn-secondary btn-sm toggle-btn" id="settings-call-detection-google-meet">Off</button>
         </div>
+        <div class="about-controls">
+          <div class="about-controls-group">
+            <div class="about-controls-copy">Stop when call ends</div>
+            <div class="about-controls-meta">When the detected call app exits mid-recording, show a countdown prompt
+              with Stop now and Keep recording. Only applies to recordings started from the call-detection banner.</div>
+          </div>
+          <button class="btn btn-secondary btn-sm toggle-btn" id="settings-call-detection-stop-when-call-ends">Off</button>
+        </div>
+        <div class="about-controls">
+          <div class="about-controls-group">
+            <div class="about-controls-copy">Auto-stop countdown</div>
+            <div class="about-controls-meta">Seconds to wait before stopping when the call ends.</div>
+            <input type="number" id="settings-call-detection-countdown-secs" min="1" class="settings-field">
+          </div>
+        </div>
       </div>
 
       <!-- Privacy -->
@@ -7130,6 +7145,8 @@
           document.getElementById('settings-call-detection-polling-interval').value = String(s.call_detection.poll_interval_secs ?? 1);
           document.getElementById('settings-call-detection-cooldown').value = String(s.call_detection.cooldown_minutes ?? 5);
           setSettingsToggle('settings-call-detection-google-meet', Boolean(s.call_detection.google_meet_enabled));
+          setSettingsToggle('settings-call-detection-stop-when-call-ends', Boolean(s.call_detection.stop_when_call_ends));
+          document.getElementById('settings-call-detection-countdown-secs').value = String(s.call_detection.call_end_stop_countdown_secs ?? 30);
         }
         // Dictation settings
         if (s.dictation) {
@@ -7442,6 +7459,23 @@
       const next = !Boolean(s.call_detection.google_meet_enabled);
       await invoke('cmd_set_setting', { section: 'call_detection', key: 'google_meet_enabled', value: String(next) });
       setSettingsToggle('settings-call-detection-google-meet', next);
+    });
+    document.getElementById('settings-call-detection-stop-when-call-ends').addEventListener('click', async () => {
+      const s = await invoke('cmd_get_settings');
+      const next = !Boolean(s.call_detection.stop_when_call_ends);
+      await invoke('cmd_set_setting', { section: 'call_detection', key: 'stop_when_call_ends', value: String(next) });
+      setSettingsToggle('settings-call-detection-stop-when-call-ends', next);
+    });
+    document.getElementById('settings-call-detection-countdown-secs').addEventListener('change', async (e) => {
+      try {
+        await invoke('cmd_set_setting', { section: 'call_detection', key: 'call_end_stop_countdown_secs', value: e.target.value });
+      } catch (err) {
+        // Reject of 0/invalid — snap back to the persisted value rather than
+        // leaving the user staring at a rejected input.
+        console.error('countdown secs:', err);
+        const s = await invoke('cmd_get_settings');
+        e.target.value = String(s.call_detection.call_end_stop_countdown_secs ?? 30);
+      }
     });
 
     // Dictation settings handlers — guarded for removed HTML elements


### PR DESCRIPTION
## Summary

Follow-up to #131. That PR added the backend plumbing for \`stop_when_call_ends\` but left the toggle config.toml-only, so opting in required hand-editing the TOML. This adds the setting to the Settings -> Call Detection card.

## Changes

- \`cmd_get_settings\` returns \`stop_when_call_ends\` and \`call_end_stop_countdown_secs\` alongside the existing call-detection keys.
- \`cmd_set_setting\` handles both. Countdown rejects \`0\` so a misclick can't persist an instant-stop setting (detector clamps with \`max(1)\` anyway, but failing loudly at the boundary beats silently normalizing).
- Settings card gets a new toggle (\"Stop when call ends\") and number input (\"Auto-stop countdown\") under the Google Meet row. Invalid countdown values snap back to the persisted value.

## Test plan

- [ ] \`cargo fmt --all -- --check\` (clean)
- [ ] \`cargo clippy --all --no-default-features -- -D warnings\` (clean)
- [ ] \`cargo test -p minutes-app\` (102 pass; pre-existing parakeet env failure)
- [ ] Dev app rebuilt via \`./scripts/install-dev-app.sh\`
- [ ] Manual QA:
  - [ ] Open Settings in \`~/Applications/Minutes Dev.app\`.
  - [ ] Toggle Stop when call ends on; confirm \`stop_when_call_ends = true\` appears in \`~/.config/minutes/config.toml\`.
  - [ ] Change countdown to 45; confirm TOML updates.
  - [ ] Enter 0; confirm backend rejects and UI snaps back to the prior value.
  - [ ] Restart the app; settings round-trip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)