### PR TITLE
Clarify Apple Speech live scope in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ minutes consistency                                # Flag contradicting decision
 minutes live                                     # Start real-time transcription
 minutes stop                                     # Stop live session
 ```
-Streams whisper transcription to a JSONL file in real time — any AI agent can read it mid-meeting for live coaching. The MCP `read_live_transcript` tool provides delta reads (by line cursor or wall-clock duration). Works with Claude Code, Codex, OpenCode, Gemini CLI, or any agent that reads files. The Tauri desktop app has a Live Mode toggle that starts this with one click.
+Streams local transcription to a JSONL file in real time — any AI agent can read it mid-meeting for live coaching. Depending on your build and config, live mode can run on Whisper, Parakeet, or the experimental Apple Speech standalone-live path. Apple Speech currently applies only to standalone live transcript (`minutes live`), not recording-sidecar, dictation, or batch transcription, and it falls back to a ready Parakeet backend before Whisper if Apple Speech is unavailable or fails mid-session. The MCP `read_live_transcript` tool provides delta reads (by line cursor or wall-clock duration). Works with Claude Code, Codex, OpenCode, Gemini CLI, or any agent that reads files. The Tauri desktop app has a Live Mode toggle that starts this with one click.
 
 ### Dictation mode
 ```bash
@@ -992,10 +992,12 @@ Optional — minutes works out of the box.
 # Or: $XDG_CONFIG_HOME/minutes/config.toml when XDG_CONFIG_HOME is set
 
 [transcription]
-engine = "whisper"        # "whisper" (default) or "parakeet" (opt-in, lower WER)
+engine = "whisper"        # "whisper" (default), "parakeet" (opt-in, lower WER), or "apple-speech" (experimental)
 model = "small"           # whisper: tiny (75MB), base, small (466MB), medium, large-v3 (3.1GB)
 # language = "ur"          # Force transcription language (ISO 639-1 code, e.g. "en", "ur", "es", "zh")
                           # Default: auto-detect. Set this for similar-sounding languages (Urdu/Hindi, etc.)
+# engine = "apple-speech"  # Experimental: standalone `minutes live` only. Configure via config file or CLI, not desktop settings.
+#                         # If Apple Speech cannot run, standalone live falls back to a ready Parakeet backend, then Whisper.
 # parakeet_model = "tdt-600m"                    # parakeet: tdt-ctc-110m (English), tdt-600m (multilingual v3)
 # parakeet_binary = "parakeet"                   # Path to parakeet.cpp binary (or name in PATH)
 # parakeet_boost_limit = 25                      # Experimental: boost top graph-derived phrases (0 disables)

--- a/docs/PARAKEET.md
+++ b/docs/PARAKEET.md
@@ -33,6 +33,13 @@ otherwise they fall back to the Parakeet subprocess path for each utterance.
 The standalone live path additionally warms the sidecar at session start so the
 first utterance does not pay the subprocess-spawn + model-load cost.
 
+Parakeet also participates in the experimental Apple Speech standalone-live
+path as the **first runtime fallback**. If `engine = "apple-speech"` is set for
+`minutes live` and Apple Speech cannot run or fails mid-session, Minutes tries
+a ready Parakeet backend before falling back to Whisper. Apple Speech itself is
+still configured separately and remains standalone-live-only; this note is just
+about the fallback order behind that path.
+
 Strongly recommended for live use: set `parakeet_sidecar_enabled = true` and
 ensure `example-server` is discoverable (either on `PATH` or via
 `MINUTES_PARAKEET_SERVER_BINARY`). Without the warm sidecar, every live

--- a/docs/designs/apple-speech-benchmark-2026-04-22.md
+++ b/docs/designs/apple-speech-benchmark-2026-04-22.md
@@ -3,6 +3,32 @@
 This document records the first real local benchmark run for Minutes' Apple
 speech evaluation path.
 
+It now also serves as the practical scope note for the current Apple Speech
+experiment, because the runtime warnings and CLI help text point users toward
+this document when they ask "what does Apple Speech actually do today?"
+
+## Current product scope
+
+As of the current `main` branch:
+
+- `engine = "apple-speech"` is an **experimental standalone live-transcript
+  path**. It applies to `minutes live` only.
+- Apple Speech does **not** currently replace the recording-sidecar live path,
+  dictation, or post-recording / batch transcription.
+- The desktop settings UI can surface Apple Speech availability, but it does
+  **not** let you switch to Apple Speech from the transcription-engine picker.
+  Configure it via the config file or CLI flows instead.
+- If standalone live transcript is configured to use Apple Speech and Apple
+  Speech cannot run or fails mid-session, Minutes falls back to:
+  1. a ready Parakeet backend, if one is available
+  2. Whisper, if Parakeet is unavailable or also fails
+- The benchmark commands below remain useful for evaluation, but the benchmark
+  memo is still narrower than a full backend decision or product rollout plan.
+
+If you are looking for the current user-facing behavior rather than the
+historical benchmark snapshot, treat this section as authoritative and the
+benchmark results below as background evidence.
+
 It is intentionally narrower than a final backend decision memo. The goal of
 this run was to answer:
 
@@ -39,6 +65,9 @@ Related first-install run:
 Important limitation:
 - this corpus is synthetic TTS speech, not real human meeting audio
 - the result is useful for relative backend shape, not for a final product default
+- the summary table below captures the first benchmark snapshot; later product
+  updates added richer reporting such as punctuation-insensitive WER and
+  per-content-type slices in generated benchmark artifacts
 
 ## Measured result
 


### PR DESCRIPTION
## Summary
- update README live transcript copy so it no longer implies whisper-only behavior
- document the experimental  engine path and its standalone-live-only scope
- add current-scope guidance to the Apple Speech benchmark doc, including desktop-settings limitations and fallback order
- note in  that Parakeet can serve as the first runtime fallback behind Apple Speech in standalone live sessions

## Verification
- git diff --check
- targeted scan to confirm stale whisper-only/config wording was removed

## Notes
- This is a docs-only follow-up to #174.
- The next cleanup beyond this would be a dedicated non-historical Apple Speech scope doc instead of relying on the benchmark memo as the help target.