### PR TITLE
fix(build): declare calendar-events resource macOS-only

### DIFF
--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -17,8 +17,7 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "resources": [
-      "resources/assistant-skill-bundle/**/*",
-      "resources/calendar-events"
+      "resources/assistant-skill-bundle/**/*"
     ],
     "icon": [
       "icons/icon.icns",

--- a/tauri/src-tauri/tauri.macos.conf.json
+++ b/tauri/src-tauri/tauri.macos.conf.json
@@ -4,6 +4,10 @@
       "bin/mic_check",
       "bin/system_audio_record"
     ],
+    "resources": [
+      "resources/assistant-skill-bundle/**/*",
+      "resources/calendar-events"
+    ],
     "macOS": {
       "entitlements": "entitlements.plist",
       "infoPlist": "Info.plist"


### PR DESCRIPTION
## Summary
PR #165 added `resources/calendar-events` to the shared `tauri.conf.json`, but `tauri/src-tauri/build.rs` only compiles the Swift helper on macOS. On Windows, the resource doesn't exist at build time and Tauri errors:

```
resource path `resources\calendar-events` doesn't exist
```

This is the Windows Desktop App Installer failure from PR #165's post-merge CI.

## Fix
Move the `resources/calendar-events` declaration into `tauri.macos.conf.json` so only macOS builds try to bundle it. Tauri's platform-config merge replaces arrays rather than appending, so the macOS overlay redeclares both the shared `assistant-skill-bundle` resource and the new `calendar-events` resource.

## Why this slipped through
Desktop App Installer (windows-latest) wasn't in the required-checks list on `main` when PR #165 was auto-merged. That job is ~20 min and was left out for merge speed. Adding it to required checks is a separate decision worth considering now.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p minutes-app --features metal` (build.rs still stages helper at `tauri/src-tauri/resources/calendar-events`)
- [x] Verified helper is still a Mach-O arm64 executable
- [ ] CI: Desktop App Installer (windows-latest) and release-windows-desktop.yml both pass
- [ ] CI: Test/Install on all three OSes pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)