### PR TITLE
fix(capture): prevent PipeWire segfault from double host init/teardown

### DIFF
--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -469,7 +469,7 @@ fn select_device_with_override(
 }
 
 fn resolve_capture_plan(config: &Config) -> Result<CapturePlan, CaptureError> {
-    let host = cpal::default_host();
+    let host = cached_default_host();
     resolve_capture_plan_with_host(&host, config)
 }
 
@@ -1246,7 +1246,7 @@ pub fn record_to_wav(
     #[cfg(feature = "streaming")]
     crate::streaming::clear_mic_mute_for_new_recording();
 
-    let host = cpal::default_host();
+    let host = cached_default_host();
     let device_override = match &capture_plan {
         CapturePlan::Single(plan) => plan.device_override.as_deref(),
         #[cfg(feature = "streaming")]
@@ -1596,6 +1596,30 @@ pub fn strip_device_format_suffix(name: &str) -> &str {
 /// devices). Caching the first host that works keeps later lookups stable.
 static PREFERRED_HOST: std::sync::OnceLock<std::sync::Mutex<Option<cpal::HostId>>> =
     std::sync::OnceLock::new();
+
+/// AIDEV-NOTE: Keeps the cpal `Host` alive for the entire process lifetime.
+/// On Linux with the PipeWire backend, dropping a `cpal::Host` calls `pw_deinit()`,
+/// and re-creating one calls `pw_init()` again — but PipeWire's internal state is
+/// corrupted after deinit/reinit, causing a segfault in `pw_main_loop_new()`.
+/// By leaking the Host (intentionally never freeing it), we prevent Drop from
+/// running, so PipeWire stays initialized. The leak is negligible: one Host per
+/// process lifetime. This matches cpal's own `PwInitGuard` design intent (the
+/// Host holds the guard), but ensures the guard survives across multiple
+/// `default_host()` call sites within minutes.
+static HOST_CACHE: std::sync::OnceLock<&'static cpal::Host> = std::sync::OnceLock::new();
+
+/// Return a reference to the process-wide cached `cpal::Host`, creating it on
+/// first call. Uses `cpal::default_host()` internally, but ensures the Host
+/// (and its PipeWire init guard) is never dropped, preventing the segfault
+/// described in HOST_CACHE.
+pub fn cached_default_host() -> &'static cpal::Host {
+    HOST_CACHE.get_or_init(|| {
+        // Intentionally leak: Host must live for the process duration so that
+        // PipeWire's pw_deinit() is never called between enumeration and stream
+        // creation, which would corrupt PipeWire state and segfault on re-init.
+        Box::leak(Box::new(cpal::default_host()))
+    })
+}
 
 fn preferred_host_id() -> Option<cpal::HostId> {
     *PREFERRED_HOST
@@ -1956,7 +1980,7 @@ fn is_pipewire_host(_: cpal::HostId) -> bool {
 pub fn selected_input_device_name(config: &Config) -> Result<String, CaptureError> {
     use cpal::traits::DeviceTrait;
 
-    let host = cpal::default_host();
+    let host = cached_default_host();
     let device = select_input_device(&host, config.recording.device.as_deref())?;
     device
         .description()
@@ -2150,7 +2174,7 @@ pub struct InputDeviceEntry {
 pub fn list_input_devices_detailed() -> Vec<InputDeviceEntry> {
     use cpal::traits::{DeviceTrait, HostTrait};
 
-    let host = cpal::default_host();
+    let host = cached_default_host();
     tracing::debug!(host_id = ?host.id(), "cpal host for input device listing");
     let mut devices = Vec::new();
 
@@ -2210,7 +2234,7 @@ pub enum DeviceCategory {
 pub fn list_devices_categorized() -> Vec<CategorizedDevice> {
     use cpal::traits::{DeviceTrait, HostTrait};
 
-    let host = cpal::default_host();
+    let host = cached_default_host();
     let host_id = host.id();
     tracing::debug!(host_id = ?host_id, "cpal host for categorized device listing");
     let is_pipewire = is_pipewire_host(host_id);
@@ -2667,7 +2691,7 @@ mod tests {
         let _g = LOCK.lock().unwrap();
 
         let prior = preferred_host_id();
-        let id = cpal::default_host().id();
+        let id = cached_default_host().id();
         set_preferred_host_id(id);
         assert_eq!(preferred_host_id(), Some(id));
 

--- a/crates/core/src/device_monitor.rs
+++ b/crates/core/src/device_monitor.rs
@@ -115,7 +115,7 @@ impl DeviceMonitor {
         #[cfg(not(target_os = "macos"))]
         {
             use cpal::traits::{DeviceTrait, HostTrait};
-            cpal::default_host()
+            crate::capture::cached_default_host()
                 .default_input_device()
                 .and_then(|d| d.description().ok().map(|desc| desc.name().to_string()))
         }

--- a/crates/core/src/streaming.rs
+++ b/crates/core/src/streaming.rs
@@ -191,7 +191,7 @@ impl AudioStream {
     /// Returns a stream handle with a channel receiver for audio chunks.
     /// Chunks arrive at ~10Hz (100ms each at 16kHz = 1600 samples).
     pub fn start(device_override: Option<&str>) -> Result<Self, CaptureError> {
-        let host = cpal::default_host();
+        let host = crate::capture::cached_default_host();
         let device = crate::capture::select_input_device(&host, device_override)?;
 
         // Bounded channel: 64 chunks = ~6.4 seconds of buffered audio.


### PR DESCRIPTION
## Summary

- **Fixes a segfault on `minutes record` with PipeWire backend (Linux)** by caching the `cpal::Host` for the process lifetime instead of creating and dropping it multiple times.

## Problem

`minutes record` crashes with a segmentation fault on Linux when using the PipeWire audio host:

```
#0  __strstr_sse2_unaligned ()
#1  load_spa_handle () at ../pipewire/src/pipewire/pipewire.c:235
#2  pw_load_spa_handle () at ../pipewire/pipewire/pipewire.c:304
#3  pw_loop_new () at ../pipewire/src/pipewire/loop.c:65
#4  pw_main_loop_new () at ../pipewire/src/pipewire/main-loop.c:64
```

### Root cause

cpal's `Host` struct on PipeWire holds a `PwInitGuard` that calls `pw_init()` on creation and `pw_deinit()` on drop. Minutes calls `cpal::default_host()` in at least two places in the recording path:

1. `resolve_capture_plan()` (preflight) — creates Host, enumerates devices, then **drops** Host → `pw_deinit()`
2. `record_to_wav()` — creates a new Host → `pw_init()` → `pw_main_loop_new()` → **segfault**

PipeWire cannot safely reinitialize in a process after `pw_deinit()` — internal state is corrupted, causing a NULL pointer passed to `strstr()` inside `load_spa_handle()`.

### Reproduction

A minimal reproducer confirmed this: calling `cpal::default_host()` twice and **dropping the first Host** before creating the second segfaults on PipeWire. Keeping the first Host alive (or only creating one) does not crash.

## Fix

Introduce `cached_default_host()` — a process-wide `OnceLock` that creates the `cpal::Host` once and **intentionally leaks it** via `Box::leak()`. This ensures the PipeWire init guard is never dropped, so `pw_deinit()` is never called between enumeration and stream creation.

All 8 `cpal::default_host()` call sites across `capture.rs`, `device_monitor.rs`, and `streaming.rs` now use `cached_default_host()`.

The intentional leak is negligible: one `Host` per process lifetime.

## Testing

- `minutes record --source "C922 Pro Stream Webcam" -v` — previously segfaulted, now records successfully
- `cargo test -p minutes-core --lib -- capture` — 38 tests pass
- `cargo build -p minutes-cli` — builds clean
- Tested with both PipeWire and ALSA backends

## Files changed

- `crates/core/src/capture.rs` — `HOST_CACHE` + `cached_default_host()` + 6 call sites updated
- `crates/core/src/device_monitor.rs` — 1 call site updated
- `crates/core/src/streaming.rs` — 1 call site updated