### PR TITLE
feat(settings): identity card (name, emails, name variants)

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1984,6 +1984,18 @@ fn parse_optional_string_setting(value: &str) -> Option<String> {
     }
 }
 
+/// Parse a comma-separated setting string (e.g. `"foo, bar, baz"`) into a
+/// `Vec<String>`. Trims whitespace around each entry, drops empties, preserves
+/// input order. Case-sensitive — callers that need case-insensitive dedup
+/// should use `IdentityConfig::all_user_aliases` downstream.
+fn parse_comma_separated_setting(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 fn call_detection_has_sentinel(config: &Config, sentinel: &str) -> bool {
     config.call_detection.apps.iter().any(|app| app == sentinel)
 }
@@ -5754,6 +5766,12 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "shortcut_enabled": config.palette.shortcut_enabled,
             "shortcut": config.palette.shortcut,
         },
+        "identity": {
+            "name": config.identity.name,
+            "email": config.identity.email,
+            "emails": config.identity.emails,
+            "aliases": config.identity.aliases,
+        },
     })
 }
 
@@ -5962,6 +5980,20 @@ pub fn cmd_set_setting(section: String, key: String, value: String) -> Result<St
         }
         ("palette", "shortcut") => config.palette.shortcut = value.clone(),
 
+        // Identity — name + email list + alias list. Used by the attribution
+        // pipeline to fold calendar attendees arriving under different emails
+        // or name spellings onto the canonical user entity. See
+        // `IdentityConfig::all_user_aliases` at config.rs for the merge path.
+        ("identity", "name") => {
+            config.identity.name = parse_optional_string_setting(&value);
+        }
+        ("identity", "emails") => {
+            config.identity.emails = parse_comma_separated_setting(&value);
+        }
+        ("identity", "aliases") => {
+            config.identity.aliases = parse_comma_separated_setting(&value);
+        }
+
         _ => return Err(format!("Unknown setting: {}.{}", section, key)),
     }
 
@@ -6127,6 +6159,25 @@ mod tests {
         assert_eq!(
             parse_optional_string_setting(" es "),
             Some("es".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_comma_separated_setting_splits_trims_and_drops_empties() {
+        assert_eq!(parse_comma_separated_setting(""), Vec::<String>::new());
+        assert_eq!(parse_comma_separated_setting("   "), Vec::<String>::new());
+        assert_eq!(parse_comma_separated_setting(","), Vec::<String>::new());
+        assert_eq!(
+            parse_comma_separated_setting("a@x.com"),
+            vec!["a@x.com".to_string()]
+        );
+        assert_eq!(
+            parse_comma_separated_setting("a@x.com, b@y.com"),
+            vec!["a@x.com".to_string(), "b@y.com".to_string()]
+        );
+        assert_eq!(
+            parse_comma_separated_setting("  a , ,   b  "),
+            vec!["a".to_string(), "b".to_string()]
         );
     }
 

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -4188,6 +4188,32 @@
         <button class="btn btn-secondary btn-sm" id="btn-settings-close">Close</button>
       </div>
 
+      <!-- Identity -->
+      <div class="settings-section">
+        <div class="about-item-title">IDENTITY</div>
+        <div class="about-controls">
+          <div class="about-controls-group">
+            <div class="about-controls-copy">Your name</div>
+            <div class="about-controls-meta">Used to attribute meeting content to you ("Mat said…"). Leave blank if you'd rather stay anonymous.</div>
+            <input type="text" id="settings-identity-name" class="settings-field" placeholder="e.g. Mat Silverstein" spellcheck="false">
+          </div>
+        </div>
+        <div class="about-controls">
+          <div class="about-controls-group">
+            <div class="about-controls-copy">Your email addresses</div>
+            <div class="about-controls-meta">Comma-separated. Every address you send from, so calendar attendees arriving under different emails fold onto the same person.</div>
+            <input type="text" id="settings-identity-emails" class="settings-field" placeholder="you@work.com, you@personal.com" spellcheck="false">
+          </div>
+        </div>
+        <div class="about-controls">
+          <div class="about-controls-group">
+            <div class="about-controls-copy">Name variants</div>
+            <div class="about-controls-meta">Comma-separated. Alternate forms — nicknames, formal spellings — so everything folds onto your canonical name.</div>
+            <input type="text" id="settings-identity-aliases" class="settings-field" placeholder="e.g. Mathieu, Matt, Matthew" spellcheck="false">
+          </div>
+        </div>
+      </div>
+
       <!-- General -->
       <div class="settings-section">
         <div class="about-item-title">GENERAL</div>
@@ -7068,6 +7094,15 @@
       try {
         const s = await invoke('cmd_get_settings');
         document.getElementById('settings-config-path').textContent = s.config_path;
+        // Identity — populate name, emails, and aliases. The legacy
+        // `identity.email` field (single) is merged into the emails list
+        // via IdentityConfig::all_user_aliases downstream, so we only edit
+        // the plural lists here and leave the legacy field in TOML alone.
+        if (s.identity) {
+          document.getElementById('settings-identity-name').value = s.identity.name || '';
+          document.getElementById('settings-identity-emails').value = (s.identity.emails || []).join(', ');
+          document.getElementById('settings-identity-aliases').value = (s.identity.aliases || []).join(', ');
+        }
         // General: sync with existing app state
         setSettingsToggle('settings-notifications', notifyOnCompletion);
         setSettingsToggle('settings-cues', playCaptureCues);
@@ -7328,6 +7363,25 @@
           'Meetings: ' + f(st.meetings.bytes) + ' (' + st.meetings.count + ' files)  •  Memos: ' + f(st.memos.bytes) + ' (' + st.memos.count + ')  •  Models: ' + f(st.models.bytes) + '  •  Screenshots: ' + f(st.screens.bytes) + '  •  Total: ' + f(st.total_bytes);
       } catch (e) { document.getElementById('settings-storage-info').textContent = 'Could not load.'; }
     }
+    // Identity handlers — save each field on blur (`change` event fires on blur
+    // for text inputs). Empty-string submits clear the field (Rust maps "" → None
+    // for name; empty Vec for emails/aliases).
+    document.getElementById('settings-identity-name').addEventListener('change', async (e) => {
+      try {
+        await invoke('cmd_set_setting', { section: 'identity', key: 'name', value: e.target.value });
+      } catch (err) { console.error('identity name save:', err); }
+    });
+    document.getElementById('settings-identity-emails').addEventListener('change', async (e) => {
+      try {
+        await invoke('cmd_set_setting', { section: 'identity', key: 'emails', value: e.target.value });
+      } catch (err) { console.error('identity emails save:', err); }
+    });
+    document.getElementById('settings-identity-aliases').addEventListener('change', async (e) => {
+      try {
+        await invoke('cmd_set_setting', { section: 'identity', key: 'aliases', value: e.target.value });
+      } catch (err) { console.error('identity aliases save:', err); }
+    });
+
     // Settings General handlers — delegate to existing app logic
     document.getElementById('settings-notifications').addEventListener('click', async () => {
       const next = !notifyOnCompletion;


### PR DESCRIPTION
## Summary

Highest Tier 2 item from the 2026-04-16 settings audit. Every meeting's attribution quality depends on Minutes knowing who the user is and which emails / name spellings fold onto their canonical person entity. Before this, users had to hand-edit `config.toml`.

Three inputs in a new `IDENTITY` section at the top of Settings, above `GENERAL`:

- **Your name** → `identity.name` (`Option<String>`)
- **Your email addresses** → `identity.emails` (`Vec<String>`, comma-separated)
- **Name variants** → `identity.aliases` (`Vec<String>`, comma-separated)

Legacy `identity.email` (single `Option<String>`) stays untouched in TOML for backwards compatibility. `IdentityConfig::all_user_aliases` at `config.rs:285` folds all three sources (`email` + `emails` + `aliases`) into a deduped lowercase set — partial data from any entry point still works.

## Changes

**Rust** (`tauri/src-tauri/src/commands.rs`):
- `cmd_set_setting` gains three arms for `identity.name`, `.emails`, `.aliases`.
- New `parse_comma_separated_setting` helper — trims whitespace, drops empties, preserves input order. Case-sensitive (downstream `all_user_aliases` handles case-insensitive dedup).
- `cmd_get_settings` returns an `identity` block with all four fields so the UI can render initial state and downstream consumers have full visibility.
- New unit test `parse_comma_separated_setting_splits_trims_and_drops_empties`.

**HTML + JS** (`tauri/src/index.html`):
- New `IDENTITY` settings section above `GENERAL`.
- Helper text under each label explains the attribution mechanism in plain English (no jargon, no "AI").
- `loadSettings` populates each input from `s.identity` (emails + aliases joined with `", "`).
- `change` listeners save on blur via `cmd_set_setting`.

Also includes the stray rustfmt diff from PR #125 (in `crates/core/src/summarize.rs` + `config.rs`) so CI goes green. This is the same fix as PR #135's fmt commit — it will no-op on rebase if #135 merges first.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p minutes-app --no-default-features -- -D warnings`
- [x] `cargo test -p minutes-app commands::tests::parse_comma_separated_setting_splits_trims_and_drops_empties` passes
- [x] Dev app rebuilt via `install-dev-app.sh`. Settings panel opens directly to IDENTITY section at top:
  - "Your name" populated from existing `config.identity.name`
  - "Your email addresses" empty → placeholder `you@work.com, you@personal.com`
  - "Name variants" empty → placeholder `e.g. Mathieu, Matt, Matthew`
  - Helper text renders under each label with no layout issues
- [ ] Persistence test (type a value, blur, reopen settings, confirm it persisted in `config.toml`) — manual, next session

## Context

Tier 2 from the 2026-04-16 settings audit. The audit memo notes:

> `identity.name` / `.emails` / `.aliases` are **user-facing** and directly affect attribution quality — the only Tier 2 item that compounds across every meeting, every week, forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)