### PR TITLE
Split standalone live transcript backend config

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -527,6 +527,13 @@ pub struct HooksConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LiveTranscriptConfig {
+    /// Standalone live transcript backend selection.
+    ///
+    /// - `"inherit"` (default): follow `transcription.engine`
+    /// - `"whisper"`: force Whisper for standalone live transcript
+    /// - `"parakeet"`: force Parakeet for standalone live transcript
+    /// - `"apple-speech"`: experimental macOS standalone-live-only path
+    pub backend: String,
     /// Whisper model to use for live transcription.
     /// Empty string means "use the dictation model".
     pub model: String,
@@ -543,6 +550,7 @@ pub struct LiveTranscriptConfig {
 impl Default for LiveTranscriptConfig {
     fn default() -> Self {
         Self {
+            backend: LIVE_TRANSCRIPT_BACKEND_INHERIT.into(),
             model: String::new(), // empty = use dictation model
             max_utterance_secs: 30,
             save_wav: true,
@@ -551,6 +559,14 @@ impl Default for LiveTranscriptConfig {
         }
     }
 }
+
+pub const LIVE_TRANSCRIPT_BACKEND_INHERIT: &str = "inherit";
+pub const VALID_LIVE_TRANSCRIPT_BACKENDS: &[&str] = &[
+    LIVE_TRANSCRIPT_BACKEND_INHERIT,
+    "whisper",
+    "parakeet",
+    "apple-speech",
+];
 
 impl Default for ScreenContextConfig {
     fn default() -> Self {
@@ -746,6 +762,39 @@ impl Default for WatchConfig {
 // ── Loading ──────────────────────────────────────────────────
 
 impl Config {
+    /// Effective backend for the standalone live transcript path.
+    ///
+    /// `live_transcript.backend = "inherit"` follows `transcription.engine`,
+    /// except for the legacy `transcription.engine = "apple-speech"` case,
+    /// which older configs used to express the standalone-live-only Apple
+    /// experiment. We keep honoring that value here so non-Tauri consumers
+    /// preserve behavior even before the migration has rewritten the file.
+    pub fn effective_live_transcript_backend(&self) -> &str {
+        let backend = self.live_transcript.backend.trim();
+        if backend.is_empty() || backend == LIVE_TRANSCRIPT_BACKEND_INHERIT {
+            if self
+                .transcription
+                .engine
+                .eq_ignore_ascii_case("apple-speech")
+            {
+                "apple-speech"
+            } else {
+                &self.transcription.engine
+            }
+        } else {
+            &self.live_transcript.backend
+        }
+    }
+
+    pub fn standalone_live_backend_setting(&self) -> &str {
+        let backend = self.live_transcript.backend.trim();
+        if backend.is_empty() {
+            LIVE_TRANSCRIPT_BACKEND_INHERIT
+        } else {
+            &self.live_transcript.backend
+        }
+    }
+
     /// Standard config file location.
     pub fn config_path() -> PathBuf {
         config_base_dir().join("minutes").join("config.toml")
@@ -805,8 +854,41 @@ impl Config {
             None
         };
 
-        let config = Self::load_from(path);
+        let mut config = Self::load_from(path);
         let mut migrated_toml: Option<String> = None;
+
+        // Apple Speech migration: older configs overloaded
+        // `transcription.engine = "apple-speech"` to mean "standalone live
+        // transcript should try Apple Speech". That was always a product/model
+        // mismatch because batch and recording-sidecar flows never actually
+        // used Apple Speech. Normalize those existing configs to:
+        //
+        //   [transcription]
+        //   engine = "whisper"
+        //
+        //   [live_transcript]
+        //   backend = "apple-speech"
+        //
+        // We intentionally persist the migrated config back to disk so the
+        // desktop app stops carrying the old overload forward after the first
+        // upgraded launch.
+        if file_existed
+            && config
+                .transcription
+                .engine
+                .eq_ignore_ascii_case("apple-speech")
+            && raw_toml.as_deref().is_some_and(|raw| {
+                !raw_toml_has_setting_in_section(raw, "live_transcript", "backend")
+            })
+        {
+            config.transcription.engine = "whisper".into();
+            config.live_transcript.backend = "apple-speech".into();
+            migrated_toml = toml::to_string_pretty(&config).ok();
+            tracing::info!(
+                "live transcript backend migration: moved legacy apple-speech engine setting into [live_transcript].backend at {}",
+                path.display()
+            );
+        }
 
         // Palette section persistence: if the config file exists but
         // has no `[palette]` section, write the default section out
@@ -822,7 +904,7 @@ impl Config {
         // fills missing sections with `Default`, so the parsed struct
         // alone cannot distinguish "user opted out" from "field never
         // seen" — only a text check on the raw TOML can.
-        if file_existed {
+        if file_existed && migrated_toml.is_none() {
             if let Some(raw) = raw_toml.as_deref() {
                 if !raw_toml_has_section(raw, "palette") {
                     migrated_toml = Some(append_palette_section(raw, &config.palette));
@@ -953,6 +1035,26 @@ fn raw_toml_has_section(raw: &str, section: &str) -> bool {
     false
 }
 
+fn raw_toml_has_setting_in_section(raw: &str, section: &str, key: &str) -> bool {
+    let target = format!("[{}]", section);
+    let key_prefix = format!("{} =", key);
+    let mut in_section = false;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed.starts_with('[') {
+            in_section = trimmed == target;
+            continue;
+        }
+        if in_section && trimmed.starts_with(&key_prefix) {
+            return true;
+        }
+    }
+    false
+}
+
 fn append_palette_section(raw: &str, palette: &PaletteConfig) -> String {
     let mut output = raw.trim_end_matches('\n').to_string();
     if !output.is_empty() {
@@ -979,6 +1081,10 @@ mod tests {
     fn default_config_is_valid() {
         let config = Config::default();
         assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(
+            config.live_transcript.backend,
+            LIVE_TRANSCRIPT_BACKEND_INHERIT
+        );
         assert_eq!(config.transcription.model, "small");
         assert_eq!(config.transcription.min_words, 3);
         assert_eq!(config.transcription.parakeet_binary, "parakeet");
@@ -1155,6 +1261,46 @@ model = "tiny"
     }
 
     #[test]
+    fn effective_live_transcript_backend_inherits_batch_engine_by_default() {
+        let mut config = Config::default();
+        config.transcription.engine = "parakeet".into();
+
+        assert_eq!(config.standalone_live_backend_setting(), "inherit");
+        assert_eq!(config.effective_live_transcript_backend(), "parakeet");
+    }
+
+    #[test]
+    fn effective_live_transcript_backend_preserves_legacy_apple_engine_configs() {
+        let mut config = Config::default();
+        config.transcription.engine = "apple-speech".into();
+
+        assert_eq!(config.standalone_live_backend_setting(), "inherit");
+        assert_eq!(config.effective_live_transcript_backend(), "apple-speech");
+    }
+
+    #[test]
+    fn live_transcript_backend_can_be_set_from_toml() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[transcription]
+engine = "whisper"
+
+[live_transcript]
+backend = "apple-speech"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_from(&config_path);
+        assert_eq!(config.live_transcript.backend, "apple-speech");
+        assert_eq!(config.effective_live_transcript_backend(), "apple-speech");
+        assert_eq!(config.transcription.engine, "whisper");
+    }
+
+    #[test]
     fn parakeet_sidecar_flag_can_be_enabled_from_toml() {
         let dir = TempDir::new().unwrap();
         let config_path = dir.path().join("config.toml");
@@ -1284,6 +1430,26 @@ enabled = true
     fn raw_toml_has_section_rejects_non_matching_sections() {
         assert!(!raw_toml_has_section("[dictation]\n", "palette"));
         assert!(!raw_toml_has_section("[palette.inner]\n", "palette"));
+    }
+
+    #[test]
+    fn raw_toml_has_setting_in_section_matches_exact_key() {
+        let raw = r#"
+[live_transcript]
+backend = "apple-speech"
+shortcut = "CmdOrCtrl+Shift+L"
+"#;
+
+        assert!(raw_toml_has_setting_in_section(
+            raw,
+            "live_transcript",
+            "backend"
+        ));
+        assert!(!raw_toml_has_setting_in_section(
+            raw,
+            "live_transcript",
+            "missing"
+        ));
     }
 
     #[test]
@@ -1425,6 +1591,53 @@ shortcut_enabled = false
         assert!(reloaded.contains("# top comment"));
         assert!(reloaded.contains("mystery = \"keep-me\""));
         assert!(raw_toml_has_section(&reloaded, "palette"));
+    }
+
+    #[test]
+    fn upgrade_migrates_legacy_apple_engine_into_live_backend() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[transcription]
+engine = "apple-speech"
+model = "small"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_with_migrations_from(&config_path);
+        assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(config.live_transcript.backend, "apple-speech");
+        assert_eq!(config.effective_live_transcript_backend(), "apple-speech");
+
+        let reloaded = std::fs::read_to_string(&config_path).unwrap();
+        assert!(reloaded.contains("engine = \"whisper\""));
+        assert!(reloaded.contains("[live_transcript]"));
+        assert!(reloaded.contains("backend = \"apple-speech\""));
+    }
+
+    #[test]
+    fn upgrade_does_not_override_explicit_live_backend_setting() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[transcription]
+engine = "apple-speech"
+
+[live_transcript]
+backend = "whisper"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load_with_migrations_from(&config_path);
+        assert_eq!(config.transcription.engine, "apple-speech");
+        assert_eq!(config.live_transcript.backend, "whisper");
+        assert_eq!(config.effective_live_transcript_backend(), "whisper");
     }
 
     #[test]

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -633,14 +633,12 @@ fn run_inner(
 
     let mut vad = Vad::new();
     let mut streaming = StreamingWhisper::new(config.transcription.language.clone());
+    let standalone_backend = config.effective_live_transcript_backend();
     #[cfg(target_os = "macos")]
     let mut apple_utterance_samples: Vec<f32> = Vec::new();
     #[cfg(target_os = "macos")]
-    let mut apple_live_enabled = config
-        .transcription
-        .engine
-        .eq_ignore_ascii_case("apple-speech")
-        && live_supports_apple_speech();
+    let mut apple_live_enabled =
+        standalone_backend.eq_ignore_ascii_case("apple-speech") && live_supports_apple_speech();
     #[cfg(not(target_os = "macos"))]
     let mut apple_live_enabled = false;
 
@@ -653,7 +651,7 @@ fn run_inner(
     #[cfg(feature = "parakeet")]
     let mut parakeet_utterance_samples: Vec<f32> = Vec::new();
     #[cfg(feature = "parakeet")]
-    let mut parakeet_live_enabled = live_supports_parakeet(&config.transcription.engine);
+    let mut parakeet_live_enabled = live_supports_parakeet(standalone_backend);
     #[cfg(feature = "parakeet")]
     let parakeet_fallback_ready = live_ready_parakeet_fallback(config);
     #[cfg(not(feature = "parakeet"))]
@@ -668,16 +666,11 @@ fn run_inner(
 
     // One-time scope warning when the user configured parakeet but the feature
     // isn't compiled in. Same warning the recording sidecar emits.
-    if config.transcription.engine.eq_ignore_ascii_case("parakeet") && !parakeet_live_enabled {
-        emit_live_engine_scope_warning(&config.transcription.engine, "standalone");
+    if standalone_backend.eq_ignore_ascii_case("parakeet") && !parakeet_live_enabled {
+        emit_live_engine_scope_warning(standalone_backend, "standalone");
     }
-    if config
-        .transcription
-        .engine
-        .eq_ignore_ascii_case("apple-speech")
-        && !apple_live_enabled
-    {
-        emit_live_engine_scope_warning(&config.transcription.engine, "standalone");
+    if standalone_backend.eq_ignore_ascii_case("apple-speech") && !apple_live_enabled {
+        emit_live_engine_scope_warning(standalone_backend, "standalone");
     }
     if apple_live_enabled {
         eprintln!("[minutes] Apple Speech live transcript enabled (experimental, standalone only)");

--- a/crates/core/src/transcription_coordinator.rs
+++ b/crates/core/src/transcription_coordinator.rs
@@ -375,11 +375,14 @@ pub fn diagnostics_snapshot(config: &Config) -> TranscriptionDiagnosticsSnapshot
     }
 }
 
+fn parakeet_warmup_selected(config: &Config) -> bool {
+    config.transcription.engine == "parakeet"
+        || config.effective_live_transcript_backend() == "parakeet"
+}
+
 pub fn warmup_active_backend(config: &Config) -> Result<BackendWarmupResult, TranscribeError> {
-    if config.transcription.engine != "parakeet" {
-        return Err(TranscribeError::EngineNotAvailable(
-            config.transcription.engine.clone(),
-        ));
+    if !parakeet_warmup_selected(config) {
+        return Err(TranscribeError::EngineNotAvailable("parakeet".into()));
     }
 
     #[cfg(feature = "parakeet")]
@@ -418,6 +421,30 @@ pub fn warmup_active_backend(config: &Config) -> Result<BackendWarmupResult, Tra
     #[cfg(not(feature = "parakeet"))]
     {
         Err(TranscribeError::EngineNotAvailable("parakeet".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parakeet_warmup_selected;
+    use crate::Config;
+
+    #[test]
+    fn parakeet_warmup_selection_includes_live_backend() {
+        let mut config = Config::default();
+        config.transcription.engine = "whisper".into();
+        config.live_transcript.backend = "parakeet".into();
+
+        assert!(parakeet_warmup_selected(&config));
+    }
+
+    #[test]
+    fn parakeet_warmup_selection_skips_non_parakeet_backends() {
+        let mut config = Config::default();
+        config.transcription.engine = "whisper".into();
+        config.live_transcript.backend = "apple-speech".into();
+
+        assert!(!parakeet_warmup_selected(&config));
     }
 }
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use futures_util::StreamExt;
 use minisign_verify::{PublicKey, Signature};
 use minutes_core::capture::RecordingIntent;
-use minutes_core::config::VALID_PARAKEET_MODELS;
+use minutes_core::config::{VALID_LIVE_TRANSCRIPT_BACKENDS, VALID_PARAKEET_MODELS};
 use minutes_core::{CaptureMode, Config, ContentType};
 use reqwest::header::{ACCEPT, CONTENT_LENGTH};
 use std::cmp::Reverse;
@@ -98,6 +98,319 @@ fn apple_speech_status_view() -> serde_json::Value {
             "selectable": false,
             "error": error.to_string(),
         }),
+    }
+}
+
+fn live_transcript_fallback_order_view(config: &Config) -> Vec<String> {
+    let resolved = config.effective_live_transcript_backend();
+    let parakeet_ready = parakeet_status_view(config).ready;
+    match resolved {
+        "apple-speech" => {
+            let mut order = vec!["apple-speech".to_string()];
+            if parakeet_ready {
+                order.push("parakeet".to_string());
+            }
+            order.push("whisper".to_string());
+            order
+        }
+        "parakeet" => vec!["parakeet".to_string(), "whisper".to_string()],
+        _ => vec!["whisper".to_string()],
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SurfaceReadinessView {
+    configured_backend: String,
+    resolved_backend: String,
+    ready: bool,
+    model_name: String,
+    detail: String,
+    next_action: String,
+    fallback_order: Vec<String>,
+}
+
+fn whisper_model_file(config: &Config, model_name: &str) -> PathBuf {
+    config
+        .transcription
+        .model_path
+        .join(format!("ggml-{}.bin", model_name))
+}
+
+fn whisper_model_readiness(
+    config: &Config,
+    model_name: &str,
+) -> (bool, String, std::path::PathBuf) {
+    let selected_model = if model_name.trim().is_empty() {
+        config.transcription.model.clone()
+    } else {
+        model_name.to_string()
+    };
+    let model_file = whisper_model_file(config, &selected_model);
+    (model_file.exists(), selected_model, model_file)
+}
+
+fn apple_speech_selectable() -> bool {
+    match minutes_core::apple_speech::probe_capabilities() {
+        Ok(report) => {
+            report.runtime_supported && report.speech_transcriber.is_available.unwrap_or(false)
+        }
+        Err(_) => false,
+    }
+}
+
+fn batch_transcription_readiness_view(config: &Config) -> SurfaceReadinessView {
+    if config.transcription.engine == "parakeet" {
+        let status = parakeet_status_view(config);
+        let detail = if status.ready {
+            let tokenizer_label = status
+                .tokenizer_label
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            format!(
+                "Batch and recording transcription use Parakeet. Model: {}. Tokenizer: {}. Warm: {}.",
+                status.model,
+                tokenizer_label,
+                if status.warm { "yes" } else { "no" }
+            )
+        } else {
+            format!(
+                "Batch and recording transcription need Parakeet setup: {}. Run: {}",
+                status.issues.join(", "),
+                status.setup_command
+            )
+        };
+        return SurfaceReadinessView {
+            configured_backend: "parakeet".into(),
+            resolved_backend: "parakeet".into(),
+            ready: status.ready,
+            model_name: status.model,
+            detail,
+            next_action: if status.ready {
+                "none".into()
+            } else {
+                "setup-parakeet".into()
+            },
+            fallback_order: vec!["parakeet".into()],
+        };
+    }
+
+    let (ready, model_name, model_file) =
+        whisper_model_readiness(config, &config.transcription.model);
+    SurfaceReadinessView {
+        configured_backend: config.transcription.engine.clone(),
+        resolved_backend: "whisper".into(),
+        ready,
+        model_name: model_name.clone(),
+        detail: if ready {
+            format!(
+                "Batch and recording transcription use Whisper. {} is installed at {}.",
+                model_name,
+                model_file.display()
+            )
+        } else {
+            format!(
+                "Batch and recording transcription need a Whisper model. {} is missing at {}.",
+                model_name,
+                model_file.display()
+            )
+        },
+        next_action: if ready {
+            "none".into()
+        } else {
+            "download-model".into()
+        },
+        fallback_order: vec!["whisper".into()],
+    }
+}
+
+fn standalone_live_readiness_view(config: &Config) -> SurfaceReadinessView {
+    let configured_backend = config.standalone_live_backend_setting().to_string();
+    let resolved_backend = config.effective_live_transcript_backend().to_string();
+    let fallback_order = live_transcript_fallback_order_view(config);
+    let parakeet = parakeet_status_view(config);
+    let live_whisper_model = if config.live_transcript.model.trim().is_empty() {
+        config.transcription.model.as_str()
+    } else {
+        config.live_transcript.model.as_str()
+    };
+    let (whisper_ready, whisper_model_name, whisper_model_file) =
+        whisper_model_readiness(config, live_whisper_model);
+    let apple_selectable = apple_speech_selectable();
+
+    match resolved_backend.as_str() {
+        "parakeet" => SurfaceReadinessView {
+            configured_backend,
+            resolved_backend,
+            ready: parakeet.ready,
+            model_name: parakeet.model.clone(),
+            detail: if parakeet.ready {
+                format!(
+                    "Standalone live transcript uses Parakeet. Fallback order: {}.",
+                    fallback_order.join(" -> ")
+                )
+            } else {
+                format!(
+                    "Standalone live transcript needs Parakeet setup: {}. Fallback order: {}.",
+                    parakeet.issues.join(", "),
+                    fallback_order.join(" -> ")
+                )
+            },
+            next_action: if parakeet.ready {
+                "none".into()
+            } else {
+                "setup-parakeet".into()
+            },
+            fallback_order,
+        },
+        "apple-speech" => {
+            let ready = apple_selectable || parakeet.ready || whisper_ready;
+            let (detail, next_action) = if apple_selectable {
+                (
+                    format!(
+                        "Standalone live transcript can use Apple Speech directly. Fallback order: {}.",
+                        fallback_order.join(" -> ")
+                    ),
+                    "none".into(),
+                )
+            } else if parakeet.ready {
+                (
+                    format!(
+                        "Apple Speech is unavailable on this Mac, but standalone live transcript can run through Parakeet fallback. Fallback order: {}.",
+                        fallback_order.join(" -> ")
+                    ),
+                    "none".into(),
+                )
+            } else if whisper_ready {
+                (
+                    format!(
+                        "Apple Speech is unavailable on this Mac, but standalone live transcript can still run through Whisper fallback. Fallback order: {}.",
+                        fallback_order.join(" -> ")
+                    ),
+                    "none".into(),
+                )
+            } else {
+                (
+                    format!(
+                        "Apple Speech is unavailable on this Mac and no fallback backend is ready. Install a Whisper model at {} or set up Parakeet. Fallback order: {}.",
+                        whisper_model_file.display(),
+                        fallback_order.join(" -> ")
+                    ),
+                    "download-model".into(),
+                )
+            };
+            SurfaceReadinessView {
+                configured_backend,
+                resolved_backend,
+                ready,
+                model_name: "apple-speech".into(),
+                detail,
+                next_action,
+                fallback_order,
+            }
+        }
+        _ => SurfaceReadinessView {
+            configured_backend,
+            resolved_backend,
+            ready: whisper_ready,
+            model_name: whisper_model_name.clone(),
+            detail: if whisper_ready {
+                format!(
+                    "Standalone live transcript uses Whisper. {} is installed at {}.",
+                    whisper_model_name,
+                    whisper_model_file.display()
+                )
+            } else {
+                format!(
+                    "Standalone live transcript needs a Whisper model. {} is missing at {}.",
+                    whisper_model_name,
+                    whisper_model_file.display()
+                )
+            },
+            next_action: if whisper_ready {
+                "none".into()
+            } else {
+                "download-model".into()
+            },
+            fallback_order,
+        },
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TranscriptionSurfaceSetupView {
+    pub surface: String,
+    pub engine: String,
+    pub model_name: String,
+    pub has_model: bool,
+    pub needs_setup: bool,
+    pub parakeet: Option<ParakeetStatusView>,
+    pub activation: ActivationStatusView,
+}
+
+fn transcription_surface_setup_view(
+    config: &Config,
+    surface: &str,
+    readiness: &SurfaceReadinessView,
+    progress: &ActivationProgress,
+    has_saved_artifact: bool,
+    recording: bool,
+    processing: bool,
+) -> TranscriptionSurfaceSetupView {
+    let engine = readiness.resolved_backend.as_str();
+    TranscriptionSurfaceSetupView {
+        surface: surface.into(),
+        engine: readiness.resolved_backend.clone(),
+        model_name: readiness.model_name.clone(),
+        has_model: readiness.ready,
+        needs_setup: readiness.next_action != "none",
+        parakeet: (engine == "parakeet").then(|| parakeet_status_view(config)),
+        activation: activation_status_view(
+            engine,
+            progress,
+            readiness.ready,
+            has_saved_artifact,
+            recording,
+            processing,
+        ),
+    }
+}
+
+fn primary_setup_surface<'a>(
+    batch: &'a TranscriptionSurfaceSetupView,
+    standalone_live: &'a TranscriptionSurfaceSetupView,
+) -> &'a TranscriptionSurfaceSetupView {
+    if batch.needs_setup {
+        batch
+    } else if standalone_live.needs_setup {
+        standalone_live
+    } else {
+        batch
+    }
+}
+
+fn mark_model_ready_for_surface(
+    config: &Config,
+    readiness: &SurfaceReadinessView,
+    activation_progress: &Arc<Mutex<ActivationProgress>>,
+) {
+    match readiness.resolved_backend.as_str() {
+        "parakeet" => {
+            let parakeet = parakeet_status_view(config);
+            if parakeet.ready {
+                if let Some(model_path) = parakeet.model_path.as_ref() {
+                    mark_activation_model_ready(activation_progress, Path::new(model_path));
+                }
+            }
+        }
+        "whisper" => {
+            let model_file = whisper_model_file(config, &readiness.model_name);
+            if model_file.exists() {
+                mark_activation_model_ready(activation_progress, &model_file);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -950,10 +1263,7 @@ fn mark_activation_next_step_nudge_shown(
 }
 
 fn model_file_for_config(config: &Config) -> PathBuf {
-    config
-        .transcription
-        .model_path
-        .join(format!("ggml-{}.bin", config.transcription.model))
+    whisper_model_file(config, &config.transcription.model)
 }
 
 fn latest_saved_artifact_from_search(config: &Config) -> Option<PathBuf> {
@@ -2869,50 +3179,16 @@ fn build_artifact_template(
 }
 
 fn model_status(config: &Config) -> ReadinessItem {
-    if config.transcription.engine == "parakeet" {
-        let status = parakeet_status_view(config);
-
-        return ReadinessItem {
-            label: "Speech model".into(),
-            state: if status.ready { "ready" } else { "attention" }.into(),
-            detail: if status.ready {
-                let tokenizer_label = status
-                    .tokenizer_label
-                    .unwrap_or_else(|| "unknown".to_string());
-                format!(
-                    "Parakeet backend ready. Model: {}. Tokenizer: {}. Warm: {}.",
-                    status.model,
-                    tokenizer_label,
-                    if status.warm { "yes" } else { "no" }
-                )
-            } else {
-                format!(
-                    "Parakeet backend needs setup: {}. Run: minutes setup --parakeet",
-                    status.issues.join(", ")
-                )
-            },
-            optional: false,
-        };
-    }
-
-    let model_name = &config.transcription.model;
-    let model_file = config
-        .transcription
-        .model_path
-        .join(format!("ggml-{}.bin", model_name));
-    let exists = model_file.exists();
-
+    let batch = batch_transcription_readiness_view(config);
+    let live = standalone_live_readiness_view(config);
     ReadinessItem {
-        label: "Speech model".into(),
-        state: if exists { "ready" } else { "attention" }.into(),
-        detail: if exists {
-            format!("{} is installed at {}.", model_name, model_file.display())
+        label: "Speech backends".into(),
+        state: if batch.ready && live.ready {
+            "ready".into()
         } else {
-            format!(
-                "{} is not installed yet. Download it before recording.",
-                model_name
-            )
+            "attention".into()
         },
+        detail: format!("Batch: {} Live: {}", batch.detail, live.detail),
         optional: false,
     }
 }
@@ -4193,21 +4469,10 @@ pub fn cmd_status(state: tauri::State<AppState>) -> serde_json::Value {
         .map(|guard| guard.clone())
         .unwrap_or_default();
     let config = Config::load();
-    let has_model = if config.transcription.engine == "parakeet" {
-        let parakeet = parakeet_status_view(&config);
-        if parakeet.ready {
-            if let Some(model_path) = parakeet.model_path.as_ref() {
-                mark_activation_model_ready(&state.activation_progress, Path::new(model_path));
-            }
-        }
-        parakeet.ready
-    } else {
-        let model_file = model_file_for_config(&config);
-        if model_file.exists() {
-            mark_activation_model_ready(&state.activation_progress, &model_file);
-        }
-        model_file.exists()
-    };
+    let batch_readiness = batch_transcription_readiness_view(&config);
+    let live_readiness = standalone_live_readiness_view(&config);
+    mark_model_ready_for_surface(&config, &batch_readiness, &state.activation_progress);
+    mark_model_ready_for_surface(&config, &live_readiness, &state.activation_progress);
     let activation_progress = state
         .activation_progress
         .lock()
@@ -4215,17 +4480,29 @@ pub fn cmd_status(state: tauri::State<AppState>) -> serde_json::Value {
         .map(|progress| progress.clone())
         .unwrap_or_default();
     let has_saved_artifact = activation_progress.first_artifact_saved_at.is_some();
-    let activation = activation_status_view(
-        &config.transcription.engine,
+    let recording_active = recording || (status.recording && !processing);
+    let batch_setup = transcription_surface_setup_view(
+        &config,
+        "batch",
+        &batch_readiness,
         &activation_progress,
-        has_model,
         has_saved_artifact,
-        recording || (status.recording && !processing),
+        recording_active,
         processing,
     );
+    let standalone_live_setup = transcription_surface_setup_view(
+        &config,
+        "standalone-live",
+        &live_readiness,
+        &activation_progress,
+        has_saved_artifact,
+        recording_active,
+        processing,
+    );
+    let primary_setup = primary_setup_surface(&batch_setup, &standalone_live_setup);
 
     // Get elapsed time if recording
-    let elapsed = if recording || (status.recording && !processing) {
+    let elapsed = if recording_active {
         let start_path = minutes_core::notes::recording_start_path();
         if start_path.exists() {
             if let Ok(s) = std::fs::read_to_string(&start_path) {
@@ -4249,7 +4526,7 @@ pub fn cmd_status(state: tauri::State<AppState>) -> serde_json::Value {
         None
     };
 
-    let audio_level = if recording || (status.recording && !processing) {
+    let audio_level = if recording_active {
         minutes_core::capture::audio_level()
     } else {
         0
@@ -4267,7 +4544,14 @@ pub fn cmd_status(state: tauri::State<AppState>) -> serde_json::Value {
         "processingJobs": processing_jobs,
         "updateState": update_state,
         "latestOutput": latest_output,
-        "activation": activation,
+        "activation": primary_setup.activation.clone(),
+        "batch_transcription": batch_readiness,
+        "standalone_live": live_readiness,
+        "transcriptionSetup": {
+            "needsSetup": batch_setup.needs_setup || standalone_live_setup.needs_setup,
+            "batch": batch_setup,
+            "standaloneLive": standalone_live_setup,
+        },
         "callCaptureHealth": call_capture_health,
         "pid": status.pid,
         "elapsed": elapsed,
@@ -5449,31 +5733,10 @@ pub async fn cmd_upcoming_meetings() -> serde_json::Value {
 #[tauri::command]
 pub fn cmd_needs_setup(state: tauri::State<AppState>) -> serde_json::Value {
     let config = Config::load();
-    let model_name = if config.transcription.engine == "parakeet" {
-        &config.transcription.parakeet_model
-    } else {
-        &config.transcription.model
-    };
-    let parakeet = if config.transcription.engine == "parakeet" {
-        Some(parakeet_status_view(&config))
-    } else {
-        None
-    };
-    let has_model = if let Some(status) = parakeet.as_ref() {
-        if status.ready {
-            if let Some(model_path) = status.model_path.as_ref() {
-                mark_activation_model_ready(&state.activation_progress, Path::new(model_path));
-            }
-        }
-        status.ready
-    } else {
-        let model_file = model_file_for_config(&config);
-        let exists = model_file.exists();
-        if exists {
-            mark_activation_model_ready(&state.activation_progress, &model_file);
-        }
-        exists
-    };
+    let batch_readiness = batch_transcription_readiness_view(&config);
+    let live_readiness = standalone_live_readiness_view(&config);
+    mark_model_ready_for_surface(&config, &batch_readiness, &state.activation_progress);
+    mark_model_ready_for_surface(&config, &live_readiness, &state.activation_progress);
 
     let meetings_dir = config.output_dir.clone();
     let has_meetings_dir = meetings_dir.exists();
@@ -5483,22 +5746,41 @@ pub fn cmd_needs_setup(state: tauri::State<AppState>) -> serde_json::Value {
         .ok()
         .map(|progress| progress.clone())
         .unwrap_or_default();
+    let has_saved_artifact = activation_progress.first_artifact_saved_at.is_some();
+    let batch_setup = transcription_surface_setup_view(
+        &config,
+        "batch",
+        &batch_readiness,
+        &activation_progress,
+        has_saved_artifact,
+        false,
+        false,
+    );
+    let standalone_live_setup = transcription_surface_setup_view(
+        &config,
+        "standalone-live",
+        &live_readiness,
+        &activation_progress,
+        has_saved_artifact,
+        false,
+        false,
+    );
+    let primary_setup = primary_setup_surface(&batch_setup, &standalone_live_setup);
 
     serde_json::json!({
-        "needsSetup": !has_model,
-        "hasModel": has_model,
-        "engine": config.transcription.engine,
-        "modelName": model_name,
-        "parakeet": parakeet,
+        "needsSetup": batch_setup.needs_setup || standalone_live_setup.needs_setup,
+        "hasModel": primary_setup.has_model,
+        "engine": primary_setup.engine.clone(),
+        "modelName": primary_setup.model_name.clone(),
+        "parakeet": primary_setup.parakeet.clone(),
+        "batch_transcription": batch_readiness,
+        "standalone_live": live_readiness,
+        "transcriptionSetup": {
+            "batch": batch_setup,
+            "standaloneLive": standalone_live_setup,
+        },
         "hasMeetingsDir": has_meetings_dir,
-        "activation": activation_status_view(
-            &config.transcription.engine,
-            &activation_progress,
-            has_model,
-            activation_progress.first_artifact_saved_at.is_some(),
-            false,
-            false,
-        ),
+        "activation": primary_setup.activation.clone(),
     })
 }
 
@@ -6024,6 +6306,16 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "hotkey_enabled": config.dictation.hotkey_enabled,
             "hotkey_keycode": config.dictation.hotkey_keycode,
         },
+        "live_transcript": {
+            "backend": config.standalone_live_backend_setting(),
+            "resolved_backend": config.effective_live_transcript_backend(),
+            "fallback_order": live_transcript_fallback_order_view(&config),
+            "model": config.live_transcript.model,
+            "max_utterance_secs": config.live_transcript.max_utterance_secs,
+            "save_wav": config.live_transcript.save_wav,
+            "shortcut_enabled": config.live_transcript.shortcut_enabled,
+            "shortcut": config.live_transcript.shortcut,
+        },
         "palette": {
             "shortcut_enabled": config.palette.shortcut_enabled,
             "shortcut": config.palette.shortcut,
@@ -6040,10 +6332,12 @@ pub fn cmd_get_settings() -> serde_json::Value {
 #[tauri::command]
 pub async fn cmd_warm_parakeet() -> Result<serde_json::Value, String> {
     let config = Config::load();
-    if config.transcription.engine != "parakeet" {
+    if config.transcription.engine != "parakeet"
+        && config.effective_live_transcript_backend() != "parakeet"
+    {
         return Ok(serde_json::json!({
             "status": "skipped",
-            "reason": "parakeet not selected",
+            "reason": "parakeet not selected for batch or standalone live transcript",
         }));
     }
     #[cfg(feature = "parakeet")]
@@ -6248,6 +6542,16 @@ pub fn cmd_set_setting(section: String, key: String, value: String) -> Result<St
         }
 
         // Live transcript
+        ("live_transcript", "backend") => {
+            if !VALID_LIVE_TRANSCRIPT_BACKENDS.contains(&value.as_str()) {
+                return Err(format!(
+                    "unknown live transcript backend '{}'. Valid: {}",
+                    value,
+                    VALID_LIVE_TRANSCRIPT_BACKENDS.join(", ")
+                ));
+            }
+            config.live_transcript.backend = value.clone();
+        }
         ("live_transcript", "shortcut_enabled") => {
             config.live_transcript.shortcut_enabled = value == "true";
         }
@@ -6763,6 +7067,118 @@ mod tests {
         .unwrap_err();
 
         assert!(error.contains("standalone live transcript"));
+    }
+
+    #[test]
+    fn desktop_settings_accept_live_transcript_backend_selection() {
+        cmd_set_setting(
+            "live_transcript".into(),
+            "backend".into(),
+            "apple-speech".into(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn desktop_settings_reject_unknown_live_transcript_backend() {
+        let error = cmd_set_setting("live_transcript".into(), "backend".into(), "laser".into())
+            .unwrap_err();
+
+        assert!(error.contains("unknown live transcript backend"));
+    }
+
+    #[test]
+    fn primary_setup_surface_switches_to_live_parakeet_when_batch_is_ready() {
+        let dir = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.transcription.engine = "whisper".into();
+        config.transcription.model_path = dir.path().to_path_buf();
+        config.live_transcript.backend = "parakeet".into();
+
+        let whisper_model = model_file_for_config(&config);
+        std::fs::create_dir_all(whisper_model.parent().unwrap()).unwrap();
+        std::fs::write(&whisper_model, b"model").unwrap();
+
+        let batch_readiness = batch_transcription_readiness_view(&config);
+        let live_readiness = standalone_live_readiness_view(&config);
+        let progress = ActivationProgress::default();
+        let batch_setup = transcription_surface_setup_view(
+            &config,
+            "batch",
+            &batch_readiness,
+            &progress,
+            false,
+            false,
+            false,
+        );
+        let standalone_live_setup = transcription_surface_setup_view(
+            &config,
+            "standalone-live",
+            &live_readiness,
+            &progress,
+            false,
+            false,
+            false,
+        );
+        let primary = primary_setup_surface(&batch_setup, &standalone_live_setup);
+
+        assert!(!batch_setup.needs_setup);
+        assert!(standalone_live_setup.needs_setup);
+        assert_eq!(primary.engine, "parakeet");
+        assert_eq!(primary.activation.next_action, "setup-parakeet");
+    }
+
+    #[test]
+    fn primary_setup_surface_keeps_batch_when_batch_needs_setup() {
+        let dir = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.transcription.model_path = dir.path().to_path_buf();
+        let batch_readiness = batch_transcription_readiness_view(&config);
+        let live_readiness = standalone_live_readiness_view(&config);
+        let progress = ActivationProgress::default();
+        let batch_setup = transcription_surface_setup_view(
+            &config,
+            "batch",
+            &batch_readiness,
+            &progress,
+            false,
+            false,
+            false,
+        );
+        let standalone_live_setup = transcription_surface_setup_view(
+            &config,
+            "standalone-live",
+            &live_readiness,
+            &progress,
+            false,
+            false,
+            false,
+        );
+        let primary = primary_setup_surface(&batch_setup, &standalone_live_setup);
+
+        assert!(batch_setup.needs_setup);
+        assert_eq!(primary.engine, batch_setup.engine);
+        assert_eq!(primary.surface, "batch");
+    }
+
+    #[test]
+    fn standalone_live_readiness_uses_live_whisper_model_name() {
+        let dir = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.transcription.model_path = dir.path().to_path_buf();
+        config.transcription.model = "base".into();
+        config.live_transcript.backend = "whisper".into();
+        config.live_transcript.model = "small".into();
+
+        let batch_model = whisper_model_file(&config, &config.transcription.model);
+        std::fs::create_dir_all(batch_model.parent().unwrap()).unwrap();
+        std::fs::write(&batch_model, b"base-model").unwrap();
+
+        let live = standalone_live_readiness_view(&config);
+
+        assert_eq!(live.model_name, "small");
+        assert!(!live.ready);
+        assert!(live.detail.contains("ggml-small.bin"));
     }
 
     #[test]
@@ -7560,7 +7976,7 @@ mod tests {
         };
 
         let status = model_status(&config);
-        assert_eq!(status.label, "Speech model");
+        assert_eq!(status.label, "Speech backends");
         assert_eq!(status.state, "attention");
     }
 

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -4304,6 +4304,18 @@
         <div class="about-item-title">LIVE TRANSCRIPT</div>
         <div class="about-controls">
           <div class="about-controls-group">
+            <div class="about-controls-copy">Backend</div>
+            <select id="settings-live-backend" class="settings-field">
+              <option value="inherit">Inherit main transcription engine</option>
+              <option value="whisper">Whisper — built-in, broad language support</option>
+              <option value="parakeet">Parakeet — lower WER, fast on Apple Silicon</option>
+              <option value="apple-speech">Apple Speech — experimental standalone live transcript</option>
+            </select>
+            <div class="about-controls-meta" id="settings-live-backend-detail">Standalone live transcript currently inherits your main transcription engine.</div>
+          </div>
+        </div>
+        <div class="about-controls">
+          <div class="about-controls-group">
             <div class="about-controls-copy">Keyboard shortcut</div>
             <select class="shortcut-select settings-field" id="settings-live-shortcut-select">
               <option value="CmdOrCtrl+Shift+L">Cmd+Shift+L</option>
@@ -4342,9 +4354,8 @@
             <select id="settings-transcription-engine" class="settings-field">
               <option value="whisper">Whisper — broad language support, built-in</option>
               <option value="parakeet">Parakeet — lower WER, fast on Apple Silicon</option>
-              <option value="apple-speech" hidden disabled>Apple Speech — standalone live transcript only; configured outside desktop settings</option>
             </select>
-            <div class="about-controls-meta" id="settings-transcription-engine-detail">Whisper and Parakeet are the configurable transcription engines in desktop settings.</div>
+            <div class="about-controls-meta" id="settings-transcription-engine-detail">Whisper and Parakeet control batch, recording, and recording-sidecar transcription. Standalone live transcript has its own backend setting above.</div>
           </div>
         </div>
         <div class="about-controls" id="settings-whisper-section">
@@ -5184,6 +5195,16 @@
       }
     }
 
+    function renderStandaloneLiveNote(setup) {
+      const live = setup?.standalone_live || null;
+      if (!live) return '';
+      const configured = live.configured_backend || 'inherit';
+      if (configured === 'inherit') return '';
+      const detail = escapeHtml(live.detail || '');
+      const status = live.ready ? 'Ready' : 'Needs setup';
+      return `<p class="about-controls-meta"><strong>Standalone live transcript:</strong> ${status}. ${detail}</p>`;
+    }
+
     function escapeHtml(text) {
       return String(text)
         .replaceAll('&', '&amp;')
@@ -5277,6 +5298,37 @@
       } catch (e) {
         console.error('parakeet warmup:', e);
       }
+    }
+
+    function backendLabel(backend) {
+      switch (backend) {
+        case 'apple-speech': return 'Apple Speech';
+        case 'parakeet': return 'Parakeet';
+        case 'whisper': return 'Whisper';
+        case 'inherit': return 'your main transcription engine';
+        default: return backend || 'Whisper';
+      }
+    }
+
+    function fallbackOrderLabel(order) {
+      const list = Array.isArray(order) ? order : [];
+      if (!list.length) return 'Whisper';
+      return list.map(backendLabel).join(' -> ');
+    }
+
+    function describeLiveBackendSelection(selectedBackend, resolvedBackend, fallbackOrder, batchEngine) {
+      const fallbackText = fallbackOrderLabel(fallbackOrder);
+      const batchLabel = backendLabel(batchEngine);
+      if (selectedBackend === 'inherit') {
+        return `Standalone live transcript currently inherits ${backendLabel(resolvedBackend)} from the main transcription engine. Fallback order: ${fallbackText}. Recording-sidecar live and batch transcription stay on ${batchLabel}.`;
+      }
+      if (selectedBackend === 'apple-speech') {
+        return `Standalone live transcript will try Apple Speech first. Fallback order: ${fallbackText}. Recording-sidecar live and batch transcription remain on ${batchLabel}.`;
+      }
+      if (selectedBackend === 'parakeet') {
+        return `Standalone live transcript will use Parakeet when available. Fallback order: ${fallbackText}. Recording-sidecar live and batch transcription remain on ${batchLabel}.`;
+      }
+      return `Standalone live transcript will use Whisper. Fallback order: ${fallbackText}. Recording-sidecar live and batch transcription remain on ${batchLabel}.`;
     }
 
     function currentModeLabel(mode) {
@@ -7060,9 +7112,11 @@
     }
 
     function renderSetupEmptyState() {
-      const setupEngine = currentSetup?.engine || 'whisper';
+      const batchSetup = currentSetup?.batch_transcription || null;
+      const setupEngine = batchSetup?.resolved_backend || currentSetup?.engine || 'whisper';
       const parakeet = currentSetup?.parakeet || null;
       const parakeetIssues = (parakeet?.issues || []).map(issue => `<li>${escapeHtml(issue)}</li>`).join('');
+      const standaloneLiveNote = renderStandaloneLiveNote(currentSetup);
       const modelStepBody = setupEngine === 'parakeet'
         ? `
                 <p>Minutes is set to use Parakeet, which needs the local <code>parakeet</code> binary plus converted model assets.</p>
@@ -7071,7 +7125,8 @@
                   <button class="btn btn-primary btn-sm" id="btn-open-parakeet-guide-onboarding">Open Parakeet setup guide</button>
                   <button class="btn btn-secondary btn-sm" id="btn-switch-to-whisper-onboarding">Use Whisper instead</button>
                 </div>
-                <div class="about-controls-meta">${escapeHtml(parakeet?.setupCommand || 'minutes setup --parakeet')}<\/div>`
+                <div class="about-controls-meta">${escapeHtml(parakeet?.setupCommand || 'minutes setup --parakeet')}<\/div>
+                ${standaloneLiveNote}`
         : `
                 <p>Choose a model size:</p>
                 <div class="model-options">
@@ -7082,7 +7137,8 @@
                 <div class="download-progress ui-hidden">
                   <div class="progress-bar"><div class="progress-fill"></div></div>
                   <span class="progress-text">Downloading...</span>
-                </div>`;
+                </div>
+                ${standaloneLiveNote}`;
       const empty = document.createElement('div');
       empty.className = 'empty-state';
       empty.innerHTML = `
@@ -7218,42 +7274,60 @@
         }
         // Engine selector
         const eng = s.transcription.engine || 'whisper';
+        const liveTranscript = s.live_transcript || {};
+        const liveBackend = liveTranscript.backend || 'inherit';
+        const resolvedLiveBackend = liveTranscript.resolved_backend || eng;
+        const liveFallbackOrder = liveTranscript.fallback_order || [resolvedLiveBackend];
+        const liveMentionsParakeet = liveBackend === 'parakeet' || liveBackend === 'apple-speech' || liveFallbackOrder.includes('parakeet');
         const parakeetCompiled = s.transcription.parakeet_compiled || false;
         const parakeetStatus = s.transcription.parakeet_status || null;
         const appleSpeechStatus = s.transcription.apple_speech_status || null;
         const engineSelect = document.getElementById('settings-transcription-engine');
         const parakeetOpt = engineSelect.querySelector('option[value="parakeet"]');
-        const appleSpeechOpt = engineSelect.querySelector('option[value="apple-speech"]');
         const engineDetail = document.getElementById('settings-transcription-engine-detail');
-        const appleSpeechConfigured = eng === 'apple-speech';
+        const liveBackendSelect = document.getElementById('settings-live-backend');
+        const liveBackendDetail = document.getElementById('settings-live-backend-detail');
+        const liveParakeetOpt = liveBackendSelect ? liveBackendSelect.querySelector('option[value="parakeet"]') : null;
+        const liveAppleOpt = liveBackendSelect ? liveBackendSelect.querySelector('option[value="apple-speech"]') : null;
         if (parakeetOpt) {
           parakeetOpt.disabled = !parakeetCompiled;
           parakeetOpt.textContent = parakeetCompiled
             ? 'Parakeet — local backend, best quality on Apple Silicon'
             : 'Parakeet — unavailable in this build';
         }
-        if (appleSpeechOpt) {
-          appleSpeechOpt.disabled = true;
-          appleSpeechOpt.hidden = !appleSpeechConfigured;
-          appleSpeechOpt.textContent = appleSpeechConfigured
-            ? 'Apple Speech — standalone live transcript only; configured outside desktop settings'
-            : (appleSpeechStatus && appleSpeechStatus.selectable)
-              ? 'Apple Speech — available for standalone live transcript, but not configurable here'
-              : 'Apple Speech — unavailable on this Mac';
-        }
         if (engineDetail) {
-          engineDetail.textContent = appleSpeechConfigured
-            ? 'Apple Speech is configured outside desktop settings for standalone live transcript experiments. Recording and batch flows still use Whisper today.'
-            : (appleSpeechStatus && appleSpeechStatus.selectable)
-              ? 'This Mac supports Apple Speech for standalone live transcript experiments, but desktop settings still only configure Whisper and Parakeet.'
-              : 'Whisper and Parakeet are the configurable transcription engines in desktop settings.';
+          engineDetail.textContent = 'Whisper and Parakeet control batch, recording, and recording-sidecar transcription. Standalone live transcript has its own backend setting above.';
         }
-        engineSelect.value = appleSpeechConfigured ? 'apple-speech' : eng;
+        engineSelect.value = eng;
+        if (liveParakeetOpt) {
+          liveParakeetOpt.disabled = !parakeetCompiled;
+          liveParakeetOpt.textContent = parakeetCompiled
+            ? 'Parakeet — lower WER, fast on Apple Silicon'
+            : 'Parakeet — unavailable in this build';
+        }
+        if (liveAppleOpt) {
+          const appleSelectable = Boolean(appleSpeechStatus && appleSpeechStatus.selectable);
+          liveAppleOpt.disabled = !appleSelectable && liveBackend !== 'apple-speech';
+          liveAppleOpt.textContent = appleSelectable
+            ? 'Apple Speech — experimental standalone live transcript'
+            : 'Apple Speech — unavailable on this Mac';
+        }
+        if (liveBackendSelect) {
+          liveBackendSelect.value = liveBackend;
+        }
+        if (liveBackendDetail) {
+          liveBackendDetail.textContent = describeLiveBackendSelection(
+            liveBackend,
+            resolvedLiveBackend,
+            liveFallbackOrder,
+            eng,
+          );
+        }
         document.getElementById('settings-whisper-section').classList.toggle('is-hidden', eng !== 'whisper');
-        document.getElementById('settings-parakeet-section').classList.toggle('is-hidden', eng !== 'parakeet');
+        document.getElementById('settings-parakeet-section').classList.toggle('is-hidden', !(eng === 'parakeet' || liveMentionsParakeet));
         document.getElementById('settings-parakeet-model').value = s.transcription.parakeet_model || 'tdt-ctc-110m';
         renderParakeetSettingsStatus(parakeetStatus);
-        warmParakeetIfSelected(eng);
+        warmParakeetIfSelected(eng === 'parakeet' || resolvedLiveBackend === 'parakeet' ? 'parakeet' : eng);
         document.getElementById('settings-whisper-model').value = s.transcription.model;
         const dl = s.transcription.downloaded_models || [];
         const selectedModel = s.transcription.model;
@@ -7651,19 +7725,12 @@
     document.getElementById('settings-transcription-engine').addEventListener('change', async (e) => {
       await invoke('cmd_set_setting', { section: 'transcription', key: 'engine', value: e.target.value });
       await checkSetup();
-      document.getElementById('settings-whisper-section').classList.toggle('is-hidden', e.target.value !== 'whisper');
-      document.getElementById('settings-parakeet-section').classList.toggle('is-hidden', e.target.value !== 'parakeet');
-      const s = await invoke('cmd_get_settings');
-      renderParakeetSettingsStatus(s.transcription.parakeet_status || null);
-      warmParakeetIfSelected(e.target.value);
+      await loadSettings();
     });
     document.getElementById('settings-parakeet-model').addEventListener('change', async (e) => {
       await invoke('cmd_set_setting', { section: 'transcription', key: 'parakeet_model', value: e.target.value });
       await checkSetup();
-      const s = await invoke('cmd_get_settings');
-      document.getElementById('settings-parakeet-model').value = s.transcription.parakeet_model || 'tdt-ctc-110m';
-      renderParakeetSettingsStatus(s.transcription.parakeet_status || null);
-      warmParakeetIfSelected('parakeet');
+      await loadSettings();
     });
     document.getElementById('settings-whisper-model').addEventListener('change', async (e) => {
       await invoke('cmd_set_setting', { section: 'transcription', key: 'model', value: e.target.value });
@@ -7994,6 +8061,11 @@
       const select = document.getElementById('settings-live-shortcut-select');
       if (select) select.value = settings.shortcut;
     }).catch(() => { });
+    document.getElementById('settings-live-backend').addEventListener('change', async (e) => {
+      await invoke('cmd_set_setting', { section: 'live_transcript', key: 'backend', value: e.target.value });
+      await loadSettings();
+      await checkSetup();
+    });
 
     // ── Command palette shortcut settings ──
     // Backend (cmd_set_palette_shortcut at commands.rs:7356) exists and


### PR DESCRIPTION
## Summary
- add a dedicated `live_transcript.backend` setting for standalone live transcript instead of overloading `transcription.engine`
- preserve legacy `transcription.engine = "apple-speech"` behavior through an effective-backend helper and a desktop-app migration that rewrites old configs to `transcription.engine = "whisper"` plus `live_transcript.backend = "apple-speech"`
- update the standalone live runtime to use the new effective backend while keeping recording-sidecar behavior on the main transcription engine
- expose standalone live backend selection, resolved backend, and fallback order in desktop settings
- move Apple Speech capability/fallback messaging into the Live Transcript section and remove Apple Speech from the global transcription-engine picker
- keep Parakeet setup/status visible when it matters to standalone live, even if batch transcription stays on Whisper

## Verification
- cargo fmt --all -- --check
- cargo test -p minutes-core live_transcript_backend
- cargo test -p minutes-core upgrade_
- cargo test -p minutes-app desktop_settings_
- cargo test -p minutes-app every_cmd_set_setting_arm_has_a_caller
- cargo check -p minutes-app

## Notes
- Recording-sidecar live transcription still follows `transcription.engine`; this change only splits the standalone live transcript path.
- The migration intentionally normalizes old Apple configs on desktop startup so the settings UI stops perpetuating the old overload.
