### PR TITLE
fix(build): bundle calendar-events helper into release .app

### DIFF
--- a/crates/core/src/calendar.rs
+++ b/crates/core/src/calendar.rs
@@ -243,10 +243,12 @@ fn is_calendar_app_running() -> bool {
 }
 
 /// AppleScript query that fetches current/recent events WITH attendee names.
+#[cfg(target_os = "macos")]
 fn query_events_with_attendees() -> Vec<CalendarEvent> {
     query_events_with_attendees_at(Local::now())
 }
 
+#[cfg(target_os = "macos")]
 fn applescript_month(month: u32) -> &'static str {
     match month {
         1 => "January",
@@ -266,6 +268,7 @@ fn applescript_month(month: u32) -> &'static str {
 }
 
 /// AppleScript query centered on an explicit timestamp.
+#[cfg(target_os = "macos")]
 fn query_events_with_attendees_at(center: DateTime<Local>) -> Vec<CalendarEvent> {
     // Never auto-launch Calendar.app from a background query. `tell
     // application "Calendar"` launches the app as a side effect, which
@@ -496,6 +499,7 @@ fn find_calendar_helper() -> Option<std::path::PathBuf> {
 
 /// AppleScript approach: fetch ALL events for today+tomorrow, filter by time.
 /// Avoids `whose start date >= ...` which times out on CalDAV calendars.
+#[cfg(target_os = "macos")]
 fn query_via_applescript(lookahead_minutes: u32) -> Vec<CalendarEvent> {
     // See `query_events_with_attendees_at`: skip when Calendar.app isn't
     // already running so periodic polling never auto-launches the app.

--- a/crates/core/src/calendar.rs
+++ b/crates/core/src/calendar.rs
@@ -453,12 +453,17 @@ fn query_overlap_via_eventkit_with_helper(
 ///
 /// Lookup order:
 /// 1. `<exe>/../Resources/calendar-events` — inside a packaged .app bundle
+///    (populated by Tauri's bundler from `tauri/src-tauri/resources/calendar-events`)
 /// 2. `<exe>/calendar-events` — beside the main binary
-/// 3. Workspace `target/release/calendar-events` — dev fallback for anyone
-///    running `cargo tauri dev` against the source tree after `./scripts/build.sh`
-///    has compiled the Swift helper. The workspace root is derived from
-///    `CARGO_MANIFEST_DIR` at compile time so it works regardless of where
-///    the user cloned the repo.
+/// 3. Workspace `tauri/src-tauri/resources/calendar-events` — dev fallback.
+///    `tauri/src-tauri/build.rs` compiles the Swift helper here on every
+///    `cargo tauri build` / `cargo tauri dev`, so the CLI finds it when
+///    running from source after at least one Tauri build has completed.
+/// 4. Workspace `target/release/calendar-events` — legacy dev fallback for
+///    older local workflows that compiled the helper directly into `target/`.
+///
+/// The workspace root is derived from `CARGO_MANIFEST_DIR` at compile time
+/// so it works regardless of where the user cloned the repo.
 fn find_calendar_helper() -> Option<std::path::PathBuf> {
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
@@ -477,9 +482,13 @@ fn find_calendar_helper() -> Option<std::path::PathBuf> {
         .parent()
         .and_then(|p| p.parent());
     if let Some(root) = workspace_root {
-        let dev = root.join("target/release/calendar-events");
-        if dev.exists() {
-            return Some(dev);
+        let staged = root.join("tauri/src-tauri/resources/calendar-events");
+        if staged.exists() {
+            return Some(staged);
+        }
+        let legacy = root.join("target/release/calendar-events");
+        if legacy.exists() {
+            return Some(legacy);
         }
     }
     None

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,21 +31,11 @@ if ! cargo build --release -p minutes-cli --features metal 2>&1 | tee "$_build_t
 fi
 rm -f "$_build_tmp"
 
-echo "=== Building calendar helper ==="
-swiftc -O \
-    -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist \
-    -Xlinker scripts/calendar-helper-Info.plist \
-    scripts/calendar-events.swift -o target/release/calendar-events
-echo "  Built target/release/calendar-events"
-
 echo "=== Building Tauri app ==="
+# The calendar-events Swift helper is compiled and staged into
+# tauri/src-tauri/resources/ by tauri/src-tauri/build.rs, and Tauri bundles it
+# into Minutes.app/Contents/Resources/ automatically via tauri.conf.json.
 cargo tauri build --features metal --bundles app
-
-echo "=== Embedding calendar helper in app bundle ==="
-APP_RESOURCES="target/release/bundle/macos/Minutes.app/Contents/Resources"
-mkdir -p "$APP_RESOURCES"
-cp -f target/release/calendar-events "$APP_RESOURCES/calendar-events"
-echo "  Embedded in $APP_RESOURCES/"
 
 echo "=== Signing + Installing CLI ==="
 mkdir -p ~/.local/bin

--- a/scripts/install-dev-app.sh
+++ b/scripts/install-dev-app.sh
@@ -41,19 +41,11 @@ fi
 echo "=== Building CLI (release) ==="
 cargo build --release -p minutes-cli --features metal
 
-echo "=== Building calendar helper ==="
-swiftc -O \
-  -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist \
-  -Xlinker scripts/calendar-helper-Info.plist \
-  scripts/calendar-events.swift -o target/release/calendar-events
-
 echo "=== Building ${DEV_PRODUCT_NAME}.app ==="
+# The calendar-events Swift helper is compiled and staged into
+# tauri/src-tauri/resources/ by tauri/src-tauri/build.rs, and Tauri bundles it
+# into the .app automatically via tauri.conf.json.
 cargo tauri build --bundles app --config "$DEV_CONFIG" --features parakeet,metal --no-sign
-
-echo "=== Embedding calendar helper in dev bundle ==="
-APP_RESOURCES="${BUILD_APP}/Contents/Resources"
-mkdir -p "$APP_RESOURCES"
-cp -f target/release/calendar-events "$APP_RESOURCES/calendar-events"
 
 if [[ "$SIGN_MODE" == "identity" ]]; then
   echo "=== Pre-signing nested executables with configured identity ==="

--- a/tauri/src-tauri/build.rs
+++ b/tauri/src-tauri/build.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 
 fn main() {
     compile_system_audio_helper();
+    compile_calendar_helper();
     stage_assistant_skill_bundle();
     tauri_build::build()
 }
@@ -43,6 +44,55 @@ fn compile_system_audio_helper() {
 
     std::fs::copy(&binary, &target_binary)
         .expect("failed to copy target-specific system_audio_record helper");
+}
+
+fn compile_calendar_helper() {
+    // The Swift EventKit helper (`calendar-events`) is the fast, non-intrusive
+    // path for reading Apple Calendar. Without it, callers fall through to
+    // AppleScript — which, since PR #164, returns empty unless Calendar.app
+    // is already running. Bundling the helper inside the signed .app means
+    // release DMG users get real calendar data regardless of Calendar.app state.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os != "macos" {
+        return;
+    }
+
+    let manifest_dir = PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"),
+    );
+    let repo_root = manifest_dir.join("../..");
+    let source = repo_root.join("scripts/calendar-events.swift");
+    let info_plist = repo_root.join("scripts/calendar-helper-Info.plist");
+    let resources_dir = manifest_dir.join("resources");
+    let binary = resources_dir.join("calendar-events");
+
+    println!("cargo:rerun-if-changed={}", source.display());
+    println!("cargo:rerun-if-changed={}", info_plist.display());
+
+    fs::create_dir_all(&resources_dir).expect("failed to create tauri resources dir");
+
+    // Mirrors `scripts/build.sh` / `scripts/install-dev-app.sh`: `-sectcreate
+    // __TEXT __info_plist` embeds the plist so macOS can display the
+    // NSCalendarsFullAccessUsageDescription string on the EventKit prompt.
+    let output = Command::new("swiftc")
+        .arg("-O")
+        .args(["-Xlinker", "-sectcreate"])
+        .args(["-Xlinker", "__TEXT"])
+        .args(["-Xlinker", "__info_plist"])
+        .arg("-Xlinker")
+        .arg(&info_plist)
+        .arg(&source)
+        .arg("-o")
+        .arg(&binary)
+        .output()
+        .expect("failed to run swiftc for calendar-events");
+
+    if !output.status.success() {
+        panic!(
+            "failed to compile calendar-events.swift: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 fn stage_assistant_skill_bundle() {

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "resources": [
-      "resources/assistant-skill-bundle/**/*"
+      "resources/assistant-skill-bundle/**/*",
+      "resources/calendar-events"
     ],
     "icon": [
       "icons/icon.icns",


### PR DESCRIPTION
## Summary
Follow-up to #164. PR #164 correctly gated the AppleScript fallback on Calendar.app already running, but the release DMG never bundled the EventKit Swift helper, so release users now silently get zero calendar events unless Calendar.app happens to be open.

This PR closes that gap by compiling and bundling `calendar-events` as part of `cargo tauri build`, so every release .app ships with the fast EventKit path.

## What changed
- `tauri/src-tauri/build.rs`: extended with `compile_calendar_helper()` that runs `swiftc` against `scripts/calendar-events.swift` + `scripts/calendar-helper-Info.plist` and stages the binary at `tauri/src-tauri/resources/calendar-events`. macOS-only, same pattern as the existing `compile_system_audio_helper`.
- `tauri/src-tauri/tauri.conf.json`: adds `resources/calendar-events` to `bundle.resources` so Tauri packages and signs it as part of the .app.
- `scripts/build.sh` / `scripts/install-dev-app.sh`: drop the manual `swiftc` + post-build `cp` (both redundant now that `build.rs` + Tauri resources handle it).
- `crates/core/src/calendar.rs`: update `find_calendar_helper` dev fallback to check the new staged location first, keep `target/release/calendar-events` as a legacy fallback.

## Why this matters
- `.github/workflows/release-macos.yml` runs `cargo tauri build` but never invoked `swiftc` for the calendar helper
- `tauri.conf.json` didn't declare it as a resource
- So every published DMG fell through to AppleScript. Pre-#164 that auto-launched Calendar.app (annoying but functional). Post-#164 that's a silent no-op.

After this PR, the helper is compiled by the Tauri build script, bundled as a signed resource, and discovered by `find_calendar_helper` via `<exe>/../Resources/calendar-events`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --no-default-features -- -D warnings`
- [x] `cargo test -p minutes-core --no-default-features --lib calendar` (11 passed)
- [x] `cargo check -p minutes-app --features metal`: build.rs runs, produces `tauri/src-tauri/resources/calendar-events` (Mach-O arm64, +x, Info.plist section present)
- [x] `file` confirms Mach-O executable; `otool -s __TEXT __info_plist` confirms plist embedded
- [ ] Manual: `cargo tauri build --bundles app` produces a `Minutes.app` with `Contents/Resources/calendar-events` intact; verify in release workflow artifact before next tag
- [ ] Manual: after tag release, download DMG, quit Calendar.app, launch Minutes, confirm upcoming meetings populate without auto-launching Calendar.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)