### PR TITLE
[codex] Prefer Parakeet fallback for Apple Speech live transcript

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6726,7 +6726,7 @@ fn cmd_live(config: &Config) -> Result<()> {
     eprintln!("Starting live transcript session...");
     if config.transcription.engine == "apple-speech" {
         eprintln!(
-            "[minutes] Apple Speech experimental live path selected. If unavailable, Minutes will fall back to whisper for this session."
+            "[minutes] Apple Speech experimental live path selected. If unavailable or weak, Minutes will fall back to Parakeet or Whisper for this session."
         );
     }
     eprintln!("Press Ctrl-C or run `minutes stop` to end.\n");

--- a/crates/core/src/apple_speech.rs
+++ b/crates/core/src/apple_speech.rs
@@ -127,6 +127,7 @@ pub struct AppleSpeechBackendBenchmark {
     pub segment_count: usize,
     pub has_timestamps: bool,
     pub wer: Option<f64>,
+    pub wer_punct_insensitive: Option<f64>,
     pub error: Option<String>,
 }
 
@@ -153,6 +154,7 @@ pub struct AppleSpeechAggregateMetrics {
     pub average_elapsed_ms: Option<f64>,
     pub average_first_result_elapsed_ms: Option<f64>,
     pub average_wer: Option<f64>,
+    pub average_wer_punct_insensitive: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -166,6 +168,15 @@ pub struct AppleSpeechBenchmarkTotals {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AppleSpeechBenchmarkSlices {
+    pub overall: AppleSpeechBenchmarkTotals,
+    pub meeting: AppleSpeechBenchmarkTotals,
+    pub dictation: AppleSpeechBenchmarkTotals,
+    pub memo: AppleSpeechBenchmarkTotals,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppleSpeechBenchmarkReport {
     pub generated_at: String,
     pub corpus_path: PathBuf,
@@ -173,6 +184,7 @@ pub struct AppleSpeechBenchmarkReport {
     pub capabilities: AppleSpeechCapabilityReport,
     pub cases: Vec<AppleSpeechBenchmarkCaseResult>,
     pub totals: AppleSpeechBenchmarkTotals,
+    pub slices: AppleSpeechBenchmarkSlices,
     pub notes: Vec<String>,
 }
 
@@ -309,11 +321,30 @@ pub fn run_benchmark_corpus(
         corpus_path: corpus_path.to_path_buf(),
         configured_engine: config.transcription.engine.clone(),
         capabilities,
-        totals: AppleSpeechBenchmarkTotals {
-            speech_transcriber: aggregate_metrics(&results, |case| &case.speech_transcriber),
-            dictation_transcriber: aggregate_metrics(&results, |case| &case.dictation_transcriber),
-            whisper: aggregate_metrics(&results, |case| &case.whisper),
-            parakeet: aggregate_metrics(&results, |case| &case.parakeet),
+        totals: totals_for_cases(&results),
+        slices: AppleSpeechBenchmarkSlices {
+            overall: totals_for_cases(&results),
+            meeting: totals_for_cases(
+                &results
+                    .iter()
+                    .filter(|case| case.content_type == ContentType::Meeting)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
+            dictation: totals_for_cases(
+                &results
+                    .iter()
+                    .filter(|case| case.content_type == ContentType::Dictation)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
+            memo: totals_for_cases(
+                &results
+                    .iter()
+                    .filter(|case| case.content_type == ContentType::Memo)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
         },
         cases: results,
         notes,
@@ -430,7 +461,7 @@ pub fn render_benchmark_summary(report: &AppleSpeechBenchmarkReport) -> String {
         ));
     }
     lines.push(String::new());
-    lines.push("## Aggregate metrics".to_string());
+    lines.push("## Overall metrics".to_string());
     lines.push(String::new());
     for (label, metrics) in [
         ("SpeechTranscriber", &report.totals.speech_transcriber),
@@ -439,14 +470,49 @@ pub fn render_benchmark_summary(report: &AppleSpeechBenchmarkReport) -> String {
         ("Parakeet", &report.totals.parakeet),
     ] {
         lines.push(format!(
-            "- {}: succeeded `{}/{}`; avg elapsed `{}` ms; avg first-result `{}` ms; avg WER `{}`",
+            "- {}: succeeded `{}/{}`; avg elapsed `{}` ms; avg first-result `{}` ms; avg WER `{}`; avg WER (punct-insensitive) `{}`",
             label,
             metrics.cases_succeeded,
             metrics.cases_total,
             format_optional_f64(metrics.average_elapsed_ms),
             format_optional_f64(metrics.average_first_result_elapsed_ms),
             format_optional_f64(metrics.average_wer.map(|value| value * 100.0)),
+            format_optional_f64(
+                metrics
+                    .average_wer_punct_insensitive
+                    .map(|value| value * 100.0)
+            ),
         ));
+    }
+    for (slice_label, totals) in [
+        ("meeting", &report.slices.meeting),
+        ("dictation", &report.slices.dictation),
+        ("memo", &report.slices.memo),
+    ] {
+        lines.push(String::new());
+        lines.push(format!("## {} metrics", slice_label));
+        lines.push(String::new());
+        for (label, metrics) in [
+            ("SpeechTranscriber", &totals.speech_transcriber),
+            ("DictationTranscriber", &totals.dictation_transcriber),
+            ("Whisper", &totals.whisper),
+            ("Parakeet", &totals.parakeet),
+        ] {
+            lines.push(format!(
+                "- {}: succeeded `{}/{}`; avg elapsed `{}` ms; avg first-result `{}` ms; avg WER `{}`; avg WER (punct-insensitive) `{}`",
+                label,
+                metrics.cases_succeeded,
+                metrics.cases_total,
+                format_optional_f64(metrics.average_elapsed_ms),
+                format_optional_f64(metrics.average_first_result_elapsed_ms),
+                format_optional_f64(metrics.average_wer.map(|value| value * 100.0)),
+                format_optional_f64(
+                    metrics
+                        .average_wer_punct_insensitive
+                        .map(|value| value * 100.0)
+                ),
+            ));
+        }
     }
     lines.push(String::new());
     lines.push("## Cases".to_string());
@@ -459,40 +525,60 @@ pub fn render_benchmark_summary(report: &AppleSpeechBenchmarkReport) -> String {
             case.locale
         ));
         lines.push(format!(
-            "  speech: {} / {} ms / WER {}",
+            "  speech: {} / {} ms / WER {} / WER no-punct {}",
             case.speech_transcriber.status,
             case.speech_transcriber
                 .total_elapsed_ms
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "n/a".into()),
             format_optional_f64(case.speech_transcriber.wer.map(|value| value * 100.0)),
+            format_optional_f64(
+                case.speech_transcriber
+                    .wer_punct_insensitive
+                    .map(|value| value * 100.0)
+            ),
         ));
         lines.push(format!(
-            "  dictation: {} / {} ms / WER {}",
+            "  dictation: {} / {} ms / WER {} / WER no-punct {}",
             case.dictation_transcriber.status,
             case.dictation_transcriber
                 .total_elapsed_ms
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "n/a".into()),
             format_optional_f64(case.dictation_transcriber.wer.map(|value| value * 100.0)),
+            format_optional_f64(
+                case.dictation_transcriber
+                    .wer_punct_insensitive
+                    .map(|value| value * 100.0)
+            ),
         ));
         lines.push(format!(
-            "  whisper: {} / {} ms / WER {}",
+            "  whisper: {} / {} ms / WER {} / WER no-punct {}",
             case.whisper.status,
             case.whisper
                 .total_elapsed_ms
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "n/a".into()),
             format_optional_f64(case.whisper.wer.map(|value| value * 100.0)),
+            format_optional_f64(
+                case.whisper
+                    .wer_punct_insensitive
+                    .map(|value| value * 100.0)
+            ),
         ));
         lines.push(format!(
-            "  parakeet: {} / {} ms / WER {}",
+            "  parakeet: {} / {} ms / WER {} / WER no-punct {}",
             case.parakeet.status,
             case.parakeet
                 .total_elapsed_ms
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "n/a".into()),
             format_optional_f64(case.parakeet.wer.map(|value| value * 100.0)),
+            format_optional_f64(
+                case.parakeet
+                    .wer_punct_insensitive
+                    .map(|value| value * 100.0)
+            ),
         ));
     }
     lines.push(String::new());
@@ -523,6 +609,8 @@ fn aggregate_metrics(
     let mut first_count = 0usize;
     let mut wer_sum = 0f64;
     let mut wer_count = 0usize;
+    let mut wer_punct_insensitive_sum = 0f64;
+    let mut wer_punct_insensitive_count = 0usize;
 
     for case in cases {
         let result = select(case);
@@ -543,13 +631,28 @@ fn aggregate_metrics(
                 wer_sum += wer;
                 wer_count += 1;
             }
+            if let Some(wer) = result.wer_punct_insensitive {
+                wer_punct_insensitive_sum += wer;
+                wer_punct_insensitive_count += 1;
+            }
         }
     }
 
     metrics.average_elapsed_ms = average(elapsed_sum, elapsed_count);
     metrics.average_first_result_elapsed_ms = average(first_sum, first_count);
     metrics.average_wer = average(wer_sum, wer_count);
+    metrics.average_wer_punct_insensitive =
+        average(wer_punct_insensitive_sum, wer_punct_insensitive_count);
     metrics
+}
+
+fn totals_for_cases(cases: &[AppleSpeechBenchmarkCaseResult]) -> AppleSpeechBenchmarkTotals {
+    AppleSpeechBenchmarkTotals {
+        speech_transcriber: aggregate_metrics(cases, |case| &case.speech_transcriber),
+        dictation_transcriber: aggregate_metrics(cases, |case| &case.dictation_transcriber),
+        whisper: aggregate_metrics(cases, |case| &case.whisper),
+        parakeet: aggregate_metrics(cases, |case| &case.parakeet),
+    }
 }
 
 fn average(sum: f64, count: usize) -> Option<f64> {
@@ -629,6 +732,8 @@ fn benchmark_apple_mode(
             .iter()
             .any(|segment| segment.start_ms > 0 || segment.duration_ms > 0),
         wer: reference_text.map(|reference| word_error_rate(reference, &selected.transcript)),
+        wer_punct_insensitive: reference_text
+            .map(|reference| word_error_rate_punct_insensitive(reference, &selected.transcript)),
         error: selected.error.clone(),
     })
 }
@@ -663,6 +768,8 @@ fn benchmark_minutes_backend(
             segment_count: result.text.lines().count(),
             has_timestamps: result.text.lines().any(|line| line.starts_with('[')),
             wer: reference_text.map(|reference| word_error_rate(reference, &result.text)),
+            wer_punct_insensitive: reference_text
+                .map(|reference| word_error_rate_punct_insensitive(reference, &result.text)),
             error: None,
         },
         Err(error) => {
@@ -687,6 +794,7 @@ fn benchmark_minutes_backend(
                 segment_count: 0,
                 has_timestamps: false,
                 wer: None,
+                wer_punct_insensitive: None,
                 error: Some(error.to_string()),
             }
         }
@@ -712,9 +820,61 @@ fn eval_text_for_compare(text: &str) -> String {
         .join(" ")
 }
 
+fn eval_text_for_compare_punct_insensitive(text: &str) -> String {
+    eval_text_for_compare(text)
+        .chars()
+        .map(|ch| {
+            if ch.is_alphanumeric() || ch.is_whitespace() {
+                ch
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn word_error_rate(reference: &str, hypothesis: &str) -> f64 {
     let reference = eval_text_for_compare(reference);
     let hypothesis = eval_text_for_compare(hypothesis);
+    let reference_words: Vec<&str> = reference.split_whitespace().collect();
+    let hypothesis_words: Vec<&str> = hypothesis.split_whitespace().collect();
+    if reference_words.is_empty() {
+        return if hypothesis_words.is_empty() {
+            0.0
+        } else {
+            1.0
+        };
+    }
+
+    let mut dp = vec![vec![0usize; hypothesis_words.len() + 1]; reference_words.len() + 1];
+    for (i, row) in dp.iter_mut().enumerate().take(reference_words.len() + 1) {
+        row[0] = i;
+    }
+    for (j, cell) in dp[0]
+        .iter_mut()
+        .enumerate()
+        .take(hypothesis_words.len() + 1)
+    {
+        *cell = j;
+    }
+    for i in 1..=reference_words.len() {
+        for j in 1..=hypothesis_words.len() {
+            let cost = usize::from(reference_words[i - 1] != hypothesis_words[j - 1]);
+            dp[i][j] = (dp[i - 1][j] + 1)
+                .min(dp[i][j - 1] + 1)
+                .min(dp[i - 1][j - 1] + cost);
+        }
+    }
+
+    dp[reference_words.len()][hypothesis_words.len()] as f64 / reference_words.len() as f64
+}
+
+fn word_error_rate_punct_insensitive(reference: &str, hypothesis: &str) -> f64 {
+    let reference = eval_text_for_compare_punct_insensitive(reference);
+    let hypothesis = eval_text_for_compare_punct_insensitive(hypothesis);
     let reference_words: Vec<&str> = reference.split_whitespace().collect();
     let hypothesis_words: Vec<&str> = hypothesis.split_whitespace().collect();
     if reference_words.is_empty() {
@@ -985,5 +1145,16 @@ mod tests {
             Some(corpus_dir.join(Path::new("refs").join("sample.txt")))
         );
         assert_eq!(cases[1].audio_path, absolute_audio);
+    }
+
+    #[test]
+    fn punct_insensitive_wer_ignores_terminal_punctuation() {
+        let reference = "Minutes benchmark dictation check. Apple speech should handle short form voice notes locally.";
+        let hypothesis =
+            "Minutes benchmark dictation check Apple speech should handle short form voice notes locally";
+        let punct_sensitive = word_error_rate(reference, hypothesis);
+        let punct_insensitive = word_error_rate_punct_insensitive(reference, hypothesis);
+        assert!(punct_sensitive > punct_insensitive);
+        assert_eq!(punct_insensitive, 0.0);
     }
 }

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -88,9 +88,9 @@ pub const PARAKEET_LIVE_FALLBACK_WARNING: &str =
 
 pub const APPLE_SPEECH_SCOPE_DOC_REF: &str = "docs/designs/apple-speech-benchmark-2026-04-22.md";
 pub const APPLE_SPEECH_LIVE_SCOPE_WARNING: &str =
-    "apple-speech live transcript is unavailable on this machine; falling back to whisper for this session";
+    "apple-speech live transcript is unavailable on this machine; falling back to parakeet or whisper for this session";
 pub const APPLE_SPEECH_LIVE_FALLBACK_WARNING: &str =
-    "apple-speech live transcription failed; falling back to whisper for this session";
+    "apple-speech live transcription failed; falling back to parakeet or whisper for this session";
 
 /// True iff this build can route `engine = "parakeet"` to the parakeet path.
 /// Used at session start to decide between scope-warning (compile-time gap)
@@ -116,6 +116,17 @@ fn live_supports_parakeet(engine: &str) -> bool {
         let _ = engine;
         false
     }
+}
+
+#[cfg(feature = "parakeet")]
+fn live_ready_parakeet_fallback(config: &Config) -> bool {
+    crate::transcription_coordinator::parakeet_backend_status(config).ready
+}
+
+#[cfg(not(feature = "parakeet"))]
+#[allow(dead_code)]
+fn live_ready_parakeet_fallback(_config: &Config) -> bool {
+    false
 }
 
 fn live_supports_apple_speech() -> bool {
@@ -601,22 +612,7 @@ fn run_inner(
     config: &Config,
     context_session_id: Option<String>,
 ) -> Result<(usize, f64, PathBuf), MinutesError> {
-    // Load whisper model: use live_transcript.model if set, otherwise dictation.model
-    let whisper_ctx = {
-        let model_path = if config.live_transcript.model.is_empty() {
-            crate::transcribe::resolve_model_path_for_dictation(config)?
-        } else {
-            crate::transcribe::resolve_model_path_by_name(&config.live_transcript.model, config)?
-        };
-        tracing::info!(model = %model_path.display(), "loading whisper model for live transcript");
-        whisper_rs::WhisperContext::new_with_params(
-            model_path
-                .to_str()
-                .ok_or_else(|| TranscribeError::ModelLoadError("invalid path".into()))?,
-            crate::transcribe::whisper_context_params(),
-        )
-        .map_err(|e| TranscribeError::ModelLoadError(format!("{}", e)))?
-    };
+    let mut whisper_ctx: Option<whisper_rs::WhisperContext> = None;
 
     // Start audio stream FIRST — validate mic access before truncating any files
     let device_override = config.recording.device.as_deref();
@@ -658,8 +654,12 @@ fn run_inner(
     let mut parakeet_utterance_samples: Vec<f32> = Vec::new();
     #[cfg(feature = "parakeet")]
     let mut parakeet_live_enabled = live_supports_parakeet(&config.transcription.engine);
+    #[cfg(feature = "parakeet")]
+    let parakeet_fallback_ready = live_ready_parakeet_fallback(config);
     #[cfg(not(feature = "parakeet"))]
     let parakeet_live_enabled = false;
+    #[cfg(not(feature = "parakeet"))]
+    let parakeet_fallback_ready = false;
 
     let mut was_speaking = false;
     let mut utterance_samples: usize = 0;
@@ -742,11 +742,12 @@ fn run_inner(
                     &mut apple_live_enabled,
                     #[cfg(target_os = "macos")]
                     &mut apple_utterance_samples,
+                    parakeet_fallback_ready,
                     &mut parakeet_live_enabled,
                     &mut parakeet_utterance_samples,
                     config,
                     &mut streaming,
-                    &whisper_ctx,
+                    &mut whisper_ctx,
                     "standalone",
                 );
                 #[cfg(not(feature = "parakeet"))]
@@ -755,9 +756,10 @@ fn run_inner(
                     &mut apple_live_enabled,
                     #[cfg(target_os = "macos")]
                     &mut apple_utterance_samples,
+                    parakeet_fallback_ready,
                     config,
                     &mut streaming,
-                    &whisper_ctx,
+                    &mut whisper_ctx,
                     "standalone",
                 );
             }
@@ -773,11 +775,12 @@ fn run_inner(
                     &mut apple_live_enabled,
                     #[cfg(target_os = "macos")]
                     &mut apple_utterance_samples,
+                    parakeet_fallback_ready,
                     &mut parakeet_live_enabled,
                     &mut parakeet_utterance_samples,
                     config,
                     &mut streaming,
-                    &whisper_ctx,
+                    &mut whisper_ctx,
                     "standalone",
                 );
                 #[cfg(not(feature = "parakeet"))]
@@ -786,9 +789,10 @@ fn run_inner(
                     &mut apple_live_enabled,
                     #[cfg(target_os = "macos")]
                     &mut apple_utterance_samples,
+                    parakeet_fallback_ready,
                     config,
                     &mut streaming,
-                    &whisper_ctx,
+                    &mut whisper_ctx,
                     "standalone",
                 );
             }
@@ -836,11 +840,12 @@ fn run_inner(
                             &mut apple_live_enabled,
                             #[cfg(target_os = "macos")]
                             &mut apple_utterance_samples,
+                            parakeet_fallback_ready,
                             &mut parakeet_live_enabled,
                             &mut parakeet_utterance_samples,
                             config,
                             &mut streaming,
-                            &whisper_ctx,
+                            &mut whisper_ctx,
                             "standalone",
                         );
                         #[cfg(not(feature = "parakeet"))]
@@ -849,9 +854,10 @@ fn run_inner(
                             &mut apple_live_enabled,
                             #[cfg(target_os = "macos")]
                             &mut apple_utterance_samples,
+                            parakeet_fallback_ready,
                             config,
                             &mut streaming,
-                            &whisper_ctx,
+                            &mut whisper_ctx,
                             "standalone",
                         );
                     }
@@ -905,11 +911,12 @@ fn run_inner(
                                 &mut apple_live_enabled,
                                 #[cfg(target_os = "macos")]
                                 &mut apple_utterance_samples,
+                                parakeet_fallback_ready,
                                 &mut parakeet_live_enabled,
                                 &mut parakeet_utterance_samples,
                                 config,
                                 &mut streaming,
-                                &whisper_ctx,
+                                &mut whisper_ctx,
                                 "standalone",
                             );
                             #[cfg(not(feature = "parakeet"))]
@@ -918,9 +925,10 @@ fn run_inner(
                                 &mut apple_live_enabled,
                                 #[cfg(target_os = "macos")]
                                 &mut apple_utterance_samples,
+                                parakeet_fallback_ready,
                                 config,
                                 &mut streaming,
-                                &whisper_ctx,
+                                &mut whisper_ctx,
                                 "standalone",
                             );
                         }
@@ -949,8 +957,10 @@ fn run_inner(
                 {
                     parakeet_utterance_samples.extend_from_slice(&chunk.samples);
                 }
-            } else if let Some(_sr) = streaming.feed(&chunk.samples, &whisper_ctx) {
-                // Partial result available — could emit event in the future
+            } else if let Ok(whisper_ctx) = ensure_live_whisper_ctx(&mut whisper_ctx, config) {
+                if let Some(_sr) = streaming.feed(&chunk.samples, whisper_ctx) {
+                    // Partial result available — could emit event in the future
+                }
             }
 
             // Force-finalize if max utterance reached
@@ -962,11 +972,12 @@ fn run_inner(
                     &mut apple_live_enabled,
                     #[cfg(target_os = "macos")]
                     &mut apple_utterance_samples,
+                    parakeet_fallback_ready,
                     &mut parakeet_live_enabled,
                     &mut parakeet_utterance_samples,
                     config,
                     &mut streaming,
-                    &whisper_ctx,
+                    &mut whisper_ctx,
                     "standalone",
                 );
                 #[cfg(not(feature = "parakeet"))]
@@ -975,9 +986,10 @@ fn run_inner(
                     &mut apple_live_enabled,
                     #[cfg(target_os = "macos")]
                     &mut apple_utterance_samples,
+                    parakeet_fallback_ready,
                     config,
                     &mut streaming,
-                    &whisper_ctx,
+                    &mut whisper_ctx,
                     "standalone",
                 );
                 if !write_ok {
@@ -995,11 +1007,12 @@ fn run_inner(
                 &mut apple_live_enabled,
                 #[cfg(target_os = "macos")]
                 &mut apple_utterance_samples,
+                parakeet_fallback_ready,
                 &mut parakeet_live_enabled,
                 &mut parakeet_utterance_samples,
                 config,
                 &mut streaming,
-                &whisper_ctx,
+                &mut whisper_ctx,
                 "standalone",
             );
             #[cfg(not(feature = "parakeet"))]
@@ -1008,9 +1021,10 @@ fn run_inner(
                 &mut apple_live_enabled,
                 #[cfg(target_os = "macos")]
                 &mut apple_utterance_samples,
+                parakeet_fallback_ready,
                 config,
                 &mut streaming,
-                &whisper_ctx,
+                &mut whisper_ctx,
                 "standalone",
             );
             if !write_ok {
@@ -1373,6 +1387,57 @@ where
     Ok(Some((result.transcript, samples.len() as f64 / 16000.0)))
 }
 
+#[cfg(feature = "whisper")]
+fn ensure_live_whisper_ctx<'a>(
+    whisper_ctx: &'a mut Option<whisper_rs::WhisperContext>,
+    config: &Config,
+) -> Result<&'a whisper_rs::WhisperContext, MinutesError> {
+    if whisper_ctx.is_none() {
+        let model_path = if config.live_transcript.model.is_empty() {
+            crate::transcribe::resolve_model_path_for_dictation(config)?
+        } else {
+            crate::transcribe::resolve_model_path_by_name(&config.live_transcript.model, config)?
+        };
+        tracing::info!(
+            model = %model_path.display(),
+            "loading whisper model for live transcript fallback"
+        );
+        let ctx = whisper_rs::WhisperContext::new_with_params(
+            model_path
+                .to_str()
+                .ok_or_else(|| TranscribeError::ModelLoadError("invalid path".into()))?,
+            crate::transcribe::whisper_context_params(),
+        )
+        .map_err(|e| TranscribeError::ModelLoadError(format!("{}", e)))?;
+        *whisper_ctx = Some(ctx);
+    }
+
+    Ok(whisper_ctx
+        .as_ref()
+        .expect("whisper context should exist after ensure_live_whisper_ctx"))
+}
+
+#[cfg(all(feature = "whisper", feature = "parakeet"))]
+fn resolve_apple_speech_live_fallback<P, W>(
+    parakeet_fallback_ready: bool,
+    mut try_parakeet: P,
+    mut try_whisper: W,
+) -> Result<Option<(String, f64)>, MinutesError>
+where
+    P: FnMut() -> Result<Option<(String, f64)>, MinutesError>,
+    W: FnMut() -> Result<Option<(String, f64)>, MinutesError>,
+{
+    if parakeet_fallback_ready {
+        match try_parakeet() {
+            Ok(Some(result)) => return Ok(Some(result)),
+            Ok(None) => return Ok(None),
+            Err(_) => {}
+        }
+    }
+
+    try_whisper()
+}
+
 /// Finalize one utterance via the active engine (apple-speech, parakeet, or whisper)
 /// and write the resulting JSONL line.
 ///
@@ -1384,15 +1449,17 @@ where
 /// for the accumulated samples and flips that engine flag to `false` so the
 /// remainder of the session uses whisper.
 #[cfg(all(feature = "whisper", feature = "parakeet"))]
+#[allow(clippy::too_many_arguments)]
 fn finalize_live_utterance(
     writer: &mut LiveTranscriptWriter,
     apple_live_enabled: &mut bool,
     #[cfg(target_os = "macos")] apple_utterance_samples: &mut Vec<f32>,
+    parakeet_fallback_ready: bool,
     parakeet_live_enabled: &mut bool,
     parakeet_utterance_samples: &mut Vec<f32>,
     config: &Config,
     streaming: &mut StreamingWhisper,
-    whisper_ctx: &whisper_rs::WhisperContext,
+    whisper_ctx: &mut Option<whisper_rs::WhisperContext>,
     source: &'static str,
 ) -> bool {
     #[cfg(target_os = "macos")]
@@ -1410,18 +1477,56 @@ fn finalize_live_utterance(
             Err(error) => {
                 tracing::warn!(
                     error = %error,
-                    "live apple-speech path failed — switching this session to whisper"
+                    "live apple-speech path failed — switching this session to fallback backend"
                 );
                 *apple_live_enabled = false;
                 emit_apple_speech_fallback_warning(source, &error.to_string());
-                if let Some((text, duration_secs)) = transcribe_with_whisper_for_live_sidecar(
-                    apple_utterance_samples,
-                    whisper_ctx,
-                    config.transcription.language.clone(),
-                ) {
-                    let ok = writer.write_utterance(&text, duration_secs);
-                    apple_utterance_samples.clear();
-                    return ok;
+                let fallback_result = resolve_apple_speech_live_fallback(
+                    parakeet_fallback_ready,
+                    || {
+                        *parakeet_live_enabled = true;
+                        match transcribe_with_parakeet_for_live_sidecar(
+                            apple_utterance_samples,
+                            config,
+                        ) {
+                            Ok(result) => Ok(result),
+                            Err(parakeet_error) => {
+                                tracing::warn!(
+                                    error = %parakeet_error,
+                                    "parakeet fallback after apple-speech live failure also failed — switching this session to whisper"
+                                );
+                                *parakeet_live_enabled = false;
+                                Err(parakeet_error)
+                            }
+                        }
+                    },
+                    || {
+                        let whisper_ctx = ensure_live_whisper_ctx(whisper_ctx, config).map_err(|load_error| {
+                            tracing::error!(
+                                error = %load_error,
+                                "failed to load whisper fallback after apple-speech live failure"
+                            );
+                            load_error
+                        })?;
+                        Ok(transcribe_with_whisper_for_live_sidecar(
+                            apple_utterance_samples,
+                            whisper_ctx,
+                            config.transcription.language.clone(),
+                        ))
+                    },
+                );
+
+                match fallback_result {
+                    Ok(Some((text, duration_secs))) => {
+                        let ok = writer.write_utterance(&text, duration_secs);
+                        apple_utterance_samples.clear();
+                        return ok;
+                    }
+                    Ok(None) => {
+                        apple_utterance_samples.clear();
+                        return true;
+                    }
+                    Err(_) => {}
                 }
                 apple_utterance_samples.clear();
                 return true;
@@ -1447,16 +1552,26 @@ fn finalize_live_utterance(
                 );
                 *parakeet_live_enabled = false;
                 emit_live_engine_fallback_warning(source, &error.to_string());
-                // Fall back: transcribe the accumulated samples via whisper so
-                // this utterance still lands in the JSONL.
-                if let Some((text, duration_secs)) = transcribe_with_whisper_for_live_sidecar(
-                    parakeet_utterance_samples,
-                    whisper_ctx,
-                    config.transcription.language.clone(),
-                ) {
-                    let ok = writer.write_utterance(&text, duration_secs);
-                    parakeet_utterance_samples.clear();
-                    return ok;
+                match ensure_live_whisper_ctx(whisper_ctx, config) {
+                    Ok(whisper_ctx) => {
+                        if let Some((text, duration_secs)) =
+                            transcribe_with_whisper_for_live_sidecar(
+                                parakeet_utterance_samples,
+                                whisper_ctx,
+                                config.transcription.language.clone(),
+                            )
+                        {
+                            let ok = writer.write_utterance(&text, duration_secs);
+                            parakeet_utterance_samples.clear();
+                            return ok;
+                        }
+                    }
+                    Err(load_error) => {
+                        tracing::error!(
+                            error = %load_error,
+                            "failed to load whisper fallback after parakeet live failure"
+                        );
+                    }
                 }
                 parakeet_utterance_samples.clear();
                 return true;
@@ -1465,12 +1580,25 @@ fn finalize_live_utterance(
     }
 
     // Whisper path
-    let write_ok = if let Some(sr) = streaming.finalize(whisper_ctx) {
-        writer.write_utterance(&sr.text, sr.duration_secs)
-    } else {
-        true
+    let write_ok = match ensure_live_whisper_ctx(whisper_ctx, config) {
+        Ok(whisper_ctx) => {
+            let ok = if let Some(sr) = streaming.finalize(whisper_ctx) {
+                writer.write_utterance(&sr.text, sr.duration_secs)
+            } else {
+                true
+            };
+            streaming.reset();
+            ok
+        }
+        Err(error) => {
+            tracing::error!(
+                error = %error,
+                "failed to load whisper backend for live transcript"
+            );
+            streaming.reset();
+            false
+        }
     };
-    streaming.reset();
     write_ok
 }
 
@@ -1482,15 +1610,17 @@ fn finalize_live_utterance(
 /// at these branches — we're already breaking out of the loop. But if the
 /// write failed, the last utterance is silently dropped unless we log it.
 #[cfg(all(feature = "whisper", feature = "parakeet"))]
+#[allow(clippy::too_many_arguments)]
 fn finalize_on_exit(
     writer: &mut LiveTranscriptWriter,
     apple_live_enabled: &mut bool,
     #[cfg(target_os = "macos")] apple_utterance_samples: &mut Vec<f32>,
+    parakeet_fallback_ready: bool,
     parakeet_live_enabled: &mut bool,
     parakeet_utterance_samples: &mut Vec<f32>,
     config: &Config,
     streaming: &mut StreamingWhisper,
-    whisper_ctx: &whisper_rs::WhisperContext,
+    whisper_ctx: &mut Option<whisper_rs::WhisperContext>,
     source: &'static str,
 ) {
     if !finalize_live_utterance(
@@ -1498,6 +1628,7 @@ fn finalize_on_exit(
         apple_live_enabled,
         #[cfg(target_os = "macos")]
         apple_utterance_samples,
+        parakeet_fallback_ready,
         parakeet_live_enabled,
         parakeet_utterance_samples,
         config,
@@ -1512,13 +1643,15 @@ fn finalize_on_exit(
 }
 
 #[cfg(all(feature = "whisper", not(feature = "parakeet")))]
+#[allow(clippy::too_many_arguments)]
 fn finalize_live_utterance(
     writer: &mut LiveTranscriptWriter,
     apple_live_enabled: &mut bool,
     #[cfg(target_os = "macos")] apple_utterance_samples: &mut Vec<f32>,
+    _parakeet_fallback_ready: bool,
     config: &Config,
     streaming: &mut StreamingWhisper,
-    whisper_ctx: &whisper_rs::WhisperContext,
+    whisper_ctx: &mut Option<whisper_rs::WhisperContext>,
     source: &'static str,
 ) -> bool {
     #[cfg(target_os = "macos")]
@@ -1540,14 +1673,26 @@ fn finalize_live_utterance(
                 );
                 *apple_live_enabled = false;
                 emit_apple_speech_fallback_warning(source, &error.to_string());
-                if let Some((text, duration_secs)) = transcribe_with_whisper_for_live_sidecar(
-                    apple_utterance_samples,
-                    whisper_ctx,
-                    config.transcription.language.clone(),
-                ) {
-                    let ok = writer.write_utterance(&text, duration_secs);
-                    apple_utterance_samples.clear();
-                    return ok;
+                match ensure_live_whisper_ctx(whisper_ctx, config) {
+                    Ok(whisper_ctx) => {
+                        if let Some((text, duration_secs)) =
+                            transcribe_with_whisper_for_live_sidecar(
+                                apple_utterance_samples,
+                                whisper_ctx,
+                                config.transcription.language.clone(),
+                            )
+                        {
+                            let ok = writer.write_utterance(&text, duration_secs);
+                            apple_utterance_samples.clear();
+                            return ok;
+                        }
+                    }
+                    Err(load_error) => {
+                        tracing::error!(
+                            error = %load_error,
+                            "failed to load whisper fallback after apple-speech live failure"
+                        );
+                    }
                 }
                 apple_utterance_samples.clear();
                 return true;
@@ -1555,10 +1700,21 @@ fn finalize_live_utterance(
         }
     }
 
-    let write_ok = if let Some(sr) = streaming.finalize(whisper_ctx) {
-        writer.write_utterance(&sr.text, sr.duration_secs)
-    } else {
-        true
+    let write_ok = match ensure_live_whisper_ctx(whisper_ctx, config) {
+        Ok(whisper_ctx) => {
+            if let Some(sr) = streaming.finalize(whisper_ctx) {
+                writer.write_utterance(&sr.text, sr.duration_secs)
+            } else {
+                true
+            }
+        }
+        Err(error) => {
+            tracing::error!(
+                error = %error,
+                "failed to load whisper backend for live transcript"
+            );
+            false
+        }
     };
     #[cfg(not(target_os = "macos"))]
     let _ = (&apple_live_enabled, &config, source);
@@ -1567,13 +1723,15 @@ fn finalize_live_utterance(
 }
 
 #[cfg(all(feature = "whisper", not(feature = "parakeet")))]
+#[allow(clippy::too_many_arguments)]
 fn finalize_on_exit(
     writer: &mut LiveTranscriptWriter,
     apple_live_enabled: &mut bool,
     #[cfg(target_os = "macos")] apple_utterance_samples: &mut Vec<f32>,
+    parakeet_fallback_ready: bool,
     config: &Config,
     streaming: &mut StreamingWhisper,
-    whisper_ctx: &whisper_rs::WhisperContext,
+    whisper_ctx: &mut Option<whisper_rs::WhisperContext>,
     source: &'static str,
 ) {
     if !finalize_live_utterance(
@@ -1581,6 +1739,7 @@ fn finalize_on_exit(
         apple_live_enabled,
         #[cfg(target_os = "macos")]
         apple_utterance_samples,
+        parakeet_fallback_ready,
         config,
         streaming,
         whisper_ctx,
@@ -2608,6 +2767,69 @@ mod tests {
         // (We can't assert the threshold-exceeds branch here — it requires a
         // real parakeet binary. The subprocess path is exercised by the smoke
         // test in the RFC.)
+    }
+
+    #[cfg(all(feature = "whisper", feature = "parakeet"))]
+    #[test]
+    fn apple_speech_fallback_prefers_ready_parakeet_before_whisper() {
+        let calls = std::sync::Mutex::new(Vec::<&'static str>::new());
+        let result = resolve_apple_speech_live_fallback(
+            true,
+            || {
+                calls.lock().unwrap().push("parakeet");
+                Ok(Some(("parakeet transcript".into(), 1.2)))
+            },
+            || {
+                calls.lock().unwrap().push("whisper");
+                Ok(Some(("whisper transcript".into(), 1.2)))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(calls.lock().unwrap().as_slice(), &["parakeet"]);
+        assert_eq!(result, Some(("parakeet transcript".into(), 1.2)));
+    }
+
+    #[cfg(all(feature = "whisper", feature = "parakeet"))]
+    #[test]
+    fn apple_speech_fallback_uses_whisper_when_parakeet_is_not_ready() {
+        let calls = std::sync::Mutex::new(Vec::<&'static str>::new());
+        let result = resolve_apple_speech_live_fallback(
+            false,
+            || {
+                calls.lock().unwrap().push("parakeet");
+                Ok(Some(("parakeet transcript".into(), 1.2)))
+            },
+            || {
+                calls.lock().unwrap().push("whisper");
+                Ok(Some(("whisper transcript".into(), 1.2)))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(calls.lock().unwrap().as_slice(), &["whisper"]);
+        assert_eq!(result, Some(("whisper transcript".into(), 1.2)));
+    }
+
+    #[cfg(all(feature = "whisper", feature = "parakeet"))]
+    #[test]
+    fn apple_speech_fallback_tries_whisper_after_parakeet_error() {
+        let calls = std::sync::Mutex::new(Vec::<&'static str>::new());
+        let result = resolve_apple_speech_live_fallback(
+            true,
+            || {
+                calls.lock().unwrap().push("parakeet");
+                Err(MinutesError::Io(std::io::Error::other("parakeet failed")))
+            },
+            || {
+                calls.lock().unwrap().push("whisper");
+                Ok(Some(("whisper transcript".into(), 0.9)))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(calls.lock().unwrap().as_slice(), &["parakeet", "whisper"]);
+        assert_eq!(result, Some(("whisper transcript".into(), 0.9)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-up for `minutes-qjaq`.

This changes the standalone Apple Speech live-transcript fallback order from `apple-speech -> whisper` to `apple-speech -> parakeet -> whisper` when a ready Parakeet backend is available. In parallel, it tightens the Apple benchmark reporting so Parakeet-vs-Whisper parity can be audited with more signal instead of relying only on one aggregate WER number.

## What Changed
- prefer a ready Parakeet backend before Whisper when Apple Speech fails mid-session in standalone live transcript
- keep lazy Whisper loading for the fallback path, so Apple startup stays Apple-first until fallback is actually needed
- add focused unit tests that prove the fallback order and the Whisper fallback-after-Parakeet-error path
- add punctuation-insensitive WER alongside the existing WER metric
- add per-content-type benchmark slices (`meeting`, `dictation`, `memo`) in addition to overall totals
- expand the benchmark summary output so parity between Parakeet and Whisper can be inspected by slice and by punctuation-sensitive vs punctuation-insensitive scoring
- update the CLI live-session message so the fallback behavior matches what the runtime now does

## Why
Recent Apple benchmark runs showed Parakeet and Whisper with identical average WER, which could have been a real corpus coincidence or a reporting blind spot. The extra slice and punctuation-insensitive metrics make that easier to interpret, while the fallback change moves the live behavior closer to the intended local-first hierarchy.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p minutes-core --features 'parakeet streaming' --lib apple_speech_fallback_`
- `cargo test -p minutes-core --lib punct_insensitive_wer_ignores_terminal_punctuation`
- `cargo clippy -p minutes-core --no-default-features -- -D warnings`
