### PR TITLE
fix(summarize): handle "auto" engine in speaker mapping dispatch

### DIFF
--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -1856,6 +1856,15 @@ fn run_speaker_mapping_prompt(
 ) -> Result<String, Box<dyn std::error::Error>> {
     let agent = http_agent();
     match config.summarization.engine.as_str() {
+        "auto" => {
+            if let Some(cli) = detect_agent_cli() {
+                let mut cfg = config.clone();
+                cfg.summarization.agent_command = cli;
+                run_speaker_mapping_via_agent(prompt, &cfg)
+            } else {
+                Err("no AI CLI found (claude, codex, gemini, opencode)".into())
+            }
+        }
         "agent" => run_speaker_mapping_via_agent(prompt, config),
         "claude" => {
             let api_key =


### PR DESCRIPTION
Fixes #155.

## Summary

`run_speaker_mapping_prompt` in `crates/core/src/summarize.rs` falls through to `Err("Unknown engine: auto")` whenever `[summarization] engine` is left at its default of `"auto"`. The error is swallowed by `map_speakers` (returns an empty `Vec`), so Level 1 LLM speaker mapping is silently skipped and every transcript keeps only the raw acoustic `SPEAKER_N` attributions.

Symptom in the processing log:

    INFO Level 1: LLM speaker mapping speakers=1 attendees=2
    WARN Level 1: speaker mapping failed error=Unknown engine: auto

The `"auto"` arm was introduced in 239a744 ("feat: auto-detect AI CLI for zero-config summarization") and wired into the main `summarize_with_screens` path and `run_title_refinement_prompt`, but this third dispatch site was missed. The neighboring `speaker_mapping_model_hint` already treats `"auto"` as `"agent"`, so the hint and the runner were out of sync.

Reproduced on `main` @ 194a891 (v0.13.2).

## What changes

`crates/core/src/summarize.rs` (+9 lines): add an `"auto"` arm to `run_speaker_mapping_prompt` that mirrors the shape `run_title_refinement_prompt` already uses at line 1462. It calls `detect_agent_cli()`, clones the config with `agent_command` set to the detected CLI, and dispatches through `run_speaker_mapping_via_agent`. When no CLI is found, it returns the same `"no AI CLI found (claude, codex, gemini, opencode)"` error string used elsewhere.

```rust
"auto" => {
    if let Some(cli) = detect_agent_cli() {
        let mut cfg = config.clone();
        cfg.summarization.agent_command = cli;
        run_speaker_mapping_via_agent(prompt, &cfg)
    } else {
        Err("no AI CLI found (claude, codex, gemini, opencode)".into())
    }
}
```

No other files change. No config surface change, no behavior change for any non-`auto` engine.

## Test plan

- [x] `cargo test -p minutes-core --no-default-features --lib summarize::` - 20/20 pass on the branch. All tests in the module my change touches are green.
- [x] `cargo test -p minutes-core --no-default-features` - one pre-existing failure (`graph::tests::test_fix_frontmatter_date`), identical on `upstream/main` @ 194a891 and unrelated to this change.
- [x] `cargo clippy --all --no-default-features -- -D warnings` - 17 pre-existing errors on Linux (all in `crates/core/src/calendar.rs` macOS-only paths and one const in `crates/core/src/screen.rs`). Identical set on `upstream/main`; none in `summarize.rs`.
- [x] Rebuilt CLI (`cargo install --path crates/cli --features cuda`) with `engine = "auto"` restored and ran a real recording. Processing log now shows:

      INFO Level 1: LLM speaker mapping speakers=1 attendees=2
      INFO Level 1: speaker mapping complete mapped=1

  instead of the `Unknown engine: auto` WARN, with auto-detect correctly picking `claude`.
- [ ] Reviewer: smoke-test on macOS if desired. The `detect_agent_cli()` helper being reused here is the same one already in use at lines 82, 282, and 1538, so behavior should be identical to the existing auto paths.

## Notes

Impact is WARN-only in current releases, but it means any user on the default `engine = "auto"` config has been silently losing the Level 1 LLM speaker-mapping cleanup pass. Raw diarization labels go straight into the transcript without the LLM attendee-matching step. Existing workaround is to pin `engine = "agent"` with `agent_command = "claude"`.
