### PR TITLE
feat(live): parakeet engine for standalone live transcript

### DIFF
--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -73,18 +73,30 @@ pub enum TranscriptSource {
 }
 
 pub const PARAKEET_SCOPE_DOC_REF: &str = "docs/PARAKEET.md#scope";
-pub const PARAKEET_RECORDING_LIVE_SCOPE_WARNING: &str =
-    "live transcription during recording still uses whisper (parakeet live streaming is not yet wired; see docs/PARAKEET.md#scope)";
+/// Shown at session start when the user configured `engine = "parakeet"` but the
+/// binary was built without the `parakeet` Cargo feature. The engine choice is
+/// silently honored as whisper for this session.
+pub const PARAKEET_LIVE_SCOPE_WARNING: &str =
+    "this build does not include parakeet; live transcription uses whisper (see docs/PARAKEET.md#scope)";
+/// Shown at runtime when the parakeet engine IS compiled in but fails during a
+/// live session (warmup error, sidecar unreachable, transcribe error). The
+/// session transparently falls back to whisper for the remainder.
+#[cfg(feature = "parakeet")]
+pub const PARAKEET_LIVE_FALLBACK_WARNING: &str =
+    "parakeet live transcription failed; falling back to whisper for this session (see docs/PARAKEET.md#scope)";
 
-fn recording_sidecar_engine_scope_warning(engine: &str) -> Option<&'static str> {
-    if engine.eq_ignore_ascii_case("parakeet") && !recording_sidecar_supports_parakeet(engine) {
-        Some(PARAKEET_RECORDING_LIVE_SCOPE_WARNING)
+/// True iff this build can route `engine = "parakeet"` to the parakeet path.
+/// Used at session start to decide between scope-warning (compile-time gap)
+/// and the real parakeet dispatch.
+fn live_engine_scope_warning(engine: &str) -> Option<&'static str> {
+    if engine.eq_ignore_ascii_case("parakeet") && !live_supports_parakeet(engine) {
+        Some(PARAKEET_LIVE_SCOPE_WARNING)
     } else {
         None
     }
 }
 
-fn recording_sidecar_supports_parakeet(engine: &str) -> bool {
+fn live_supports_parakeet(engine: &str) -> bool {
     #[cfg(feature = "parakeet")]
     {
         engine.eq_ignore_ascii_case("parakeet")
@@ -97,13 +109,17 @@ fn recording_sidecar_supports_parakeet(engine: &str) -> bool {
     }
 }
 
-fn emit_recording_sidecar_engine_scope_warning(engine: &str) {
-    let Some(message) = recording_sidecar_engine_scope_warning(engine) else {
+/// Session-start warning: fires only when `engine = "parakeet"` was requested
+/// and the current build cannot honor it (parakeet feature not compiled in).
+/// Always visible on stderr so the user sees that their engine choice was
+/// silently downgraded.
+fn emit_live_engine_scope_warning(engine: &str, source: &'static str) {
+    let Some(message) = live_engine_scope_warning(engine) else {
         return;
     };
 
     eprintln!("[minutes] {}", message);
-    tracing::warn!(engine, "{}", message);
+    tracing::warn!(engine, source, "{}", message);
     crate::logging::append_log(&serde_json::json!({
         "ts": Local::now().to_rfc3339(),
         "level": "warn",
@@ -112,7 +128,33 @@ fn emit_recording_sidecar_engine_scope_warning(engine: &str) {
         "message": message,
         "extra": {
             "engine": engine,
-            "source": "recording-sidecar",
+            "source": source,
+            "doc_ref": PARAKEET_SCOPE_DOC_REF,
+        }
+    }))
+    .ok();
+}
+
+/// Runtime fallback warning: fires when the parakeet path fails mid-session
+/// (warmup error or transcribe error) and the session is transparently switched
+/// to whisper for the remainder. Always visible on stderr — the user needs to
+/// know their transcripts changed engines.
+#[cfg(feature = "parakeet")]
+fn emit_live_engine_fallback_warning(source: &'static str, detail: &str) {
+    eprintln!(
+        "[minutes] {} (detail: {})",
+        PARAKEET_LIVE_FALLBACK_WARNING, detail
+    );
+    tracing::warn!(source, detail, "{}", PARAKEET_LIVE_FALLBACK_WARNING);
+    crate::logging::append_log(&serde_json::json!({
+        "ts": Local::now().to_rfc3339(),
+        "level": "warn",
+        "step": "live_transcript_fallback",
+        "file": "",
+        "message": PARAKEET_LIVE_FALLBACK_WARNING,
+        "extra": {
+            "source": source,
+            "detail": detail,
             "doc_ref": PARAKEET_SCOPE_DOC_REF,
         }
     }))
@@ -473,10 +515,75 @@ fn run_inner(
 
     let mut vad = Vad::new();
     let mut streaming = StreamingWhisper::new(config.transcription.language.clone());
+
+    // Parakeet engine dispatch — mirrors run_sidecar_inner_mpsc. When the user
+    // configures `engine = "parakeet"` and the parakeet feature is compiled in,
+    // utterance samples are accumulated and routed through the parakeet path
+    // (warm sidecar socket when `parakeet_sidecar_enabled = true`, subprocess
+    // otherwise) at VAD-end. On failure the session transparently falls back
+    // to whisper for the remainder. See RFC 0002.
+    #[cfg(feature = "parakeet")]
+    let mut parakeet_utterance_samples: Vec<f32> = Vec::new();
+    #[cfg(feature = "parakeet")]
+    let mut parakeet_live_enabled = live_supports_parakeet(&config.transcription.engine);
+    #[cfg(not(feature = "parakeet"))]
+    let parakeet_live_enabled = false;
+
     let mut was_speaking = false;
     let mut utterance_samples: usize = 0;
     let max_utterance_secs = config.live_transcript.max_utterance_secs.max(5);
     let max_utterance_samples = (max_utterance_secs as usize).saturating_mul(16000);
+
+    // One-time scope warning when the user configured parakeet but the feature
+    // isn't compiled in. Same warning the recording sidecar emits.
+    if config.transcription.engine.eq_ignore_ascii_case("parakeet") && !parakeet_live_enabled {
+        emit_live_engine_scope_warning(&config.transcription.engine, "standalone");
+    }
+
+    // Warm the parakeet sidecar at session start so the first utterance doesn't
+    // pay subprocess-spawn + model-load latency. We only warm the sidecar lane
+    // because:
+    //   - `parakeet_sidecar_enabled = true` → warmup leaves a hot example-server
+    //     child + loaded model, making subsequent utterances fast.
+    //   - `parakeet_sidecar_enabled = false` → warmup would just be a throwaway
+    //     subprocess on a silent WAV; it wouldn't leave a hot backend behind,
+    //     so the first real utterance still pays full spawn/model-load cost.
+    //     Skipping the no-op warmup avoids a 4-5s startup stall for nothing.
+    //
+    // Warmup failure is ADVISORY. We do NOT disable parakeet for the session
+    // on warmup error, because `crate::transcribe::transcribe()` already falls
+    // back sidecar→subprocess gracefully on a per-utterance basis. Forcing
+    // whisper here would be strictly worse than what the per-utterance code
+    // already does.
+    #[cfg(feature = "parakeet")]
+    if parakeet_live_enabled && config.transcription.parakeet_sidecar_enabled {
+        eprintln!("[minutes] Warming parakeet sidecar... (first-run cold start can take 10-30s)");
+        let started = std::time::Instant::now();
+        match crate::transcription_coordinator::warmup_active_backend(config) {
+            Ok(result) => {
+                tracing::info!(
+                    backend_id = %result.backend_id,
+                    elapsed_ms = result.elapsed_ms,
+                    "parakeet backend warmed for live session"
+                );
+                eprintln!("[minutes] parakeet sidecar ready ({}ms)", result.elapsed_ms);
+            }
+            Err(error) => {
+                // Log loudly, but keep parakeet_live_enabled = true so the
+                // per-utterance transcribe() path gets a chance to fall back
+                // sidecar→subprocess on its own.
+                tracing::warn!(
+                    error = %error,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "parakeet sidecar warmup failed; falling through to per-utterance dispatch (may still succeed via subprocess)"
+                );
+                eprintln!(
+                    "[minutes] parakeet sidecar warmup failed ({}); will try per-utterance subprocess path",
+                    error
+                );
+            }
+        }
+    }
 
     tracing::info!("live transcript session started");
 
@@ -486,9 +593,18 @@ fn run_inner(
         if stop_flag.load(Ordering::Relaxed) {
             // Finalize any in-progress utterance
             if utterance_samples > 0 {
-                if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                    writer.write_utterance(&sr.text, sr.duration_secs);
-                }
+                #[cfg(feature = "parakeet")]
+                finalize_on_exit(
+                    &mut writer,
+                    &mut parakeet_live_enabled,
+                    &mut parakeet_utterance_samples,
+                    config,
+                    &mut streaming,
+                    &whisper_ctx,
+                    "standalone",
+                );
+                #[cfg(not(feature = "parakeet"))]
+                finalize_on_exit(&mut writer, &mut streaming, &whisper_ctx);
             }
             break;
         }
@@ -496,9 +612,18 @@ fn run_inner(
         // Check for stop sentinel (from `minutes stop`)
         if pid::check_and_clear_sentinel() {
             if utterance_samples > 0 {
-                if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                    writer.write_utterance(&sr.text, sr.duration_secs);
-                }
+                #[cfg(feature = "parakeet")]
+                finalize_on_exit(
+                    &mut writer,
+                    &mut parakeet_live_enabled,
+                    &mut parakeet_utterance_samples,
+                    config,
+                    &mut streaming,
+                    &whisper_ctx,
+                    "standalone",
+                );
+                #[cfg(not(feature = "parakeet"))]
+                finalize_on_exit(&mut writer, &mut streaming, &whisper_ctx);
             }
             break;
         }
@@ -516,14 +641,38 @@ fn run_inner(
                     );
                     device_monitor.update_device(&new_stream.device_name);
                     stream = new_stream;
+                    // Discard any partial utterance — mic dropped mid-speech,
+                    // pre-reconnect audio is unreliable. Splicing pre+post
+                    // reconnect samples into one JSONL line would be silent
+                    // transcript corruption.
+                    if utterance_samples > 0 {
+                        tracing::info!(
+                            samples_discarded = utterance_samples,
+                            "discarding partial utterance across device reconnect"
+                        );
+                    }
+                    streaming.reset();
+                    #[cfg(feature = "parakeet")]
+                    parakeet_utterance_samples.clear();
+                    utterance_samples = 0;
+                    was_speaking = false;
                     continue;
                 }
                 Err(e) => {
                     tracing::error!("live transcript reconnect failed: {}", e);
                     if utterance_samples > 0 {
-                        if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                            writer.write_utterance(&sr.text, sr.duration_secs);
-                        }
+                        #[cfg(feature = "parakeet")]
+                        finalize_on_exit(
+                            &mut writer,
+                            &mut parakeet_live_enabled,
+                            &mut parakeet_utterance_samples,
+                            config,
+                            &mut streaming,
+                            &whisper_ctx,
+                            "standalone",
+                        );
+                        #[cfg(not(feature = "parakeet"))]
+                        finalize_on_exit(&mut writer, &mut streaming, &whisper_ctx);
                     }
                     break;
                 }
@@ -549,14 +698,36 @@ fn run_inner(
                         );
                         device_monitor.update_device(&new_stream.device_name);
                         stream = new_stream;
+                        // Discard partial utterance — see comment above the
+                        // device-change reconnect branch for rationale.
+                        if utterance_samples > 0 {
+                            tracing::info!(
+                                samples_discarded = utterance_samples,
+                                "discarding partial utterance across stream reconnect"
+                            );
+                        }
+                        streaming.reset();
+                        #[cfg(feature = "parakeet")]
+                        parakeet_utterance_samples.clear();
+                        utterance_samples = 0;
+                        was_speaking = false;
                         continue;
                     }
                     Err(e) => {
                         tracing::error!("reconnect after disconnect failed: {}", e);
                         if utterance_samples > 0 {
-                            if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                                writer.write_utterance(&sr.text, sr.duration_secs);
-                            }
+                            #[cfg(feature = "parakeet")]
+                            finalize_on_exit(
+                                &mut writer,
+                                &mut parakeet_live_enabled,
+                                &mut parakeet_utterance_samples,
+                                config,
+                                &mut streaming,
+                                &whisper_ctx,
+                                "standalone",
+                            );
+                            #[cfg(not(feature = "parakeet"))]
+                            finalize_on_exit(&mut writer, &mut streaming, &whisper_ctx);
                         }
                         break;
                     }
@@ -573,35 +744,69 @@ fn run_inner(
             was_speaking = true;
             utterance_samples += chunk.samples.len();
 
-            // Feed to streaming whisper
-            if let Some(_sr) = streaming.feed(&chunk.samples, &whisper_ctx) {
-                // Partial result available — could emit event, but for now just continue
+            if parakeet_live_enabled {
+                #[cfg(feature = "parakeet")]
+                {
+                    parakeet_utterance_samples.extend_from_slice(&chunk.samples);
+                }
+            } else if let Some(_sr) = streaming.feed(&chunk.samples, &whisper_ctx) {
+                // Partial result available — could emit event in the future
             }
 
             // Force-finalize if max utterance reached
             if utterance_samples >= max_utterance_samples {
                 tracing::info!("max utterance duration reached, force-finalizing");
-                if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                    if !writer.write_utterance(&sr.text, sr.duration_secs) {
-                        tracing::error!(
-                            "JSONL write failed — stopping session to prevent data loss"
-                        );
-                        break;
-                    }
+                #[cfg(feature = "parakeet")]
+                let write_ok = finalize_live_utterance(
+                    &mut writer,
+                    &mut parakeet_live_enabled,
+                    &mut parakeet_utterance_samples,
+                    config,
+                    &mut streaming,
+                    &whisper_ctx,
+                    "standalone",
+                );
+                #[cfg(not(feature = "parakeet"))]
+                let write_ok = if let Some(sr) = streaming.finalize(&whisper_ctx) {
+                    let ok = writer.write_utterance(&sr.text, sr.duration_secs);
+                    streaming.reset();
+                    ok
+                } else {
+                    streaming.reset();
+                    true
+                };
+                if !write_ok {
+                    tracing::error!("JSONL write failed — stopping session to prevent data loss");
+                    break;
                 }
-                streaming.reset();
                 utterance_samples = 0;
                 was_speaking = false;
             }
         } else if was_speaking && utterance_samples > 0 {
             // Speech just ended — finalize the utterance
-            if let Some(sr) = streaming.finalize(&whisper_ctx) {
-                if !writer.write_utterance(&sr.text, sr.duration_secs) {
-                    tracing::error!("JSONL write failed — stopping session to prevent data loss");
-                    break;
-                }
+            #[cfg(feature = "parakeet")]
+            let write_ok = finalize_live_utterance(
+                &mut writer,
+                &mut parakeet_live_enabled,
+                &mut parakeet_utterance_samples,
+                config,
+                &mut streaming,
+                &whisper_ctx,
+                "standalone",
+            );
+            #[cfg(not(feature = "parakeet"))]
+            let write_ok = if let Some(sr) = streaming.finalize(&whisper_ctx) {
+                let ok = writer.write_utterance(&sr.text, sr.duration_secs);
+                streaming.reset();
+                ok
+            } else {
+                streaming.reset();
+                true
+            };
+            if !write_ok {
+                tracing::error!("JSONL write failed — stopping session to prevent data loss");
+                break;
             }
-            streaming.reset();
             utterance_samples = 0;
             was_speaking = false;
             // No silence timeout — keep running until stop
@@ -872,12 +1077,21 @@ fn transcribe_with_whisper_for_live_sidecar(
         .map(|result| (result.text, result.duration_secs))
 }
 
+/// Minimum utterance length for the parakeet path — mirrors
+/// `StreamingWhisper::MIN_TRANSCRIBE_SAMPLES`. VAD blips shorter than this
+/// are dropped without hitting the sidecar/subprocess, avoiding temp-file
+/// churn and latency spikes on noisy inputs.
+#[cfg(feature = "parakeet")]
+const PARAKEET_LIVE_MIN_SAMPLES: usize = 16_000; // 1 second at 16kHz
+
 #[cfg(feature = "parakeet")]
 fn transcribe_with_parakeet_for_live_sidecar(
     samples: &[f32],
     config: &Config,
 ) -> Result<Option<(String, f64)>, MinutesError> {
-    if samples.is_empty() {
+    if samples.len() < PARAKEET_LIVE_MIN_SAMPLES {
+        // Drop sub-1s blips silently — they're almost always noise or mic
+        // pops that VAD didn't fully suppress. Same threshold whisper uses.
         return Ok(None);
     }
 
@@ -892,6 +1106,119 @@ fn transcribe_with_parakeet_for_live_sidecar(
         Ok(result) => Ok(Some((result.text, samples.len() as f64 / 16000.0))),
         Err(TranscribeError::EmptyAudio) | Err(TranscribeError::EmptyTranscript(_)) => Ok(None),
         Err(error) => Err(error.into()),
+    }
+}
+
+/// Finalize one utterance via the active engine (parakeet if enabled, else whisper)
+/// and write the resulting JSONL line.
+///
+/// Returns `true` if the write succeeded (or there was no text to write) and the
+/// session should continue; `false` on JSONL write failure, which signals the
+/// caller to stop to prevent data loss.
+///
+/// On parakeet failure, the function automatically falls back to whisper for
+/// the accumulated samples and flips `parakeet_live_enabled` to `false` so the
+/// remainder of the session uses whisper. This matches the recording-sidecar
+/// behavior — no runtime retries, one error per session.
+#[cfg(all(feature = "whisper", feature = "parakeet"))]
+fn finalize_live_utterance(
+    writer: &mut LiveTranscriptWriter,
+    parakeet_live_enabled: &mut bool,
+    parakeet_utterance_samples: &mut Vec<f32>,
+    config: &Config,
+    streaming: &mut StreamingWhisper,
+    whisper_ctx: &whisper_rs::WhisperContext,
+    source: &'static str,
+) -> bool {
+    if *parakeet_live_enabled {
+        match transcribe_with_parakeet_for_live_sidecar(parakeet_utterance_samples, config) {
+            Ok(Some((text, duration_secs))) => {
+                let ok = writer.write_utterance(&text, duration_secs);
+                parakeet_utterance_samples.clear();
+                return ok;
+            }
+            Ok(None) => {
+                parakeet_utterance_samples.clear();
+                return true;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "live parakeet path failed — switching this session to whisper"
+                );
+                *parakeet_live_enabled = false;
+                emit_live_engine_fallback_warning(source, &error.to_string());
+                // Fall back: transcribe the accumulated samples via whisper so
+                // this utterance still lands in the JSONL.
+                if let Some((text, duration_secs)) = transcribe_with_whisper_for_live_sidecar(
+                    parakeet_utterance_samples,
+                    whisper_ctx,
+                    config.transcription.language.clone(),
+                ) {
+                    let ok = writer.write_utterance(&text, duration_secs);
+                    parakeet_utterance_samples.clear();
+                    return ok;
+                }
+                parakeet_utterance_samples.clear();
+                return true;
+            }
+        }
+    }
+
+    // Whisper path
+    let write_ok = if let Some(sr) = streaming.finalize(whisper_ctx) {
+        writer.write_utterance(&sr.text, sr.duration_secs)
+    } else {
+        true
+    };
+    streaming.reset();
+    write_ok
+}
+
+/// Shutdown-time helper: finalize any partial utterance and log loudly on
+/// JSONL write failure. Called at every early-exit branch of `run_inner`
+/// (stop flag, stop sentinel, reconnect failure, stream disconnect failure).
+///
+/// We can't propagate the write_ok signal back into the caller's control flow
+/// at these branches — we're already breaking out of the loop. But if the
+/// write failed, the last utterance is silently dropped unless we log it.
+#[cfg(all(feature = "whisper", feature = "parakeet"))]
+fn finalize_on_exit(
+    writer: &mut LiveTranscriptWriter,
+    parakeet_live_enabled: &mut bool,
+    parakeet_utterance_samples: &mut Vec<f32>,
+    config: &Config,
+    streaming: &mut StreamingWhisper,
+    whisper_ctx: &whisper_rs::WhisperContext,
+    source: &'static str,
+) {
+    if !finalize_live_utterance(
+        writer,
+        parakeet_live_enabled,
+        parakeet_utterance_samples,
+        config,
+        streaming,
+        whisper_ctx,
+        source,
+    ) {
+        tracing::error!(
+            "JSONL write failed while finalizing last utterance on shutdown — last utterance may be lost"
+        );
+    }
+}
+
+#[cfg(all(feature = "whisper", not(feature = "parakeet")))]
+fn finalize_on_exit(
+    writer: &mut LiveTranscriptWriter,
+    streaming: &mut StreamingWhisper,
+    whisper_ctx: &whisper_rs::WhisperContext,
+) {
+    if let Some(sr) = streaming.finalize(whisper_ctx) {
+        if !writer.write_utterance(&sr.text, sr.duration_secs) {
+            tracing::error!(
+                "JSONL write failed while finalizing last utterance on shutdown — last utterance may be lost"
+            );
+        }
     }
 }
 
@@ -974,8 +1301,7 @@ fn run_sidecar_inner_mpsc(
     #[cfg(feature = "parakeet")]
     let mut parakeet_utterance_samples: Vec<f32> = Vec::new();
     #[cfg(feature = "parakeet")]
-    let mut parakeet_live_enabled =
-        recording_sidecar_supports_parakeet(&config.transcription.engine);
+    let mut parakeet_live_enabled = live_supports_parakeet(&config.transcription.engine);
     #[cfg(not(feature = "parakeet"))]
     let parakeet_live_enabled = false;
     let mut was_speaking = false;
@@ -985,7 +1311,7 @@ fn run_sidecar_inner_mpsc(
     let max_utterance_samples = (max_utterance_secs as usize).saturating_mul(16000);
 
     if config.transcription.engine.eq_ignore_ascii_case("parakeet") && !parakeet_live_enabled {
-        emit_recording_sidecar_engine_scope_warning(&config.transcription.engine);
+        emit_live_engine_scope_warning(&config.transcription.engine, "recording-sidecar");
     }
 
     tracing::info!("live sidecar started (recording mode)");
@@ -1112,7 +1438,10 @@ fn run_sidecar_inner_mpsc(
                                     "live recording-sidecar parakeet path failed — switching this session to whisper"
                                 );
                                 parakeet_live_enabled = false;
-                                emit_recording_sidecar_engine_scope_warning("parakeet");
+                                emit_live_engine_fallback_warning(
+                                    "recording-sidecar",
+                                    &error.to_string(),
+                                );
                                 if let Some((text, duration_secs)) =
                                     transcribe_with_whisper_for_live_sidecar(
                                         &parakeet_utterance_samples,
@@ -1151,7 +1480,10 @@ fn run_sidecar_inner_mpsc(
                                 "live recording-sidecar parakeet path failed — switching this session to whisper"
                             );
                             parakeet_live_enabled = false;
-                            emit_recording_sidecar_engine_scope_warning("parakeet");
+                            emit_live_engine_fallback_warning(
+                                "recording-sidecar",
+                                &error.to_string(),
+                            );
                             if let Some((text, duration_secs)) =
                                 transcribe_with_whisper_for_live_sidecar(
                                     &parakeet_utterance_samples,
@@ -1466,9 +1798,11 @@ pub fn clear_status_file() {
 
 #[cfg(test)]
 mod tests {
-    use super::recording_sidecar_engine_scope_warning;
+    use super::live_engine_scope_warning;
+    #[cfg(feature = "parakeet")]
+    use super::PARAKEET_LIVE_FALLBACK_WARNING;
     #[cfg(not(feature = "parakeet"))]
-    use super::PARAKEET_RECORDING_LIVE_SCOPE_WARNING;
+    use super::PARAKEET_LIVE_SCOPE_WARNING;
     use super::*;
     use chrono::Duration as ChronoDuration;
     use std::io::Write;
@@ -1759,24 +2093,78 @@ mod tests {
     }
 
     #[test]
-    fn recording_sidecar_scope_warning_only_applies_to_parakeet() {
+    fn live_scope_warning_only_applies_to_parakeet() {
         #[cfg(feature = "parakeet")]
         {
-            assert_eq!(recording_sidecar_engine_scope_warning("parakeet"), None);
-            assert_eq!(recording_sidecar_engine_scope_warning("PaRaKeEt"), None);
+            assert_eq!(live_engine_scope_warning("parakeet"), None);
+            assert_eq!(live_engine_scope_warning("PaRaKeEt"), None);
         }
         #[cfg(not(feature = "parakeet"))]
         {
             assert_eq!(
-                recording_sidecar_engine_scope_warning("parakeet"),
-                Some(PARAKEET_RECORDING_LIVE_SCOPE_WARNING)
+                live_engine_scope_warning("parakeet"),
+                Some(PARAKEET_LIVE_SCOPE_WARNING)
             );
             assert_eq!(
-                recording_sidecar_engine_scope_warning("PaRaKeEt"),
-                Some(PARAKEET_RECORDING_LIVE_SCOPE_WARNING)
+                live_engine_scope_warning("PaRaKeEt"),
+                Some(PARAKEET_LIVE_SCOPE_WARNING)
             );
         }
-        assert_eq!(recording_sidecar_engine_scope_warning("whisper"), None);
+        assert_eq!(live_engine_scope_warning("whisper"), None);
+    }
+
+    /// Scope-warning and runtime-fallback-warning are semantically distinct:
+    /// - scope = "this build doesn't support parakeet"
+    /// - fallback = "parakeet failed at runtime; falling back"
+    /// If they drift to the same message, users can't distinguish whether
+    /// their config was ignored at compile time or broken at runtime.
+    #[cfg(feature = "parakeet")]
+    #[test]
+    fn scope_and_fallback_warnings_are_distinct_messages() {
+        // The fallback message must not claim the feature is unavailable —
+        // by definition it fires when the feature IS compiled in.
+        assert!(!PARAKEET_LIVE_FALLBACK_WARNING.contains("does not include"));
+        assert!(PARAKEET_LIVE_FALLBACK_WARNING.contains("fall"));
+    }
+
+    /// The parakeet live helper drops sub-1s utterances without hitting the
+    /// sidecar/subprocess. This guards against temp-file churn and latency
+    /// spikes on VAD blips. Matches StreamingWhisper::MIN_TRANSCRIBE_SAMPLES.
+    #[cfg(feature = "parakeet")]
+    #[test]
+    fn parakeet_live_helper_drops_subsecond_utterances() {
+        use super::transcribe_with_parakeet_for_live_sidecar;
+        let cfg = Config::default();
+        // 0.5s of silence at 16kHz. Should return Ok(None) without attempting
+        // to write a temp WAV or spawn a subprocess. If the floor is missing
+        // and this test reaches the parakeet subprocess path, it will fail or
+        // hang (no parakeet binary configured in default test Config).
+        let samples = vec![0.0f32; 8_000];
+        let result = transcribe_with_parakeet_for_live_sidecar(&samples, &cfg);
+        assert!(matches!(result, Ok(None)));
+    }
+
+    /// Zero-length and exactly-at-threshold edge cases for the 1s floor.
+    #[cfg(feature = "parakeet")]
+    #[test]
+    fn parakeet_live_helper_threshold_edges() {
+        use super::transcribe_with_parakeet_for_live_sidecar;
+        use super::PARAKEET_LIVE_MIN_SAMPLES;
+        let cfg = Config::default();
+        // Empty buffer — drop.
+        assert!(matches!(
+            transcribe_with_parakeet_for_live_sidecar(&[], &cfg),
+            Ok(None)
+        ));
+        // One sample below threshold — drop.
+        let below = vec![0.0f32; PARAKEET_LIVE_MIN_SAMPLES - 1];
+        assert!(matches!(
+            transcribe_with_parakeet_for_live_sidecar(&below, &cfg),
+            Ok(None)
+        ));
+        // (We can't assert the threshold-exceeds branch here — it requires a
+        // real parakeet binary. The subprocess path is exercised by the smoke
+        // test in the RFC.)
     }
 
     #[test]

--- a/docs/PARAKEET.md
+++ b/docs/PARAKEET.md
@@ -25,18 +25,32 @@ Today, `engine = "parakeet"` is wired for these paths:
 - post-recording batch transcription (`minutes process`, desktop processing, and the shared cleanup pipeline)
 - folder watcher memo processing after a file lands on disk
 - recording-sidecar live transcription during `minutes record`
+- standalone live transcription (`minutes live` and desktop Live Mode) — see RFC 0002
 
-The recording sidecar routes each finalized utterance through the Parakeet path. If
-`parakeet_sidecar_enabled = true`, it reuses the warm `example-server` socket; otherwise
-it falls back to the Parakeet subprocess path for each utterance.
+Both live paths route each VAD-gated utterance through the Parakeet path. If
+`parakeet_sidecar_enabled = true`, they reuse the warm `example-server` socket;
+otherwise they fall back to the Parakeet subprocess path for each utterance.
+The standalone live path additionally warms the sidecar at session start so the
+first utterance does not pay the subprocess-spawn + model-load cost.
+
+Strongly recommended for live use: set `parakeet_sidecar_enabled = true` and
+ensure `example-server` is discoverable (either on `PATH` or via
+`MINUTES_PARAKEET_SERVER_BINARY`). Without the warm sidecar, every live
+utterance incurs full subprocess startup, which makes live mode visibly slow.
 
 These paths still use Whisper today, even if the global transcription engine is set to `parakeet`:
 
-- standalone live transcription (`minutes live` and desktop Live Mode)
-- dictation
+- dictation (`minutes dictate` and the dictation hotkey) — deferred to a future RFC because dictation streams mid-utterance partials for the overlay typing effect, which requires a different socket integration than utterance-granular live mode
 
-If Parakeet support is not compiled into the current build, Minutes logs a warning and
-falls back to Whisper for `minutes record` live transcription.
+If Parakeet support is not compiled into the current build, Minutes logs a
+warning and falls back to Whisper for both live paths.
+
+Note: both live paths still require the `whisper` Cargo feature to be compiled
+in. Whisper is the runtime fallback when Parakeet fails mid-session (warmup
+error, sidecar unreachable, transcription failure), so builds with
+`--features parakeet` and `--no-default-features` (no whisper) cannot run
+`minutes live` — the session errors out immediately. Whisper is a default
+feature, so this only matters for unusual build configurations.
 
 ## Fastest Path on Apple Silicon
 
@@ -314,9 +328,9 @@ cargo build --release -p minutes-cli --features parakeet
 
 Note: The `parakeet` feature is opt-in and not included in the default build.
 Whisper is always compiled in (it's the default feature). Both engines can coexist
-in the same binary — today the config file selects the offline/batch path plus
-recording-sidecar live transcription during `minutes record`, while standalone
-live transcription and dictation still use Whisper. See [Scope](#scope).
+in the same binary — the config file selects the offline/batch path plus both
+live transcription paths (`minutes record` sidecar and standalone `minutes live`).
+Dictation still uses Whisper. See [Scope](#scope).
 
 ## Switching Back to Whisper
 

--- a/docs/rfcs/0001-templates.md
+++ b/docs/rfcs/0001-templates.md
@@ -1,0 +1,367 @@
+# RFC 0001: First-class templates for domain-shaped summaries
+
+- **Status**: Draft
+- **Authors**: @silverstein, @ed0c
+- **Related**: #143
+- **Created**: 2026-04-17
+
+## Summary
+
+Introduce **templates** as a first-class primitive in Minutes. A template is a markdown file with YAML frontmatter that extends Minutes' structured extraction for a specific domain (medical notes, standup summaries, sales discovery, legal intake, etc.). Templates are additive, not replacement: they preserve the baseline extraction contract (`KEY POINTS`, `DECISIONS`, `ACTION ITEMS`, `OPEN QUESTIONS`, `COMMITMENTS`, `PARTICIPANTS`) and layer custom extraction fields, agent context, compliance rules, and additional prompt instructions on top.
+
+Templates ship bundled with Minutes, live in `~/.minutes/templates/` for user customization, and get contributed to a `templates/` directory in this repository as a community library.
+
+## Motivation
+
+Issue #143 surfaced a real limitation: the summarization prompt is hardcoded in `crates/core/src/summarize.rs`, which forces a recompile for any customization and offers no path to domain-specific output formats.
+
+The straightforward reading of that ask is "add `--prompt` / `--prompt-file` flags." That approach breaks the pipeline: the current prompt isn't a casual default, it's the contract that produces the structured output parsed into YAML frontmatter. That frontmatter powers `minutes search-actions`, the MCP tools, the knowledge graph, hooks, skills, and the agent coaching loop. A replacement prompt would silently break all of that without an obvious error signal.
+
+Templates solve the underlying problem (domain customization without recompile) while preserving the structured-extraction contract, and they unlock three things a prompt flag cannot:
+
+1. **Vertical product surfaces** — per-template landing pages, SEO-indexable, each with a working example
+2. **Community contribution** — medical, legal, therapy, and sales verticals need domain expertise Minutes will never have internally; templates let that expertise live in community-PRable markdown files
+3. **Agent-aware domain semantics** — templates carry `agent_context` that informs Claude/Codex/Gemini/OpenCode when working with template-tagged meetings, without prompting users to re-explain context
+
+## Non-goals
+
+- Replace or bypass the baseline structured extraction
+- Support arbitrary free-form prompts that produce unparseable output
+- Build a separate package registry before a repo-based contribution workflow exists
+- Duplicate skill functionality (templates define *schema*; skills define *interaction*)
+
+## Prior art
+
+- **Granola templates** — closed-source, opaque dropdown, single-vendor. The closest functional analog, and their moat. Minutes can do better by being markdown-native and community-driven.
+- **Fathom AI Summary Templates** — similar dropdown UX
+- **Fireflies SmartMatch** — keyword-triggered templates
+- **Obsidian templates** — variable substitution, no LLM awareness
+- **Rust RFCs / Python PEPs** — the RFC process itself; structured proposals with implementation phases
+
+## Design
+
+### Three-layer architecture this clarifies
+
+- **Capture layer**: audio → transcript (Rust pipeline, whisper/parakeet, diarization). Unchanged.
+- **Schema layer**: transcript → structured extraction, **template-aware**. This RFC defines this layer.
+- **Interaction layer**: structured data → agent conversation via skills, MCP, hooks, graph. Templates can route to skills but don't replace them.
+
+Templates and skills compose. A SOAP template guarantees the `subjective`/`objective`/`assessment`/`plan` shape in frontmatter; a `/minutes-soap-review` skill knows how to walk an agent through that shape conversationally. Template = schema; skill = interaction.
+
+### Template anatomy
+
+A template is a markdown file:
+
+```yaml
+---
+name: Engineering Standup
+slug: standup
+version: 1.0.0
+author: silverstein
+license: MIT
+description: Engineering standup summary with yesterday/today/blockers.
+keywords: [standup, daily, engineering]
+extends_base: true
+triggers:
+  calendar_keywords: [standup, daily, scrum]
+  transcript_keywords: [yesterday, today, blocked]
+extract:
+  yesterday: "What was completed since the last standup"
+  today: "Plans for today"
+  blockers:
+    technical: "Engineering blockers"
+    cross_team: "Cross-team dependencies"
+post_record_skill: minutes-standup-digest
+agent_context: |
+  This is an engineering standup. Keep responses engineering-specific.
+additional_instructions: |
+  Be concise. Blockers are the priority section.
+language: en
+---
+
+# Engineering Standup Template
+
+Human-readable documentation goes here: usage notes, examples, edge cases.
+```
+
+### Frontmatter fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `name` | string | Human-readable name |
+| `slug` | string | CLI identifier, URL-safe |
+| `version` | semver | Template versioning for upgrades |
+| `author` | string | Contributor credit |
+| `license` | string | Per-template license (default MIT) |
+| `description` | string | One-line summary (for listing + SEO) |
+| `keywords` | [string] | Search + SEO |
+| `extends` | slug (optional) | Inherit from another template (see Inheritance) |
+| `extends_base` | bool | If true, baseline structured extraction still runs and custom fields layer on top. Default true. |
+| `triggers.calendar_keywords` | [string] | Auto-select template from calendar event title |
+| `triggers.transcript_keywords` | [string] | Post-hoc suggestion if no template was picked |
+| `extract` | object | Custom extraction schema. Values can be strings (descriptions) or nested objects (sub-fields). Capped at 3 levels. |
+| `post_record_skill` | string | `/minutes-*` skill invoked by post-record hook |
+| `agent_context` | string | Injected into LLM prompts for agents working with this meeting later |
+| `compliance` | object | Declarative rules (see Compliance) |
+| `additional_instructions` | string | Appended to base system prompt (NEVER replaces) |
+| `language` | string | Override `[summarization] language` for this template |
+
+### Storage and resolution
+
+Templates are resolved in this order (earlier wins):
+
+1. Project: `.minutes/templates/` (repo-local, checked into git)
+2. User: `~/.minutes/templates/`
+3. Bundled: shipped with the binary (`crates/assets/templates/`)
+4. Community: `templates/` in this repository, distributed with releases
+
+Users can override bundled templates by putting a file with the same slug in `~/.minutes/templates/`.
+
+### Inheritance (family pattern)
+
+Templates can extend another template via `extends:`. Common use case: shared compliance + language + agent_context across a family of domain-specific templates.
+
+```yaml
+# medical-fr-base.md
+---
+name: Medical (French, base)
+slug: medical-fr-base
+language: fr
+compliance:
+  redact_phi: true
+  require_local_processing: true
+agent_context: |
+  This is clinical data under French HDS and RGPD.
+additional_instructions: |
+  Utilisez la terminologie clinique française.
+---
+```
+
+```yaml
+# consultation-fr.md
+---
+name: Consultation Report (French)
+slug: consultation-fr
+extends: medical-fr-base
+extract:
+  motif_consultation: "Motif de la consultation"
+  anamnese: "Anamnèse"
+  examen_clinique: "Résultats de l'examen clinique"
+  assessment:
+    diagnostic_principal: "Diagnostic principal"
+    diagnostics_differentiels: "Diagnostics différentiels"
+  plan:
+    traitement: "Traitement prescrit"
+    suivi: "Suivi recommandé"
+---
+```
+
+Inheritance rules:
+- Child inherits: `compliance`, `agent_context`, `additional_instructions`, `language`
+- Child overrides: `extract`, `triggers`, `post_record_skill`, `name`, `description`, `keywords`
+- Child merges (with conflict warning): `compliance` individual fields, `additional_instructions` (concat)
+- Inheritance is single-parent (no multiple inheritance); grandparents resolve transitively
+
+### Extract fields
+
+`extract:` accepts either a string (a description for a flat field) or a nested object (sub-fields, each with its own string or nested-object value). Nesting is capped at 3 levels.
+
+```yaml
+extract:
+  subjective: "Patient-reported symptoms and history"          # flat
+  objective: "Exam findings, vitals, labs"
+  assessment:                                                   # nested
+    diagnosis: "Primary clinical impression"
+    differential: "Differential diagnoses"
+  plan:
+    treatment:                                                  # 3rd level
+      medications: "Prescribed medications with dosing"
+      procedures: "Procedures performed"
+    followup: "Next steps and referrals"
+```
+
+The summarizer converts the `extract:` tree into a JSON schema, passes it to the LLM as structured-output guidance, and round-trips the result back into YAML frontmatter with the nested shape intact.
+
+Reliability note: depth > 3 levels is unreliable with current open-weights models and will produce a validation error at template-load time.
+
+### Triggers and auto-selection
+
+If `--template` isn't explicitly provided on the command line, Minutes picks a template in this order:
+
+1. Match `triggers.calendar_keywords` against the upcoming/current calendar event title (requires calendar integration enabled)
+2. After transcription, match `triggers.transcript_keywords` against the transcript content
+3. Fall back to the `meeting` template
+
+Manual override: `minutes record --template <slug>` or `minutes process <file> --template <slug>`.
+
+### Compliance
+
+The `compliance` field encodes declarative rules checked by the pipeline:
+
+| Field | Type | Behavior |
+|---|---|---|
+| `redact_phi` | bool | Post-extraction, redact likely PHI patterns (names, DOBs, phone numbers, MRNs) before persistence |
+| `forbid_in_summary` | [string] | Enum of `[phone_number, full_ssn, full_dob, full_name, email, mrn]`; validator rejects summary if detected |
+| `require_local_processing` | bool | If true, Minutes errors when a cloud summarization engine (Claude, OpenAI, Mistral) is configured |
+| `retention_days` | int | Annotates frontmatter with `retention_until`; downstream tools can enforce deletion |
+| `audit_log` | bool | Writes a timestamped entry to `~/.minutes/logs/audit.log` (template, action, file hash) |
+
+Compliance rules compose through inheritance. Child can tighten (stricter) but a warning fires if child loosens a parent's rule.
+
+### CLI surface
+
+```bash
+minutes template list                         # list installed templates
+minutes template show <slug>                  # dump template contents
+minutes template install <url|gh:user/repo>   # install from URL / gh repo / gist
+minutes template search <query>               # search gallery + installed
+minutes template create <name>                # scaffold new template with heredoc
+minutes template validate <path>              # schema check + smoke test
+minutes template upgrade                      # check for template updates
+
+minutes record --template <slug>              # record with explicit template
+minutes process <file> --template <slug>      # re-process existing recording with new template
+```
+
+### Agent integration
+
+When an agent (Claude Desktop, Code, Cowork, Codex, Gemini, OpenCode) interacts with a template-tagged meeting via MCP:
+
+- The meeting's frontmatter includes `template: <slug>` and the full extracted shape
+- MCP tool responses include `agent_context` from the template, injected as guidance
+- Skills declared via `post_record_skill` are invoked automatically on record completion
+
+The interaction layer stays skill-driven; templates just enrich what skills have to work with.
+
+## Worked examples
+
+### `meeting` (bundled, baseline)
+
+Minimal default, used when no other template matches.
+
+```yaml
+---
+name: Meeting
+slug: meeting
+version: 1.0.0
+description: Generic meeting summary (default).
+extends_base: true
+---
+```
+
+### `standup` (bundled)
+
+```yaml
+---
+name: Engineering Standup
+slug: standup
+extends_base: true
+triggers:
+  calendar_keywords: [standup, daily, scrum]
+extract:
+  yesterday: "What was completed since last standup"
+  today: "Plans for today"
+  blockers:
+    technical: "Engineering blockers"
+    cross_team: "Cross-team dependencies"
+post_record_skill: minutes-standup-digest
+---
+```
+
+### `medical-fr-base` (community, co-authored with @ed0c)
+
+See Inheritance section above.
+
+### `consultation-fr` (community, extends `medical-fr-base`)
+
+See Inheritance section above.
+
+### `soap-fr` (community, extends `medical-fr-base`)
+
+```yaml
+---
+name: SOAP (French)
+slug: soap-fr
+extends: medical-fr-base
+description: Note SOAP en français pour consultations médicales
+extract:
+  subjective: "Symptômes rapportés par le patient"
+  objective: "Examen clinique, signes vitaux, résultats de laboratoire"
+  assessment:
+    diagnostic: "Diagnostic principal"
+    differentiel: "Diagnostics différentiels"
+  plan:
+    traitement: "Traitement"
+    suivi: "Suivi et orientations"
+post_record_skill: minutes-soap-review
+---
+```
+
+## Implementation phases
+
+### Phase 1 — shippable, resolves #143
+- `crates/core/src/template.rs`: Template struct, loader, resolver (project > user > bundled)
+- `additional_instructions` appended to `build_system_prompt` (base prompt preserved)
+- `--template <slug>` flag in CLI
+- Bundled templates: `meeting`, `standup`, `1-on-1`, `voice-memo`
+- CLI: `minutes template list`, `show`, `validate`
+- Tests: loader, resolver, prompt composition, schema validation
+
+### Phase 2 — custom extract fields
+- Summarizer reads `extract:` from active template, requests structured output from LLM
+- Nested objects supported (max 3 levels)
+- YAML frontmatter writer extends output with custom fields
+- Reader crate (`crates/reader/`, `crates/sdk/src/reader.ts`) passes custom fields through
+- MCP tools expose custom fields in responses
+- Ship: `interview`, `sales-discovery`, `lecture`
+
+### Phase 3 — compliance + post_record_skill
+- Compliance rules enforced pre-persistence (redaction, validation)
+- `post_record_skill` wired into post-record hook
+- `agent_context` injected into MCP responses
+- Ship regulated verticals: `soap`, `medical-fr-base`, `consultation-fr`, `soap-fr`, `therapy-intake`, `legal-consult`
+- Audit log infrastructure
+
+### Phase 4 — calendar routing, community gallery, inheritance
+- Calendar keyword auto-selection
+- `templates/` dir in repo accepting community PRs
+- Template validation in CI (schema + smoke test against `example.md`)
+- `minutes template install` for gh repos + gists
+- `extends:` inheritance resolution
+- Gallery landing page on useminutes.app
+
+### Phase 5 — graph schema extensions
+- Custom extract fields flow into `graph.db`
+- Domain-aware MCP graph tools (query across medical, legal, sales templates)
+- Cross-template queries ("all SOAP notes where diagnosis includes X")
+
+## Open questions
+
+These are the areas where community input most changes the shape. Comments welcome on any of them.
+
+1. **Multi-template composition**: Some recordings straddle domains (a lunch conversation that's half personal + half clinical). Should Minutes support `--templates soap,voice-memo` that merges? My lean is no, too much complexity for marginal benefit, but open to a strong use case.
+
+2. **Template signing**: Community templates declare `agent_context` that gets injected into LLM prompts, which is adjacent to prompt-injection territory. Should templates be signed, reviewed first-party, or sandboxed? My lean: first-party review via PR is enough for Phase 4, signing is a Phase 6+ concern.
+
+3. **Template versioning and re-processing**: If a template bumps major version, do previously-processed meetings get re-processed? My lean: immutable by default; `minutes process <file> --template soap@2.0` is an explicit re-processing action. `version` in frontmatter records which template version was used.
+
+4. **Engine compatibility**: Some templates may rely on structured-output features of specific LLMs (JSON mode in OpenAI/Claude). Should templates declare `supported_engines:` and error loudly on incompatible engines? My lean: yes, fail fast is better than silent degradation, especially for compliance-sensitive templates where partial extraction could be worse than none.
+
+5. **Live transcript interaction**: Live mode streams utterances incrementally. Does the `extract:` schema progress during a live meeting, or only finalize at stop? My lean: finalize at stop for Phase 2 simplicity; streaming structured extraction is a later design.
+
+6. **Compliance extensibility**: Should `compliance` be pluggable so that a Rust plugin could define new rules (e.g., `hipaa_bulk_export_check`)? My lean: Phase 5 or later; start with the fixed enum in `forbid_in_summary` and expand as needs surface.
+
+7. **Inheritance depth**: Single-parent with transitive grandparents, or should we support multiple inheritance (mixins)? My lean: single-parent, explicit and auditable.
+
+8. **Template search / discovery**: CLI `minutes template search` queries bundled + installed; should it also query the gh repo's `templates/` directory? My lean: yes, via a periodic index refresh, not live queries per search.
+
+## Acknowledgments
+
+- **@ed0c** (#143) surfaced the limitation and agreed to co-author the regulated-vertical reference implementation. The HDS + RGPD constraints shaped the compliance field directly.
+
+## Next steps
+
+- Collect feedback on this RFC for ~2 weeks
+- @ed0c and @silverstein co-author first draft of `medical-fr-base`, `consultation-fr`, `soap-fr`
+- Begin Phase 1 implementation on a separate branch
+- RFC merges once feedback has converged

--- a/docs/rfcs/0001-templates.md
+++ b/docs/rfcs/0001-templates.md
@@ -19,9 +19,9 @@ The straightforward reading of that ask is "add `--prompt` / `--prompt-file` fla
 
 Templates solve the underlying problem (domain customization without recompile) while preserving the structured-extraction contract, and they unlock three things a prompt flag cannot:
 
-1. **Vertical product surfaces** — per-template landing pages, SEO-indexable, each with a working example
-2. **Community contribution** — medical, legal, therapy, and sales verticals need domain expertise Minutes will never have internally; templates let that expertise live in community-PRable markdown files
-3. **Agent-aware domain semantics** — templates carry `agent_context` that informs Claude/Codex/Gemini/OpenCode when working with template-tagged meetings, without prompting users to re-explain context
+1. **Vertical product surfaces**: per-template landing pages, SEO-indexable, each with a working example
+2. **Community contribution**: medical, legal, therapy, and sales verticals need domain expertise Minutes will never have internally; templates let that expertise live in community-PRable markdown files
+3. **Agent-aware domain semantics**: templates carry `agent_context` that informs Claude/Codex/Gemini/OpenCode when working with template-tagged meetings, without prompting users to re-explain context
 
 ## Non-goals
 
@@ -32,11 +32,11 @@ Templates solve the underlying problem (domain customization without recompile) 
 
 ## Prior art
 
-- **Granola templates** — closed-source, opaque dropdown, single-vendor. The closest functional analog, and their moat. Minutes can do better by being markdown-native and community-driven.
-- **Fathom AI Summary Templates** — similar dropdown UX
-- **Fireflies SmartMatch** — keyword-triggered templates
-- **Obsidian templates** — variable substitution, no LLM awareness
-- **Rust RFCs / Python PEPs** — the RFC process itself; structured proposals with implementation phases
+- **Granola templates**: closed-source, opaque dropdown, single-vendor. The closest functional analog, and their moat. Minutes can do better by being markdown-native and community-driven.
+- **Fathom AI Summary Templates**: similar dropdown UX
+- **Fireflies SmartMatch**: keyword-triggered templates
+- **Obsidian templates**: variable substitution, no LLM awareness
+- **Rust RFCs / Python PEPs**: the RFC process itself; structured proposals with implementation phases
 
 ## Design
 
@@ -299,7 +299,7 @@ post_record_skill: minutes-soap-review
 
 ## Implementation phases
 
-### Phase 1 — shippable, resolves #143
+### Phase 1: shippable, resolves #143
 - `crates/core/src/template.rs`: Template struct, loader, resolver (project > user > bundled)
 - `additional_instructions` appended to `build_system_prompt` (base prompt preserved)
 - `--template <slug>` flag in CLI
@@ -307,7 +307,7 @@ post_record_skill: minutes-soap-review
 - CLI: `minutes template list`, `show`, `validate`
 - Tests: loader, resolver, prompt composition, schema validation
 
-### Phase 2 — custom extract fields
+### Phase 2: custom extract fields
 - Summarizer reads `extract:` from active template, requests structured output from LLM
 - Nested objects supported (max 3 levels)
 - YAML frontmatter writer extends output with custom fields
@@ -315,14 +315,14 @@ post_record_skill: minutes-soap-review
 - MCP tools expose custom fields in responses
 - Ship: `interview`, `sales-discovery`, `lecture`
 
-### Phase 3 — compliance + post_record_skill
+### Phase 3: compliance + post_record_skill
 - Compliance rules enforced pre-persistence (redaction, validation)
 - `post_record_skill` wired into post-record hook
 - `agent_context` injected into MCP responses
 - Ship regulated verticals: `soap`, `medical-fr-base`, `consultation-fr`, `soap-fr`, `therapy-intake`, `legal-consult`
 - Audit log infrastructure
 
-### Phase 4 — calendar routing, community gallery, inheritance
+### Phase 4: calendar routing, community gallery, inheritance
 - Calendar keyword auto-selection
 - `templates/` dir in repo accepting community PRs
 - Template validation in CI (schema + smoke test against `example.md`)
@@ -330,7 +330,7 @@ post_record_skill: minutes-soap-review
 - `extends:` inheritance resolution
 - Gallery landing page on useminutes.app
 
-### Phase 5 — graph schema extensions
+### Phase 5: graph schema extensions
 - Custom extract fields flow into `graph.db`
 - Domain-aware MCP graph tools (query across medical, legal, sales templates)
 - Cross-template queries ("all SOAP notes where diagnosis includes X")

--- a/docs/rfcs/0002-parakeet-live-streaming.md
+++ b/docs/rfcs/0002-parakeet-live-streaming.md
@@ -1,0 +1,206 @@
+# RFC 0002: Parakeet support for standalone live transcript
+
+- **Status**: Draft
+- **Authors**: @silverstein
+- **Related**: `docs/PARAKEET.md#scope`, `docs/designs/parakeet-warm-server-sidecar-2026-04-14.md`, `docs/designs/parakeet-perf-2026-04-14.md`
+- **Created**: 2026-04-17
+
+## Summary
+
+Wire the Parakeet transcription engine into the standalone live transcript path (`minutes live` and desktop Live Mode) so that users with `engine = "parakeet"` get parakeet-produced JSONL lines instead of a silent whisper fallback. Reuse the existing warm `example-server` socket and mirror the accumulator pattern already shipping in the recording sidecar. Defer dictation to a follow-up RFC.
+
+## Motivation
+
+`docs/PARAKEET.md#scope` documents a real gap: `engine = "parakeet"` is honored for batch transcription, folder-watcher memos, and the recording-sidecar live path, but NOT for standalone live (`minutes live`) or dictation. Users who configure parakeet and run `minutes live` silently get whisper instead, with a `tracing::warn!` and no user-visible signal that the engine choice was ignored.
+
+This gap exists because:
+
+1. Parakeet landed incrementally: batch first, then warm sidecar, then recording-sidecar live.
+2. Standalone live was deferred pending the warm socket.
+3. The warm socket landed (`d0c13b3`, `parakeet_sidecar.rs`) and the perf investigation (`docs/designs/parakeet-perf-2026-04-14.md`) validated ~12.6× realtime on tdt-600m fp32, but the live-transcript integration was never cut.
+
+Parakeet users today have one of three suboptimal experiences:
+
+- They set `engine = "parakeet"` thinking it covers their live coaching workflow, and silently get whisper without noticing.
+- They run `minutes record` (which now uses parakeet via the recording sidecar after `afdbf91`) but can't use `minutes live` with parakeet.
+- They accept the whisper fallback as a "known limitation" and forgo the accuracy advantage (tdt-600m matches whisper large-v3 at 14× fewer parameters).
+
+With the warm sidecar infrastructure in place, the remaining work is mechanical: reuse the recording-sidecar's VAD-gated accumulator pattern in the standalone live path.
+
+## Non-goals
+
+- Dictation (`dictation.rs`). Dictation emits mid-utterance rolling partials via `DictationEvent::PartialText` (for the overlay typing effect). That requires re-transcribing a growing buffer on a 2-second cadence against the sidecar socket, which is a meaningfully different design question. Deferred to a future RFC.
+- Mid-utterance partials in the JSONL itself. The current standalone live path calls `StreamingWhisper::feed` every 2s but discards the partial (`live_transcript.rs:577-579`). JSONL only receives one line per VAD-gated utterance. This RFC preserves that contract for parakeet; it does not introduce rolling partials to the JSONL.
+- Changes to the warm sidecar protocol, socket location, or lifecycle. This RFC consumes the existing `transcribe_via_global_sidecar` / `warmup_global_sidecar` APIs as-is.
+- Cross-engine fallback during a live session. The recording-sidecar implementation already falls back to whisper on parakeet failure mid-session; this RFC mirrors that behavior.
+
+## Prior art within this repo
+
+- **Recording sidecar parakeet path** (`live_transcript.rs:875-896`, commit `afdbf91`). VAD-gated accumulator that writes a temp WAV on utterance-end and routes through `crate::transcribe::transcribe()`, which itself routes to the warm sidecar if `parakeet_sidecar_enabled = true`. This is the pattern this RFC ports into the standalone path.
+- **Warm sidecar design** (`docs/designs/parakeet-warm-server-sidecar-2026-04-14.md`). Full lifecycle: lazy spawn, Unix socket, stderr ring buffer, startup health check, per-process child with `~/.minutes/tmp/parakeet-sidecar-<pid>-<model>.sock`, graceful shutdown.
+- **Warmup helper** (`transcription_coordinator.rs:378` — `warmup_active_backend`). Already handles both sidecar-enabled and subprocess-enabled cases; this RFC calls it at live-session start to amortize first-utterance cost.
+
+## Current state
+
+`live_transcript::run` (the standalone path, `live_transcript.rs:470-620`):
+
+1. Loads a whisper context unconditionally.
+2. Uses `StreamingWhisper::feed` every audio chunk (re-transcribes accumulated buffer every 2s, discards result).
+3. Uses `StreamingWhisper::finalize` on VAD-end and writes one JSONL line per utterance.
+
+`run_sidecar_inner_mpsc` (the recording-sidecar path, `live_transcript.rs:937+`):
+
+1. Loads a whisper context for fallback.
+2. Checks `recording_sidecar_supports_parakeet(engine)` at startup → sets `parakeet_live_enabled`.
+3. On speech: either appends to `parakeet_utterance_samples` (parakeet) OR feeds to `StreamingWhisper` (whisper).
+4. On VAD-end or max-utterance: either calls `transcribe_with_parakeet_for_live_sidecar` (parakeet) OR `streaming.finalize()` (whisper). On parakeet failure, logs, flips `parakeet_live_enabled = false`, emits scope warning, and falls back to whisper for the remainder of the session.
+
+The scope warning (`PARAKEET_RECORDING_LIVE_SCOPE_WARNING`) currently fires whenever `engine = "parakeet"` AND parakeet support is not compiled in. After this RFC, the same message becomes accurate for both paths, so the constant name drops the `RECORDING_` prefix.
+
+## Design
+
+### Runtime engine dispatch in `live_transcript::run`
+
+Mirror `run_sidecar_inner_mpsc` structure in `run`:
+
+1. Add `parakeet_live_enabled` boolean at session start, gated on `cfg(feature = "parakeet")` and `config.transcription.engine == "parakeet"`.
+2. Add `parakeet_utterance_samples: Vec<f32>` as the accumulator (feature-gated).
+3. On VAD-gated speech: dispatch to parakeet accumulator or whisper streaming.
+4. On VAD-end or max-utterance: dispatch to `transcribe_with_parakeet_for_live_sidecar` or `streaming.finalize`.
+5. On parakeet failure: flip the flag, log, emit the scope warning, fall back to whisper for the remainder.
+
+### Shared helper extraction
+
+`transcribe_with_parakeet_for_live_sidecar` and `transcribe_with_whisper_for_live_sidecar` are currently `#[cfg(feature = "parakeet")]`-gated and sit above `run_sidecar_inner_mpsc`. They already operate on `&[f32]` samples + `&Config` (parakeet) or samples + `&WhisperContext` + language (whisper). Both callable from `run` as-is. No extraction needed — same function, two callers.
+
+### First-utterance warmup
+
+The recording sidecar today lets the first utterance pay the full sidecar startup cost (spawn subprocess, load model, wait for socket). That's acceptable because recordings typically run for minutes; the first VAD-end utterance takes longer but subsequent ones are fast.
+
+For standalone live, users often start `minutes live`, speak one short sentence, and expect a JSONL line quickly. To avoid a 10-30s wait on first utterance:
+
+- At session start, if `engine == "parakeet"` and the parakeet feature is enabled, call `transcription_coordinator::warmup_active_backend(config)` before entering the main loop.
+- If warmup fails, log and fall back to whisper immediately (don't block the session).
+- Log warmup elapsed_ms for operator visibility.
+
+This is additive: existing whisper sessions are unchanged.
+
+### Error handling and fallback semantics
+
+Match the recording-sidecar's approach exactly:
+
+- Parakeet failure on a single utterance → log error, flip `parakeet_live_enabled = false`, emit the runtime-fallback warning to stderr, re-attempt the same utterance through whisper so the JSONL line still lands.
+- Subsequent utterances in the same session use whisper until restart.
+- No automatic recovery within the session — operator restarts the session to retry parakeet. This matches the recording-sidecar behavior and keeps the implementation simple.
+- **Warmup failure is advisory, not fatal.** If `warmup_active_backend` returns an error at session start, we log it and continue with `parakeet_live_enabled = true`. The per-utterance `crate::transcribe::transcribe()` path already falls back sidecar→subprocess gracefully, so forcing whisper here would be strictly worse than the per-utterance degradation path. Each utterance still gets a chance to succeed via the parakeet binary.
+- **Warmup is only called when the sidecar is enabled.** When `parakeet_sidecar_enabled = false`, warmup would be a throwaway subprocess invocation that leaves no hot backend behind, so we skip it entirely to avoid a 4-5s startup stall for no benefit.
+
+### Warning surfaces
+
+Two distinct user-visible messages, each with a clear trigger:
+
+**Scope warning** (`PARAKEET_LIVE_SCOPE_WARNING`): fires at session start when the user configured `engine = "parakeet"` but the binary was built without the `parakeet` Cargo feature.
+- Message: `"this build does not include parakeet; live transcription uses whisper (see docs/PARAKEET.md#scope)"`
+- Source field: `"standalone"` or `"recording-sidecar"`
+
+**Runtime fallback warning** (`PARAKEET_LIVE_FALLBACK_WARNING`): fires when the parakeet engine IS compiled in but fails mid-session (transcribe error). The session transparently switches to whisper for the remainder.
+- Message: `"parakeet live transcription failed; falling back to whisper for this session (see docs/PARAKEET.md#scope)"`
+- Source field + detail: identifies which path failed and why
+
+Both write to stderr, tracing, and the JSON structured log.
+
+### Silent transcript corruption on reconnect — fixed
+
+The initial implementation did not reset the utterance accumulator on device reconnect / stream disconnect, which would have spliced pre-reconnect and post-reconnect audio into one JSONL line. Codex caught this during adversarial review. Current behavior: on successful reconnect, discard any partial utterance (both the whisper `StreamingWhisper` buffer and the parakeet `Vec<f32>` accumulator), log `samples_discarded = N`, and continue cleanly. Rationale: pre-reconnect audio is unreliable when the mic drops out mid-speech.
+
+### Minimum utterance length
+
+Sub-1s VAD blips are dropped before reaching the parakeet sidecar/subprocess, matching `StreamingWhisper::MIN_TRANSCRIBE_SAMPLES` (16,000 samples = 1 second at 16kHz). This avoids temp-file churn and latency spikes on noisy inputs. Exposed as `PARAKEET_LIVE_MIN_SAMPLES` for test assertions.
+
+## Implementation plan
+
+### Phase 1: standalone live parakeet (this RFC)
+
+- `crates/core/src/live_transcript.rs`:
+  - Extend `run` with parakeet dispatch mirroring `run_sidecar_inner_mpsc`.
+  - Rename `PARAKEET_RECORDING_LIVE_SCOPE_WARNING` → `PARAKEET_LIVE_SCOPE_WARNING` and update message.
+  - Call `warmup_active_backend` at session start when `engine == "parakeet"`.
+- `crates/core/src/transcription_coordinator.rs`: no code change; `warmup_active_backend` already handles both sidecar and subprocess lanes.
+- `docs/PARAKEET.md`: update `## Scope` section to list standalone live as parakeet-wired. Keep dictation listed as whisper-only.
+- `CLAUDE.md`: no change. The architecture description already covers the shared helper pattern.
+
+### Phase 2: dictation (future RFC)
+
+Dictation needs rolling mid-utterance partials for the overlay typing effect (`DictationEvent::PartialText`). Options sketched, not selected:
+
+- Option A: add a `StreamingParakeet` that re-sends the growing buffer to the warm socket every 2s. Socket traffic ~2× per session vs current, acceptable given warm-socket per-call is ~240ms for a 3s buffer.
+- Option B: degrade UX in dictation — no mid-utterance partials on parakeet, overlay shows "Transcribing..." until VAD-end, then the full utterance appears. Simpler but visibly worse UX.
+- Option C: parakeet for final-text write, whisper tiny for mid-utterance partials only. Dual-engine session. Hybrid complexity.
+
+Defer until live-transcript parakeet is shipping and we have operator signal on which option users accept.
+
+## Test plan
+
+Unit tests (in `live_transcript.rs` test module):
+
+- `standalone_run_uses_parakeet_when_engine_parakeet_and_feature_enabled` — assert dispatch path via instrumented helper (mock `transcribe_with_parakeet_for_live_sidecar`).
+- `standalone_run_falls_back_to_whisper_on_parakeet_failure` — inject failure, assert `parakeet_live_enabled` flips, assert whisper path produces the line.
+- `standalone_run_without_parakeet_feature_emits_scope_warning` — assert warning fires once, not per-utterance.
+
+Integration test (`tests/integration/`):
+
+- `live_parakeet_smoke.rs` (feature-gated on `parakeet`) — spawn `minutes live`, feed a known WAV, assert JSONL contains parakeet-produced text (marker: parakeet-specific tokenization differences).
+
+Smoke test (manual, documented in notes file):
+
+1. `MINUTES_PARAKEET_SERVER_BINARY=/path/to/example-server`
+2. `parakeet_sidecar_enabled = true` in config
+3. `cargo run --release -p minutes-cli --features parakeet -- live`
+4. Speak 2-3 utterances
+5. Assert JSONL lines appear, check `~/.minutes/logs/minutes.log` for `parakeet-sidecar: using warm server path` entries
+
+## Rollout
+
+No feature flag. Controlled by existing `transcription.engine` and `transcription.parakeet_sidecar_enabled` config knobs.
+
+Default behavior unchanged:
+
+- `engine = "whisper"` (default) → whisper, same as today
+- `engine = "parakeet"` + parakeet feature compiled in → parakeet on both record and live
+- `engine = "parakeet"` + parakeet feature NOT compiled in → whisper with one-time scope warning per session
+- `engine = "parakeet"` + `parakeet_sidecar_enabled = false` → per-utterance subprocess (slow; likely unusable for live; same code path as batch today). Documented as "works but not recommended for live — enable the sidecar."
+
+Release note language: "`minutes live` and desktop Live Mode now honor `engine = "parakeet"`. If you've been setting `engine = "parakeet"` and wondering why live mode felt different from record mode, this closes the gap. Enable `parakeet_sidecar_enabled = true` for acceptable latency."
+
+## Open questions (resolved during implementation + adversarial review)
+
+1. **Sidecar contention between concurrent sessions.** RESOLVED. Existing mutual-exclusion code in `pid.rs` and `cmd_record` / `cmd_live` handlers blocks simultaneous record + live in the same user session, so the multi-sidecar scenario cannot arise through the CLI. Each process still gets its own per-PID socket (`parakeet-sidecar-<pid>-<model>.sock`), so cross-process contention would be memory-bounded, not racy. Not a correctness issue.
+
+2. **Warmup timeout.** RESOLVED. We emit `[minutes] Warming parakeet sidecar... (first-run cold start can take 10-30s)` on stderr before calling `warmup_active_backend`, then `[minutes] parakeet sidecar ready (Nms)` on success or `[minutes] parakeet sidecar warmup failed (...)` on failure. No config knob needed. If a user hits repeated warmup timeouts, the per-utterance subprocess fallback still works.
+
+3. **Short utterances (<1s).** RESOLVED. Applied a 1s floor (`PARAKEET_LIVE_MIN_SAMPLES = 16_000`) in `transcribe_with_parakeet_for_live_sidecar`. Sub-1s buffers return `Ok(None)` without writing a temp WAV or spawning a subprocess. Matches whisper behavior. Two unit tests cover the floor (`parakeet_live_helper_drops_subsecond_utterances`, `parakeet_live_helper_threshold_edges`).
+
+4. **fp16 reactivation.** UNCHANGED. The warm sidecar's fp16 crash (`docs/designs/parakeet-perf-2026-04-14.md:111`) is gated by `parakeet_fp16_blacklist` in `parakeet_sidecar.rs`. Live mode inherits that blacklist automatically. Nothing to do in this RFC.
+
+## Adversarial review findings (codex + Claude)
+
+Summary of issues found and resolved before landing:
+
+| Finding | Source | Severity | Resolution |
+|---------|--------|----------|-----------|
+| Warmup failure forced whole-session whisper fallback even when per-utterance subprocess would have worked | codex | blocker (regression) | Made warmup advisory; `parakeet_live_enabled` stays `true` on warmup error so per-utterance code can try |
+| Accumulator not cleared on device reconnect → silent transcript corruption | codex | blocker | Clear both whisper and parakeet buffers on successful reconnect, log `samples_discarded` |
+| `finalize_live_utterance` returned `false` on write failure but 4 shutdown sites discarded the return value → silent data loss | codex | blocker | Added `finalize_on_exit` wrapper that logs `tracing::error!` on write failure even during shutdown |
+| Scope-warning function called on runtime fallback was silently suppressed when parakeet feature was compiled in | codex + Claude | important | Split into `PARAKEET_LIVE_SCOPE_WARNING` (compile-time) and `PARAKEET_LIVE_FALLBACK_WARNING` (runtime); both reach stderr |
+| Warmup ran even when `parakeet_sidecar_enabled = false`, producing a useless 4-5s stall | codex | important | Gated warmup on `parakeet_sidecar_enabled = true` |
+| RFC promised user-visible "Warming parakeet sidecar..." stderr line; code didn't emit it | codex | drift | Implemented on stderr before + after warmup |
+| RFC promised 1s minimum-audio floor; code did not apply it | codex | drift | Added `PARAKEET_LIVE_MIN_SAMPLES = 16_000` + two tests |
+| Fallback path had zero test coverage | Claude | important | Added `scope_and_fallback_warnings_are_distinct_messages`, `parakeet_live_helper_drops_subsecond_utterances`, `parakeet_live_helper_threshold_edges` |
+| Docs presented parakeet live as unconditional once feature is on, but still requires whisper feature for runtime fallback | codex | doc drift | Added note to `docs/PARAKEET.md#scope` clarifying whisper is required |
+
+Net result: the implementation is stricter about silent-failure modes than the recording-sidecar pattern it was originally copied from — and the recording-sidecar itself was patched to use the new `emit_live_engine_fallback_warning` for its runtime fallback sites.
+
+## Acknowledgments
+
+- The warm sidecar design (`docs/designs/parakeet-warm-server-sidecar-2026-04-14.md`) and perf benchmark (`docs/designs/parakeet-perf-2026-04-14.md`) did the hard research. This RFC is a mechanical extension of that work to the standalone live path.
+- The recording-sidecar parakeet wiring (`afdbf91`) proves the accumulator pattern works end-to-end.


### PR DESCRIPTION
## Summary

Users with `engine = "parakeet"` now get parakeet-produced JSONL lines in `minutes live` and desktop Live Mode instead of the silent whisper fallback. Closes a scope gap that was documented in `docs/PARAKEET.md#scope` but never fixed.

- VAD-gated accumulator mirrors the recording-sidecar pattern
- Warms the `example-server` socket at session start when `parakeet_sidecar_enabled = true`
- Falls back to whisper on runtime failure with user-visible stderr messages

See `docs/rfcs/0002-parakeet-live-streaming.md` for the full design.

## Adversarial review

One round of parallel adversarial review (codex `challenge` + Claude code-reviewer) surfaced 9 issues: 3 blockers, 3 important, 3 drift. All fixed before landing.

- **warmup-failure regression**: no longer force-disables parakeet for the whole session. Per-utterance `transcribe()` keeps its sidecar->subprocess fallback.
- **silent reconnect corruption**: device reconnect now discards the partial utterance instead of splicing pre/post-reconnect audio into one JSONL line.
- **silent data loss on shutdown**: 4 exit branches now log `tracing::error!` on JSONL write failure instead of swallowing it.
- **scope vs fallback warnings**: split into two distinct messages, both reach stderr. Recording-sidecar patched for the pre-existing silent version of the same bug.
- **useless warmup**: only runs when `parakeet_sidecar_enabled = true`.
- **1s minimum-audio floor**: applied to parakeet path, matches whisper.

Full findings table in the RFC under "Adversarial review findings (codex + Claude)".

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --no-default-features -- -D warnings` (CI gate)
- [x] `cargo test -p minutes-core --no-default-features --lib`: 456 pass
- [x] `cargo test -p minutes-core --features streaming,parakeet --lib live_transcript::tests`: 19 pass (3 new)
- [x] Smoke test with real `example-server`: warmup in 1.1s, clean session lifecycle, both user-visible stderr messages fire
- [ ] CI green on this branch

## Notes

- Dictation is explicitly out of scope (deferred to a future RFC). It streams mid-utterance partials via `DictationEvent::PartialText` for the overlay typing effect, which is a different socket integration problem.
- Pre-existing test `health::tests::test_parakeet_model_status_ready_with_metadata` fails on HEAD independent of this PR. Worth filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)