### PR TITLE
[codex] Fix desktop context runtime settings and Apple Speech locale hints

### DIFF
--- a/crates/core/src/apple_speech.rs
+++ b/crates/core/src/apple_speech.rs
@@ -205,13 +205,7 @@ pub fn live_locale_hint(language: Option<&str>) -> Option<String> {
     if trimmed.is_empty() {
         return None;
     }
-    if trimmed.contains('_') {
-        return Some(trimmed.to_string());
-    }
-    if trimmed.contains('-') {
-        return Some(trimmed.replace('-', "_"));
-    }
-    None
+    Some(trimmed.replace('-', "_"))
 }
 
 pub fn probe_capabilities() -> Result<AppleSpeechCapabilityReport> {
@@ -931,6 +925,15 @@ mod tests {
         assert_eq!(locale_language_hint("en_US"), Some("en".into()));
         assert_eq!(locale_language_hint("pt-BR"), Some("pt".into()));
         assert_eq!(locale_language_hint(""), None);
+    }
+
+    #[test]
+    fn live_locale_hint_preserves_plain_language_codes() {
+        assert_eq!(live_locale_hint(Some("en")), Some("en".into()));
+        assert_eq!(live_locale_hint(Some(" fr ")), Some("fr".into()));
+        assert_eq!(live_locale_hint(Some("pt-BR")), Some("pt_BR".into()));
+        assert_eq!(live_locale_hint(Some("")), None);
+        assert_eq!(live_locale_hint(None), None);
     }
 
     #[test]

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -2356,18 +2356,16 @@ mod tests {
     fn meeting_audio_artifact_paths_include_stems_and_embeddings_sidecar() {
         let markdown = Path::new("/tmp/meetings/2026-04-01-standup.md");
         let artifacts = meeting_audio_artifact_paths(markdown);
-        let rendered = artifacts
-            .iter()
-            .map(|path| path.to_string_lossy().to_string())
-            .collect::<Vec<_>>();
+        let audio_path = markdown.with_extension("wav");
+        let stems = stem_paths_for(&audio_path).expect("expected stem paths for meeting audio");
 
         assert_eq!(
-            rendered,
+            artifacts,
             vec![
-                "/tmp/meetings/2026-04-01-standup.wav",
-                "/tmp/meetings/2026-04-01-standup.voice.wav",
-                "/tmp/meetings/2026-04-01-standup.system.wav",
-                "/tmp/meetings/.2026-04-01-standup.embeddings",
+                audio_path,
+                stems.voice,
+                stems.system,
+                crate::voice::meeting_embeddings_sidecar_path(markdown),
             ]
         );
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -223,7 +223,7 @@ pub struct ScreenContextConfig {
     pub keep_after_summary: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct DesktopContextConfig {
     pub enabled: bool,

--- a/crates/core/src/desktop_context.rs
+++ b/crates/core/src/desktop_context.rs
@@ -123,19 +123,36 @@ impl Drop for DesktopContextCollector {
     }
 }
 
+fn load_runtime_settings() -> DesktopContextConfig {
+    crate::config::Config::load().desktop_context
+}
+
 fn run_collector_loop(
     stop: Arc<AtomicBool>,
     session_id: String,
     session_kind: DesktopContextSessionKind,
-    settings: DesktopContextConfig,
+    initial_settings: DesktopContextConfig,
 ) {
     let mut previous: Option<PlatformSnapshot> = None;
+    let mut settings = initial_settings;
+    let mut previous_settings = settings.clone();
 
     while !stop.load(Ordering::Relaxed) {
+        settings = load_runtime_settings();
+        if settings != previous_settings {
+            previous = None;
+            previous_settings = settings.clone();
+        }
+        if !settings.enabled {
+            previous = None;
+            sleep_with_stop(&stop, Duration::from_millis(DEFAULT_POLL_INTERVAL_MS));
+            continue;
+        }
+
         match platform::snapshot_frontmost_context() {
             Ok(Some(current)) => {
                 if !app_allowed(&settings, current.bundle_id.as_deref(), &current.app_name) {
-                    previous = Some(current);
+                    previous = None;
                     sleep_with_stop(&stop, Duration::from_millis(DEFAULT_POLL_INTERVAL_MS));
                     continue;
                 }
@@ -178,12 +195,12 @@ fn run_collector_loop(
                         let browser_candidate =
                             is_browser_candidate(current.bundle_id.as_deref(), &current.app_name);
                         if browser_candidate && !settings.capture_browser_context {
-                            previous = Some(current);
+                            previous = None;
                             sleep_with_stop(&stop, Duration::from_millis(DEFAULT_POLL_INTERVAL_MS));
                             continue;
                         }
                         if !browser_candidate && !settings.capture_window_titles {
-                            previous = Some(current);
+                            previous = None;
                             sleep_with_stop(&stop, Duration::from_millis(DEFAULT_POLL_INTERVAL_MS));
                             continue;
                         }
@@ -822,6 +839,35 @@ mod platform {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
+        let _lock = crate::test_home_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let original_home = std::env::var_os("HOME");
+        #[cfg(windows)]
+        let original_userprofile = std::env::var_os("USERPROFILE");
+
+        std::env::set_var("HOME", dir.path());
+        #[cfg(windows)]
+        std::env::set_var("USERPROFILE", dir.path());
+
+        let result = f(&dir);
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        #[cfg(windows)]
+        if let Some(userprofile) = original_userprofile {
+            std::env::set_var("USERPROFILE", userprofile);
+        } else {
+            std::env::remove_var("USERPROFILE");
+        }
+
+        result
+    }
 
     #[test]
     fn desktop_context_session_tracking_requires_opt_in() {
@@ -873,5 +919,31 @@ mod tests {
         let session =
             maybe_start_live_transcript_session(&DesktopContextConfig::default(), Local::now());
         assert!(session.is_none());
+    }
+
+    #[test]
+    fn desktop_context_runtime_settings_reload_from_saved_config() {
+        with_temp_home(|_| {
+            let path = crate::config::Config::config_path();
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &path,
+                r#"[desktop_context]
+enabled = true
+capture_window_titles = false
+capture_browser_context = true
+allowed_apps = ["Arc"]
+denied_apps = ["Messages"]
+"#,
+            )
+            .unwrap();
+
+            let settings = load_runtime_settings();
+            assert!(settings.enabled);
+            assert!(!settings.capture_window_titles);
+            assert!(settings.capture_browser_context);
+            assert_eq!(settings.allowed_apps, vec!["Arc"]);
+            assert_eq!(settings.denied_apps, vec!["Messages"]);
+        });
     }
 }

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1472,13 +1472,31 @@ pub fn folder_reveal_label() -> &'static str {
 fn desktop_context_limited(config: &Config, accessibility_trusted: bool) -> bool {
     #[cfg(target_os = "macos")]
     {
-        config.desktop_context.capture_window_titles && !accessibility_trusted
+        (config.desktop_context.capture_window_titles
+            || config.desktop_context.capture_browser_context)
+            && !accessibility_trusted
     }
 
     #[cfg(not(target_os = "macos"))]
     {
         let _ = (config, accessibility_trusted);
         false
+    }
+}
+
+fn desktop_context_state(
+    config: &Config,
+    capture_supported: bool,
+    capture_active: bool,
+) -> &'static str {
+    if !config.desktop_context.enabled {
+        "off"
+    } else if !capture_supported {
+        "unsupported"
+    } else if capture_active {
+        "recording"
+    } else {
+        "idle"
     }
 }
 
@@ -5862,6 +5880,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
     let path = Config::config_path();
     let recording_status = minutes_core::pid::status();
     let live_status = minutes_core::live_transcript::session_status();
+    let desktop_context_supported = minutes_core::desktop_context::capture_supported();
     #[cfg(target_os = "macos")]
     let accessibility_trusted = minutes_core::hotkey_macos::is_accessibility_trusted();
     #[cfg(not(target_os = "macos"))]
@@ -5869,13 +5888,11 @@ pub fn cmd_get_settings() -> serde_json::Value {
     let desktop_context_filtered = !config.desktop_context.denied_apps.is_empty()
         || !config.desktop_context.allowed_apps.is_empty();
     let desktop_context_limited = desktop_context_limited(&config, accessibility_trusted);
-    let desktop_context_state = if !config.desktop_context.enabled {
-        "off"
-    } else if recording_status.recording || live_status.active {
-        "recording"
-    } else {
-        "idle"
-    };
+    let desktop_context_state = desktop_context_state(
+        &config,
+        desktop_context_supported,
+        recording_status.recording || live_status.active,
+    );
 
     // Check env vars for API key status
     let anthropic_key_set = std::env::var("ANTHROPIC_API_KEY").is_ok();
@@ -5951,6 +5968,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "capture_browser_context": config.desktop_context.capture_browser_context,
             "allowed_apps": config.desktop_context.allowed_apps,
             "denied_apps": config.desktop_context.denied_apps,
+            "supported": desktop_context_supported,
             "state": desktop_context_state,
             "filtered": desktop_context_filtered,
             "limited": desktop_context_limited,
@@ -6686,14 +6704,10 @@ mod tests {
 
     #[test]
     fn desktop_context_limited_matches_platform_behavior() {
-        let config = Config {
-            desktop_context: minutes_core::config::DesktopContextConfig {
-                enabled: true,
-                capture_window_titles: true,
-                ..Config::default().desktop_context
-            },
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.desktop_context.enabled = true;
+        config.desktop_context.capture_window_titles = false;
+        config.desktop_context.capture_browser_context = true;
 
         #[cfg(target_os = "macos")]
         {
@@ -6706,6 +6720,20 @@ mod tests {
             assert!(!desktop_context_limited(&config, false));
             assert!(!desktop_context_limited(&config, true));
         }
+    }
+
+    #[test]
+    fn desktop_context_state_reports_unsupported_before_idle_or_recording() {
+        let mut config = Config::default();
+        config.desktop_context.enabled = true;
+
+        assert_eq!(desktop_context_state(&config, false, false), "unsupported");
+        assert_eq!(desktop_context_state(&config, false, true), "unsupported");
+        assert_eq!(desktop_context_state(&config, true, false), "idle");
+        assert_eq!(desktop_context_state(&config, true, true), "recording");
+
+        config.desktop_context.enabled = false;
+        assert_eq!(desktop_context_state(&config, false, true), "off");
     }
 
     #[test]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -7472,6 +7472,10 @@
 
     function setSettingsToggle(id, on) { const b = document.getElementById(id); b.textContent = on ? 'On' : 'Off'; b.style.opacity = on ? '1' : '0.5'; }
     function desktopContextStateLabel(state, filtered = false, limited = false) {
+      if (state === 'unsupported') {
+        if (filtered) return 'Enabled in config, but unavailable on this platform right now. Saved app filters will apply once desktop-context capture is supported.';
+        return 'Enabled in config, but unavailable on this platform right now.';
+      }
       if (state === 'recording') {
         if (limited && filtered) return 'Active during a recording or live session. Limited by Accessibility availability and narrowed by app filters.';
         if (limited) return 'Active during a recording or live session. Limited because Accessibility-backed window titles are unavailable right now.';


### PR DESCRIPTION
## Summary
Split out of #172 to keep the hybrid diarization fix for #169 tightly scoped.

This follow-up makes desktop context settings reload from saved config at runtime, reports an explicit unsupported desktop-context state to the Tauri UI, and fixes Apple Speech live locale hints so plain language codes like `en` stay valid instead of collapsing to `None`.

## What Changed
- reloaded desktop-context runtime settings inside the collector loop so config changes take effect without stale in-memory state
- reset collector diffing when desktop-context settings change so filtering/title-capture changes do not reuse the previous snapshot incorrectly
- surfaced a distinct `unsupported` desktop-context state through the Tauri settings payload and desktop UI copy
- treated browser-context capture the same as window-title capture for macOS Accessibility-limited status reporting
- normalized Apple Speech live locale hints by trimming input and converting hyphenated tags like `pt-BR` to `pt_BR` while preserving plain codes like `en`
- added focused regression tests for runtime settings reload, desktop-context state reporting, and Apple Speech locale hints

## Validation
- `cargo test -p minutes-core --lib desktop_context_`
- `cargo test -p minutes-core --lib locale_hint`
- `cargo check -p minutes-app`
