### PR TITLE
Fix minutes-video-review config resolution and fallback

### DIFF
--- a/.agents/skills/minutes/minutes-video-review/scripts/video_review.py
+++ b/.agents/skills/minutes/minutes-video-review/scripts/video_review.py
@@ -46,6 +46,19 @@ def slugify(value: str) -> str:
     return lowered or "video-review"
 
 
+def resolved_home_dir() -> Path:
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def source_minutes_config_path() -> Path:
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_base = Path(xdg_config_home).expanduser() if xdg_config_home else resolved_home_dir() / ".config"
+    return config_base / "minutes" / "config.toml"
+
+
 def load_env_file(env_file: Path) -> None:
     if not env_file.exists():
         raise RuntimeError(f"Env file not found: {env_file}")
@@ -462,22 +475,27 @@ def detect_minutes_config_engine(source_config: Path) -> str:
     return "whisper"
 
 
+def load_source_minutes_config(source_config: Path) -> dict[str, Any]:
+    if not source_config.exists():
+        return {}
+    try:
+        return tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
+    except tomllib.TOMLDecodeError:
+        return {}
+
+
 def write_minutes_config(
     config_path: Path,
     output_dir: Path,
+    source_config_data: dict[str, Any],
     source_engine: str,
     language: str | None,
     forced_engine: str | None,
 ) -> None:
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
-    data: dict[str, Any] = {}
-    if source_config.exists():
-        data = tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
-
-    transcription = dict(data.get("transcription", {}))
+    transcription = dict(source_config_data.get("transcription", {}))
     transcription["engine"] = forced_engine or source_engine
     if "model_path" not in transcription:
-        transcription["model_path"] = str(Path.home() / ".minutes" / "models")
+        transcription["model_path"] = str(resolved_home_dir() / ".minutes" / "models")
     if language:
         transcription["language"] = language
     if "min_words" not in transcription:
@@ -537,7 +555,8 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     if backend_mode in {"0", "false", "off", "disabled"}:
         return None, None
 
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
+    source_config = source_minutes_config_path()
+    source_config_data = load_source_minutes_config(source_config)
     configured_engine = detect_minutes_config_engine(source_config)
     requested_engine = configured_engine if backend_mode == "auto" else backend_mode
     language = os.environ.get("VIDEO_REVIEW_TRANSCRIPT_LANGUAGE", "en")
@@ -548,7 +567,14 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     config_path = xdg_config_home / "minutes" / "config.toml"
 
     def run_minutes_process(forced_engine: str | None) -> tuple[str | None, str | None]:
-        write_minutes_config(config_path, output_dir, configured_engine, language, forced_engine)
+        write_minutes_config(
+            config_path,
+            output_dir,
+            source_config_data,
+            configured_engine,
+            language,
+            forced_engine,
+        )
         env = os.environ.copy()
         env["XDG_CONFIG_HOME"] = str(xdg_config_home)
         result = subprocess.run(
@@ -690,6 +716,12 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         return None
+    if not shutil.which("openai"):
+        print(
+            "Warning: OPENAI_API_KEY is set but the openai CLI is not installed; skipping OpenAI transcription fallback.",
+            file=sys.stderr,
+        )
+        return None
 
     model = os.environ.get("VIDEO_REVIEW_OPENAI_TRANSCRIBE_MODEL", "gpt-4o-transcribe")
     try:
@@ -706,20 +738,29 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
                 "text",
             ]
         )
-    except RuntimeError:
-        result = run(
-            [
-                "openai",
-                "api",
-                "audio.transcriptions.create",
-                "-m",
-                "whisper-1",
-                "-f",
-                str(audio_path),
-                "--response-format",
-                "text",
-            ]
-        )
+    except RuntimeError as first_error:
+        try:
+            result = run(
+                [
+                    "openai",
+                    "api",
+                    "audio.transcriptions.create",
+                    "-m",
+                    "whisper-1",
+                    "-f",
+                    str(audio_path),
+                    "--response-format",
+                    "text",
+                ]
+            )
+        except RuntimeError as second_error:
+            print(
+                "Warning: OpenAI transcription fallback unavailable.\n"
+                f"Primary attempt: {first_error}\n"
+                f"Fallback attempt: {second_error}",
+                file=sys.stderr,
+            )
+            return None
 
     transcript = (result.stdout or "").strip()
     return transcript if transcript else None

--- a/.claude/plugins/minutes/skills/minutes-video-review/scripts/video_review.py
+++ b/.claude/plugins/minutes/skills/minutes-video-review/scripts/video_review.py
@@ -46,6 +46,19 @@ def slugify(value: str) -> str:
     return lowered or "video-review"
 
 
+def resolved_home_dir() -> Path:
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def source_minutes_config_path() -> Path:
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_base = Path(xdg_config_home).expanduser() if xdg_config_home else resolved_home_dir() / ".config"
+    return config_base / "minutes" / "config.toml"
+
+
 def load_env_file(env_file: Path) -> None:
     if not env_file.exists():
         raise RuntimeError(f"Env file not found: {env_file}")
@@ -462,22 +475,27 @@ def detect_minutes_config_engine(source_config: Path) -> str:
     return "whisper"
 
 
+def load_source_minutes_config(source_config: Path) -> dict[str, Any]:
+    if not source_config.exists():
+        return {}
+    try:
+        return tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
+    except tomllib.TOMLDecodeError:
+        return {}
+
+
 def write_minutes_config(
     config_path: Path,
     output_dir: Path,
+    source_config_data: dict[str, Any],
     source_engine: str,
     language: str | None,
     forced_engine: str | None,
 ) -> None:
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
-    data: dict[str, Any] = {}
-    if source_config.exists():
-        data = tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
-
-    transcription = dict(data.get("transcription", {}))
+    transcription = dict(source_config_data.get("transcription", {}))
     transcription["engine"] = forced_engine or source_engine
     if "model_path" not in transcription:
-        transcription["model_path"] = str(Path.home() / ".minutes" / "models")
+        transcription["model_path"] = str(resolved_home_dir() / ".minutes" / "models")
     if language:
         transcription["language"] = language
     if "min_words" not in transcription:
@@ -537,7 +555,8 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     if backend_mode in {"0", "false", "off", "disabled"}:
         return None, None
 
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
+    source_config = source_minutes_config_path()
+    source_config_data = load_source_minutes_config(source_config)
     configured_engine = detect_minutes_config_engine(source_config)
     requested_engine = configured_engine if backend_mode == "auto" else backend_mode
     language = os.environ.get("VIDEO_REVIEW_TRANSCRIPT_LANGUAGE", "en")
@@ -548,7 +567,14 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     config_path = xdg_config_home / "minutes" / "config.toml"
 
     def run_minutes_process(forced_engine: str | None) -> tuple[str | None, str | None]:
-        write_minutes_config(config_path, output_dir, configured_engine, language, forced_engine)
+        write_minutes_config(
+            config_path,
+            output_dir,
+            source_config_data,
+            configured_engine,
+            language,
+            forced_engine,
+        )
         env = os.environ.copy()
         env["XDG_CONFIG_HOME"] = str(xdg_config_home)
         result = subprocess.run(
@@ -690,6 +716,12 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         return None
+    if not shutil.which("openai"):
+        print(
+            "Warning: OPENAI_API_KEY is set but the openai CLI is not installed; skipping OpenAI transcription fallback.",
+            file=sys.stderr,
+        )
+        return None
 
     model = os.environ.get("VIDEO_REVIEW_OPENAI_TRANSCRIBE_MODEL", "gpt-4o-transcribe")
     try:
@@ -706,20 +738,29 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
                 "text",
             ]
         )
-    except RuntimeError:
-        result = run(
-            [
-                "openai",
-                "api",
-                "audio.transcriptions.create",
-                "-m",
-                "whisper-1",
-                "-f",
-                str(audio_path),
-                "--response-format",
-                "text",
-            ]
-        )
+    except RuntimeError as first_error:
+        try:
+            result = run(
+                [
+                    "openai",
+                    "api",
+                    "audio.transcriptions.create",
+                    "-m",
+                    "whisper-1",
+                    "-f",
+                    str(audio_path),
+                    "--response-format",
+                    "text",
+                ]
+            )
+        except RuntimeError as second_error:
+            print(
+                "Warning: OpenAI transcription fallback unavailable.\n"
+                f"Primary attempt: {first_error}\n"
+                f"Fallback attempt: {second_error}",
+                file=sys.stderr,
+            )
+            return None
 
     transcript = (result.stdout or "").strip()
     return transcript if transcript else None

--- a/.opencode/skills/minutes-video-review/scripts/video_review.py
+++ b/.opencode/skills/minutes-video-review/scripts/video_review.py
@@ -46,6 +46,19 @@ def slugify(value: str) -> str:
     return lowered or "video-review"
 
 
+def resolved_home_dir() -> Path:
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def source_minutes_config_path() -> Path:
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_base = Path(xdg_config_home).expanduser() if xdg_config_home else resolved_home_dir() / ".config"
+    return config_base / "minutes" / "config.toml"
+
+
 def load_env_file(env_file: Path) -> None:
     if not env_file.exists():
         raise RuntimeError(f"Env file not found: {env_file}")
@@ -462,22 +475,27 @@ def detect_minutes_config_engine(source_config: Path) -> str:
     return "whisper"
 
 
+def load_source_minutes_config(source_config: Path) -> dict[str, Any]:
+    if not source_config.exists():
+        return {}
+    try:
+        return tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
+    except tomllib.TOMLDecodeError:
+        return {}
+
+
 def write_minutes_config(
     config_path: Path,
     output_dir: Path,
+    source_config_data: dict[str, Any],
     source_engine: str,
     language: str | None,
     forced_engine: str | None,
 ) -> None:
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
-    data: dict[str, Any] = {}
-    if source_config.exists():
-        data = tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
-
-    transcription = dict(data.get("transcription", {}))
+    transcription = dict(source_config_data.get("transcription", {}))
     transcription["engine"] = forced_engine or source_engine
     if "model_path" not in transcription:
-        transcription["model_path"] = str(Path.home() / ".minutes" / "models")
+        transcription["model_path"] = str(resolved_home_dir() / ".minutes" / "models")
     if language:
         transcription["language"] = language
     if "min_words" not in transcription:
@@ -537,7 +555,8 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     if backend_mode in {"0", "false", "off", "disabled"}:
         return None, None
 
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
+    source_config = source_minutes_config_path()
+    source_config_data = load_source_minutes_config(source_config)
     configured_engine = detect_minutes_config_engine(source_config)
     requested_engine = configured_engine if backend_mode == "auto" else backend_mode
     language = os.environ.get("VIDEO_REVIEW_TRANSCRIPT_LANGUAGE", "en")
@@ -548,7 +567,14 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     config_path = xdg_config_home / "minutes" / "config.toml"
 
     def run_minutes_process(forced_engine: str | None) -> tuple[str | None, str | None]:
-        write_minutes_config(config_path, output_dir, configured_engine, language, forced_engine)
+        write_minutes_config(
+            config_path,
+            output_dir,
+            source_config_data,
+            configured_engine,
+            language,
+            forced_engine,
+        )
         env = os.environ.copy()
         env["XDG_CONFIG_HOME"] = str(xdg_config_home)
         result = subprocess.run(
@@ -690,6 +716,12 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         return None
+    if not shutil.which("openai"):
+        print(
+            "Warning: OPENAI_API_KEY is set but the openai CLI is not installed; skipping OpenAI transcription fallback.",
+            file=sys.stderr,
+        )
+        return None
 
     model = os.environ.get("VIDEO_REVIEW_OPENAI_TRANSCRIBE_MODEL", "gpt-4o-transcribe")
     try:
@@ -706,20 +738,29 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
                 "text",
             ]
         )
-    except RuntimeError:
-        result = run(
-            [
-                "openai",
-                "api",
-                "audio.transcriptions.create",
-                "-m",
-                "whisper-1",
-                "-f",
-                str(audio_path),
-                "--response-format",
-                "text",
-            ]
-        )
+    except RuntimeError as first_error:
+        try:
+            result = run(
+                [
+                    "openai",
+                    "api",
+                    "audio.transcriptions.create",
+                    "-m",
+                    "whisper-1",
+                    "-f",
+                    str(audio_path),
+                    "--response-format",
+                    "text",
+                ]
+            )
+        except RuntimeError as second_error:
+            print(
+                "Warning: OpenAI transcription fallback unavailable.\n"
+                f"Primary attempt: {first_error}\n"
+                f"Fallback attempt: {second_error}",
+                file=sys.stderr,
+            )
+            return None
 
     transcript = (result.stdout or "").strip()
     return transcript if transcript else None

--- a/tooling/skills/sources/minutes-video-review/scripts/test_video_review.py
+++ b/tooling/skills/sources/minutes-video-review/scripts/test_video_review.py
@@ -1,0 +1,82 @@
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("video_review.py")
+SPEC = importlib.util.spec_from_file_location("minutes_video_review", MODULE_PATH)
+assert SPEC and SPEC.loader
+video_review = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(video_review)
+
+
+class VideoReviewTests(unittest.TestCase):
+    def test_source_minutes_config_path_prefers_xdg_config_home(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"XDG_CONFIG_HOME": "/tmp/xdg-home", "HOME": "/tmp/fallback-home"},
+            clear=False,
+        ):
+            self.assertEqual(
+                video_review.source_minutes_config_path(),
+                Path("/tmp/xdg-home/minutes/config.toml"),
+            )
+
+    def test_write_minutes_config_preserves_existing_model_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            config_path = temp_path / "minutes" / "config.toml"
+            output_dir = temp_path / "out"
+            source_config_data = {
+                "transcription": {
+                    "engine": "parakeet",
+                    "model_path": "/custom/models",
+                }
+            }
+
+            video_review.write_minutes_config(
+                config_path=config_path,
+                output_dir=output_dir,
+                source_config_data=source_config_data,
+                source_engine="parakeet",
+                language="en",
+                forced_engine=None,
+            )
+
+            config_data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(config_data["transcription"]["engine"], "parakeet")
+            self.assertEqual(config_data["transcription"]["model_path"], "/custom/models")
+            self.assertEqual(config_data["transcription"]["language"], "en")
+
+    def test_load_source_minutes_config_invalid_toml_returns_empty_dict(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.toml"
+            config_path.write_text("not = [valid", encoding="utf-8")
+
+            self.assertEqual(video_review.load_source_minutes_config(config_path), {})
+
+    def test_transcribe_with_openai_skips_when_cli_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            audio_path = Path(temp_dir) / "sample.wav"
+            audio_path.write_bytes(b"fake")
+            stderr = io.StringIO()
+
+            with (
+                mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False),
+                mock.patch.object(video_review.shutil, "which", return_value=None),
+                contextlib.redirect_stderr(stderr),
+            ):
+                result = video_review.transcribe_with_openai(audio_path)
+
+            self.assertIsNone(result)
+            self.assertIn("openai CLI is not installed", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/skills/sources/minutes-video-review/scripts/video_review.py
+++ b/tooling/skills/sources/minutes-video-review/scripts/video_review.py
@@ -46,6 +46,19 @@ def slugify(value: str) -> str:
     return lowered or "video-review"
 
 
+def resolved_home_dir() -> Path:
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def source_minutes_config_path() -> Path:
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_base = Path(xdg_config_home).expanduser() if xdg_config_home else resolved_home_dir() / ".config"
+    return config_base / "minutes" / "config.toml"
+
+
 def load_env_file(env_file: Path) -> None:
     if not env_file.exists():
         raise RuntimeError(f"Env file not found: {env_file}")
@@ -462,22 +475,27 @@ def detect_minutes_config_engine(source_config: Path) -> str:
     return "whisper"
 
 
+def load_source_minutes_config(source_config: Path) -> dict[str, Any]:
+    if not source_config.exists():
+        return {}
+    try:
+        return tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
+    except tomllib.TOMLDecodeError:
+        return {}
+
+
 def write_minutes_config(
     config_path: Path,
     output_dir: Path,
+    source_config_data: dict[str, Any],
     source_engine: str,
     language: str | None,
     forced_engine: str | None,
 ) -> None:
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
-    data: dict[str, Any] = {}
-    if source_config.exists():
-        data = tomllib.loads(source_config.read_text(encoding="utf-8", errors="ignore"))
-
-    transcription = dict(data.get("transcription", {}))
+    transcription = dict(source_config_data.get("transcription", {}))
     transcription["engine"] = forced_engine or source_engine
     if "model_path" not in transcription:
-        transcription["model_path"] = str(Path.home() / ".minutes" / "models")
+        transcription["model_path"] = str(resolved_home_dir() / ".minutes" / "models")
     if language:
         transcription["language"] = language
     if "min_words" not in transcription:
@@ -537,7 +555,8 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     if backend_mode in {"0", "false", "off", "disabled"}:
         return None, None
 
-    source_config = Path.home() / ".config" / "minutes" / "config.toml"
+    source_config = source_minutes_config_path()
+    source_config_data = load_source_minutes_config(source_config)
     configured_engine = detect_minutes_config_engine(source_config)
     requested_engine = configured_engine if backend_mode == "auto" else backend_mode
     language = os.environ.get("VIDEO_REVIEW_TRANSCRIPT_LANGUAGE", "en")
@@ -548,7 +567,14 @@ def transcribe_with_minutes(audio_path: Path, workspace: Path) -> tuple[str | No
     config_path = xdg_config_home / "minutes" / "config.toml"
 
     def run_minutes_process(forced_engine: str | None) -> tuple[str | None, str | None]:
-        write_minutes_config(config_path, output_dir, configured_engine, language, forced_engine)
+        write_minutes_config(
+            config_path,
+            output_dir,
+            source_config_data,
+            configured_engine,
+            language,
+            forced_engine,
+        )
         env = os.environ.copy()
         env["XDG_CONFIG_HOME"] = str(xdg_config_home)
         result = subprocess.run(
@@ -690,6 +716,12 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         return None
+    if not shutil.which("openai"):
+        print(
+            "Warning: OPENAI_API_KEY is set but the openai CLI is not installed; skipping OpenAI transcription fallback.",
+            file=sys.stderr,
+        )
+        return None
 
     model = os.environ.get("VIDEO_REVIEW_OPENAI_TRANSCRIBE_MODEL", "gpt-4o-transcribe")
     try:
@@ -706,20 +738,29 @@ def transcribe_with_openai(audio_path: Path) -> str | None:
                 "text",
             ]
         )
-    except RuntimeError:
-        result = run(
-            [
-                "openai",
-                "api",
-                "audio.transcriptions.create",
-                "-m",
-                "whisper-1",
-                "-f",
-                str(audio_path),
-                "--response-format",
-                "text",
-            ]
-        )
+    except RuntimeError as first_error:
+        try:
+            result = run(
+                [
+                    "openai",
+                    "api",
+                    "audio.transcriptions.create",
+                    "-m",
+                    "whisper-1",
+                    "-f",
+                    str(audio_path),
+                    "--response-format",
+                    "text",
+                ]
+            )
+        except RuntimeError as second_error:
+            print(
+                "Warning: OpenAI transcription fallback unavailable.\n"
+                f"Primary attempt: {first_error}\n"
+                f"Fallback attempt: {second_error}",
+                file=sys.stderr,
+            )
+            return None
 
     transcript = (result.stdout or "").strip()
     return transcript if transcript else None


### PR DESCRIPTION
## Summary
- resolve the source Minutes config using HOME/XDG-aware path helpers instead of assuming `Path.home()/.config`
- preserve and reuse the source transcription config data when writing the temp Minutes config for video review runs
- make the OpenAI transcription fallback degrade cleanly when the `openai` CLI is missing or both API attempts fail
- add a regression test for the video-review script behavior
- keep the mirrored skill script copies in sync across the Claude, agents, and OpenCode trees

## Verification
- PYTHONPYCACHEPREFIX=/tmp/minutes-video-review-pycache python3 -m py_compile tooling/skills/sources/minutes-video-review/scripts/video_review.py tooling/skills/sources/minutes-video-review/scripts/test_video_review.py
- python3 -m unittest tooling.skills.sources.minutes-video-review.scripts.test_video_review
- ./scripts/check-agents-sync.sh

## Notes
- This PR preserves the remaining local-only rescue slice from the shared dirty worktree on top of current main.
