### PR TITLE
[codex] Clarify Apple Speech live scope in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ minutes consistency                                # Flag contradicting decision
 minutes live                                     # Start real-time transcription
 minutes stop                                     # Stop live session
 ```
-Streams local transcription to a JSONL file in real time — any AI agent can read it mid-meeting for live coaching. Depending on your build and config, live mode can run on Whisper, Parakeet, or the experimental Apple Speech standalone-live path. Apple Speech currently applies only to standalone live transcript (`minutes live`), not recording-sidecar, dictation, or batch transcription, and it falls back to a ready Parakeet backend before Whisper if Apple Speech is unavailable or fails mid-session. The MCP `read_live_transcript` tool provides delta reads (by line cursor or wall-clock duration). Works with Claude Code, Codex, OpenCode, Gemini CLI, or any agent that reads files. The Tauri desktop app has a Live Mode toggle that starts this with one click.
+Streams local transcription to a JSONL file in real time — any AI agent can read it mid-meeting for live coaching. Depending on your build and config, live mode can run on Whisper, Parakeet, or the experimental Apple Speech standalone-live path. Apple Speech currently applies only to standalone live transcript (`minutes live`), not recording-sidecar, dictation, or batch transcription, and it falls back to a ready Parakeet backend before Whisper if Apple Speech is unavailable or fails mid-session. See [docs/APPLE_SPEECH.md](docs/APPLE_SPEECH.md) for the current Apple Speech scope. The MCP `read_live_transcript` tool provides delta reads (by line cursor or wall-clock duration). Works with Claude Code, Codex, OpenCode, Gemini CLI, or any agent that reads files. The Tauri desktop app has a Live Mode toggle that starts this with one click.
 
 ### Dictation mode
 ```bash
@@ -998,6 +998,7 @@ model = "small"           # whisper: tiny (75MB), base, small (466MB), medium, l
                           # Default: auto-detect. Set this for similar-sounding languages (Urdu/Hindi, etc.)
 # engine = "apple-speech"  # Experimental: standalone `minutes live` only. Configure via config file or CLI, not desktop settings.
 #                         # If Apple Speech cannot run, standalone live falls back to a ready Parakeet backend, then Whisper.
+#                         # See docs/APPLE_SPEECH.md for current scope and limitations.
 # parakeet_model = "tdt-600m"                    # parakeet: tdt-ctc-110m (English), tdt-600m (multilingual v3)
 # parakeet_binary = "parakeet"                   # Path to parakeet.cpp binary (or name in PATH)
 # parakeet_boost_limit = 25                      # Experimental: boost top graph-derived phrases (0 disables)

--- a/docs/APPLE_SPEECH.md
+++ b/docs/APPLE_SPEECH.md
@@ -1,0 +1,49 @@
+# Apple Speech Scope
+
+This document describes the **current shipped scope** of Minutes' experimental
+Apple Speech path. It is intentionally practical and user-facing.
+
+If you want the benchmark evidence that informed this experiment, see
+[`docs/designs/apple-speech-benchmark-2026-04-22.md`](designs/apple-speech-benchmark-2026-04-22.md).
+
+## Current product scope
+
+As of the current `main` branch:
+
+- `engine = "apple-speech"` is an **experimental standalone live-transcript
+  path**.
+- It applies to `minutes live`, not to `minutes record`, dictation, or
+  post-recording / batch transcription.
+- The desktop settings UI can surface Apple Speech availability, but it does
+  **not** currently let you switch the transcription engine to Apple Speech
+  from the settings picker.
+- To use Apple Speech, configure it through the config file or CLI-driven
+  flows instead of the desktop transcription-engine dropdown.
+
+## Fallback behavior
+
+If standalone live transcript is configured to use Apple Speech and Apple
+Speech cannot run or fails mid-session, Minutes falls back in this order:
+
+1. a ready Parakeet backend, if one is available
+2. Whisper, if Parakeet is unavailable or also fails
+
+That means Apple Speech is not a replacement for the rest of the transcription
+stack. It is an experimental first-choice backend for standalone live mode
+only, with the existing local engines still providing the safety net.
+
+## What Apple Speech does not do today
+
+Apple Speech does **not** currently:
+
+- replace the recording-sidecar live path used during `minutes record`
+- replace dictation (`minutes dictate` and the dictation hotkey)
+- replace post-recording batch transcription or watcher processing
+- become selectable from the desktop settings transcription-engine picker
+
+## Related docs
+
+- Benchmark evidence:
+  [`docs/designs/apple-speech-benchmark-2026-04-22.md`](designs/apple-speech-benchmark-2026-04-22.md)
+- Parakeet setup and scope:
+  [`docs/PARAKEET.md`](PARAKEET.md)

--- a/docs/PARAKEET.md
+++ b/docs/PARAKEET.md
@@ -38,7 +38,8 @@ path as the **first runtime fallback**. If `engine = "apple-speech"` is set for
 `minutes live` and Apple Speech cannot run or fails mid-session, Minutes tries
 a ready Parakeet backend before falling back to Whisper. Apple Speech itself is
 still configured separately and remains standalone-live-only; this note is just
-about the fallback order behind that path.
+about the fallback order behind that path. See [`docs/APPLE_SPEECH.md`](APPLE_SPEECH.md)
+for the current Apple Speech scope and desktop-settings limitation.
 
 Strongly recommended for live use: set `parakeet_sidecar_enabled = true` and
 ensure `example-server` is discoverable (either on `PATH` or via

--- a/docs/designs/apple-speech-benchmark-2026-04-22.md
+++ b/docs/designs/apple-speech-benchmark-2026-04-22.md
@@ -3,31 +3,9 @@
 This document records the first real local benchmark run for Minutes' Apple
 speech evaluation path.
 
-It now also serves as the practical scope note for the current Apple Speech
-experiment, because the runtime warnings and CLI help text point users toward
-this document when they ask "what does Apple Speech actually do today?"
-
-## Current product scope
-
-As of the current `main` branch:
-
-- `engine = "apple-speech"` is an **experimental standalone live-transcript
-  path**. It applies to `minutes live` only.
-- Apple Speech does **not** currently replace the recording-sidecar live path,
-  dictation, or post-recording / batch transcription.
-- The desktop settings UI can surface Apple Speech availability, but it does
-  **not** let you switch to Apple Speech from the transcription-engine picker.
-  Configure it via the config file or CLI flows instead.
-- If standalone live transcript is configured to use Apple Speech and Apple
-  Speech cannot run or fails mid-session, Minutes falls back to:
-  1. a ready Parakeet backend, if one is available
-  2. Whisper, if Parakeet is unavailable or also fails
-- The benchmark commands below remain useful for evaluation, but the benchmark
-  memo is still narrower than a full backend decision or product rollout plan.
-
-If you are looking for the current user-facing behavior rather than the
-historical benchmark snapshot, treat this section as authoritative and the
-benchmark results below as background evidence.
+If you are looking for the **current shipped Apple Speech scope**, see
+[`docs/APPLE_SPEECH.md`](../APPLE_SPEECH.md). This benchmark memo is historical
+evidence and backend-evaluation context, not the primary product-scope doc.
 
 It is intentionally narrower than a final backend decision memo. The goal of
 this run was to answer:


### PR DESCRIPTION
## Summary
Docs-only follow-up to align Apple Speech and live-transcript messaging with the current shipped behavior after the recent Apple Speech live fallback work.

## What Changed
- updated README live-transcript copy so it no longer implies live mode is Whisper-only
- updated README config docs so `[transcription].engine` mentions the experimental `apple-speech` path and clarifies it is standalone-live-only
- revised the Apple benchmark/scope doc so it now explains current product scope, desktop-settings limitations, and fallback order
- updated `docs/PARAKEET.md` to mention Parakeet can act as the first fallback behind Apple Speech in standalone live sessions

## Why
The runtime and UI messages now describe Apple Speech as an experimental standalone-live path with `apple-speech -> parakeet -> whisper` fallback behavior, but the public docs had drifted behind and still implied Whisper-only live behavior or omitted the Apple Speech config path entirely.

## Verification
- `git diff --check`
- targeted text scan of the touched docs for the stale Whisper-only/config wording
