### PR TITLE
ci: skip heavy Rust/desktop jobs when PR touches no Rust paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,38 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Detect which areas of the repo changed so heavy Rust/Tauri jobs can
+  # skip when a PR only touches docs, site/, MCP, skills, or scripts.
+  # The Windows Desktop Installer job alone is ~20 min; on a no-Rust PR
+  # that's pure waste. Any path touched by the `rust` filter triggers the
+  # full desktop/test/install matrix. The workflow file itself is in the
+  # filter defensively, so edits to CI always get verified end-to-end.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'tauri/**'
+              - 'crates/core/**'
+              - 'crates/cli/**'
+              - 'crates/reader/**'
+              - 'crates/whisper-guard/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
+
   test:
     name: Test (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -92,6 +122,8 @@ jobs:
 
   install:
     name: Install CLI (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -136,6 +168,8 @@ jobs:
     # (~5 min vs ~15 min cold) compound across every PR. release-cli.yml still
     # does the release build at tag time as the final gate.
     name: Build CLI (ubuntu-latest, default features)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -170,6 +204,8 @@ jobs:
 
   desktop_windows:
     name: Desktop App Installer (windows-latest)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Path-filter the heavy Rust/desktop CI jobs so PRs that don't touch Rust or Tauri finish CI in about 3 min instead of 20.

## What changes

A new `changes` job uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) to detect whether any path in this list changed:

- `tauri/**`
- `crates/core/**`, `crates/cli/**`, `crates/reader/**`, `crates/whisper-guard/**`
- `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`
- `.github/workflows/ci.yml` (defensive: edits to CI itself still get full verification)

It exposes a `rust` boolean output. Four jobs now gate on `needs.changes.outputs.rust == 'true'`:

- `test` (macOS/Windows/Ubuntu matrix)
- `install` (Ubuntu/Windows matrix)
- `linux_full_build` (CLI debug build with whisper+diarize)
- `desktop_windows` (NSIS installer, about 20 min on its own)

The always-on jobs (MCP Server, Site Release Link Consistency, Agents Skill Sync) stay unconditional. Each is under 2 min and covers the non-Rust surface.

## Why

The Windows Desktop Installer job is the single slowest step. For the last three merges (MCP packaging fix, release cut, post-publish dep bump) none of the heavy jobs had any chance of catching a real bug, yet we paid about 20 min of CI wall time per push.

## Test plan

- [x] YAML parses as valid
- [x] All four gated jobs have `needs: changes` + `if: needs.changes.outputs.rust == 'true'`
- [ ] This PR touches `.github/workflows/ci.yml`, which IS in the filter, so the full Rust/desktop suite should run once here, proving the workflow still works end-to-end
- [ ] Follow-up: open a dummy docs-only PR after merge to confirm heavy jobs skip
