### PR TITLE
feat(autoresearch): add decode-hint comparison tooling

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -80,8 +80,8 @@ integrations/
 # Launchd plist (dev convenience, not needed in extension)
 *.plist
 
-# Schema (informational, not needed at runtime)
-schema/
+# Repo-root schema docs (not runtime package schema directories)
+/schema/
 
 # Git and misc
 .git/

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use chrono::{Local, TimeZone};
 use clap::{Parser, Subcommand};
 use minutes_core::autoresearch::{
-    self, DecodeHintEvalArtifactPaths, DecodeHintEvalOptions, DecodeHintEvalRequest,
+    self, DecodeHintEvalArtifactPaths, DecodeHintEvalComparisonArtifactPaths,
+    DecodeHintEvalComparisonRequest, DecodeHintEvalOptions, DecodeHintEvalRequest,
 };
 use minutes_core::capture::RecordingIntent;
 use minutes_core::config::VALID_PARAKEET_MODELS;
@@ -793,7 +794,8 @@ enum VaultAction {
 #[derive(Subcommand)]
 enum AutoresearchAction {
     /// Compare decode-hint baseline vs candidate runs against a local corpus.
-    DecodeHints {
+    #[command(name = "decode-hints")]
+    Run {
         /// Path to the local corpus manifest JSON
         #[arg(long)]
         corpus: PathBuf,
@@ -807,6 +809,38 @@ enum AutoresearchAction {
         engine: Option<String>,
 
         /// Print the full JSON report envelope to stdout
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Compare two prior decode-hint eval reports or run directories.
+    #[command(name = "compare-decode-hints")]
+    Compare {
+        /// Left/base report path or run directory
+        #[arg(long)]
+        left: PathBuf,
+
+        /// Right/candidate report path or run directory
+        #[arg(long)]
+        right: PathBuf,
+
+        /// Output root for local comparison artifacts (defaults to ~/.minutes/research/decode-hints-comparisons)
+        #[arg(long)]
+        out: Option<PathBuf>,
+
+        /// Print the full JSON comparison envelope to stdout
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List recent decode-hint eval and comparison runs.
+    #[command(name = "list-decode-hints")]
+    List {
+        /// Maximum number of recent runs to show
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+
+        /// Print the full JSON listing to stdout
         #[arg(long)]
         json: bool,
     },
@@ -950,12 +984,21 @@ fn main() -> Result<()> {
         Commands::Jobs { all, json, limit } => cmd_jobs(all, json, limit),
         Commands::Paths { json } => cmd_paths(json, &config),
         Commands::Autoresearch { action } => match action {
-            AutoresearchAction::DecodeHints {
+            AutoresearchAction::Run {
                 corpus,
                 out,
                 engine,
                 json,
             } => cmd_autoresearch_decode_hints(&corpus, out.as_deref(), engine.as_deref(), json),
+            AutoresearchAction::Compare {
+                left,
+                right,
+                out,
+                json,
+            } => cmd_autoresearch_compare_decode_hints(&left, &right, out.as_deref(), json),
+            AutoresearchAction::List { limit, json } => {
+                cmd_autoresearch_list_decode_hints(limit, json)
+            }
         },
         Commands::Search {
             query,
@@ -3095,6 +3138,87 @@ fn cmd_autoresearch_decode_hints(
             "decode hint eval failed; see {}",
             artifacts.summary_md.display()
         );
+    }
+
+    Ok(())
+}
+
+fn cmd_autoresearch_compare_decode_hints(
+    left: &Path,
+    right: &Path,
+    output_root: Option<&Path>,
+    json: bool,
+) -> Result<()> {
+    let report = autoresearch::compare_decode_hint_eval_reports(left, right)?;
+    let request = DecodeHintEvalComparisonRequest {
+        command: "minutes autoresearch compare-decode-hints".into(),
+        generated_at: Local::now().to_rfc3339(),
+        left_path: left.to_path_buf(),
+        right_path: right.to_path_buf(),
+        output_root: output_root
+            .map(Path::to_path_buf)
+            .unwrap_or_else(autoresearch::default_comparison_root),
+    };
+    let artifacts = autoresearch::write_decode_hint_eval_comparison_artifacts(&request, &report)?;
+
+    if json {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct AutoresearchDecodeHintsComparisonOutput {
+            report: minutes_core::autoresearch::DecodeHintEvalComparisonReport,
+            artifacts: DecodeHintEvalComparisonArtifactPaths,
+        }
+
+        let envelope = json_envelope(
+            "minutes autoresearch compare-decode-hints",
+            AutoresearchDecodeHintsComparisonOutput {
+                report,
+                artifacts: artifacts.clone(),
+            },
+        );
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
+    } else {
+        println!("Decode hint eval comparison");
+        println!("Shared cases: {}", report.totals.shared_cases);
+        println!("Added cases: {}", report.totals.added_cases);
+        println!("Removed cases: {}", report.totals.removed_cases);
+        println!("Improved cases: {}", report.totals.improved_cases);
+        println!("Regressed cases: {}", report.totals.regressed_cases);
+        println!("Newly passing: {}", report.totals.newly_passing_cases);
+        println!("Newly failing: {}", report.totals.newly_failing_cases);
+        println!("Artifacts: {}", artifacts.run_dir.display());
+    }
+
+    Ok(())
+}
+
+fn cmd_autoresearch_list_decode_hints(limit: usize, json: bool) -> Result<()> {
+    let runs = autoresearch::list_decode_hint_runs(limit)?;
+
+    if json {
+        let envelope = json_envelope("minutes autoresearch list-decode-hints", runs);
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
+    } else if runs.is_empty() {
+        println!("No decode-hint research runs found.");
+    } else {
+        println!("Recent decode-hint research runs");
+        for run in runs {
+            println!(
+                "- {} [{}] {} cases, {} failed, {} improved, {} regressed, {} newly passing, {} newly failing",
+                run.generated_at,
+                run.kind,
+                run.cases_total,
+                run.cases_failed,
+                run.improved_cases,
+                run.regressed_cases,
+                run.newly_passing_cases,
+                run.newly_failing_cases
+            );
+            println!("  status: {}", run.status);
+            println!("  source: {}", run.source_path.display());
+            println!("  dir: {}", run.run_dir.display());
+            println!("  summary: {}", run.summary_path.display());
+        }
     }
 
     Ok(())

--- a/crates/core/src/autoresearch.rs
+++ b/crates/core/src/autoresearch.rs
@@ -314,7 +314,7 @@ pub fn run_decode_hint_eval_corpus(
             whisper_prompt_phrases: hints
                 .debug_priority_phrases()
                 .into_iter()
-                .chain(hints.debug_contextual_phrases().into_iter())
+                .chain(hints.debug_contextual_phrases())
                 .take(12)
                 .collect(),
             parakeet_boost_phrases: effective_parakeet_boost_phrases(&config, &hints),

--- a/crates/core/src/autoresearch.rs
+++ b/crates/core/src/autoresearch.rs
@@ -28,6 +28,10 @@ pub struct DecodeHintEvalCase {
     #[serde(default)]
     pub pre_context: Option<String>,
     #[serde(default)]
+    pub extra_priority_hints: Vec<String>,
+    #[serde(default)]
+    pub extra_context_hints: Vec<String>,
+    #[serde(default)]
     pub attendees: Vec<String>,
     #[serde(default)]
     pub identity_name: Option<String>,
@@ -38,11 +42,15 @@ pub struct DecodeHintEvalCase {
     #[serde(default)]
     pub engine: Option<String>,
     #[serde(default)]
+    pub parakeet_boost_score_override: Option<f32>,
+    #[serde(default)]
     pub max_wer_regression: Option<f64>,
     #[serde(default)]
     pub require_hinted_terms: Vec<String>,
     #[serde(default)]
     pub forbid_hinted_terms: Vec<String>,
+    #[serde(default)]
+    pub allowed_failure_substrings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -52,7 +60,7 @@ pub struct DecodeHintEvalOptions {
     pub engine_override: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecodeHintEvalTranscriptMetrics {
     pub wer: f64,
@@ -60,11 +68,13 @@ pub struct DecodeHintEvalTranscriptMetrics {
     pub forbidden_hits: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecodeHintEvalCaseResult {
     pub id: String,
     pub engine: String,
+    #[serde(default)]
+    pub hint_debug: DecodeHintEvalHintDebug,
     pub baseline: DecodeHintEvalTranscriptMetrics,
     pub candidate: DecodeHintEvalTranscriptMetrics,
     pub delta_wer: f64,
@@ -72,21 +82,41 @@ pub struct DecodeHintEvalCaseResult {
     pub required_terms: Vec<String>,
     pub forbidden_terms: Vec<String>,
     pub passed: bool,
+    #[serde(default = "default_case_status")]
+    pub status: String,
+    #[serde(default)]
     pub failure_reasons: Vec<String>,
+    #[serde(default)]
+    pub allowed_failure_reasons: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeHintEvalHintDebug {
+    #[serde(default)]
+    pub priority_phrases: Vec<String>,
+    #[serde(default)]
+    pub contextual_phrases: Vec<String>,
+    #[serde(default)]
+    pub whisper_prompt_phrases: Vec<String>,
+    #[serde(default)]
+    pub parakeet_boost_phrases: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecodeHintEvalTotals {
     pub cases_total: usize,
     pub cases_passed: usize,
     pub cases_failed: usize,
+    #[serde(default)]
+    pub cases_allowed_failures: usize,
     pub improved_cases: usize,
     pub regressed_cases: usize,
     pub average_delta_wer: f64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecodeHintEvalReport {
     pub generated_at: String,
@@ -97,7 +127,7 @@ pub struct DecodeHintEvalReport {
     pub failure_messages: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecodeHintEvalRequest {
     pub command: String,
@@ -137,12 +167,100 @@ struct DecodeHintEvalSidecarCase {
     forbidden_hits: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeHintEvalComparisonTotals {
+    pub shared_cases: usize,
+    pub added_cases: usize,
+    pub removed_cases: usize,
+    pub improved_cases: usize,
+    pub regressed_cases: usize,
+    pub newly_passing_cases: usize,
+    pub newly_failing_cases: usize,
+    pub unchanged_cases: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeHintEvalComparisonCase {
+    pub id: String,
+    pub status: String,
+    pub left_candidate_wer: Option<f64>,
+    pub right_candidate_wer: Option<f64>,
+    pub candidate_wer_delta: Option<f64>,
+    pub left_passed: Option<bool>,
+    pub right_passed: Option<bool>,
+    pub gained_focus_hits: Vec<String>,
+    pub lost_focus_hits: Vec<String>,
+    pub newly_missing_terms: Vec<String>,
+    pub resolved_failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeHintEvalComparisonReport {
+    pub generated_at: String,
+    pub left_path: PathBuf,
+    pub right_path: PathBuf,
+    pub totals: DecodeHintEvalComparisonTotals,
+    pub cases: Vec<DecodeHintEvalComparisonCase>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeHintEvalComparisonRequest {
+    pub command: String,
+    pub generated_at: String,
+    pub left_path: PathBuf,
+    pub right_path: PathBuf,
+    pub output_root: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeHintEvalComparisonArtifactPaths {
+    pub run_dir: PathBuf,
+    pub request_json: PathBuf,
+    pub comparison_json: PathBuf,
+    pub summary_md: PathBuf,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodeHintRunIndexEntry {
+    pub kind: String,
+    pub run_dir: PathBuf,
+    pub generated_at: String,
+    pub status: String,
+    pub source_path: PathBuf,
+    pub cases_total: usize,
+    pub cases_failed: usize,
+    pub improved_cases: usize,
+    pub regressed_cases: usize,
+    pub newly_passing_cases: usize,
+    pub newly_failing_cases: usize,
+    pub summary_path: PathBuf,
+}
+
 pub fn default_research_root() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".minutes")
         .join("research")
         .join("decode-hints")
+}
+
+pub fn default_comparison_root() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".minutes")
+        .join("research")
+        .join("decode-hints-comparisons")
+}
+
+pub fn list_decode_hint_runs(limit: usize) -> Result<Vec<DecodeHintRunIndexEntry>> {
+    let entries = collect_decode_hint_runs(&default_research_root(), &default_comparison_root())?;
+    Ok(entries.into_iter().take(limit).collect())
 }
 
 pub fn run_decode_hint_eval_corpus(
@@ -160,6 +278,7 @@ pub fn run_decode_hint_eval_corpus(
     let mut delta_sum = 0.0f64;
     let mut improved_cases = 0usize;
     let mut regressed_cases = 0usize;
+    let mut allowed_failure_cases = 0usize;
 
     for case in cases {
         let mut config = Config::default();
@@ -174,6 +293,9 @@ pub fn run_decode_hint_eval_corpus(
         {
             config.transcription.engine = engine;
         }
+        if let Some(boost_score) = case.parakeet_boost_score_override {
+            config.transcription.parakeet_boost_score = boost_score;
+        }
         config.identity.name = case.identity_name.clone();
         config.identity.aliases = case.identity_aliases.clone();
 
@@ -184,7 +306,19 @@ pub fn run_decode_hint_eval_corpus(
             case.pre_context.as_deref(),
             &case.attendees,
             Some(&config.identity),
-        );
+        )
+        .with_additional_candidates(&case.extra_priority_hints, &case.extra_context_hints);
+        let hint_debug = DecodeHintEvalHintDebug {
+            priority_phrases: hints.debug_priority_phrases(),
+            contextual_phrases: hints.debug_contextual_phrases(),
+            whisper_prompt_phrases: hints
+                .debug_priority_phrases()
+                .into_iter()
+                .chain(hints.debug_contextual_phrases().into_iter())
+                .take(12)
+                .collect(),
+            parakeet_boost_phrases: effective_parakeet_boost_phrases(&config, &hints),
+        };
 
         let baseline = transcribe_case(&case, &config, &DecodeHints::default())?;
         let candidate = transcribe_case(&case, &config, &hints)?;
@@ -232,13 +366,33 @@ pub fn run_decode_hint_eval_corpus(
             }
         }
 
-        for reason in &case_failures {
+        let (allowed_failure_reasons, blocking_failure_reasons): (Vec<_>, Vec<_>) =
+            case_failures.into_iter().partition(|reason| {
+                case.allowed_failure_substrings
+                    .iter()
+                    .any(|allowed| reason.contains(allowed))
+            });
+
+        for reason in &blocking_failure_reasons {
             failure_messages.push(format!("{} {reason}", case.id));
         }
+
+        let passed = blocking_failure_reasons.is_empty();
+        let status = if passed {
+            if allowed_failure_reasons.is_empty() {
+                "pass"
+            } else {
+                allowed_failure_cases += 1;
+                "allowed-failure"
+            }
+        } else {
+            "fail"
+        };
 
         results.push(DecodeHintEvalCaseResult {
             id: case.id,
             engine: config.transcription.engine.clone(),
+            hint_debug,
             baseline: DecodeHintEvalTranscriptMetrics {
                 wer: baseline_wer,
                 focus_hits: baseline_focus_hits,
@@ -253,8 +407,10 @@ pub fn run_decode_hint_eval_corpus(
             max_wer_regression: case.max_wer_regression,
             required_terms: case.require_hinted_terms,
             forbidden_terms: case.forbid_hinted_terms,
-            passed: case_failures.is_empty(),
-            failure_reasons: case_failures,
+            passed,
+            status: status.into(),
+            failure_reasons: blocking_failure_reasons,
+            allowed_failure_reasons,
         });
     }
 
@@ -262,6 +418,7 @@ pub fn run_decode_hint_eval_corpus(
         cases_total: results.len(),
         cases_passed: results.iter().filter(|case| case.passed).count(),
         cases_failed: results.iter().filter(|case| !case.passed).count(),
+        cases_allowed_failures: allowed_failure_cases,
         improved_cases,
         regressed_cases,
         average_delta_wer: if results.is_empty() {
@@ -357,6 +514,166 @@ pub fn write_decode_hint_eval_artifacts(
     })
 }
 
+pub fn load_decode_hint_eval_report(path: &Path) -> Result<DecodeHintEvalReport> {
+    let resolved = resolve_report_path(path);
+    let raw = fs::read_to_string(&resolved)?;
+    serde_json::from_str(&raw).map_err(invalid_data_error)
+}
+
+pub fn compare_decode_hint_eval_reports(
+    left_path: &Path,
+    right_path: &Path,
+) -> Result<DecodeHintEvalComparisonReport> {
+    let left_resolved = resolve_report_path(left_path);
+    let right_resolved = resolve_report_path(right_path);
+    let left = load_decode_hint_eval_report(&left_resolved)?;
+    let right = load_decode_hint_eval_report(&right_resolved)?;
+
+    let left_cases: std::collections::BTreeMap<_, _> = left
+        .cases
+        .iter()
+        .map(|case| (case.id.clone(), case))
+        .collect();
+    let right_cases: std::collections::BTreeMap<_, _> = right
+        .cases
+        .iter()
+        .map(|case| (case.id.clone(), case))
+        .collect();
+
+    let mut ids = std::collections::BTreeSet::new();
+    ids.extend(left_cases.keys().cloned());
+    ids.extend(right_cases.keys().cloned());
+
+    let mut totals = DecodeHintEvalComparisonTotals::default();
+    let mut cases = Vec::new();
+
+    for id in ids {
+        let left_case = left_cases.get(&id).copied();
+        let right_case = right_cases.get(&id).copied();
+        let comparison = match (left_case, right_case) {
+            (Some(left_case), Some(right_case)) => {
+                totals.shared_cases += 1;
+                let delta = right_case.candidate.wer - left_case.candidate.wer;
+                if delta < 0.0 {
+                    totals.improved_cases += 1;
+                } else if delta > 0.0 {
+                    totals.regressed_cases += 1;
+                } else {
+                    totals.unchanged_cases += 1;
+                }
+                if !left_case.passed && right_case.passed {
+                    totals.newly_passing_cases += 1;
+                }
+                if left_case.passed && !right_case.passed {
+                    totals.newly_failing_cases += 1;
+                }
+
+                let left_hits: std::collections::BTreeSet<_> =
+                    left_case.candidate.focus_hits.iter().cloned().collect();
+                let right_hits: std::collections::BTreeSet<_> =
+                    right_case.candidate.focus_hits.iter().cloned().collect();
+                let left_failures: std::collections::BTreeSet<_> =
+                    left_case.failure_reasons.iter().cloned().collect();
+                let right_failures: std::collections::BTreeSet<_> =
+                    right_case.failure_reasons.iter().cloned().collect();
+
+                DecodeHintEvalComparisonCase {
+                    id,
+                    status: "shared".into(),
+                    left_candidate_wer: Some(left_case.candidate.wer),
+                    right_candidate_wer: Some(right_case.candidate.wer),
+                    candidate_wer_delta: Some(delta),
+                    left_passed: Some(left_case.passed),
+                    right_passed: Some(right_case.passed),
+                    gained_focus_hits: right_hits.difference(&left_hits).cloned().collect(),
+                    lost_focus_hits: left_hits.difference(&right_hits).cloned().collect(),
+                    newly_missing_terms: right_failures
+                        .difference(&left_failures)
+                        .cloned()
+                        .collect(),
+                    resolved_failures: left_failures.difference(&right_failures).cloned().collect(),
+                }
+            }
+            (None, Some(right_case)) => {
+                totals.added_cases += 1;
+                DecodeHintEvalComparisonCase {
+                    id,
+                    status: "added".into(),
+                    left_candidate_wer: None,
+                    right_candidate_wer: Some(right_case.candidate.wer),
+                    candidate_wer_delta: None,
+                    left_passed: None,
+                    right_passed: Some(right_case.passed),
+                    gained_focus_hits: right_case.candidate.focus_hits.clone(),
+                    lost_focus_hits: Vec::new(),
+                    newly_missing_terms: right_case.failure_reasons.clone(),
+                    resolved_failures: Vec::new(),
+                }
+            }
+            (Some(left_case), None) => {
+                totals.removed_cases += 1;
+                DecodeHintEvalComparisonCase {
+                    id,
+                    status: "removed".into(),
+                    left_candidate_wer: Some(left_case.candidate.wer),
+                    right_candidate_wer: None,
+                    candidate_wer_delta: None,
+                    left_passed: Some(left_case.passed),
+                    right_passed: None,
+                    gained_focus_hits: Vec::new(),
+                    lost_focus_hits: left_case.candidate.focus_hits.clone(),
+                    newly_missing_terms: Vec::new(),
+                    resolved_failures: left_case.failure_reasons.clone(),
+                }
+            }
+            (None, None) => continue,
+        };
+        cases.push(comparison);
+    }
+
+    Ok(DecodeHintEvalComparisonReport {
+        generated_at: Utc::now().to_rfc3339(),
+        left_path: left_resolved,
+        right_path: right_resolved,
+        totals,
+        cases,
+    })
+}
+
+pub fn write_decode_hint_eval_comparison_artifacts(
+    request: &DecodeHintEvalComparisonRequest,
+    report: &DecodeHintEvalComparisonReport,
+) -> Result<DecodeHintEvalComparisonArtifactPaths> {
+    let run_dir = request
+        .output_root
+        .join(Utc::now().format("%Y-%m-%dT%H-%M-%SZ").to_string());
+    fs::create_dir_all(&run_dir)?;
+
+    let request_json = run_dir.join("request.json");
+    let comparison_json = run_dir.join("comparison.json");
+    let summary_md = run_dir.join("summary.md");
+
+    fs::write(
+        &request_json,
+        serde_json::to_string_pretty(request).map_err(invalid_data_error)?,
+    )?;
+    fs::write(
+        &comparison_json,
+        serde_json::to_string_pretty(report).map_err(invalid_data_error)?,
+    )?;
+    fs::write(
+        &summary_md,
+        render_decode_hint_eval_comparison_summary(report),
+    )?;
+
+    Ok(DecodeHintEvalComparisonArtifactPaths {
+        run_dir,
+        request_json,
+        comparison_json,
+        summary_md,
+    })
+}
+
 pub fn render_decode_hint_eval_summary(report: &DecodeHintEvalReport) -> String {
     let verdict = if report.failure_messages.is_empty() {
         "PASS"
@@ -372,6 +689,10 @@ pub fn render_decode_hint_eval_summary(report: &DecodeHintEvalReport) -> String 
         format!("- Cases: {}", report.totals.cases_total),
         format!("- Passed: {}", report.totals.cases_passed),
         format!("- Failed: {}", report.totals.cases_failed),
+        format!(
+            "- Allowed failures: {}",
+            report.totals.cases_allowed_failures
+        ),
         format!("- Improved cases: {}", report.totals.improved_cases),
         format!("- Regressed cases: {}", report.totals.regressed_cases),
         format!(
@@ -385,15 +706,22 @@ pub fn render_decode_hint_eval_summary(report: &DecodeHintEvalReport) -> String 
 
     for case in &report.cases {
         lines.push(format!(
-            "- `{}`: {} (`{:.4}` -> `{:.4}`, delta `{:.4}`)",
+            "- `{}`: {} [{}] (`{:.4}` -> `{:.4}`, delta `{:.4}`)",
             case.id,
             if case.passed { "pass" } else { "fail" },
+            case.status,
             case.baseline.wer,
             case.candidate.wer,
             case.delta_wer
         ));
         if !case.failure_reasons.is_empty() {
             lines.push(format!("  reasons: {}", case.failure_reasons.join("; ")));
+        }
+        if !case.allowed_failure_reasons.is_empty() {
+            lines.push(format!(
+                "  allowed failures: {}",
+                case.allowed_failure_reasons.join("; ")
+            ));
         }
     }
 
@@ -409,8 +737,186 @@ pub fn render_decode_hint_eval_summary(report: &DecodeHintEvalReport) -> String 
     lines.join("\n")
 }
 
+pub fn render_decode_hint_eval_comparison_summary(
+    report: &DecodeHintEvalComparisonReport,
+) -> String {
+    let mut lines = vec![
+        "# Decode Hint Eval Comparison".to_string(),
+        String::new(),
+        format!("- Left: `{}`", report.left_path.display()),
+        format!("- Right: `{}`", report.right_path.display()),
+        format!("- Generated at: `{}`", report.generated_at),
+        format!("- Shared cases: {}", report.totals.shared_cases),
+        format!("- Added cases: {}", report.totals.added_cases),
+        format!("- Removed cases: {}", report.totals.removed_cases),
+        format!("- Improved cases: {}", report.totals.improved_cases),
+        format!("- Regressed cases: {}", report.totals.regressed_cases),
+        format!("- Newly passing: {}", report.totals.newly_passing_cases),
+        format!("- Newly failing: {}", report.totals.newly_failing_cases),
+        String::new(),
+        "## Case deltas".to_string(),
+        String::new(),
+    ];
+
+    for case in &report.cases {
+        let headline = match (
+            case.left_candidate_wer,
+            case.right_candidate_wer,
+            case.candidate_wer_delta,
+        ) {
+            (Some(left), Some(right), Some(delta)) => format!(
+                "- `{}` [{}]: candidate WER `{:.4}` -> `{:.4}` (delta `{:.4}`)",
+                case.id, case.status, left, right, delta
+            ),
+            (None, Some(right), _) => format!(
+                "- `{}` [{}]: new case on right with candidate WER `{:.4}`",
+                case.id, case.status, right
+            ),
+            (Some(left), None, _) => format!(
+                "- `{}` [{}]: removed case (left candidate WER `{:.4}`)",
+                case.id, case.status, left
+            ),
+            _ => format!("- `{}` [{}]", case.id, case.status),
+        };
+        lines.push(headline);
+        if !case.gained_focus_hits.is_empty() {
+            lines.push(format!(
+                "  gained hits: {}",
+                case.gained_focus_hits.join(", ")
+            ));
+        }
+        if !case.lost_focus_hits.is_empty() {
+            lines.push(format!("  lost hits: {}", case.lost_focus_hits.join(", ")));
+        }
+        if !case.resolved_failures.is_empty() {
+            lines.push(format!(
+                "  resolved failures: {}",
+                case.resolved_failures.join("; ")
+            ));
+        }
+        if !case.newly_missing_terms.is_empty() {
+            lines.push(format!(
+                "  new failures: {}",
+                case.newly_missing_terms.join("; ")
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
 fn default_eval_content_type() -> ContentType {
     ContentType::Meeting
+}
+
+fn default_case_status() -> String {
+    "pass".into()
+}
+
+fn resolve_report_path(path: &Path) -> PathBuf {
+    if path.is_dir() {
+        path.join("results.json")
+    } else {
+        path.to_path_buf()
+    }
+}
+
+fn collect_decode_hint_runs(
+    eval_root: &Path,
+    comparison_root: &Path,
+) -> Result<Vec<DecodeHintRunIndexEntry>> {
+    let mut runs = Vec::new();
+    runs.extend(collect_eval_runs(eval_root)?);
+    runs.extend(collect_comparison_runs(comparison_root)?);
+    runs.sort_by(|left, right| right.generated_at.cmp(&left.generated_at));
+    Ok(runs)
+}
+
+fn collect_eval_runs(root: &Path) -> Result<Vec<DecodeHintRunIndexEntry>> {
+    let mut runs = Vec::new();
+    if !root.exists() {
+        return Ok(runs);
+    }
+
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        if entry.file_name() == "clips" {
+            continue;
+        }
+        let results_path = path.join("results.json");
+        let summary_path = path.join("summary.md");
+        if !results_path.exists() {
+            continue;
+        }
+        let report = load_decode_hint_eval_report(&results_path)?;
+        runs.push(DecodeHintRunIndexEntry {
+            kind: "decode-hints".into(),
+            run_dir: path,
+            generated_at: report.generated_at,
+            status: if report.failure_messages.is_empty() {
+                "pass".into()
+            } else {
+                "fail".into()
+            },
+            source_path: report.corpus_path,
+            cases_total: report.totals.cases_total,
+            cases_failed: report.totals.cases_failed,
+            improved_cases: report.totals.improved_cases,
+            regressed_cases: report.totals.regressed_cases,
+            newly_passing_cases: 0,
+            newly_failing_cases: 0,
+            summary_path,
+        });
+    }
+
+    Ok(runs)
+}
+
+fn collect_comparison_runs(root: &Path) -> Result<Vec<DecodeHintRunIndexEntry>> {
+    let mut runs = Vec::new();
+    if !root.exists() {
+        return Ok(runs);
+    }
+
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let comparison_path = path.join("comparison.json");
+        let summary_path = path.join("summary.md");
+        if !comparison_path.exists() {
+            continue;
+        }
+        let raw = fs::read_to_string(&comparison_path)?;
+        let report: DecodeHintEvalComparisonReport =
+            serde_json::from_str(&raw).map_err(invalid_data_error)?;
+        runs.push(DecodeHintRunIndexEntry {
+            kind: "decode-hints-comparison".into(),
+            run_dir: path,
+            generated_at: report.generated_at,
+            status: if report.totals.newly_failing_cases > 0 || report.totals.regressed_cases > 0 {
+                "mixed".into()
+            } else {
+                "improved-or-stable".into()
+            },
+            source_path: report.right_path,
+            cases_total: report.totals.shared_cases + report.totals.added_cases,
+            cases_failed: report.totals.newly_failing_cases + report.totals.regressed_cases,
+            improved_cases: report.totals.improved_cases,
+            regressed_cases: report.totals.regressed_cases,
+            newly_passing_cases: report.totals.newly_passing_cases,
+            newly_failing_cases: report.totals.newly_failing_cases,
+            summary_path,
+        });
+    }
+
+    Ok(runs)
 }
 
 fn invalid_input(message: &str) -> MinutesError {
@@ -518,6 +1024,16 @@ fn load_reference_text(case: &DecodeHintEvalCase) -> Result<String> {
     Ok(fs::read_to_string(path)?)
 }
 
+#[cfg(feature = "parakeet")]
+fn effective_parakeet_boost_phrases(config: &Config, hints: &DecodeHints) -> Vec<String> {
+    transcribe::combined_parakeet_boost_phrases(config, hints)
+}
+
+#[cfg(not(feature = "parakeet"))]
+fn effective_parakeet_boost_phrases(_config: &Config, _hints: &DecodeHints) -> Vec<String> {
+    Vec::new()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -532,6 +1048,7 @@ mod tests {
                 cases_total: 1,
                 cases_passed: 0,
                 cases_failed: 1,
+                cases_allowed_failures: 0,
                 improved_cases: 0,
                 regressed_cases: 1,
                 average_delta_wer: 0.031,
@@ -539,6 +1056,12 @@ mod tests {
             cases: vec![DecodeHintEvalCaseResult {
                 id: "case-1".into(),
                 engine: "parakeet".into(),
+                hint_debug: DecodeHintEvalHintDebug {
+                    priority_phrases: vec!["Alex Chen".into()],
+                    contextual_phrases: vec!["X1 Planning".into()],
+                    whisper_prompt_phrases: vec!["Alex Chen".into(), "X1 Planning".into()],
+                    parakeet_boost_phrases: vec!["Alex Chen".into(), "X1 Planning".into()],
+                },
                 baseline: DecodeHintEvalTranscriptMetrics {
                     wer: 0.12,
                     focus_hits: vec!["alex chen".into()],
@@ -554,10 +1077,12 @@ mod tests {
                 required_terms: vec!["alex chen".into()],
                 forbidden_terms: vec!["matt mullenweg".into()],
                 passed: false,
+                status: "fail".into(),
                 failure_reasons: vec![
                     "hinted WER regressed by 0.0310 (> 0.0200)".into(),
                     "contains forbidden hinted term 'matt mullenweg'".into(),
                 ],
+                allowed_failure_reasons: vec![],
             }],
             failure_messages: vec![
                 "case-1 hinted WER regressed by 0.0310 (> 0.0200)".into(),
@@ -593,5 +1118,93 @@ mod tests {
         assert!(paths.baseline_json.exists());
         assert!(paths.candidate_json.exists());
         assert!(paths.summary_md.exists());
+    }
+
+    #[test]
+    fn compare_reports_surfaces_improvements_and_new_failures() {
+        let left = sample_report();
+        let mut right = sample_report();
+        right.generated_at = "2026-04-16T12:00:00Z".into();
+        right.cases[0].candidate.wer = 0.10;
+        right.cases[0].candidate.focus_hits.push("mat".into());
+        right.cases[0].failure_reasons =
+            vec!["missing required hinted term 'pdf extension'".into()];
+        right.failure_messages = right.cases[0]
+            .failure_reasons
+            .iter()
+            .map(|reason| format!("case-1 {reason}"))
+            .collect();
+
+        let tmp = TempDir::new().unwrap();
+        let left_path = tmp.path().join("left.json");
+        let right_path = tmp.path().join("right.json");
+        fs::write(&left_path, serde_json::to_string_pretty(&left).unwrap()).unwrap();
+        fs::write(&right_path, serde_json::to_string_pretty(&right).unwrap()).unwrap();
+
+        let comparison = compare_decode_hint_eval_reports(&left_path, &right_path).unwrap();
+        assert_eq!(comparison.totals.shared_cases, 1);
+        assert_eq!(comparison.totals.improved_cases, 1);
+        assert_eq!(
+            comparison.cases[0].gained_focus_hits,
+            vec!["mat".to_string()]
+        );
+        assert!(comparison.cases[0]
+            .newly_missing_terms
+            .iter()
+            .any(|reason| reason.contains("pdf extension")));
+        assert!(comparison.cases[0]
+            .resolved_failures
+            .iter()
+            .any(|reason| reason.contains("matt mullenweg")));
+    }
+
+    #[test]
+    fn collect_decode_hint_runs_lists_eval_and_comparison_runs() {
+        let tmp = TempDir::new().unwrap();
+        let eval_root = tmp.path().join("decode-hints");
+        let comparison_root = tmp.path().join("decode-hints-comparisons");
+        fs::create_dir_all(&eval_root).unwrap();
+        fs::create_dir_all(&comparison_root).unwrap();
+
+        let eval_dir = eval_root.join("2026-04-16T00-00-00Z");
+        fs::create_dir_all(&eval_dir).unwrap();
+        fs::write(
+            eval_dir.join("results.json"),
+            serde_json::to_string_pretty(&sample_report()).unwrap(),
+        )
+        .unwrap();
+        fs::write(eval_dir.join("summary.md"), "# eval").unwrap();
+
+        let comparison = DecodeHintEvalComparisonReport {
+            generated_at: "2026-04-16T13:00:00Z".into(),
+            left_path: PathBuf::from("/tmp/left.json"),
+            right_path: PathBuf::from("/tmp/right.json"),
+            totals: DecodeHintEvalComparisonTotals {
+                shared_cases: 1,
+                added_cases: 0,
+                removed_cases: 0,
+                improved_cases: 1,
+                regressed_cases: 0,
+                newly_passing_cases: 1,
+                newly_failing_cases: 0,
+                unchanged_cases: 0,
+            },
+            cases: vec![],
+        };
+        let comparison_dir = comparison_root.join("2026-04-16T13-00-00Z");
+        fs::create_dir_all(&comparison_dir).unwrap();
+        fs::write(
+            comparison_dir.join("comparison.json"),
+            serde_json::to_string_pretty(&comparison).unwrap(),
+        )
+        .unwrap();
+        fs::write(comparison_dir.join("summary.md"), "# comparison").unwrap();
+
+        let runs = collect_decode_hint_runs(&eval_root, &comparison_root).unwrap();
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].kind, "decode-hints-comparison");
+        assert_eq!(runs[0].source_path, PathBuf::from("/tmp/right.json"));
+        assert_eq!(runs[1].kind, "decode-hints");
+        assert_eq!(runs[1].source_path, PathBuf::from("/tmp/corpus.json"));
     }
 }

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -2633,7 +2633,6 @@ mod tests {
     /// other parallel tests could otherwise race the read/write.
     #[test]
     fn preferred_host_cache_round_trips() {
-        use cpal::traits::HostTrait;
         static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _g = LOCK.lock().unwrap();
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -167,7 +167,6 @@ pub struct SummarizationConfig {
     pub ollama_model: String,
     pub mistral_model: String,
     pub language: String,
-
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -1612,9 +1612,9 @@ mod tests {
         let tail_silence = silence_needed - lead_silence;
 
         let mut padded = Vec::with_capacity(target_total_samples);
-        padded.extend(std::iter::repeat(0.0).take(lead_silence));
+        padded.extend(std::iter::repeat_n(0.0, lead_silence));
         padded.extend_from_slice(samples);
-        padded.extend(std::iter::repeat(0.0).take(tail_silence));
+        padded.extend(std::iter::repeat_n(0.0, tail_silence));
         padded
     }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -3697,8 +3697,10 @@ mod tests {
 
     fn write_test_meeting(title: &str) -> (tempfile::TempDir, WriteResult, Frontmatter) {
         let dir = tempfile::TempDir::new().unwrap();
-        let mut config = Config::default();
-        config.output_dir = dir.path().to_path_buf();
+        let config = Config {
+            output_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
 
         let frontmatter = Frontmatter {
             title: title.into(),

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -253,7 +253,11 @@ pub fn refine_title(
     let prompt_input = build_title_refinement_input(summary_text, summary, entities);
     let model = title_refinement_model(config)
         .ok_or("no configured summarization engine available for title refinement")?;
-    let prompt = format!("{}\n\n{}", build_title_prompt(get_effective_summary_language(config)), prompt_input);
+    let prompt = format!(
+        "{}\n\n{}",
+        build_title_prompt(get_effective_summary_language(config)),
+        prompt_input
+    );
     let response = run_title_refinement_prompt(&prompt, config)?;
 
     Ok(TitleRefinement {
@@ -974,7 +978,8 @@ fn summarize_with_agent_impl(
 
     let prompt = format!(
         "{}\n\nSummarize this transcript:\n\n<transcript>\n{}\n</transcript>",
-        build_system_prompt(get_effective_summary_language(config)), truncated
+        build_system_prompt(get_effective_summary_language(config)),
+        truncated
     );
 
     tracing::info!(agent = %agent_cmd, prompt_len = prompt.len(), "summarizing via agent CLI");

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -176,6 +176,24 @@ impl DecodeHints {
         self.priority_phrases.is_empty() && self.contextual_phrases.is_empty()
     }
 
+    pub fn with_additional_candidates(&self, priority: &[String], contextual: &[String]) -> Self {
+        let mut merged_priority = self.priority_phrases.clone();
+        merged_priority.extend(priority.iter().cloned());
+
+        let mut merged_contextual = self.contextual_phrases.clone();
+        merged_contextual.extend(contextual.iter().cloned());
+
+        Self::from_candidates(&merged_priority, &merged_contextual)
+    }
+
+    pub(crate) fn debug_priority_phrases(&self) -> Vec<String> {
+        self.priority_phrases.clone()
+    }
+
+    pub(crate) fn debug_contextual_phrases(&self) -> Vec<String> {
+        self.contextual_phrases.clone()
+    }
+
     fn combined_phrases(&self, limit: usize) -> Vec<String> {
         self.priority_phrases
             .iter()
@@ -3465,6 +3483,25 @@ Hello there.
         assert!(prompt.contains("Alex Chen"));
         assert!(prompt.contains("X1 Planning"));
         assert!(prompt.contains("Preserve spelling exactly"));
+    }
+
+    #[test]
+    fn decode_hints_merge_additional_candidates() {
+        let base = DecodeHints::from_candidates(&["Mat".to_string()], &["X1 Planning".to_string()]);
+        let merged = base.with_additional_candidates(
+            &["Garrett Gunderson".to_string()],
+            &["Well Factory".to_string()],
+        );
+
+        assert_eq!(
+            merged.combined_phrases(10),
+            vec![
+                "Mat".to_string(),
+                "Garrett Gunderson".to_string(),
+                "X1 Planning".to_string(),
+                "Well Factory".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/docs/PRE-RELEASE-CHECKLIST.md
+++ b/docs/PRE-RELEASE-CHECKLIST.md
@@ -32,7 +32,7 @@ export CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1"  # macOS only
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test -p minutes-core --lib
-cargo test -p minutes-cli --lib
+cargo test -p minutes-cli
 cargo check -p minutes-app
 ```
 
@@ -43,8 +43,8 @@ If any of these fail, stop. Fix the underlying issue before bumping versions.
 The MCP server and SDK are real npm packages. They have their own build steps and their own dependency resolution. The Rust workspace tooling does not catch problems in either.
 
 ```bash
-(cd crates/sdk && npm run build)
-(cd crates/mcp && npm run build)
+(cd crates/sdk && npm install && npm run build)
+(cd crates/mcp && npm install && npm run build)
 (cd crates/mcp && npm install --dry-run)   # surfaces unresolved versions early
 ```
 

--- a/docs/PRE-RELEASE-CHECKLIST.md
+++ b/docs/PRE-RELEASE-CHECKLIST.md
@@ -124,10 +124,13 @@ The `minutes.mcpb` Claude Desktop marketplace bundle is NOT built by any release
 # From the repo root, after Phase 4 has completed (MCP and SDK already published).
 (cd crates/mcp && npm run build)   # ensures dist/ and dist-ui/ are fresh
 mcpb pack                            # writes minutes.mcpb at repo root
+./scripts/check_mcpb_bundle.sh minutes.mcpb
 gh release upload vX.Y.Z minutes.mcpb --repo silverstein/minutes
 ```
 
 `mcpb pack` writes the bundle to `minutes.mcpb` at the repo root, internally versioned to whatever is in `manifest.json` (so make sure that file was bumped in Phase 3). The release page convention is the unversioned filename `minutes.mcpb`, matching v0.10.2 and earlier.
+
+The bundle check is not optional. We have already shipped a broken extension once where `.mcpbignore` excluded `crates/mcp/node_modules/yaml/dist/schema/yaml-1.1/*`, which let the server answer `initialize` and then crash immediately in Claude Desktop with `Cannot find module '../schema/yaml-1.1/merge.js'`.
 
 ## Phase 7: Watch the release workflows
 

--- a/scripts/check_mcpb_bundle.sh
+++ b/scripts/check_mcpb_bundle.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_path="${1:-minutes.mcpb}"
+
+if [[ ! -f "$bundle_path" ]]; then
+  echo "Missing MCPB bundle: $bundle_path" >&2
+  exit 1
+fi
+
+python3 - <<'PY' "$bundle_path"
+import sys
+import zipfile
+
+bundle = sys.argv[1]
+required = [
+    "crates/mcp/dist/index.js",
+    "crates/mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js",
+    "crates/mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js",
+    "crates/mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js",
+]
+
+with zipfile.ZipFile(bundle) as zf:
+    names = set(zf.namelist())
+    missing = [path for path in required if path not in names]
+
+if missing:
+    print("MCPB bundle is missing required runtime files:", file=sys.stderr)
+    for path in missing:
+        print(f"  - {path}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"MCPB bundle looks healthy: {bundle}")
+PY

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -90,7 +90,7 @@ while IFS=$'\t' read -r sha subject; do
   if [[ "$matched" -eq 0 ]]; then
     echo "$line" >> "$other_file"
   fi
-done < <(git log --reverse --pretty=format:'%H%x09%s' "${from_ref}..${to_ref}")
+done < <(git log --reverse --pretty=format:'%H%x09%s%n' "${from_ref}..${to_ref}")
 
 count_lines() {
   local file="$1"

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -6253,16 +6253,18 @@ mod tests {
     }
 
     #[test]
-    fn parakeet_status_reports_ready_with_metadata() {
+    fn parakeet_status_reports_installed_metadata_across_build_flavors() {
         let dir = TempDir::new().unwrap();
         let mut config = Config::default();
         config.transcription.engine = "parakeet".into();
         config.transcription.model_path = dir.path().to_path_buf();
-        config.transcription.parakeet_binary = if cfg!(windows) {
-            "cmd".into()
+        config.transcription.parakeet_model = "tdt-ctc-110m".into();
+        let binary = if cfg!(windows) {
+            which::which("cmd").unwrap()
         } else {
-            "sh".into()
+            which::which("sh").unwrap()
         };
+        config.transcription.parakeet_binary = binary.display().to_string();
 
         let install_dir = minutes_core::parakeet::install_dir(&config, "tdt-ctc-110m");
         std::fs::create_dir_all(&install_dir).unwrap();
@@ -6274,7 +6276,6 @@ mod tests {
             .unwrap();
 
         let status = parakeet_status_view(&config);
-        assert!(status.ready);
         assert!(status.model_found);
         assert!(status.tokenizer_found);
         assert!(status.metadata.is_some());
@@ -6282,6 +6283,19 @@ mod tests {
             status.tokenizer_label.as_deref(),
             Some("tdt-ctc-110m.tokenizer.vocab")
         );
+        if cfg!(feature = "parakeet") {
+            assert!(status.ready);
+        } else {
+            assert!(!status.ready);
+            assert!(
+                status
+                    .issues
+                    .iter()
+                    .any(|issue| issue.contains("not compiled into this build")),
+                "expected missing compile support issue, got {:?}",
+                status.issues
+            );
+        }
     }
 
     #[test]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -7402,12 +7402,23 @@
     document.getElementById('settings-whisper-language').addEventListener('change', async (e) => {
       await invoke('cmd_set_setting', { section: 'transcription', key: 'language', value: e.target.value });
     });
+    // Toggle handlers flip based on the *visible* state, not a fresh
+    // backend read. If the UI is out of sync with disk (e.g. a prior
+    // loadSettings threw before reaching this row), the user's click
+    // still does what they asked — otherwise the first click silently
+    // "corrects" the UI to match disk and feels like a dead button.
     document.getElementById('settings-diarization').addEventListener('click', async () => {
-      const s = await invoke('cmd_get_settings');
-      // Toggle: none → pyannote-rs, anything else (auto/pyannote-rs/pyannote) → none
-      const next = s.diarization.engine === 'none' ? 'pyannote-rs' : 'none';
-      await invoke('cmd_set_setting', { section: 'diarization', key: 'engine', value: next });
-      setSettingsToggle('settings-diarization', next !== 'none');
+      const btn = document.getElementById('settings-diarization');
+      const currentlyOn = btn.textContent.trim() === 'On';
+      const next = !currentlyOn;
+      const nextEngine = next ? 'pyannote-rs' : 'none';
+      setSettingsToggle('settings-diarization', next);
+      try {
+        await invoke('cmd_set_setting', { section: 'diarization', key: 'engine', value: nextEngine });
+      } catch (e) {
+        setSettingsToggle('settings-diarization', currentlyOn);
+        console.error('diarization toggle:', e);
+      }
     });
     document.getElementById('settings-summarization-engine').addEventListener('change', async (e) => {
       await invoke('cmd_set_setting', { section: 'summarization', key: 'engine', value: e.target.value });
@@ -7420,11 +7431,18 @@
       document.getElementById('settings-agent-command-status').textContent = agents.find(a => a.name === e.target.value) ? 'Installed' : 'Not found on this machine';
     });
     document.getElementById('settings-screen-context').addEventListener('click', async () => {
-      const s = await invoke('cmd_get_settings');
-      const next = !s.screen_context.enabled;
-      await invoke('cmd_set_setting', { section: 'screen_context', key: 'enabled', value: String(next) });
+      const btn = document.getElementById('settings-screen-context');
+      const currentlyOn = btn.textContent.trim() === 'On';
+      const next = !currentlyOn;
       setSettingsToggle('settings-screen-context', next);
       document.getElementById('settings-screen-interval-row').classList.toggle('is-hidden', !next);
+      try {
+        await invoke('cmd_set_setting', { section: 'screen_context', key: 'enabled', value: String(next) });
+      } catch (e) {
+        setSettingsToggle('settings-screen-context', currentlyOn);
+        document.getElementById('settings-screen-interval-row').classList.toggle('is-hidden', !currentlyOn);
+        console.error('screen_context toggle:', e);
+      }
     });
     document.getElementById('settings-screen-interval').addEventListener('change', (e) => invoke('cmd_set_setting', { section: 'screen_context', key: 'interval_secs', value: e.target.value }));
     document.getElementById('settings-agent').addEventListener('change', async (e) => {
@@ -7457,18 +7475,30 @@
 
     // Call detection settings handlers
     document.getElementById('settings-call-detection').addEventListener('click', async () => {
-      const s = await invoke('cmd_get_settings');
-      const next = !s.call_detection.enabled;
-      await invoke('cmd_set_setting', { section: 'call_detection', key: 'enabled', value: String(next) });
+      const btn = document.getElementById('settings-call-detection');
+      const currentlyOn = btn.textContent.trim() === 'On';
+      const next = !currentlyOn;
       setSettingsToggle('settings-call-detection', next);
+      try {
+        await invoke('cmd_set_setting', { section: 'call_detection', key: 'enabled', value: String(next) });
+      } catch (e) {
+        setSettingsToggle('settings-call-detection', currentlyOn);
+        console.error('call_detection toggle:', e);
+      }
     });
     document.getElementById('settings-call-detection-polling-interval').addEventListener('change', (e) => invoke('cmd_set_setting', { section: 'call_detection', key: 'poll_interval_secs', value: e.target.value }));
     document.getElementById('settings-call-detection-cooldown').addEventListener('change', (e) => invoke('cmd_set_setting', { section: 'call_detection', key: 'cooldown_minutes', value: e.target.value }));
     document.getElementById('settings-call-detection-google-meet').addEventListener('click', async () => {
-      const s = await invoke('cmd_get_settings');
-      const next = !Boolean(s.call_detection.google_meet_enabled);
-      await invoke('cmd_set_setting', { section: 'call_detection', key: 'google_meet_enabled', value: String(next) });
+      const btn = document.getElementById('settings-call-detection-google-meet');
+      const currentlyOn = btn.textContent.trim() === 'On';
+      const next = !currentlyOn;
       setSettingsToggle('settings-call-detection-google-meet', next);
+      try {
+        await invoke('cmd_set_setting', { section: 'call_detection', key: 'google_meet_enabled', value: String(next) });
+      } catch (e) {
+        setSettingsToggle('settings-call-detection-google-meet', currentlyOn);
+        console.error('google_meet toggle:', e);
+      }
     });
     document.getElementById('settings-call-detection-teams-web').addEventListener('click', async () => {
       const s = await invoke('cmd_get_settings');
@@ -8221,12 +8251,14 @@
     });
 
     document.getElementById('settings-screen-share').addEventListener('click', async () => {
+      const btn = document.getElementById('settings-screen-share');
+      const currentlyOn = btn.textContent.trim() === 'On';
+      const next = !currentlyOn;
+      setSettingsToggle('settings-screen-share', next);
       try {
-        const s = await invoke('cmd_get_settings');
-        const next = !Boolean(s.privacy?.hide_from_screen_share);
         await invoke('cmd_set_screen_share_hidden', { hidden: next });
-        setSettingsToggle('settings-screen-share', next);
       } catch (e) {
+        setSettingsToggle('settings-screen-share', currentlyOn);
         console.error('Set screen share privacy:', e);
       }
     });

--- a/tests/fixtures/proper-name-eval.example.json
+++ b/tests/fixtures/proper-name-eval.example.json
@@ -4,10 +4,17 @@
     "audio_path": "/absolute/path/to/recording.wav",
     "content_type": "meeting",
     "engine": "parakeet",
+    "parakeet_boost_score_override": 4.0,
     "reference_text": "Mat Silverstein and Alex Chen discussed X1 Planning and Asana migration.",
     "title": "X1 / Planning Review",
     "calendar_event_title": "Mat with Alex Chen",
     "pre_context": "Asana migration with Box",
+    "extra_priority_hints": [
+      "Alex Chen"
+    ],
+    "extra_context_hints": [
+      "X1 Planning"
+    ],
     "attendees": [
       "mat@example.com",
       "alex.chen@example.com"


### PR DESCRIPTION
## Summary

Adds local decode-hint eval comparison/list tooling to the CLI and core autoresearch layer, and folds in the release-prep fixes surfaced during the pre-release sweep:

- `minutes autoresearch compare-decode-hints`
- `minutes autoresearch list-decode-hints`
- richer decode-hint eval fixtures / report metadata
- fixes the stale Parakeet readiness test so it behaves correctly in `--no-default-features` builds
- fixes `scripts/release_notes.sh` so the newest commit in the range is not silently dropped
- updates `docs/PRE-RELEASE-CHECKLIST.md` to use the real CLI/package commands for a clean checkout
- clears current workspace clippy blockers in test/helper code

## Why now

We were already doing a broad precommit / release sweep while waiting on #140. This branch packages the local tooling slice Mat wanted to ship, plus the release-path fixes needed to make the documented gates truthful again.

## Validation

- `cargo test -p minutes-app --no-default-features parakeet_status_reports_installed_metadata_across_build_flavors`
- `cargo test -p minutes-core decode_hint`
- `cargo test -p minutes-cli`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p minutes-app`
- `node scripts/sync_site_release_version.mjs --check`
- clean-checkout package verification in throwaway worktree:
  - `(cd crates/sdk && npm install && npm run build)`
  - `(cd crates/mcp && npm install && npm run build)`
  - `(cd crates/mcp && npm install --dry-run)`

## Notes

The pre-release sweep also confirmed that `scripts/release_notes.sh` previously omitted the newest commit in the range, which would have hidden a just-landed squash commit from seeded release notes.