### PR TITLE
[codex] Canonicalize configured recording device names

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1455,7 +1455,7 @@ fn normalize_source_override(source: Option<&str>) -> Option<String> {
     match source.map(str::trim) {
         Some("") | None => None,
         Some(value) if value.eq_ignore_ascii_case("default") => None,
-        Some(value) => Some(value.to_string()),
+        Some(value) => minutes_core::capture::canonicalize_input_device_setting(value),
     }
 }
 
@@ -1501,7 +1501,7 @@ fn resolve_recording_device_overrides(
 
     if let Some(dev) = device {
         config.recording.sources = None;
-        config.recording.device = Some(dev);
+        config.recording.device = minutes_core::capture::canonicalize_input_device_setting(&dev);
         return Ok(());
     }
 
@@ -4983,6 +4983,19 @@ life (qmd://life/)
             .expect("explicit --device should override config sources");
         assert_eq!(config.recording.device.as_deref(), Some("USB Mic"));
         assert!(config.recording.sources.is_none());
+    }
+
+    #[test]
+    fn resolve_recording_device_overrides_normalizes_decorated_explicit_device() {
+        let mut config = Config::default();
+        resolve_recording_device_overrides(
+            &mut config,
+            &[],
+            Some("Ground Control (16000Hz, 1 ch)".into()),
+            false,
+        )
+        .expect("decorated --device value should normalize");
+        assert_eq!(config.recording.device.as_deref(), Some("Ground Control"));
     }
 
     #[test]

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -1635,6 +1635,17 @@ pub fn strip_device_format_suffix(name: &str) -> &str {
     &name[..open_idx]
 }
 
+/// Normalize a persisted input-device setting to the canonical CPAL device
+/// name by trimming whitespace and stripping any UI decoration suffix like
+/// `" (16000Hz, 1 ch)"`.
+pub fn canonicalize_input_device_setting(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(strip_device_format_suffix(trimmed).to_string())
+}
+
 /// Select the best input device.
 ///
 /// If `device_name` is provided, matches by name against available devices.
@@ -2429,6 +2440,19 @@ mod tests {
             label: "Ground Control (16000Hz, 1 ch)".into(),
         };
         assert_eq!(strip_device_format_suffix(&entry.label), entry.name);
+    }
+
+    #[test]
+    fn canonicalize_input_device_setting_strips_picker_decoration() {
+        assert_eq!(
+            canonicalize_input_device_setting(" Ground Control (16000Hz, 1 ch) "),
+            Some("Ground Control".into())
+        );
+        assert_eq!(
+            canonicalize_input_device_setting("Ground Control"),
+            Some("Ground Control".into())
+        );
+        assert_eq!(canonicalize_input_device_setting("   "), None);
     }
 
     #[test]

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -6411,7 +6411,8 @@ pub fn cmd_set_setting(section: String, key: String, value: String) -> Result<St
 
         // Recording
         ("recording", "device") => {
-            config.recording.device = parse_optional_string_setting(&value);
+            config.recording.device =
+                minutes_core::capture::canonicalize_input_device_setting(&value);
         }
 
         // Diarization
@@ -7089,6 +7090,19 @@ mod tests {
             .unwrap_err();
 
         assert!(error.contains("unknown live transcript backend"));
+    }
+
+    #[test]
+    fn desktop_settings_normalize_decorated_recording_device_name() {
+        cmd_set_setting(
+            "recording".into(),
+            "device".into(),
+            "Ground Control (16000Hz, 1 ch)".into(),
+        )
+        .unwrap();
+
+        let config = Config::load();
+        assert_eq!(config.recording.device.as_deref(), Some("Ground Control"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes `minutes-swez`.

Configured audio device names could still be persisted in a decorated UI/diagnostics form like `Ground Control (16000Hz, 1 ch)` even though Minutes' actual runtime matching is based on the canonical CPAL device name `Ground Control`. Runtime matching had already become tolerant of the decorated suffix, but config could remain self-inconsistent and keep reintroducing the mismatch.

## What Changed
- added a shared `canonicalize_input_device_setting(...)` helper in `minutes-core`
- canonicalized decorated device labels before persisting `[recording].device` from the desktop settings path
- canonicalized decorated device labels before persisting explicit CLI recording device overrides
- kept runtime matching tolerant of older decorated values already present in config
- added focused regression tests for both the core canonicalization helper and the CLI explicit-device override path

## Why
This makes the persisted config stable and canonical instead of depending on the capture layer's compatibility fallback. Dictation, live transcript, and recording all read `config.recording.device`, so normalizing at write time is the cleanest fix.

## Verification
- `cargo fmt --all`
- `cargo test -p minutes-core --lib canonicalize_input_device_setting_strips_picker_decoration`
- `cargo test -p minutes-cli --bin minutes resolve_recording_device_overrides_normalizes_decorated_explicit_device`
- `cargo check -p minutes-app`
