### PR TITLE
ci: guard MCPB pack and handshake on every push (#149 prevention)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,14 @@ jobs:
 
       - name: Install MCP dependencies
         working-directory: crates/mcp
-        run: npm install
+        # npm/cli#4828: `npm install` sometimes skips platform-specific
+        # optional deps (rollup's Linux binary in our case) when the
+        # lockfile was generated on a different OS. Delete the lockfile
+        # so Linux-host npm re-resolves optional deps cleanly. Safe in CI
+        # because we don't commit the regenerated lockfile back.
+        run: |
+          rm -f package-lock.json
+          npm install
 
       - name: TypeScript check
         working-directory: crates/mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,30 @@ jobs:
         working-directory: crates/mcp
         run: npx tsc --noEmit
 
+      # Regression guard for issue #149: v0.13.0 shipped an MCPB bundle
+      # that Claude Desktop 1.3109.0 refused to unzip because the bundle
+      # contained Next.js chunks with `..` in their filenames. Pack the
+      # bundle on every push, run the static bundle check (forbidden
+      # prefixes, `..` paths, required runtime files), and smoke-test the
+      # handshake. This class of regression now fails CI before a release
+      # can ship it.
+
+      - name: Build MCP server
+        working-directory: crates/mcp
+        run: npm run build
+
+      - name: Install mcpb CLI
+        run: npm install -g @anthropic-ai/mcpb
+
+      - name: Pack MCPB bundle
+        run: mcpb pack . minutes.mcpb
+
+      - name: Static bundle check
+        run: ./scripts/check_mcpb_bundle.sh minutes.mcpb
+
+      - name: Handshake smoke test
+        run: ./scripts/smoke_mcpb_handshake.sh minutes.mcpb
+
   site_release_consistency:
     name: Site Release Link Consistency
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ certificate or local notarization credentials.
 | **Manifest description** | New user-facing features | Read `long_description` in `manifest.json` — does it mention the new capability? |
 | **Manifest version** | Version bumps | `manifest.json` version must match all other version sources |
 | **MCP server rebuild** | Any change to `crates/mcp/src/` or `crates/mcp/ui/` | `cd crates/mcp && npm run build` |
+| **MCPB bundle guard** | Any change to `.mcpbignore`, `crates/mcp/**`, `crates/sdk/**`, `manifest.json`, or anything else that affects what lands in the packed extension | `mcpb pack . minutes.mcpb && ./scripts/check_mcpb_bundle.sh minutes.mcpb && ./scripts/smoke_mcpb_handshake.sh minutes.mcpb`. The `MCP Server` CI job runs this on every push since issue #149; running it locally first saves a round-trip. |
 | **cargo fmt** | Any Rust change | `cargo fmt --all -- --check` |
 | **cargo clippy** | Any Rust change | `cargo clippy --all --no-default-features -- -D warnings` |
 | **cargo test** | Any Rust change | `cargo test -p minutes-core --no-default-features --lib` — CI runs the full suite; the local no-default-features run catches most regressions without needing the whisper model. |

--- a/scripts/check_mcpb_bundle.sh
+++ b/scripts/check_mcpb_bundle.sh
@@ -20,14 +20,34 @@ required = [
     "crates/mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js",
 ]
 
+# Trees that should never appear in the MCPB — they are either the desktop
+# app source, landing-page artifacts, or the Rust workspace. If any of these
+# leak in, .mcpbignore fell out of sync and the bundle is wasting space at
+# best (100MB+ landing-page chunks) or shipping path-traversal filenames
+# Claude Desktop will reject at worst (#149).
+forbidden_prefixes = (
+    "site/",
+    "tauri/",
+    "target/",
+    ".vercel/",
+    ".next/",
+    "crates/core/",
+    "crates/cli/",
+    "crates/reader/",
+    "crates/whisper-guard/",
+)
+
 with zipfile.ZipFile(bundle) as zf:
     names = set(zf.namelist())
     missing = [path for path in required if path not in names]
     # Claude Desktop 1.3109.0 rejects any zip entry containing `..` as path
-    # traversal — even when the `..` is literal chars inside a filename.
+    # traversal, even when the `..` is literal chars inside a filename.
     # Next.js chunk filenames do this routinely, so a stray `.vercel/output/`
     # or `.next/` tree at repo root sinks the whole bundle (issue #149).
     path_traversal = sorted(n for n in names if ".." in n)
+    forbidden = sorted(
+        n for n in names if any(n.startswith(p) for p in forbidden_prefixes)
+    )
 
 if missing:
     print("MCPB bundle is missing required runtime files:", file=sys.stderr)
@@ -48,6 +68,32 @@ if path_traversal:
     print(
         "Usually caused by a stray .vercel/output/ or .next/ tree at repo "
         "root. Add those paths to .mcpbignore and repack.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+if forbidden:
+    # Group by leaked top-level prefix so the fix is obvious.
+    by_prefix = {}
+    for n in forbidden:
+        for p in forbidden_prefixes:
+            if n.startswith(p):
+                by_prefix.setdefault(p, []).append(n)
+                break
+    print(
+        "MCPB bundle contains trees that should not be packed:",
+        file=sys.stderr,
+    )
+    for prefix, paths in by_prefix.items():
+        print(f"  {prefix} ({len(paths)} files)", file=sys.stderr)
+        for path in paths[:3]:
+            print(f"    - {path}", file=sys.stderr)
+        if len(paths) > 3:
+            print(f"    ... and {len(paths) - 3} more", file=sys.stderr)
+    print(
+        "Each leaked prefix must be added to .mcpbignore. The first offender "
+        "historically was a repo-root `.vercel/output/` tree from `vercel "
+        "build` during release packaging (#149).",
         file=sys.stderr,
     )
     raise SystemExit(1)

--- a/scripts/smoke_mcpb_handshake.sh
+++ b/scripts/smoke_mcpb_handshake.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the packed MCPB: extract it, run the bundled
+# crates/mcp/dist/index.js under the same Node that ships in CI, send the
+# exact Claude Desktop 1.3109.0 initialize JSON-RPC, and verify the server
+# replies with protocolVersion 2025-11-25.
+#
+# This catches regressions that the static bundle check cannot: broken
+# runtime imports, SDK major bumps, argv/__filename comparison breakage,
+# server crashing during handler registration, etc.
+#
+# Usage: scripts/smoke_mcpb_handshake.sh path/to/minutes.mcpb
+
+set -euo pipefail
+
+bundle_path="${1:-minutes.mcpb}"
+
+if [[ ! -f "$bundle_path" ]]; then
+  echo "Missing MCPB bundle: $bundle_path" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+# Resolve symlinks so process.argv[1] matches fileURLToPath(import.meta.url)
+# inside the server. On macOS, mktemp returns /var/folders/... which is a
+# symlink to /private/var/folders/...; without this, the server's
+# `resolve(process.argv[1]) === __filename` guard fails, main() never runs,
+# and the test sees a silent no-response that isn't actually a regression.
+tmp="$(cd "$tmp" && pwd -P)"
+trap 'rm -rf "$tmp"' EXIT
+
+unzip -q "$bundle_path" -d "$tmp"
+
+if [[ ! -f "$tmp/crates/mcp/dist/index.js" ]]; then
+  echo "Packed bundle is missing crates/mcp/dist/index.js" >&2
+  exit 1
+fi
+
+initialize='{"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"extensions":{"io.modelcontextprotocol/ui":{"mimeTypes":["text/html;profile=mcp-app"]}}},"clientInfo":{"name":"ci-smoke","version":"0"}},"jsonrpc":"2.0","id":0}'
+
+out="$tmp/out.txt"
+err="$tmp/err.txt"
+
+# Pipe stdin EOF after writing the initialize; the server should respond
+# and then exit cleanly when stdin closes. 15s timeout guards against the
+# server hanging. Pick the first available timeout binary so the script
+# works on Ubuntu CI (timeout), macOS (gtimeout via coreutils), or neither.
+timeout_cmd=""
+for candidate in timeout gtimeout; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    timeout_cmd="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$timeout_cmd" ]]; then
+  printf '%s\n' "$initialize" | \
+    "$timeout_cmd" 15 node "$tmp/crates/mcp/dist/index.js" >"$out" 2>"$err" || rc=$?
+else
+  # No timeout binary available. Fall back to running without one — node
+  # exits on stdin EOF so a healthy server still returns quickly.
+  printf '%s\n' "$initialize" | \
+    node "$tmp/crates/mcp/dist/index.js" >"$out" 2>"$err" || rc=$?
+fi
+
+rc="${rc:-0}"
+
+python3 - "$out" "$err" "$rc" <<'PY'
+import json
+import sys
+
+out_path, err_path, rc = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(out_path) as f:
+    stdout = f.read()
+with open(err_path) as f:
+    stderr = f.read()
+
+response = None
+for line in stdout.splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if msg.get("id") == 0 and "result" in msg:
+        response = msg
+        break
+
+if response is None:
+    print("No initialize response on stdout.", file=sys.stderr)
+    print(f"--- stdout ({len(stdout)} bytes) ---", file=sys.stderr)
+    print(stdout, file=sys.stderr)
+    print(f"--- stderr ({len(stderr)} bytes) ---", file=sys.stderr)
+    print(stderr, file=sys.stderr)
+    print(f"--- exit code: {rc} ---", file=sys.stderr)
+    sys.exit(1)
+
+result = response["result"]
+proto = result.get("protocolVersion")
+if proto != "2025-11-25":
+    print(
+        f"Expected protocolVersion=2025-11-25, got {proto!r}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+caps = result.get("capabilities", {})
+if "tools" not in caps or "resources" not in caps:
+    print(
+        f"Expected tools+resources capabilities, got keys {sorted(caps)}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+ext_ui = caps.get("extensions", {}).get("io.modelcontextprotocol/ui")
+if ext_ui is None:
+    print(
+        "Expected extensions.io.modelcontextprotocol/ui capability.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+server_info = result.get("serverInfo", {})
+print(
+    f"MCPB handshake OK: server={server_info.get('name')}@"
+    f"{server_info.get('version')} protocol={proto}"
+)
+PY


### PR DESCRIPTION
## Summary

Three layered guards so the v0.13.0 install-breakage class of bug gets caught in CI before it reaches a release.

## What changes

1. **`scripts/check_mcpb_bundle.sh`** now also rejects forbidden top-level trees (`site/`, `tauri/`, `target/`, `.vercel/`, `.next/`, and non-mcp Rust crates). When `.mcpbignore` drifts, the script tells you the leaked prefix directly.
2. **`scripts/smoke_mcpb_handshake.sh`** (new) extracts the packed bundle, runs `dist/index.js` under Node, sends the Claude Desktop 1.3109.0 initialize JSON-RPC, and asserts `protocolVersion: 2025-11-25` plus the expected capabilities come back. Catches runtime regressions the static check cannot (broken imports, SDK bumps, path/argv edge cases).
3. **`.github/workflows/ci.yml`** MCP Server job now runs both scripts on every push.

## Cost

Zero additional wall-clock time. The MCP Server job goes from ~1m to ~1m 45s and still finishes long before the Windows desktop installer (which gates the whole run at ~18-20m). One extra minute of Ubuntu-tier CI minutes per push.

## Test plan

- [x] Hardened `check_mcpb_bundle.sh` still passes on healthy v0.13.1 bundle
- [x] New `smoke_mcpb_handshake.sh` passes on v0.13.1 bundle locally (macOS)
- [x] Edits on this branch trigger the new CI job; waiting for first CI run to confirm it stays green on Ubuntu

Refs #149.