### PR TITLE
fix(build): auto-recover from stale ort-sys clang_rt path after Xcode upgrade

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,20 @@ export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 # cargo-tauri to produce a signed + notarized bundle.
 
 echo "=== Building CLI (release) ==="
-cargo build --release -p minutes-cli --features metal
+_build_tmp=$(mktemp)
+if ! cargo build --release -p minutes-cli --features metal 2>&1 | tee "$_build_tmp"; then
+    if grep -q "library 'clang_rt\." "$_build_tmp"; then
+        echo ""
+        echo "  Stale ort-sys clang runtime path (Xcode/CLT upgrade detected)."
+        echo "  Cleaning stale build cache and retrying..."
+        rm -rf target/*/build/ort-sys-*
+        cargo build --release -p minutes-cli --features metal
+    else
+        rm -f "$_build_tmp"
+        exit 1
+    fi
+fi
+rm -f "$_build_tmp"
 
 echo "=== Building calendar helper ==="
 swiftc -O \


### PR DESCRIPTION
## Problem

When Xcode or Command Line Tools are updated, the clang version bumps (e.g. `clang/17` → `clang/21`). The `ort-sys` build script caches the runtime library search path, so after an upgrade the cached path no longer exists and the build fails with:

```
ld: warning: search path '.../clang/17/lib/darwin' not found
ld: library 'clang_rt.osx' not found
```

This is a particularly bad experience because nothing in the minutes build output points to the real cause — it looks like a broken toolchain.

The fix is to delete the stale `ort-sys` build artifacts so the build script re-runs and picks up the updated clang path. I hit this after pulling the latest `main` today.

## Fix

`scripts/build.sh` now detects the `clang_rt.osx` link failure pattern, automatically cleans the stale `ort-sys` cache, and retries — no manual intervention needed.

## Test

Reproduced the failure locally (Xcode Clang 21, stale cache pointing to `clang/17`), confirmed the auto-retry resolves it.