### PR TITLE
feat(voice): enroll teammates by name, with optional persona label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,13 +312,17 @@ minutes/
 ├── BUILD-STATUS.md            # Build progress tracker
 ├── Cargo.toml                 # Workspace root
 ├── crates/
-│   ├── core/src/              # 34 Rust modules — the engine
+│   ├── core/src/              # 40 Rust modules — the engine
 │   │   ├── capture.rs         # Audio capture (cpal), device categorization, loopback detection
 │   │   ├── resample.rs        # Shared mono-downmix + 16kHz decimation resampler (used by capture + streaming)
 │   │   ├── transcribe.rs      # Transcription: whisper.cpp (default) or parakeet.cpp (opt-in). Delegates to whisper-guard for anti-hallucination, optional nnnoiseless denoise
+│   │   ├── transcription_coordinator.rs # Engine dispatch (whisper vs parakeet); keeps pipeline engine-agnostic
+│   │   ├── parakeet.rs        # parakeet.cpp transcription path (gated behind `parakeet` feature)
+│   │   ├── parakeet_sidecar.rs # Parakeet sidecar process management (unix/non-unix split via cfg stubs — see Pre-Commit Checklist)
 │   │   ├── diarize.rs         # Speaker diarization + attribution types (pyannote-rs, or energy-based from per-source stems)
 │   │   ├── summarize.rs       # LLM summarization + speaker mapping (ureq HTTP client)
-│   │   ├── voice.rs           # Voice profile storage and matching (voices.db, enrollment, cosine similarity)
+│   │   ├── voice.rs           # Voice profile storage and matching (voices.db, enrollment self/teammate via `--name`, optional `--persona` label, cosine similarity)
+│   │   ├── person_identity.rs # User identity profile (name, emails, variants) for cross-meeting "me" attribution
 │   │   ├── pipeline.rs        # Orchestrates the full flow + structured extraction
 │   │   ├── notes.rs           # Timestamped notetaking during/after recordings
 │   │   ├── watch.rs           # Folder watcher (settle delay, dedup, lock)
@@ -343,6 +347,7 @@ minutes/
 │   │   ├── vault.rs           # Obsidian/Logseq vault sync
 │   │   ├── knowledge.rs       # Knowledge base adapters (wiki/PARA/Obsidian) + fact writing
 │   │   ├── knowledge_extract.rs # Structured fact extraction from meeting frontmatter
+│   │   ├── autoresearch.rs    # Background research runs + decode-hint eval comparison (CLI-surfaced)
 │   │   ├── desktop_control.rs # Desktop automation (AppleScript, tray interactions)
 │   │   ├── graph.rs           # Conversation knowledge graph (people, decisions, commitments)
 │   │   ├── jobs.rs            # Background job queue for async processing
@@ -388,6 +393,9 @@ node test/mcp_tools_test.mjs                        # 8 MCP integration tests
 - **Rust** for the engine — single 6.7MB binary, cross-platform, fast
 - **whisper-rs** (whisper.cpp) for transcription (default) — local, Apple Silicon optimized, params match whisper-cli defaults (best_of=5, entropy/logprob thresholds)
 - **parakeet.cpp** for transcription (opt-in) — NVIDIA FastConformer via subprocess, Metal GPU acceleration on Apple Silicon. Lower WER than Whisper at equivalent model sizes. Requires `--features parakeet` at build time. See `docs/PARAKEET.md` for setup
+- **Transcription coordinator** — `transcription_coordinator.rs` dispatches to whisper or parakeet per call so the rest of the pipeline stays engine-agnostic. Any struct/field the coordinator reads off a parakeet result must exist on both the real unix impl and the non-unix stub (see Pre-Commit Checklist → "Feature-gated stub struct parity").
+- **Person identity** — `person_identity.rs` stores the user's name, email addresses, and variants so diarization/attribution can confidently map "me" across meeting memory. Separate from voice profiles (`voices.db`) and the conversation graph (`graph.db`); survives rebuilds.
+- **Autoresearch** — `autoresearch.rs` runs background research jobs and supports comparing decode-hint eval runs. CLI surfaces recent output; used for transcription-quality regression investigations.
 - **ffmpeg preferred for audio decoding** — shells out to ffmpeg for m4a/mp3/ogg when available (identical to whisper-cli's pipeline). Falls back to symphonia (pure Rust) when ffmpeg isn't installed. This matters for non-English audio — symphonia's AAC decoder produces subtly different samples that trigger whisper hallucination loops (issue #21).
 - **Silero VAD** (via whisper-rs) — ML-based voice activity detection integrated directly into whisper's transcription params. Prevents hallucination loops by skipping silence segments. Auto-downloaded during `minutes setup`.
 - **whisper-guard** crate — standalone anti-hallucination toolkit extracted from minutes-core. 6-layer defense: Silero VAD gating, no_speech probability filtering (>80% = skip), consecutive segment dedup (3+ similar collapsed), interleaved A/B/A/B pattern detection, foreign-script hallucination detection, language-agnostic noise marker collapse (`[Śmiech]`, `[music]`, `[risas]`, etc.), trailing noise trimming. Publishable to crates.io independently.
@@ -434,7 +442,7 @@ node test/mcp_tools_test.mjs                        # 8 MCP integration tests
 
 ## Claude Ecosystem Integration
 
-- **MCP Server**: 26 tools + 6 resources for Claude Desktop / Cowork / Dispatch (`npx minutes-mcp` for zero-install)
+- **MCP Server**: 26 tools + 6 resources + 6 prompt templates for Claude Desktop / Cowork / Dispatch (`npx minutes-mcp` for zero-install)
 - **Claude Code Plugin**: 18 skills (7 capture + 1 search + 4 lifecycle + 2 coaching + 3 knowledge + 1 intelligence) + meeting-analyst agent + SessionStart + PostToolUse hooks
 - **Interactive meeting lifecycle**: `/minutes-brief` → `/minutes-prep` → record → `/minutes-tag` → `/minutes-debrief` → `/minutes-mirror` → `/minutes-weekly` with skill chaining via `.brief.md` / `.prep.md` files; `/minutes-graph` for cross-meeting entity queries
 - **Conversational summarization**: Claude reads transcripts via MCP, no API key needed

--- a/README.md
+++ b/README.md
@@ -827,8 +827,11 @@ minutes setup --parakeet --parakeet-model tdt-ctc-110m  # English-only compact m
 # Also installs native Silero VAD weights for the parakeet.cpp --vad path
 
 # Enroll your voice for automatic speaker identification
-minutes enroll              # Records 10s of your voice
-minutes voices              # View enrolled profiles
+minutes enroll                                         # Records 10s of your voice
+minutes enroll --name "Alex Chen"                      # Enroll a teammate
+minutes enroll --name "Alex Chen" --persona "PM" \
+  --file ./alex-sample.wav                             # Enroll from existing audio + tag with a persona
+minutes voices                                         # View enrolled profiles
 ```
 
 ### Speaker identification
@@ -852,8 +855,9 @@ Only **High**-confidence attributions rewrite transcript labels. Medium/Low are 
 name = "Your Name"
 
 # Enroll your voice (Level 2)
-minutes enroll                    # Record 10s sample
-minutes enroll --file sample.wav  # Or from existing audio
+minutes enroll                                   # Record 10s sample (enrolls yourself)
+minutes enroll --file sample.wav                 # Or from existing audio
+minutes enroll --name "Alex Chen" --persona "PM" # Enroll a teammate with an optional role label
 
 # Confirm attributions after a meeting (Level 3)
 minutes confirm --meeting ~/meetings/2026-03-25-standup.md

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -675,7 +675,7 @@ enum Commands {
         action: VaultAction,
     },
 
-    /// Enroll your voice for automatic speaker identification
+    /// Enroll a voice for automatic speaker identification (self, or a teammate via --name)
     Enroll {
         /// Enroll from an existing audio file instead of recording
         #[arg(long)]
@@ -683,6 +683,12 @@ enum Commands {
         /// Recording duration in seconds (default: 10)
         #[arg(long, default_value = "10")]
         duration: u64,
+        /// Enroll a voice profile for someone other than you. Omit to enroll yourself.
+        #[arg(long)]
+        name: Option<String>,
+        /// Optional label for this profile (e.g. "PM", "client-sarah", "quiet-room"). Metadata only — does not affect matching.
+        #[arg(long)]
+        persona: Option<String>,
     },
 
     /// List and manage enrolled voice profiles
@@ -1179,7 +1185,18 @@ fn main() -> Result<()> {
             VaultAction::Unlink => cmd_vault_unlink(config),
             VaultAction::Sync => cmd_vault_sync(&config),
         },
-        Commands::Enroll { file, duration } => cmd_enroll(file.as_deref(), duration, &config),
+        Commands::Enroll {
+            file,
+            duration,
+            name,
+            persona,
+        } => cmd_enroll(
+            file.as_deref(),
+            duration,
+            name.as_deref(),
+            persona.as_deref(),
+            &config,
+        ),
         Commands::Voices { delete, json } => cmd_voices(delete, json),
         Commands::Delete {
             meeting,
@@ -5512,40 +5529,59 @@ fn cmd_dictate(stdout: bool, note_only: bool, config: &Config) -> Result<()> {
     Ok(())
 }
 
-fn cmd_enroll(file: Option<&Path>, duration: u64, config: &Config) -> Result<()> {
+fn cmd_enroll(
+    file: Option<&Path>,
+    duration: u64,
+    name: Option<&str>,
+    persona: Option<&str>,
+    config: &Config,
+) -> Result<()> {
     use minutes_core::voice;
 
-    // Step 1: Check name — offer to set it if missing
-    let my_name = match config.identity.name.as_ref() {
-        Some(name) if !name.is_empty() => name.clone(),
-        _ => {
-            eprintln!(
-                "Your name isn't set yet. This is needed so Minutes knows which speaker is you."
-            );
-            eprint!("What's your name? ");
-            let mut input = String::new();
-            std::io::stdin().read_line(&mut input)?;
-            let name = input.trim().to_string();
-            if name.is_empty() {
-                return Err(anyhow::anyhow!("Name is required for voice enrollment."));
-            }
-            // Save to config file
-            let config_path = dirs::config_dir()
-                .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"))
-                .join("minutes/config.toml");
-            if config_path.exists() {
-                let mut content = std::fs::read_to_string(&config_path)?;
-                if content.contains("[identity]") {
-                    // Add name under existing [identity] section
-                    content =
-                        content.replace("[identity]", &format!("[identity]\nname = \"{}\"", name));
-                } else {
-                    content.push_str(&format!("\n[identity]\nname = \"{}\"\n", name));
+    // Resolve: are we enrolling self, or someone else?
+    // When --name is provided and differs from the configured identity name,
+    // this is "other" enrollment — skip config-write entirely.
+    let explicit_name = name.map(|s| s.trim()).filter(|s| !s.is_empty());
+    let is_self = match (explicit_name, config.identity.name.as_deref()) {
+        (None, _) => true,
+        (Some(n), Some(id)) if n.eq_ignore_ascii_case(id.trim()) => true,
+        (Some(_), _) => false,
+    };
+
+    let enroll_name = if let Some(n) = explicit_name {
+        n.to_string()
+    } else {
+        // Step 1 (self path only): check name — offer to set it if missing
+        match config.identity.name.as_ref() {
+            Some(n) if !n.is_empty() => n.clone(),
+            _ => {
+                eprintln!(
+                    "Your name isn't set yet. This is needed so Minutes knows which speaker is you."
+                );
+                eprint!("What's your name? ");
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                let n = input.trim().to_string();
+                if n.is_empty() {
+                    return Err(anyhow::anyhow!("Name is required for voice enrollment."));
                 }
-                std::fs::write(&config_path, content)?;
-                eprintln!("Saved to {}", config_path.display());
+                // Save to config file (self path only — never for --name enrollments)
+                let config_path = dirs::config_dir()
+                    .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"))
+                    .join("minutes/config.toml");
+                if config_path.exists() {
+                    let mut content = std::fs::read_to_string(&config_path)?;
+                    if content.contains("[identity]") {
+                        content =
+                            content.replace("[identity]", &format!("[identity]\nname = \"{}\"", n));
+                    } else {
+                        content.push_str(&format!("\n[identity]\nname = \"{}\"\n", n));
+                    }
+                    std::fs::write(&config_path, content)?;
+                    eprintln!("Saved to {}", config_path.display());
+                }
+                n
             }
-            name
         }
     };
 
@@ -5559,11 +5595,41 @@ fn cmd_enroll(file: Option<&Path>, duration: u64, config: &Config) -> Result<()>
         ));
     }
 
+    // Step 2.5: Slug + collision guard.
+    // Catches cases like `minutes enroll --name Alex` colliding with an
+    // existing profile for a different human who slugs the same. Without
+    // this guard, save_profile_blended would silently average two humans'
+    // embeddings under the first human's name.
+    let conn = voice::open_db().map_err(|e| anyhow::anyhow!("{}", e))?;
+    let slug = voice::slugify(&enroll_name);
+    if slug.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Name '{}' slugs to an empty string. Use letters or numbers.",
+            enroll_name
+        ));
+    }
+    if let Some(existing_name) =
+        voice::lookup_name_for_slug(&conn, &slug).map_err(|e| anyhow::anyhow!("{}", e))?
+    {
+        if existing_name != enroll_name {
+            return Err(anyhow::anyhow!(
+                "A voice profile already exists for slug '{}' with name '{}'. \
+                 Use a more specific name (e.g. 'Alex Chen' instead of 'Alex'), \
+                 or delete the existing profile first with `minutes voices --delete`.",
+                slug,
+                existing_name
+            ));
+        }
+    }
+
     // Step 3: Record or load audio
     eprintln!();
+    let header_persona = persona
+        .map(|p| format!("  \x1b[2m·\x1b[0m \x1b[3m{}\x1b[0m", p))
+        .unwrap_or_default();
     eprintln!(
-        "  \x1b[1;36m◉ Voice Enrollment\x1b[0m  \x1b[2mfor\x1b[0m \x1b[1m{}\x1b[0m",
-        my_name
+        "  \x1b[1;36m◉ Voice Enrollment\x1b[0m  \x1b[2mfor\x1b[0m \x1b[1m{}\x1b[0m{}",
+        enroll_name, header_persona
     );
     eprintln!();
 
@@ -5574,11 +5640,22 @@ fn cmd_enroll(file: Option<&Path>, duration: u64, config: &Config) -> Result<()>
         eprintln!("  Using audio file: {}", path.display());
         path.to_path_buf()
     } else {
-        eprintln!("  This creates a voice profile so Minutes can identify you");
-        eprintln!(
-            "  in future meetings. Just talk normally for {} seconds.",
-            duration
-        );
+        if is_self {
+            eprintln!("  This creates a voice profile so Minutes can identify you");
+            eprintln!(
+                "  in future meetings. Just talk normally for {} seconds.",
+                duration
+            );
+        } else {
+            eprintln!(
+                "  This creates a voice profile so Minutes can identify {} in",
+                enroll_name
+            );
+            eprintln!(
+                "  future meetings. They should talk normally for {} seconds.",
+                duration
+            );
+        }
         eprintln!();
         eprintln!("  Tips:");
         eprintln!("  - Use the same mic you use for meetings");
@@ -5611,18 +5688,19 @@ fn cmd_enroll(file: Option<&Path>, duration: u64, config: &Config) -> Result<()>
     };
 
     // Step 4: Extract voice embedding
-    eprintln!("  \x1b[2mAnalyzing your voice...\x1b[0m");
-    let result = minutes_core::diarize::diarize(&audio_path, config)
-        .ok_or_else(|| anyhow::anyhow!(
-            "Could not analyze the recording. Make sure you spoke clearly and your mic is working.\n\
+    eprintln!("  \x1b[2mAnalyzing voice...\x1b[0m");
+    let result = minutes_core::diarize::diarize(&audio_path, config).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not analyze the recording. Make sure audio is clear and your mic is working.\n\
              Check with: minutes devices"
-        ))?;
+        )
+    })?;
 
     if result.segments.is_empty() {
         return Err(anyhow::anyhow!(
             "No speech detected in the recording.\n\n\
              Try again:\n\
-             - Make sure your mic is not muted\n\
+             - Make sure the mic is not muted\n\
              - Speak at normal volume\n\
              - Reduce background noise\n\
              - Check your mic: minutes devices"
@@ -5635,10 +5713,10 @@ fn cmd_enroll(file: Option<&Path>, duration: u64, config: &Config) -> Result<()>
             "multiple speakers detected during enrollment — picking an arbitrary one"
         );
         eprintln!(
-            "  ⚠ Detected {} voices — the enrolled profile may not be yours.",
+            "  ⚠ Detected {} voices — the enrolled profile may be wrong.",
             result.num_speakers
         );
-        eprintln!("  For best results, re-run in a quiet room with just you speaking.");
+        eprintln!("  For best results, re-run in a quiet room with just one speaker.");
     }
 
     eprintln!("  \x1b[2mComputing voice profile...\x1b[0m");
@@ -5654,41 +5732,59 @@ fn cmd_enroll(file: Option<&Path>, duration: u64, config: &Config) -> Result<()>
     let embedding = embedding.clone();
 
     // Step 5: Save
-    let conn = voice::open_db().map_err(|e| anyhow::anyhow!("{}", e))?;
-    let slug: String = my_name
-        .to_lowercase()
-        .chars()
-        .map(|c: char| if c.is_alphanumeric() { c } else { '-' })
-        .collect::<String>()
-        .trim_matches('-')
-        .to_string();
+    let source = if is_self {
+        "self-enrollment"
+    } else {
+        "other-enrollment"
+    };
     voice::save_profile_blended(
         &conn,
         &slug,
-        &my_name,
+        &enroll_name,
         &embedding,
-        "self-enrollment",
+        source,
         voice::model_version(config),
+        persona,
     )
     .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let profiles = voice::list_profiles(&conn).map_err(|e| anyhow::anyhow!("{}", e))?;
-    if let Some(p) = profiles.iter().find(|p| p.person_slug == slug) {
+    if let Some(p) = profiles.iter().find(|prof| prof.person_slug == slug) {
         eprintln!();
         eprintln!("  \x1b[1;32m✓ Voice profile saved!\x1b[0m");
         eprintln!("  \x1b[2m───────────────────────\x1b[0m");
         eprintln!("  \x1b[2mName:\x1b[0m     \x1b[1m{}\x1b[0m", p.name);
+        if let Some(persona) = p.persona.as_deref() {
+            eprintln!("  \x1b[2mPersona:\x1b[0m  {}", persona);
+        }
         eprintln!("  \x1b[2mSamples:\x1b[0m  {}", p.sample_count);
         eprintln!("  \x1b[2mModel:\x1b[0m    {}", p.model_version);
         eprintln!();
         eprintln!("  \x1b[36mWhat happens next:\x1b[0m");
-        eprintln!("  \x1b[2m›\x1b[0m Your voice will be auto-identified in future meetings");
-        eprintln!(
-            "  \x1b[2m›\x1b[0m Your lines show as \x1b[1m[{}]\x1b[0m instead of [SPEAKER_X]",
-            p.name
-        );
-        eprintln!("  \x1b[2m›\x1b[0m Run \x1b[33mminutes enroll\x1b[0m again to improve accuracy");
-        eprintln!("  \x1b[2m›\x1b[0m Run \x1b[33mminutes voices\x1b[0m to see your profile");
+        if is_self {
+            eprintln!("  \x1b[2m›\x1b[0m Your voice will be auto-identified in future meetings");
+            eprintln!(
+                "  \x1b[2m›\x1b[0m Your lines show as \x1b[1m[{}]\x1b[0m instead of [SPEAKER_X]",
+                p.name
+            );
+            eprintln!(
+                "  \x1b[2m›\x1b[0m Run \x1b[33mminutes enroll\x1b[0m again to improve accuracy"
+            );
+        } else {
+            eprintln!(
+                "  \x1b[2m›\x1b[0m {}'s voice will be auto-identified in future meetings",
+                p.name
+            );
+            eprintln!(
+                "  \x1b[2m›\x1b[0m Their lines show as \x1b[1m[{}]\x1b[0m instead of [SPEAKER_X]",
+                p.name
+            );
+            eprintln!(
+                "  \x1b[2m›\x1b[0m Run \x1b[33mminutes enroll --name \"{}\"\x1b[0m again to improve accuracy",
+                p.name
+            );
+        }
+        eprintln!("  \x1b[2m›\x1b[0m Run \x1b[33mminutes voices\x1b[0m to see all profiles");
     }
 
     if file.is_none() {
@@ -5723,9 +5819,14 @@ fn cmd_voices(delete: bool, json: bool) -> Result<()> {
     }
     eprintln!("Voice profiles:");
     for p in &profiles {
+        let persona_suffix = p
+            .persona
+            .as_deref()
+            .map(|s| format!(" [{}]", s))
+            .unwrap_or_default();
         eprintln!(
-            "  {} — {} samples, {} ({})",
-            p.name, p.sample_count, p.source, p.model_version
+            "  {}{} — {} samples, {} ({})",
+            p.name, persona_suffix, p.sample_count, p.source, p.model_version
         );
         eprintln!(
             "    enrolled: {}, updated: {}",
@@ -5810,6 +5911,7 @@ fn cmd_confirm(
                             embedding,
                             "confirmed",
                             voice::model_version(config),
+                            None,
                         )
                         .map_err(|e| anyhow::anyhow!("{}", e))?;
                         eprintln!(
@@ -5903,6 +6005,7 @@ fn cmd_confirm(
                                 embedding,
                                 "confirmed",
                                 voice::model_version(config),
+                                None,
                             )
                             .map_err(|e| anyhow::anyhow!("{}", e))?;
                             eprintln!("  Voice profile saved for {}", attr.name);

--- a/crates/core/src/voice.rs
+++ b/crates/core/src/voice.rs
@@ -36,6 +36,10 @@ pub struct VoiceProfile {
     pub sample_count: u32,
     pub source: String,
     pub model_version: String,
+    /// Optional free-form label describing this profile's context or role
+    /// (e.g. "PM", "external-client", "quiet-room"). Metadata only —
+    /// does not affect voice matching.
+    pub persona: Option<String>,
 }
 
 pub struct VoiceProfileWithEmbedding {
@@ -73,6 +77,14 @@ pub fn open_db_at(path: &Path) -> Result<Connection, VoiceError> {
             model_version TEXT NOT NULL
         );",
     )?;
+    // Additive migration: add `persona` column to pre-existing voice_profiles tables.
+    // SQLite returns a "duplicate column name" error when the column already exists —
+    // safe to swallow because the column is nullable and we don't rewrite data.
+    if let Err(e) = conn.execute("ALTER TABLE voice_profiles ADD COLUMN persona TEXT", []) {
+        if !e.to_string().to_lowercase().contains("duplicate column") {
+            return Err(e.into());
+        }
+    }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -114,16 +126,18 @@ pub fn save_profile(
     embedding: &[f32],
     source: &str,
     model_version: &str,
+    persona: Option<&str>,
 ) -> Result<(), VoiceError> {
     let now = chrono::Local::now().to_rfc3339();
     let blob = embedding_to_bytes(embedding);
     conn.execute(
-        "INSERT INTO voice_profiles (person_slug, name, embedding, enrolled_at, updated_at, sample_count, source, model_version)
-         VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?7)
+        "INSERT INTO voice_profiles (person_slug, name, embedding, enrolled_at, updated_at, sample_count, source, model_version, persona)
+         VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?7, ?8)
          ON CONFLICT(person_slug) DO UPDATE SET
             name = excluded.name, embedding = excluded.embedding, updated_at = excluded.updated_at,
-            sample_count = sample_count + 1, source = excluded.source, model_version = excluded.model_version",
-        params![slug, name, blob, now, now, source, model_version],
+            sample_count = sample_count + 1, source = excluded.source, model_version = excluded.model_version,
+            persona = excluded.persona",
+        params![slug, name, blob, now, now, source, model_version, persona],
     )?;
     Ok(())
 }
@@ -135,6 +149,7 @@ pub fn save_profile_blended(
     new_embedding: &[f32],
     source: &str,
     model_version: &str,
+    persona: Option<&str>,
 ) -> Result<(), VoiceError> {
     if let Some(existing) = load_profile_with_embedding(conn, slug)? {
         let total = existing.sample_count as f32 + 1.0;
@@ -145,9 +160,17 @@ pub fn save_profile_blended(
             .zip(new_embedding.iter())
             .map(|(old, new)| (old * old_weight + new) / total)
             .collect();
-        save_profile(conn, slug, name, &blended, source, model_version)
+        save_profile(conn, slug, name, &blended, source, model_version, persona)
     } else {
-        save_profile(conn, slug, name, new_embedding, source, model_version)
+        save_profile(
+            conn,
+            slug,
+            name,
+            new_embedding,
+            source,
+            model_version,
+            persona,
+        )
     }
 }
 
@@ -172,7 +195,7 @@ fn load_profile_with_embedding(
 }
 
 pub fn list_profiles(conn: &Connection) -> Result<Vec<VoiceProfile>, VoiceError> {
-    let mut stmt = conn.prepare("SELECT person_slug, name, enrolled_at, updated_at, sample_count, source, model_version FROM voice_profiles ORDER BY updated_at DESC")?;
+    let mut stmt = conn.prepare("SELECT person_slug, name, enrolled_at, updated_at, sample_count, source, model_version, persona FROM voice_profiles ORDER BY updated_at DESC")?;
     let profiles = stmt
         .query_map([], |row| {
             Ok(VoiceProfile {
@@ -183,6 +206,7 @@ pub fn list_profiles(conn: &Connection) -> Result<Vec<VoiceProfile>, VoiceError>
                 sample_count: row.get(4)?,
                 source: row.get(5)?,
                 model_version: row.get(6)?,
+                persona: row.get(7)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -213,6 +237,17 @@ pub fn delete_profile(conn: &Connection, slug: &str) -> Result<bool, VoiceError>
         "DELETE FROM voice_profiles WHERE person_slug = ?1",
         params![slug],
     )? > 0)
+}
+
+/// Look up the display name currently stored for a given slug, if any.
+/// Used by enrollment to detect slug collisions between different humans.
+pub fn lookup_name_for_slug(conn: &Connection, slug: &str) -> Result<Option<String>, VoiceError> {
+    let mut stmt = conn.prepare("SELECT name FROM voice_profiles WHERE person_slug = ?1")?;
+    match stmt.query_row(params![slug], |row| row.get::<_, String>(0)) {
+        Ok(name) => Ok(Some(name)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
 }
 
 pub fn match_embedding(
@@ -303,7 +338,7 @@ pub fn load_self_profile(config: &Config) -> Option<VoiceProfileWithEmbedding> {
     load_profile_with_embedding(&conn, &slug).ok().flatten()
 }
 
-fn slugify(text: &str) -> String {
+pub fn slugify(text: &str) -> String {
     let slug: String = text
         .to_lowercase()
         .chars()
@@ -367,6 +402,7 @@ mod tests {
             &vec![0.1f32; 512],
             "self-enrollment",
             TEST_MODEL_VERSION,
+            None,
         )
         .unwrap();
         let profiles = list_profiles(&conn).unwrap();
@@ -385,6 +421,7 @@ mod tests {
             &[0.1f32; 4],
             "self-enrollment",
             TEST_MODEL_VERSION,
+            None,
         )
         .unwrap();
         save_profile(
@@ -394,6 +431,7 @@ mod tests {
             &[0.2f32; 4],
             "self-enrollment",
             TEST_MODEL_VERSION,
+            None,
         )
         .unwrap();
         assert_eq!(list_profiles(&conn).unwrap()[0].sample_count, 2);
@@ -409,6 +447,7 @@ mod tests {
             &[1.0f32; 4],
             "self-enrollment",
             TEST_MODEL_VERSION,
+            None,
         )
         .unwrap();
         save_profile_blended(
@@ -418,6 +457,7 @@ mod tests {
             &[3.0f32; 4],
             "self-enrollment",
             TEST_MODEL_VERSION,
+            None,
         )
         .unwrap();
         let p = load_profile_with_embedding(&conn, "mat").unwrap().unwrap();
@@ -434,6 +474,7 @@ mod tests {
             &[0.1f32; 4],
             "self-enrollment",
             TEST_MODEL_VERSION,
+            None,
         )
         .unwrap();
         assert!(delete_profile(&conn, "mat").unwrap());
@@ -513,6 +554,167 @@ mod tests {
         assert_eq!(
             p.file_name().unwrap().to_str().unwrap(),
             ".2026-03-25-standup.embeddings"
+        );
+    }
+
+    #[test]
+    fn persona_round_trips() {
+        let (conn, _tmp) = test_db();
+        save_profile(
+            &conn,
+            "alex-chen",
+            "Alex Chen",
+            &[0.1f32; 4],
+            "other-enrollment",
+            TEST_MODEL_VERSION,
+            Some("PM"),
+        )
+        .unwrap();
+        let p = &list_profiles(&conn).unwrap()[0];
+        assert_eq!(p.persona.as_deref(), Some("PM"));
+        assert_eq!(p.source, "other-enrollment");
+    }
+
+    #[test]
+    fn persona_defaults_to_none() {
+        let (conn, _tmp) = test_db();
+        save_profile(
+            &conn,
+            "mat",
+            "Mat",
+            &[0.1f32; 4],
+            "self-enrollment",
+            TEST_MODEL_VERSION,
+            None,
+        )
+        .unwrap();
+        assert!(list_profiles(&conn).unwrap()[0].persona.is_none());
+    }
+
+    #[test]
+    fn persona_is_updatable_via_upsert() {
+        let (conn, _tmp) = test_db();
+        save_profile(
+            &conn,
+            "alex-chen",
+            "Alex Chen",
+            &[0.1f32; 4],
+            "other-enrollment",
+            TEST_MODEL_VERSION,
+            None,
+        )
+        .unwrap();
+        assert!(list_profiles(&conn).unwrap()[0].persona.is_none());
+
+        save_profile_blended(
+            &conn,
+            "alex-chen",
+            "Alex Chen",
+            &[0.1f32; 4],
+            "other-enrollment",
+            TEST_MODEL_VERSION,
+            Some("PM"),
+        )
+        .unwrap();
+        assert_eq!(
+            list_profiles(&conn).unwrap()[0].persona.as_deref(),
+            Some("PM")
+        );
+    }
+
+    #[test]
+    fn migration_adds_persona_column_to_legacy_db() {
+        // Simulate a pre-migration database: create the voice_profiles table
+        // WITHOUT the persona column, then reopen via open_db_at() and verify
+        // the additive ALTER TABLE runs cleanly and the column is usable.
+        let tmp = NamedTempFile::new().unwrap();
+        {
+            let conn = Connection::open(tmp.path()).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE voice_profiles (
+                    id INTEGER PRIMARY KEY,
+                    person_slug TEXT UNIQUE NOT NULL,
+                    name TEXT NOT NULL,
+                    embedding BLOB NOT NULL,
+                    enrolled_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    sample_count INTEGER DEFAULT 1,
+                    source TEXT NOT NULL,
+                    model_version TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO voice_profiles
+                    (person_slug, name, embedding, enrolled_at, updated_at, sample_count, source, model_version)
+                 VALUES ('mat', 'Mat', X'0102', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1, 'self-enrollment', 'v1')",
+                [],
+            )
+            .unwrap();
+        }
+        // Reopen — migration runs. Existing row survives; persona reads as NULL.
+        let conn = open_db_at(tmp.path()).unwrap();
+        let profiles = list_profiles(&conn).unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].person_slug, "mat");
+        assert!(profiles[0].persona.is_none());
+
+        // New writes can set persona.
+        save_profile(
+            &conn,
+            "alex-chen",
+            "Alex Chen",
+            &[0.1f32; 4],
+            "other-enrollment",
+            TEST_MODEL_VERSION,
+            Some("PM"),
+        )
+        .unwrap();
+        let by_slug: Vec<_> = list_profiles(&conn)
+            .unwrap()
+            .into_iter()
+            .filter(|p| p.person_slug == "alex-chen")
+            .collect();
+        assert_eq!(by_slug[0].persona.as_deref(), Some("PM"));
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let tmp = NamedTempFile::new().unwrap();
+        // Open twice — second call must not error on the already-added column.
+        let _c1 = open_db_at(tmp.path()).unwrap();
+        let _c2 = open_db_at(tmp.path()).unwrap();
+        let conn = open_db_at(tmp.path()).unwrap();
+        save_profile(
+            &conn,
+            "mat",
+            "Mat",
+            &[0.1f32; 4],
+            "self-enrollment",
+            TEST_MODEL_VERSION,
+            None,
+        )
+        .unwrap();
+        assert_eq!(list_profiles(&conn).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn lookup_name_for_slug_roundtrips() {
+        let (conn, _tmp) = test_db();
+        assert!(lookup_name_for_slug(&conn, "nobody").unwrap().is_none());
+        save_profile(
+            &conn,
+            "alex-chen",
+            "Alex Chen",
+            &[0.1f32; 4],
+            "other-enrollment",
+            TEST_MODEL_VERSION,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            lookup_name_for_slug(&conn, "alex-chen").unwrap().as_deref(),
+            Some("Alex Chen")
         );
     }
 }

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -2190,7 +2190,7 @@ registerTool(
 
 registerTool(
   "list_voices",
-  "List enrolled voice profiles for speaker identification. Shows who has been enrolled, sample count, and model version.",
+  "List enrolled voice profiles for speaker identification. Shows each profile's name, optional persona label (e.g. 'PM', 'external-client'), sample count, source ('self-enrollment', 'other-enrollment', 'confirmed'), and model version.",
   {},
   { title: "Voice Profiles", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   async () => {
@@ -2203,13 +2203,14 @@ registerTool(
 
     if (!Array.isArray(profiles) || profiles.length === 0) {
       return {
-        content: [{ type: "text" as const, text: "No voice profiles enrolled. The user can enroll with: minutes enroll" }],
+        content: [{ type: "text" as const, text: "No voice profiles enrolled. The user can enroll with: minutes enroll (self), or minutes enroll --name \"<name>\" [--persona \"<label>\"] for a teammate." }],
       };
     }
 
-    const lines = profiles.map((p: any) =>
-      `${p.name} — ${p.sample_count} samples, ${p.source} (${p.model_version})`
-    );
+    const lines = profiles.map((p: any) => {
+      const personaSuffix = p.persona ? ` [${p.persona}]` : "";
+      return `${p.name}${personaSuffix} — ${p.sample_count} samples, ${p.source} (${p.model_version})`;
+    });
 
     return {
       content: [{ type: "text" as const, text: `Voice profiles (${profiles.length}):\n\n${lines.join("\n")}` }],


### PR DESCRIPTION
## Summary

Extends `minutes enroll` so the user can enroll voice profiles for teammates, not just themselves, and optionally tag each profile with a free-form persona label.

- `minutes enroll` — unchanged self-enrollment flow
- `minutes enroll --name "Alex Chen"` — enrolls a voice profile for someone other than you; does NOT write to `identity.name` in config
- `minutes enroll --name "Alex Chen" --persona "PM"` — same, plus an optional label stored alongside the profile
- `minutes enroll --name "Alex Chen" --persona "PM" --file ./alex.wav` — any combination works from a pre-recorded file

Persona is metadata only — it's surfaced in `minutes voices`, in the MCP `list_voices` tool, and in the `voices --json` output (`"persona": string | null`). It does **not** change the voice-matching algorithm. One profile per person (slug-keyed); multi-profile-per-person (Option B from the design) was explicitly deferred.

A slug-collision guard prevents a second `--name Alex` from silently blending two humans' embeddings into one profile — if the existing row has the same slug but a different `name`, enrollment refuses with a clear message pointing at `minutes voices --delete`.

## Changes

- **`crates/core/src/voice.rs`** — additive `persona TEXT` column via idempotent `ALTER TABLE`; `persona: Option<&str>` threaded through `save_profile` / `save_profile_blended`; new `lookup_name_for_slug` helper for collision detection; `slugify` exposed as `pub`.
- **`crates/cli/src/main.rs`** — new `--name` and `--persona` flags on `Enroll`; `cmd_enroll` branches on self vs other, collision guard in front of the save, distinct post-save messaging for self vs teammate; `cmd_voices` shows persona in brackets; two `save_profile_blended` call sites in `cmd_confirm_speaker` pass `None`.
- **`crates/mcp/src/index.ts`** — `list_voices` tool description mentions persona; human-readable output shows `name [persona]`; structured content unchanged (profiles flow through raw from `voices --json`, additive field).
- **`README.md`**, **`CLAUDE.md`** — enroll examples + module description updated.

Voices DB migration is additive and idempotent: existing rows read back `persona = null`. Verified on a real local `voices.db` with a pre-existing profile.

## Design notes

Option A from the brainstorm — persona as a single per-profile tag — was chosen over Option B (multiple profiles per person keyed on `(slug, persona)`). Option B would force a matcher policy decision (best-across-personas? surface which persona matched?) and was not required by the actual need. The `(person_slug, persona)` UNIQUE key can be added in a future migration without reshaping rows, so A stays forward-compatible.

## Test plan

- [x] `cargo test -p minutes-core --no-default-features --lib voice::` — 25/25 pass (5 new: round-trip, default-null, upsert-updates, migration-on-legacy-db, idempotency, lookup)
- [x] `cargo clippy --all --no-default-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cd crates/mcp && npm run build` — clean
- [x] `cd crates/mcp && npx vitest run` — 8/8 pass
- [x] `./target/debug/minutes enroll --help` — shows `--name` and `--persona`
- [x] `./target/debug/minutes voices --json` against real pre-existing `voices.db` — migration runs cleanly, old row reads back `"persona": null`
- [ ] Reviewer: smoke-test `minutes enroll --name "Test" --file <wav>` and confirm the persona surfaces in `minutes voices`
- [ ] Reviewer: try the collision guard: enroll `--name "Alex"`, then re-enroll `--name "Alex Chen"` (different slug, succeeds). Then try `--name "Alex"` again with a different profile — confirm refusal only when the slug is actually shared across different names

## Out of scope

- Version bump / release notes — deferred pending review + merge decision. This is additive user-visible functionality, so per the pre-commit checklist it warrants a SemVer minor bump (`0.13.1 → 0.14.0`) when it ships.
- Exposing `persona` in the MCP `confirm_speaker --save-voice` path — can be layered on without schema change.
- Multiple profiles per person (design Option B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)