### PR TITLE
Clarify Apple Speech desktop settings status

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -85,6 +85,22 @@ fn parakeet_status_view(config: &Config) -> ParakeetStatusView {
     minutes_core::transcription_coordinator::parakeet_backend_status(config)
 }
 
+fn apple_speech_status_view() -> serde_json::Value {
+    match minutes_core::apple_speech::probe_capabilities() {
+        Ok(report) => serde_json::json!({
+            "supported": report.runtime_supported,
+            "selectable": report.runtime_supported
+                && report.speech_transcriber.is_available.unwrap_or(false),
+            "report": report,
+        }),
+        Err(error) => serde_json::json!({
+            "supported": false,
+            "selectable": false,
+            "error": error.to_string(),
+        }),
+    }
+}
+
 /// Lifecycle state for the palette overlay window.
 ///
 /// Transitions:
@@ -5944,6 +5960,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "parakeet_sidecar_enabled": config.transcription.parakeet_sidecar_enabled,
             "parakeet_compiled": cfg!(feature = "parakeet"),
             "parakeet_status": parakeet_status_view(&config),
+            "apple_speech_status": apple_speech_status_view(),
         },
         "diarization": {
             "engine": config.diarization.engine,

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -7220,6 +7220,7 @@
         const eng = s.transcription.engine || 'whisper';
         const parakeetCompiled = s.transcription.parakeet_compiled || false;
         const parakeetStatus = s.transcription.parakeet_status || null;
+        const appleSpeechStatus = s.transcription.apple_speech_status || null;
         const engineSelect = document.getElementById('settings-transcription-engine');
         const parakeetOpt = engineSelect.querySelector('option[value="parakeet"]');
         const appleSpeechOpt = engineSelect.querySelector('option[value="apple-speech"]');
@@ -7234,12 +7235,18 @@
         if (appleSpeechOpt) {
           appleSpeechOpt.disabled = true;
           appleSpeechOpt.hidden = !appleSpeechConfigured;
-          appleSpeechOpt.textContent = 'Apple Speech — standalone live transcript only; configured outside desktop settings';
+          appleSpeechOpt.textContent = appleSpeechConfigured
+            ? 'Apple Speech — standalone live transcript only; configured outside desktop settings'
+            : (appleSpeechStatus && appleSpeechStatus.selectable)
+              ? 'Apple Speech — available for standalone live transcript, but not configurable here'
+              : 'Apple Speech — unavailable on this Mac';
         }
         if (engineDetail) {
           engineDetail.textContent = appleSpeechConfigured
             ? 'Apple Speech is configured outside desktop settings for standalone live transcript experiments. Recording and batch flows still use Whisper today.'
-            : 'Whisper and Parakeet are the configurable transcription engines in desktop settings.';
+            : (appleSpeechStatus && appleSpeechStatus.selectable)
+              ? 'This Mac supports Apple Speech for standalone live transcript experiments, but desktop settings still only configure Whisper and Parakeet.'
+              : 'Whisper and Parakeet are the configurable transcription engines in desktop settings.';
         }
         engineSelect.value = appleSpeechConfigured ? 'apple-speech' : eng;
         document.getElementById('settings-whisper-section').classList.toggle('is-hidden', eng !== 'whisper');


### PR DESCRIPTION
## Summary
- surface Apple Speech capability info in desktop settings readback
- use the stricter selectable signal for user-facing availability copy
- keep the Apple Speech desktop settings row truthful without widening the feature scope

## Testing
- cargo test -p minutes-app desktop_settings_reject_apple_speech_engine_selection

## Notes
- This is the small Tauri/settings cleanup split out from the broader Apple Speech follow-up work.
- The larger config-model and UX redesign remains tracked in bead minutes-7tmf.