### PR TITLE
Add shared Windows and Linux desktop-context collectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,9 +3115,6 @@ dependencies = [
  "minutes-core",
  "notify",
  "notify-rust",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
  "portable-pty",
  "reqwest 0.12.28",
  "serde",
@@ -3181,6 +3178,8 @@ dependencies = [
  "ndarray",
  "nnnoiseless",
  "notify",
+ "objc2",
+ "objc2-app-kit",
  "ort",
  "pyannote-rs",
  "rusqlite",
@@ -3199,6 +3198,7 @@ dependencies = [
  "whisper-guard",
  "whisper-rs",
  "windows-sys 0.59.0",
+ "zbus",
 ]
 
 [[package]]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1564,22 +1564,30 @@ fn cmd_record(
     // Check if already recording
     let recording_started_at = Local::now();
     minutes_core::pid::create().map_err(|e| anyhow::anyhow!("{}", e))?;
-    let context_session_id = match minutes_core::context_store::start_capture_session(
+    let context_session_id = minutes_core::desktop_context::maybe_start_capture_session(
+        &config.desktop_context,
         capture_mode,
         title.clone(),
         recording_started_at,
-    ) {
-        Ok(session) => Some(session.id),
-        Err(error) => {
-            tracing::warn!(error = %error, "failed to create context session for recording");
-            None
-        }
-    };
+    );
     minutes_core::pid::write_recording_metadata_with_context(
         capture_mode,
         context_session_id.as_deref(),
     )
     .ok();
+    let _desktop_context_collector = context_session_id.as_ref().and_then(|session_id| {
+        match minutes_core::desktop_context::DesktopContextCollector::start(
+            session_id.clone(),
+            minutes_core::desktop_context::DesktopContextSessionKind::Recording,
+            config.desktop_context.clone(),
+        ) {
+            Ok(collector) => Some(collector),
+            Err(error) => {
+                tracing::warn!(error = %error, "desktop context collector unavailable for CLI recording");
+                None
+            }
+        }
+    });
 
     // Save recording start time (for timestamping notes)
     minutes_core::notes::save_recording_start()?;
@@ -6502,7 +6510,26 @@ fn cmd_live(config: &Config) -> Result<()> {
 
     // No sentinel watcher needed — run_inner already polls check_and_clear_sentinel
     // directly in its main loop, avoiding the thread-join and double-consume race.
-    match minutes_core::live_transcript::run(stop, config, None) {
+    let live_context_session_id =
+        minutes_core::desktop_context::maybe_start_live_transcript_session(
+            &config.desktop_context,
+            Local::now(),
+        );
+    let _desktop_context_collector = live_context_session_id.as_ref().and_then(|session_id| {
+        match minutes_core::desktop_context::DesktopContextCollector::start(
+            session_id.clone(),
+            minutes_core::desktop_context::DesktopContextSessionKind::LiveTranscript,
+            config.desktop_context.clone(),
+        ) {
+            Ok(collector) => Some(collector),
+            Err(error) => {
+                tracing::warn!(error = %error, "desktop context collector unavailable for CLI live transcript");
+                None
+            }
+        }
+    });
+
+    match minutes_core::live_transcript::run(stop, config, live_context_session_id) {
         Ok((lines, duration, path)) => {
             eprintln!("\nLive transcript complete:");
             eprintln!("  {} utterances in {:.0}s", lines, duration);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,11 +54,18 @@ tempfile = { version = "3", optional = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSRunningApplication", "NSWorkspace", "libc"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = "5.14.0"
+
 # Native hotkey (CGEventTap) uses raw FFI — no extra crate deps needed.
 # The macOS frameworks are linked automatically via #[link(name = "...")]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -65,7 +65,7 @@ zbus = "5.14.0"
 # The macOS frameworks are linked automatically via #[link(name = "...")]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/core/src/desktop_context.rs
+++ b/crates/core/src/desktop_context.rs
@@ -1,8 +1,9 @@
-use chrono::Local;
-use minutes_core::config::DesktopContextConfig;
-use minutes_core::context_store::{
+use crate::config::DesktopContextConfig;
+use crate::context_store::{
     self, ContextEventSource, ContextPrivacyScope, ContextStoreError, NewContextEvent,
 };
+use crate::pid::CaptureMode;
+use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -36,6 +37,50 @@ struct PlatformSnapshot {
     accessibility_trusted: bool,
 }
 
+pub fn capture_supported() -> bool {
+    platform::capture_supported()
+}
+
+pub fn session_tracking_enabled(settings: &DesktopContextConfig) -> bool {
+    settings.enabled && capture_supported()
+}
+
+pub fn maybe_start_capture_session(
+    settings: &DesktopContextConfig,
+    mode: CaptureMode,
+    title: Option<String>,
+    started_at: DateTime<Local>,
+) -> Option<String> {
+    if !session_tracking_enabled(settings) {
+        return None;
+    }
+
+    match context_store::start_capture_session(mode, title, started_at) {
+        Ok(session) => Some(session.id),
+        Err(error) => {
+            tracing::warn!(error = %error, mode = ?mode, "failed to create desktop context session for capture");
+            None
+        }
+    }
+}
+
+pub fn maybe_start_live_transcript_session(
+    settings: &DesktopContextConfig,
+    started_at: DateTime<Local>,
+) -> Option<String> {
+    if !session_tracking_enabled(settings) {
+        return None;
+    }
+
+    match context_store::start_live_transcript_session(started_at) {
+        Ok(session) => Some(session.id),
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to create desktop context session for live transcript");
+            None
+        }
+    }
+}
+
 pub struct DesktopContextCollector {
     stop: Arc<AtomicBool>,
     join_handle: Option<JoinHandle<()>>,
@@ -47,9 +92,14 @@ impl DesktopContextCollector {
         session_kind: DesktopContextSessionKind,
         settings: DesktopContextConfig,
     ) -> Result<Self, String> {
-        if !settings.enabled {
-            return Err("desktop context disabled in config".into());
+        if !session_tracking_enabled(&settings) {
+            return Err(if settings.enabled {
+                "desktop context unsupported on this platform".into()
+            } else {
+                "desktop context disabled in config".into()
+            });
         }
+
         let stop = Arc::new(AtomicBool::new(false));
         let stop_for_thread = Arc::clone(&stop);
         let join_handle = thread::Builder::new()
@@ -89,6 +139,7 @@ fn run_collector_loop(
                     sleep_with_stop(&stop, Duration::from_millis(DEFAULT_POLL_INTERVAL_MS));
                     continue;
                 }
+
                 let app_focus_changed = previous
                     .as_ref()
                     .map(|prev| {
@@ -159,9 +210,6 @@ fn run_collector_loop(
                                     "title_source": "accessibility",
                                     "accessibility_trusted": current.accessibility_trusted,
                                     "browser_candidate": browser_candidate,
-                                    // Browser enrichment is intentionally deferred; if the
-                                    // frontmost app is a browser, the focused-window title
-                                    // is the only metadata we capture in this first wave.
                                     "browser_enrichment": if browser_candidate {
                                         "deferred_window_title_only"
                                     } else {
@@ -280,11 +328,6 @@ mod platform {
         pub const kAXErrorSuccess: AXError = 0;
 
         #[link(name = "ApplicationServices", kind = "framework")]
-        extern "C" {}
-
-        #[link(name = "CoreFoundation", kind = "framework")]
-        extern "C" {}
-
         extern "C" {
             pub static kAXFocusedWindowAttribute: CFStringRef;
             pub static kAXTitleAttribute: CFStringRef;
@@ -295,6 +338,10 @@ mod platform {
                 attribute: CFStringRef,
                 value: *mut CFTypeRef,
             ) -> AXError;
+        }
+
+        #[link(name = "CoreFoundation", kind = "framework")]
+        extern "C" {
             pub fn CFRelease(value: *const c_void);
             pub fn CFStringGetLength(the_string: CFStringRef) -> CFIndex;
             pub fn CFStringGetMaximumSizeForEncoding(
@@ -310,8 +357,12 @@ mod platform {
         }
     }
 
+    pub fn capture_supported() -> bool {
+        true
+    }
+
     pub fn accessibility_trusted() -> bool {
-        minutes_core::hotkey_macos::is_accessibility_trusted()
+        crate::hotkey_macos::is_accessibility_trusted()
     }
 
     pub fn snapshot_frontmost_context() -> Result<Option<PlatformSnapshot>, String> {
@@ -423,11 +474,381 @@ mod platform {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+mod platform {
+    use super::PlatformSnapshot;
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use std::path::Path;
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
+    };
+
+    pub fn capture_supported() -> bool {
+        true
+    }
+
+    pub fn snapshot_frontmost_context() -> Result<Option<PlatformSnapshot>, String> {
+        unsafe {
+            let hwnd = GetForegroundWindow();
+            if hwnd.is_null() {
+                return Ok(None);
+            }
+
+            let mut process_id = 0u32;
+            let _thread_id = GetWindowThreadProcessId(hwnd, &mut process_id);
+            if process_id == 0 {
+                return Ok(None);
+            }
+
+            let process_path = process_image_path(process_id);
+            let bundle_id = process_path
+                .as_deref()
+                .and_then(|path| Path::new(path).file_name())
+                .map(|name| name.to_string_lossy().to_string());
+            let app_name = process_path
+                .as_deref()
+                .and_then(|path| Path::new(path).file_stem())
+                .map(|name| name.to_string_lossy().to_string())
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or_else(|| format!("pid-{}", process_id));
+            let window_title = window_title(hwnd);
+
+            Ok(Some(PlatformSnapshot {
+                app_name,
+                bundle_id,
+                process_id: process_id as i32,
+                window_title,
+                accessibility_trusted: true,
+            }))
+        }
+    }
+
+    unsafe fn process_image_path(process_id: u32) -> Option<String> {
+        let process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id);
+        if process.is_null() {
+            return None;
+        }
+
+        let mut buffer = vec![0u16; 1024];
+        let mut len = buffer.len() as u32;
+        let ok = QueryFullProcessImageNameW(process, 0, buffer.as_mut_ptr(), &mut len);
+        CloseHandle(process);
+        if ok == 0 || len == 0 {
+            return None;
+        }
+
+        Some(
+            OsString::from_wide(&buffer[..len as usize])
+                .to_string_lossy()
+                .trim()
+                .to_string(),
+        )
+        .filter(|value| !value.is_empty())
+    }
+
+    unsafe fn window_title(hwnd: windows_sys::Win32::Foundation::HWND) -> Option<String> {
+        let len = GetWindowTextLengthW(hwnd);
+        if len <= 0 {
+            return None;
+        }
+
+        let mut buffer = vec![0u16; (len + 1) as usize];
+        let written = GetWindowTextW(hwnd, buffer.as_mut_ptr(), buffer.len() as i32);
+        if written <= 0 {
+            return None;
+        }
+
+        Some(
+            OsString::from_wide(&buffer[..written as usize])
+                .to_string_lossy()
+                .trim()
+                .to_string(),
+        )
+        .filter(|value| !value.is_empty())
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::PlatformSnapshot;
+    use std::cell::RefCell;
+    use zbus::blocking::{connection, Connection, Proxy};
+    use zbus::zvariant::OwnedObjectPath;
+
+    const ATSPI_BUS_SERVICE: &str = "org.a11y.Bus";
+    const ATSPI_BUS_PATH: &str = "/org/a11y/bus";
+    const ATSPI_BUS_INTERFACE: &str = "org.a11y.Bus";
+    const ATSPI_REGISTRY_SERVICE: &str = "org.a11y.atspi.Registry";
+    const ATSPI_ROOT_PATH: &str = "/org/a11y/atspi/accessible/root";
+    const ATSPI_ACCESSIBLE_INTERFACE: &str = "org.a11y.atspi.Accessible";
+    const ATSPI_APPLICATION_INTERFACE: &str = "org.a11y.atspi.Application";
+    const ATSPI_STATE_ACTIVE: u32 = 1;
+    const ATSPI_ROLE_DIALOG: u32 = 16;
+    const ATSPI_ROLE_FRAME: u32 = 23;
+    const ATSPI_ROLE_WINDOW: u32 = 69;
+    const ATSPI_ROLE_DOCUMENT_FRAME: u32 = 82;
+    const MAX_VISITED_OBJECTS: usize = 256;
+
+    thread_local! {
+        static CLIENT: RefCell<Option<AtspiClient>> = const { RefCell::new(None) };
+    }
+
+    pub fn capture_supported() -> bool {
+        with_client(|client| client.bus_available()).unwrap_or(false)
+    }
+
+    pub fn snapshot_frontmost_context() -> Result<Option<PlatformSnapshot>, String> {
+        with_client(|client| client.snapshot_frontmost_context())
+    }
+
+    fn with_client<T>(f: impl FnOnce(&AtspiClient) -> Result<T, String>) -> Result<T, String> {
+        CLIENT.with(|slot| {
+            if slot.borrow().is_none() {
+                *slot.borrow_mut() = Some(AtspiClient::connect()?);
+            }
+
+            let result = {
+                let guard = slot.borrow();
+                let client = guard
+                    .as_ref()
+                    .ok_or_else(|| "AT-SPI client not initialized".to_string())?;
+                f(client)
+            };
+
+            if result.is_err() {
+                *slot.borrow_mut() = None;
+            }
+
+            result
+        })
+    }
+
+    struct AtspiClient {
+        connection: Connection,
+    }
+
+    impl AtspiClient {
+        fn connect() -> Result<Self, String> {
+            let session = Connection::session().map_err(|error| error.to_string())?;
+            let bus_proxy = Proxy::new(
+                &session,
+                ATSPI_BUS_SERVICE,
+                ATSPI_BUS_PATH,
+                ATSPI_BUS_INTERFACE,
+            )
+            .map_err(|error| error.to_string())?;
+            let address: String = bus_proxy
+                .call("GetAddress", &())
+                .map_err(|error| error.to_string())?;
+            if address.trim().is_empty() {
+                return Err("AT-SPI bus address was empty".into());
+            }
+
+            let connection = connection::Builder::address(address.as_str())
+                .map_err(|error| error.to_string())?
+                .build()
+                .map_err(|error| error.to_string())?;
+
+            Ok(Self { connection })
+        }
+
+        fn bus_available(&self) -> Result<bool, String> {
+            let root = self.accessible_proxy(ATSPI_REGISTRY_SERVICE, ATSPI_ROOT_PATH)?;
+            let _: Vec<(String, OwnedObjectPath)> = root
+                .call("GetChildren", &())
+                .map_err(|error| error.to_string())?;
+            Ok(true)
+        }
+
+        fn snapshot_frontmost_context(&self) -> Result<Option<PlatformSnapshot>, String> {
+            let root = self.accessible_proxy(ATSPI_REGISTRY_SERVICE, ATSPI_ROOT_PATH)?;
+            let applications: Vec<(String, OwnedObjectPath)> = root
+                .call("GetChildren", &())
+                .map_err(|error| error.to_string())?;
+            if applications.is_empty() {
+                return Ok(None);
+            }
+
+            for (service, app_path) in applications {
+                let app_proxy = self.accessible_proxy(&service, app_path.as_str())?;
+                let app_name = app_proxy
+                    .get_property::<String>("Name")
+                    .unwrap_or_else(|_| service.clone())
+                    .trim()
+                    .to_string();
+                let process_id = self
+                    .application_pid(&service, app_path.as_str())
+                    .unwrap_or(0);
+                let children: Vec<(String, OwnedObjectPath)> =
+                    app_proxy
+                        .call("GetChildren", &())
+                        .map_err(|error| error.to_string())?;
+
+                for (child_service, child_path) in children {
+                    let mut visited = 0usize;
+                    if let Some(snapshot) = self.find_active_window(
+                        &child_service,
+                        child_path.as_str(),
+                        &app_name,
+                        process_id,
+                        &mut visited,
+                    )? {
+                        return Ok(Some(snapshot));
+                    }
+                }
+            }
+
+            Ok(None)
+        }
+
+        fn find_active_window(
+            &self,
+            service: &str,
+            path: &str,
+            app_name: &str,
+            process_id: i32,
+            visited: &mut usize,
+        ) -> Result<Option<PlatformSnapshot>, String> {
+            if *visited >= MAX_VISITED_OBJECTS {
+                return Ok(None);
+            }
+            *visited += 1;
+
+            let proxy = self.accessible_proxy(service, path)?;
+            let role: u32 = proxy
+                .call("GetRole", &())
+                .map_err(|error| error.to_string())?;
+            let states: Vec<u32> = proxy
+                .call("GetState", &())
+                .map_err(|error| error.to_string())?;
+            let is_top_level_window = matches!(
+                role,
+                ATSPI_ROLE_DIALOG
+                    | ATSPI_ROLE_FRAME
+                    | ATSPI_ROLE_WINDOW
+                    | ATSPI_ROLE_DOCUMENT_FRAME
+            );
+            let is_active = states.iter().any(|state| *state == ATSPI_STATE_ACTIVE);
+
+            if is_top_level_window && is_active {
+                let window_title = proxy
+                    .get_property::<String>("Name")
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty());
+                let bundle_id = Some(service.to_string()).filter(|value| !value.trim().is_empty());
+
+                return Ok(Some(PlatformSnapshot {
+                    app_name: app_name.to_string(),
+                    bundle_id,
+                    process_id,
+                    window_title,
+                    accessibility_trusted: true,
+                }));
+            }
+
+            let children: Vec<(String, OwnedObjectPath)> = proxy
+                .call("GetChildren", &())
+                .map_err(|error| error.to_string())?;
+            for (child_service, child_path) in children {
+                if let Some(snapshot) = self.find_active_window(
+                    &child_service,
+                    child_path.as_str(),
+                    app_name,
+                    process_id,
+                    visited,
+                )? {
+                    return Ok(Some(snapshot));
+                }
+            }
+
+            Ok(None)
+        }
+
+        fn application_pid(&self, service: &str, path: &str) -> Option<i32> {
+            let proxy =
+                Proxy::new(&self.connection, service, path, ATSPI_APPLICATION_INTERFACE).ok()?;
+            proxy.get_property::<i32>("Id").ok()
+        }
+
+        fn accessible_proxy(&self, service: &str, path: &str) -> Result<Proxy<'_>, String> {
+            Proxy::new(&self.connection, service, path, ATSPI_ACCESSIBLE_INTERFACE)
+                .map_err(|error| error.to_string())
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 mod platform {
     use super::PlatformSnapshot;
 
+    pub fn capture_supported() -> bool {
+        false
+    }
+
     pub fn snapshot_frontmost_context() -> Result<Option<PlatformSnapshot>, String> {
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_context_session_tracking_requires_opt_in() {
+        let mut settings = DesktopContextConfig::default();
+        assert!(!session_tracking_enabled(&settings));
+
+        settings.enabled = true;
+        assert_eq!(session_tracking_enabled(&settings), capture_supported());
+    }
+
+    #[test]
+    fn desktop_context_app_filters_deny_before_allow() {
+        let settings = DesktopContextConfig {
+            enabled: true,
+            capture_window_titles: true,
+            capture_browser_context: false,
+            allowed_apps: vec!["arc".into()],
+            denied_apps: vec!["1password".into()],
+            allowed_domains: vec![],
+            denied_domains: vec![],
+        };
+
+        assert!(app_allowed(
+            &settings,
+            Some("company.thebrowser.arc"),
+            "Arc"
+        ));
+        assert!(!app_allowed(
+            &settings,
+            Some("com.1password.1password"),
+            "1Password"
+        ));
+        assert!(!app_allowed(&settings, Some("com.apple.Safari"), "Safari"));
+    }
+
+    #[test]
+    fn desktop_context_disabled_capture_session_does_not_touch_store() {
+        let session = maybe_start_capture_session(
+            &DesktopContextConfig::default(),
+            CaptureMode::Meeting,
+            Some("test".into()),
+            Local::now(),
+        );
+        assert!(session.is_none());
+    }
+
+    #[test]
+    fn desktop_context_disabled_live_session_does_not_touch_store() {
+        let session =
+            maybe_start_live_transcript_session(&DesktopContextConfig::default(), Local::now());
+        assert!(session.is_none());
     }
 }

--- a/crates/core/src/desktop_context.rs
+++ b/crates/core/src/desktop_context.rs
@@ -423,11 +423,8 @@ mod platform {
         }
 
         let mut focused_window: ffi::CFTypeRef = std::ptr::null();
-        let focused_window_result = ffi::AXUIElementCopyAttributeValue(
-            app,
-            focused_window_attribute,
-            &mut focused_window,
-        );
+        let focused_window_result =
+            ffi::AXUIElementCopyAttributeValue(app, focused_window_attribute, &mut focused_window);
         ffi::CFRelease(focused_window_attribute.cast());
         ffi::CFRelease(app.cast());
         if focused_window_result != ffi::kAXErrorSuccess || focused_window.is_null() {
@@ -445,11 +442,8 @@ mod platform {
         }
 
         let mut title: ffi::CFTypeRef = std::ptr::null();
-        let title_result = ffi::AXUIElementCopyAttributeValue(
-            focused_window.cast(),
-            title_attribute,
-            &mut title,
-        );
+        let title_result =
+            ffi::AXUIElementCopyAttributeValue(focused_window.cast(), title_attribute, &mut title);
         ffi::CFRelease(title_attribute.cast());
         ffi::CFRelease(focused_window.cast());
         if title_result != ffi::kAXErrorSuccess || title.is_null() {

--- a/crates/core/src/desktop_context.rs
+++ b/crates/core/src/desktop_context.rs
@@ -329,9 +329,6 @@ mod platform {
 
         #[link(name = "ApplicationServices", kind = "framework")]
         extern "C" {
-            pub static kAXFocusedWindowAttribute: CFStringRef;
-            pub static kAXTitleAttribute: CFStringRef;
-
             pub fn AXUIElementCreateApplication(pid: i32) -> AXUIElementRef;
             pub fn AXUIElementCopyAttributeValue(
                 element: AXUIElementRef,
@@ -348,6 +345,11 @@ mod platform {
                 length: CFIndex,
                 encoding: CFStringEncoding,
             ) -> CFIndex;
+            pub fn CFStringCreateWithCString(
+                alloc: *const c_void,
+                c_str: *const i8,
+                encoding: CFStringEncoding,
+            ) -> CFStringRef;
             pub fn CFStringGetCString(
                 the_string: CFStringRef,
                 buffer: *mut i8,
@@ -409,23 +411,46 @@ mod platform {
             return None;
         }
 
+        // AX attribute "constants" are CFSTR() macros in Apple's headers, not exported symbols.
+        let focused_window_attribute = ffi::CFStringCreateWithCString(
+            std::ptr::null(),
+            c"AXFocusedWindow".as_ptr(),
+            ffi::kCFStringEncodingUTF8,
+        );
+        if focused_window_attribute.is_null() {
+            ffi::CFRelease(app.cast());
+            return None;
+        }
+
         let mut focused_window: ffi::CFTypeRef = std::ptr::null();
         let focused_window_result = ffi::AXUIElementCopyAttributeValue(
             app,
-            ffi::kAXFocusedWindowAttribute,
+            focused_window_attribute,
             &mut focused_window,
         );
+        ffi::CFRelease(focused_window_attribute.cast());
         ffi::CFRelease(app.cast());
         if focused_window_result != ffi::kAXErrorSuccess || focused_window.is_null() {
+            return None;
+        }
+
+        let title_attribute = ffi::CFStringCreateWithCString(
+            std::ptr::null(),
+            c"AXTitle".as_ptr(),
+            ffi::kCFStringEncodingUTF8,
+        );
+        if title_attribute.is_null() {
+            ffi::CFRelease(focused_window.cast());
             return None;
         }
 
         let mut title: ffi::CFTypeRef = std::ptr::null();
         let title_result = ffi::AXUIElementCopyAttributeValue(
             focused_window.cast(),
-            ffi::kAXTitleAttribute,
+            title_attribute,
             &mut title,
         );
+        ffi::CFRelease(title_attribute.cast());
         ffi::CFRelease(focused_window.cast());
         if title_result != ffi::kAXErrorSuccess || title.is_null() {
             return None;
@@ -776,9 +801,13 @@ mod platform {
             proxy.get_property::<i32>("Id").ok()
         }
 
-        fn accessible_proxy(&self, service: &str, path: &str) -> Result<Proxy<'_>, String> {
+        fn accessible_proxy<'a>(
+            &self,
+            service: &'a str,
+            path: &'a str,
+        ) -> Result<Proxy<'a>, String> {
             Proxy::new(&self.connection, service, path, ATSPI_ACCESSIBLE_INTERFACE)
-                .map_err(|error| error.to_string())
+                .map_err(move |error| error.to_string())
         }
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod capture;
 pub mod config;
 pub mod context_store;
 pub mod daily_notes;
+pub mod desktop_context;
 pub mod desktop_control;
 pub mod device_monitor;
 pub mod diarize;

--- a/manifest.json
+++ b/manifest.json
@@ -156,43 +156,6 @@
       "description": "Show the current state of the knowledge base — configuration, adapter, people count, log entries"
     }
   ],
-  "resources": [
-    {
-      "name": "Minutes Dashboard",
-      "uri": "ui://minutes/dashboard",
-      "description": "Interactive meeting dashboard and detail viewer"
-    },
-    {
-      "name": "recent_meetings",
-      "uri": "minutes://meetings/recent",
-      "description": "List of recent meetings and memos"
-    },
-    {
-      "name": "recording_status",
-      "uri": "minutes://status",
-      "description": "Current recording status"
-    },
-    {
-      "name": "open_actions",
-      "uri": "minutes://actions/open",
-      "description": "All open action items across meetings"
-    },
-    {
-      "name": "recent_events",
-      "uri": "minutes://events/recent",
-      "description": "Recent pipeline events (recordings, processing, notes)"
-    },
-    {
-      "name": "meeting",
-      "uri": "minutes://meetings/{slug}",
-      "description": "Get a specific meeting by its filename slug"
-    },
-    {
-      "name": "recent-ideas",
-      "uri": "minutes://ideas/recent",
-      "description": "Recent voice memos and ideas captured from any device (last 14 days)"
-    }
-  ],
   "prompts": [
     {
       "name": "meeting_prep",

--- a/scripts/generate_llms_txt.mjs
+++ b/scripts/generate_llms_txt.mjs
@@ -197,7 +197,15 @@ function classifyErrorEntry(entry) {
 function categorizeTool(name) {
   const groups = {
     Recording: new Set(["start_recording", "stop_recording", "get_status", "list_processing_jobs"]),
-    "Search and recall": new Set(["list_meetings", "get_meeting", "search_meetings", "research_topic"]),
+    "Search and recall": new Set([
+      "list_meetings",
+      "get_meeting",
+      "search_meetings",
+      "activity_summary",
+      "search_context",
+      "get_moment",
+      "research_topic",
+    ]),
     "People and relationships": new Set(["get_person_profile", "relationship_map", "track_commitments", "consistency_report"]),
     Insights: new Set(["get_meeting_insights", "ingest_meeting", "knowledge_status"]),
     "Live and dictation": new Set(["start_live_transcript", "read_live_transcript", "start_dictation", "stop_dictation"]),

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -41,11 +41,6 @@ window-vibrancy = "0.7"
 notify = "7"
 tracing = "0.1"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSRunningApplication", "NSWorkspace", "libc"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
-
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1686,17 +1686,12 @@ fn start_native_call_recording(
     };
     let output_path = session.output_path().to_path_buf();
     let recording_started_at = chrono::Local::now();
-    let context_session_id = match minutes_core::context_store::start_capture_session(
+    let context_session_id = minutes_core::desktop_context::maybe_start_capture_session(
+        &config.desktop_context,
         mode,
         requested_title.clone(),
         recording_started_at,
-    ) {
-        Ok(session) => Some(session.id),
-        Err(error) => {
-            tracing::warn!(error = %error, mode = ?mode, "failed to create context session for native recording");
-            None
-        }
-    };
+    );
 
     starting.store(false, Ordering::Relaxed);
     recording.store(true, Ordering::Relaxed);
@@ -1716,11 +1711,10 @@ fn start_native_call_recording(
         output_path.display()
     );
 
-    #[cfg(target_os = "macos")]
     let _desktop_context_collector = context_session_id.as_ref().and_then(|session_id| {
-        match crate::desktop_context::DesktopContextCollector::start(
+        match minutes_core::desktop_context::DesktopContextCollector::start(
             session_id.clone(),
-            crate::desktop_context::DesktopContextSessionKind::Recording,
+            minutes_core::desktop_context::DesktopContextSessionKind::Recording,
             config.desktop_context.clone(),
         ) {
             Ok(collector) => Some(collector),
@@ -3455,17 +3449,12 @@ pub fn start_recording(
     stop_flag.store(false, Ordering::Relaxed);
     sync_processing_indicator(&processing, &processing_stage);
     set_latest_output(&latest_output, None);
-    let context_session_id = match minutes_core::context_store::start_capture_session(
+    let context_session_id = minutes_core::desktop_context::maybe_start_capture_session(
+        &config.desktop_context,
         mode,
         requested_title.clone(),
         recording_started_at,
-    ) {
-        Ok(session) => Some(session.id),
-        Err(error) => {
-            tracing::warn!(error = %error, mode = ?mode, "failed to create context session for recording");
-            None
-        }
-    };
+    );
     minutes_core::pid::write_recording_metadata_with_context(mode, context_session_id.as_deref())
         .ok();
     crate::update_tray_state(&app_handle, true);
@@ -3479,11 +3468,10 @@ pub fn start_recording(
         update_assistant_live_context(&workspace, true);
     }
 
-    #[cfg(target_os = "macos")]
     let _desktop_context_collector = context_session_id.as_ref().and_then(|session_id| {
-        match crate::desktop_context::DesktopContextCollector::start(
+        match minutes_core::desktop_context::DesktopContextCollector::start(
             session_id.clone(),
-            crate::desktop_context::DesktopContextSessionKind::Recording,
+            minutes_core::desktop_context::DesktopContextSessionKind::Recording,
             config.desktop_context.clone(),
         ) {
             Ok(collector) => Some(collector),
@@ -6364,6 +6352,10 @@ mod tests {
         // screen_context.keep_after_summary controls post-summary screenshot
         // retention. Low-traffic; TOML-only is fine.
         ("screen_context", "keep_after_summary"),
+        // Desktop-context domain policy is intentionally deferred until the
+        // browser capture path graduates beyond window-title-only context.
+        ("desktop_context", "allowed_domains"),
+        ("desktop_context", "denied_domains"),
         // Parakeet sidecar is beta / opt-in. No UI until the sidecar path is
         // out of beta.
         ("transcription", "parakeet_sidecar_enabled"),
@@ -6589,6 +6581,28 @@ mod tests {
                 cursor = abs + anchor.len();
             }
         }
+
+        // Some UI surfaces intentionally route repeated settings through
+        // helper wrappers rather than spelling out a literal invoke call for
+        // every key. Keep this allowlist narrow and explicit so it still
+        // proves a real caller exists, rather than downgrading the guard
+        // into a generic string search.
+        if section == "desktop_context" {
+            let wrapper_anchors = ["wireDesktopContextToggle(", "wireDesktopContextList("];
+            for anchor in &wrapper_anchors {
+                let mut cursor = 0;
+                while let Some(offset) = haystack[cursor..].find(anchor) {
+                    let abs = cursor + offset;
+                    let window_end = (abs + 180).min(haystack.len());
+                    let window = &haystack[abs..window_end];
+                    if key_patterns.iter().any(|pattern| window.contains(pattern)) {
+                        return true;
+                    }
+                    cursor = abs + anchor.len();
+                }
+            }
+        }
+
         false
     }
 
@@ -7697,21 +7711,16 @@ fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: A
         update_assistant_live_context(&workspace, true);
     }
 
-    let live_context_session_id = match minutes_core::context_store::start_live_transcript_session(
-        chrono::Local::now(),
-    ) {
-        Ok(session) => Some(session.id),
-        Err(error) => {
-            tracing::warn!(error = %error, "failed to create context session for live transcript");
-            None
-        }
-    };
+    let live_context_session_id =
+        minutes_core::desktop_context::maybe_start_live_transcript_session(
+            &config.desktop_context,
+            chrono::Local::now(),
+        );
 
-    #[cfg(target_os = "macos")]
     let _desktop_context_collector = live_context_session_id.as_ref().and_then(|session_id| {
-        match crate::desktop_context::DesktopContextCollector::start(
+        match minutes_core::desktop_context::DesktopContextCollector::start(
             session_id.clone(),
-            crate::desktop_context::DesktopContextSessionKind::LiveTranscript,
+            minutes_core::desktop_context::DesktopContextSessionKind::LiveTranscript,
             config.desktop_context.clone(),
         ) {
             Ok(collector) => Some(collector),

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -19,7 +19,6 @@ mod call_capture;
 mod call_detect;
 mod commands;
 mod context;
-mod desktop_context;
 mod palette_dispatch;
 mod pty;
 mod shortcut_manager;


### PR DESCRIPTION
## What changed
- move desktop-context collection into minutes-core so CLI and Tauri share the same collector implementation
- add a Windows v1 backend using foreground-window and window-title capture
- add an AT-SPI-first Linux prototype backend with explicit unsupported fallbacks
- widen CLI and Tauri recording/live-transcript paths to start the shared collector
- update the desktop-context settings caller guard so helper-based UI wiring still counts

## Why this PR exists
We already had a macOS collector and cross-platform storage/retrieval. This PR extends the collector layer toward real Windows and Linux parity without turning Minutes into a generic ambient desktop recorder.

## Verification done locally
- cargo fmt --check
- cargo check -p minutes-cli
- cargo test -p minutes-core desktop_context -- --nocapture
- cargo test -p minutes-app every_cmd_set_setting_arm_has_a_caller -- --nocapture

## Remaining verification
Cross-platform compile validation should come from the existing CI matrix on this PR. A follow-up bead, minutes-d1bl, tracks the deeper runtime verification and toolchain-hardening work.