### PR TITLE
fix(mcp): stop telling Claude the user can speak 'stop recording'

### DIFF
--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -754,7 +754,7 @@ registerAppResource(
 
 registerTool(
  "start_recording",
-  "Start recording audio with call-aware preflight. When a known call app is active, Minutes can infer call intent and block silent mic-only call captures unless explicitly allowed.",
+  "Start recording audio with call-aware preflight. When a known call app is active, Minutes can infer call intent and block silent mic-only call captures unless explicitly allowed. Note: this server does not listen to audio content. Recordings are stopped by invoking stop_recording after the user types a request in chat — never promise the user they can speak a 'stop recording' voice command.",
   {
     title: z.string().optional().describe("Optional title for this recording"),
     mode: z
@@ -844,7 +844,7 @@ registerTool(
             {
               type: "text" as const,
               text: result.recording
-                ? `Recording started in the running Minutes desktop app (PID: ${result.pid}).${Array.isArray(preflight.warnings) && preflight.warnings.length ? ` ${preflight.warnings[0]}` : ""}${desktopLiveMsg} Say "stop recording" when done.`
+                ? `Recording started in the running Minutes desktop app (PID: ${result.pid}).${Array.isArray(preflight.warnings) && preflight.warnings.length ? ` ${preflight.warnings[0]}` : ""}${desktopLiveMsg} When the user asks to finish (typed in chat), invoke stop_recording to process the transcript and summary. This server does not listen to audio content, so do not tell the user they can speak a stop command.`
                 : response.detail,
             },
           ],
@@ -923,7 +923,7 @@ registerTool(
         {
           type: "text" as const,
           text: result.recording
-            ? `${result.recording_mode === "quick-thought" ? "Quick thought" : "Recording"} started (PID: ${result.pid}).${Array.isArray(preflight.warnings) && preflight.warnings.length ? ` ${preflight.warnings[0]}` : ""}${liveMsg} Say "stop recording" when done.`
+            ? `${result.recording_mode === "quick-thought" ? "Quick thought" : "Recording"} started (PID: ${result.pid}).${Array.isArray(preflight.warnings) && preflight.warnings.length ? ` ${preflight.warnings[0]}` : ""}${liveMsg} When the user asks to finish (typed in chat), invoke stop_recording to process the transcript and summary. This server does not listen to audio content, so do not tell the user they can speak a stop command.`
             : "Recording failed to start. Check `minutes logs` for details.",
         },
       ],


### PR DESCRIPTION
## Problem

Claude Desktop users who start a Minutes recording get back a reply like:

> Recording started. Just say 'stop recording' when you're done, and I'll process the transcript and summary.

That's Claude echoing the shape of the `start_recording` tool's response text, which ended with `Say "stop recording" when done.` A literal "just say" doesn't work. This MCP server doesn't listen to audio content. Users have to TYPE a request in chat for Claude to invoke `stop_recording`.

## Fix

Pure copy change in `crates/mcp/src/index.ts`. No behavior change.

Three places updated:

1. **Tool description** for `start_recording`. Now explicit: "this server does not listen to audio content. Recordings are stopped by invoking stop_recording after the user types a request in chat. Never promise the user they can speak a 'stop recording' voice command."

2. **Success response (desktop-app delegation path)** at index.ts:847. Old: `Say "stop recording" when done.` New: tells Claude to invoke stop_recording when the user asks to finish, with an explicit instruction not to promise voice stop.

3. **Success response (local CLI path)** at index.ts:926. Same replacement.

## Why three places

Claude blends the tool description (long-lived context) with each tool response (in-line context). Updating only one leaves the other as a contradiction Claude might resolve wrongly.

## Follow-up

A real voice-trigger feature (speak 'Minutes, stop recording' and the recording actually stops) is feasible but non-trivial. Either run live whisper during every recording and tail the JSONL for a trigger phrase (5-15% CPU overhead on base whisper), or bolt in a wake-word engine like openWakeWord (~1% CPU, needs a Rust dep plus license check). Probably worth filing as an enhancement issue, not shipping in this PR.

## Test plan

- [x] `npm run build` in `crates/mcp/`. Succeeds, dist regenerated with new copy.
- [x] Grep confirms the old `Say "stop recording"` copy is gone from the built dist.
- [x] Grep confirms the new "do not tell the user they can speak a stop command" direction is present in both response paths.
- [ ] Manual: install this bundle in Claude Desktop, ask "start a recording", confirm the reply no longer says "just say stop recording".

🤖 Generated with [Claude Code](https://claude.com/claude-code)