### PR TITLE
fix(desktop): re-heal stale recording.device on every recording start (#189)

### DIFF
--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -3087,4 +3087,53 @@ mod tests {
             }
         }
     }
+
+    /// Issue #189 regression guard. The desktop's recording entry
+    /// points (`start_recording`, `run_live_session`,
+    /// `start_dictation_session`) call `auto_heal_missing_recording_device`
+    /// against an in-memory `Config` clone; they must NOT persist the
+    /// healed config. Persistence is the startup-only concern handled
+    /// in `main.rs` so users keep their pin for when the device
+    /// reconnects on a future launch.
+    ///
+    /// This test confirms the function leaves persistence to the
+    /// caller by writing a config to disk, healing an in-memory copy
+    /// with a missing device, and verifying the on-disk config is
+    /// unchanged.
+    #[test]
+    #[cfg_attr(target_os = "windows", ignore)]
+    fn auto_heal_in_memory_does_not_persist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("config.toml");
+
+        // Write a config with a real-looking but missing device pin.
+        let bogus = "__minutes_test_device_that_should_never_exist_runtime__";
+        let original = format!(
+            "[recording]\ndevice = \"{}\"\nallow_degraded_call_capture = false\n",
+            bogus
+        );
+        std::fs::write(&path, &original).expect("write");
+
+        // Heal an in-memory copy.
+        let mut runtime = crate::config::Config::load_from(&path);
+        let result = check_input_device_availability(bogus);
+        let changed = auto_heal_missing_recording_device(&mut runtime);
+
+        // On hosts where enumeration returns Unknown, the test trivially
+        // passes — there's nothing to heal.
+        if matches!(result, DeviceAvailability::Unknown) {
+            assert!(!changed);
+            return;
+        }
+
+        // Otherwise: in-memory copy was modified, on-disk file was not.
+        assert!(changed, "should heal an in-memory missing pin");
+        assert!(runtime.recording.device.is_none());
+        let disk_after = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            disk_after.contains(bogus),
+            "on-disk config must still reference the original pin so users can reconnect later; runtime heal must NOT touch the file. Got:\n{}",
+            disk_after
+        );
+    }
 }

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 47;
-export const MINUTES_TEST_COUNT = 809;
+export const MINUTES_TEST_COUNT = 810;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3666,6 +3666,15 @@ pub fn start_recording(
     if let Some(language) = language_override {
         config.transcription.language = Some(language);
     }
+    // Re-validate the pinned input device at recording start so a
+    // mid-session disconnect (Bluetooth headset turning off, USB device
+    // unplugged) transparently falls back to the system default. Issue
+    // #189: without this, preflight surfaces "device not found" and
+    // some users press Cmd+Q out of frustration, which can trip a
+    // separate destructor-during-exit() abort. In-memory only;
+    // startup-side persistence stays in main.rs so users keep their
+    // pin for when the device reconnects on a future launch.
+    minutes_core::capture::auto_heal_missing_recording_device(&mut config);
     let preflight = match minutes_core::capture::preflight_recording_with_native_call_capture(
         mode,
         requested_intent,
@@ -8581,7 +8590,10 @@ impl Drop for LiveActiveGuard {
 fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: Arc<AtomicBool>) {
     let _guard = LiveActiveGuard(active);
 
-    let config = Config::load();
+    let mut config = Config::load();
+    // Re-validate the pinned input device for mid-session disconnects
+    // (#189). In-memory only; startup-side persistence is in main.rs.
+    minutes_core::capture::auto_heal_missing_recording_device(&mut config);
 
     if let Ok(workspace) = crate::context::create_workspace(&config) {
         update_assistant_live_context(&workspace, true);
@@ -9326,7 +9338,11 @@ fn start_dictation_session(
     let dictation_active = Arc::clone(&state.dictation_active);
 
     std::thread::spawn(move || {
-        let config = Config::load();
+        let mut config = Config::load();
+        // Re-validate the pinned input device for mid-session
+        // disconnects (#189). In-memory only; startup-side persistence
+        // is in main.rs.
+        minutes_core::capture::auto_heal_missing_recording_device(&mut config);
         let app_for_events = app_clone.clone();
         let app_for_results = app_clone.clone();
 


### PR DESCRIPTION
Closes #189.

## Background

PR #188 (shipped in v0.15.0) fixed the dominant case: a stale `recording.device` pin at app launch. The startup auto-heal runs once during `Config::load_with_migrations`, persists the cleared pin, and falls back to the system default on first record click.

That left the mid-session case unhealed.

## Repro

1. Connect a USB or Bluetooth audio input and pick it in Settings.
2. Launch Minutes. The device is present, so the pin survives the startup heal.
3. Without quitting, unplug or disconnect the device.
4. Click Start Recording.

**Pre-fix behavior:** preflight returns "device not found" with an in-app notification. Some users, not noticing the notification, pressed Cmd-Q out of frustration. The Quit handler in `main.rs` spawns a thread that runs `wait_for_recording_shutdown_forever()` then `std::process::exit(0)`; during `exit()` cleanup, a destructor in the Tauri / Cocoa stack hit `abort()`, giving the SIGABRT seen in the recent crash reports. The Rust-side recording flow was correct; the user-experience failure mode was the trigger.

## Fix

Re-run `auto_heal_missing_recording_device` against an in-memory `Config` clone at every recording entry point on the desktop:

- `start_recording` (the meeting / quick-thought path the original crash report came from)
- `run_live_session` (live transcript)
- `start_dictation_session` (dictation hotkey)

The runtime heal does **not** persist. Persistence is the startup-only concern handled in `main.rs` so users keep their pin for when the device reconnects on a future launch.

A new `auto_heal_in_memory_does_not_persist` test guards that contract by writing a config to disk, healing an in-memory copy, and asserting the on-disk file is unchanged.

## What this still does not fix

The `abort()`-during-`exit()` path itself. If a user manages to get into another stuck state (network device picker, racing hotkeys, etc.) and presses Cmd-Q before the recording flow returns, the same destructor abort can in principle trigger. That requires a debug-symbol repro to find. With this fix the dominant trigger (missing-device preflight failure) is gone, so the abort path's surface area drops to near zero in practice.

## CLI is intentionally not touched

The CLI surfaces `audio device 'X' not found` as a clean error, which is the right contract for scripts and pipelines. The desktop's silent fallback is appropriate because the desktop has notification surfaces and continues to be useful; CLI failure should be loud.

## Verified locally (macOS arm64)

- `cargo fmt --all -- --check`
- `cargo clippy --all --no-default-features -- -D warnings`
- `cargo test -p minutes-core --no-default-features --lib` -> 521 pass, 1 ignored (pre-existing `list_input_devices_returns_vec_of_strings`), 0 failed
- `auto_heal_in_memory_does_not_persist` is the new regression guard for #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)