### PR TITLE
refactor(schema): add capture health frontmatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1475,12 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2604,6 +2621,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,6 +3206,7 @@ dependencies = [
  "dirs 6.0.0",
  "fs2",
  "hound",
+ "insta",
  "libc",
  "ndarray",
  "nnnoiseless",
@@ -5456,6 +5487,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -71,6 +71,7 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage
 [dev-dependencies]
 hound = { workspace = true }
 dirs = { workspace = true }
+insta = { version = "1", features = ["json"] }
 
 [[test]]
 name = "integration"

--- a/crates/core/src/daily_notes.rs
+++ b/crates/core/src/daily_notes.rs
@@ -299,6 +299,7 @@ mod tests {
             recorded_by: None,
             visibility: None,
             speaker_map: vec![],
+            recording_health: None,
             template: None,
             filter_diagnosis: None,
         };

--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -28,6 +28,12 @@ pub struct SpeakerSegment {
 pub struct DiarizationResult {
     pub segments: Vec<SpeakerSegment>,
     pub num_speakers: usize,
+    /// Fraction of active stem-energy windows where the system stem dominated.
+    pub system_dominant_ratio: f32,
+    /// Fraction of active stem-energy windows where the voice stem dominated.
+    pub voice_dominant_ratio: f32,
+    /// Structured capture degradation evidence, populated by later recovery PRs.
+    pub degraded_capture: Option<DegradedCapture>,
     /// Whether transcript attribution should use the wider stem-timing tolerance.
     pub from_stems: bool,
     /// Whether the result came from source-aware capture and still has a stable
@@ -36,6 +42,56 @@ pub struct DiarizationResult {
     /// Per-speaker averaged embeddings (for Level 3 confirmed learning).
     /// Empty when using the Python subprocess engine.
     pub speaker_embeddings: std::collections::HashMap<String, Vec<f32>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DegradedCapture {
+    pub failure_kind: FailureKind,
+    pub capture_backend: String,
+    pub capture_source: CaptureSource,
+    pub voice_active_ratio: Option<f32>,
+    pub system_active_ratio: Option<f32>,
+    pub observed_signal: ObservedSignal,
+    pub diagnostic_confidence: DiagnosticConfidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum FailureKind {
+    Silent,
+    Sparse,
+    Missing,
+    BackendUnavailable,
+    StreamError,
+    SourceStarved,
+    UnsupportedFormat,
+    MisconfiguredRoute,
+    PermissionDenied,
+    RouteUnavailable,
+    Other { code: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum CaptureSource {
+    Voice,
+    System,
+    Both,
+    Backend,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ObservedSignal {
+    pub frames_captured: usize,
+    pub max_rms: f32,
+    pub avg_rms: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticConfidence {
+    High,
+    Inferred,
 }
 
 type EnergyWindow = (f64, f32);
@@ -60,6 +116,10 @@ pub enum AttributionSource {
     Llm,
     Enrollment,
     Manual,
+    #[serde(rename = "ml-bleed-degraded")]
+    MlBleedDegraded,
+    #[serde(rename = "stem-recovery")]
+    StemRecovery,
 }
 
 /// A mapping from an anonymous speaker label to a real person.
@@ -438,6 +498,44 @@ fn maybe_relabel_single_call_speaker_to_voice(
     }
 }
 
+fn stem_dominant_ratios(
+    voice_values: &[f32],
+    system_values: &[f32],
+    silence_threshold: f32,
+) -> (f32, f32) {
+    let mut active = 0usize;
+    let mut voice_dominant = 0usize;
+    let mut system_dominant = 0usize;
+
+    for (voice_rms, system_rms) in voice_values.iter().zip(system_values.iter()) {
+        let voice_active = *voice_rms > silence_threshold;
+        let system_active = *system_rms > silence_threshold;
+        if !voice_active && !system_active {
+            continue;
+        }
+
+        active += 1;
+        if voice_active && !system_active {
+            voice_dominant += 1;
+        } else if system_active && !voice_active {
+            system_dominant += 1;
+        } else if voice_rms >= system_rms {
+            voice_dominant += 1;
+        } else {
+            system_dominant += 1;
+        }
+    }
+
+    if active == 0 {
+        return (0.0, 0.0);
+    }
+
+    (
+        system_dominant as f32 / active as f32,
+        voice_dominant as f32 / active as f32,
+    )
+}
+
 fn diarization_from_energy_windows(
     voice_energy: &[(f64, f32)],
     system_energy: &[(f64, f32)],
@@ -469,6 +567,8 @@ fn diarization_from_energy_windows(
             **voice_rms > silence_threshold || **system_rms > silence_threshold
         })
         .count();
+    let (system_dominant_ratio, voice_dominant_ratio) =
+        stem_dominant_ratios(&voice_values, &system_values, silence_threshold);
     let correlation = correlation_coefficient(&voice_values, &system_values);
 
     // When both stems move together for most windows, we're likely seeing the
@@ -501,6 +601,9 @@ fn diarization_from_energy_windows(
         return Some(DiarizationResult {
             segments,
             num_speakers: 1,
+            system_dominant_ratio,
+            voice_dominant_ratio,
+            degraded_capture: None,
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -561,6 +664,9 @@ fn diarization_from_energy_windows(
         Some(DiarizationResult {
             segments,
             num_speakers,
+            system_dominant_ratio,
+            voice_dominant_ratio,
+            degraded_capture: None,
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -730,6 +836,9 @@ fn remap_diarization_labels(
     DiarizationResult {
         segments,
         num_speakers: label_map.len(),
+        system_dominant_ratio: result.system_dominant_ratio,
+        voice_dominant_ratio: result.voice_dominant_ratio,
+        degraded_capture: result.degraded_capture.clone(),
         from_stems: result.from_stems,
         source_aware: result.source_aware,
         speaker_embeddings,
@@ -804,6 +913,9 @@ fn merge_remote_diarization_into_stem_result(
     DiarizationResult {
         num_speakers: present_labels.len(),
         segments: merged,
+        system_dominant_ratio: stem_result.system_dominant_ratio,
+        voice_dominant_ratio: stem_result.voice_dominant_ratio,
+        degraded_capture: stem_result.degraded_capture.clone(),
         from_stems: false,
         source_aware: true,
         speaker_embeddings,
@@ -1517,6 +1629,9 @@ fn diarize_with_pyannote_rs(
     Ok(DiarizationResult {
         segments,
         num_speakers,
+        system_dominant_ratio: 0.0,
+        voice_dominant_ratio: 0.0,
+        degraded_capture: None,
         from_stems: false,
         source_aware: false,
         speaker_embeddings,
@@ -1841,6 +1956,9 @@ except Exception as e:
     Ok(DiarizationResult {
         segments,
         num_speakers,
+        system_dominant_ratio: 0.0,
+        voice_dominant_ratio: 0.0,
+        degraded_capture: None,
         from_stems: false,
         source_aware: false,
         speaker_embeddings: std::collections::HashMap::new(), // Python path can't extract embeddings
@@ -1989,6 +2107,9 @@ mod tests {
                 },
             ],
             num_speakers: 2,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2018,6 +2139,9 @@ mod tests {
                 },
             ],
             num_speakers: 2,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2050,6 +2174,9 @@ mod tests {
                 },
             ],
             num_speakers: 2,
+            system_dominant_ratio: 0.75,
+            voice_dominant_ratio: 0.25,
+            degraded_capture: None,
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2181,6 +2308,9 @@ mod tests {
                 },
             ],
             num_speakers: 2,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::from([
@@ -2224,6 +2354,9 @@ mod tests {
                 },
             ],
             num_speakers: 2,
+            system_dominant_ratio: 0.3,
+            voice_dominant_ratio: 0.7,
+            degraded_capture: None,
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2252,6 +2385,9 @@ mod tests {
                 },
             ],
             num_speakers: 2,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::from([
@@ -2308,6 +2444,9 @@ mod tests {
                 },
             ],
             num_speakers: 3,
+            system_dominant_ratio: 0.7,
+            voice_dominant_ratio: 0.3,
+            degraded_capture: None,
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2319,6 +2458,9 @@ mod tests {
                 end: 2.2,
             }],
             num_speakers: 1,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2342,6 +2484,9 @@ mod tests {
                 },
             ],
             num_speakers: 3,
+            system_dominant_ratio: 0.7,
+            voice_dominant_ratio: 0.3,
+            degraded_capture: None,
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2368,6 +2513,9 @@ mod tests {
                 },
             ],
             num_speakers: 2,
+            system_dominant_ratio: 0.6,
+            voice_dominant_ratio: 0.4,
+            degraded_capture: None,
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
@@ -2379,6 +2527,9 @@ mod tests {
                 end: 5.0,
             }],
             num_speakers: 1,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::from([(
@@ -2470,12 +2621,16 @@ mod tests {
             speaker_label: "SPEAKER_2".into(),
             name: "Sarah".into(),
             confidence: Confidence::High,
-            source: AttributionSource::Manual,
+            source: AttributionSource::MlBleedDegraded,
         };
         let yaml = serde_yaml::to_string(&attr).unwrap();
+        assert!(yaml.contains("ml-bleed-degraded"));
         let parsed: SpeakerAttribution = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed.confidence, Confidence::High);
-        assert_eq!(parsed.source, AttributionSource::Manual);
+        assert_eq!(parsed.source, AttributionSource::MlBleedDegraded);
+
+        let recovered: AttributionSource = serde_yaml::from_str("stem-recovery").unwrap();
+        assert_eq!(recovered, AttributionSource::StemRecovery);
     }
 
     #[test]
@@ -2541,6 +2696,9 @@ mod tests {
                 end: 1.0,
             }],
             num_speakers: 1,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -1120,6 +1120,7 @@ fn write_dictation_file(text: &str, duration_secs: f64, config: &Config) -> Opti
         recorded_by: config.identity.name.clone(),
         visibility: None,
         speaker_map: vec![],
+        recording_health: None,
         template: None,
         filter_diagnosis: None,
     };

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -1054,6 +1054,7 @@ mod tests {
                 recorded_by: None,
                 visibility: None,
                 speaker_map: vec![],
+                recording_health: None,
                 template: None,
                 filter_diagnosis: Some("silence strip removed ALL audio".into()),
             },

--- a/crates/core/src/knowledge_extract.rs
+++ b/crates/core/src/knowledge_extract.rs
@@ -233,6 +233,7 @@ mod tests {
             recorded_by: None,
             visibility: None,
             speaker_map: vec![],
+            recording_health: None,
             template: None,
             filter_diagnosis: None,
         }

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -32,6 +32,37 @@ pub enum OutputStatus {
     TranscriptOnly,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordingHealth {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice_stem_active_ratio: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_stem_active_ratio: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_dominant_ratio: Option<f32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capture_warnings: Vec<CaptureWarning>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diarization_path: Option<DiarizationPath>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiarizationPath {
+    StemEnergy,
+    Ml,
+    MlBleedDegraded,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct CaptureWarning {
+    pub kind: crate::diarize::FailureKind,
+    pub source: crate::diarize::CaptureSource,
+    pub message: String,
+    pub diagnostic_confidence: crate::diarize::DiagnosticConfidence,
+}
+
 /// Frontmatter for a meeting/memo markdown file.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Frontmatter {
@@ -73,6 +104,8 @@ pub struct Frontmatter {
     pub visibility: Option<Visibility>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub speaker_map: Vec<crate::diarize::SpeakerAttribution>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recording_health: Option<RecordingHealth>,
     /// Slug of the template applied to this recording, if any.
     /// Recorded so a Phase 2 reprocessor knows which template produced the
     /// summary. `None` means no template was passed (legacy / default flow).
@@ -793,6 +826,7 @@ mod tests {
             recorded_by: None,
             visibility: None,
             speaker_map: vec![],
+            recording_health: None,
             template: None,
             filter_diagnosis: None,
         }
@@ -859,10 +893,7 @@ mod tests {
     #[test]
     fn json_schema_generates_valid_schema() {
         let schema = schemars::schema_for!(Frontmatter);
-        let json = serde_json::to_string_pretty(&schema).unwrap();
-        assert!(json.contains("Frontmatter"));
-        assert!(json.contains("recorded_by"));
-        assert!(json.contains("visibility"));
+        insta::assert_json_snapshot!(schema);
     }
 
     #[test]
@@ -891,6 +922,56 @@ mod tests {
             content.contains("deterministic"),
             "source should be lowercase"
         );
+    }
+
+    #[test]
+    fn recording_health_absent_roundtrips_as_omitted() {
+        let input = "---\ntitle: Test Meeting\ntype: meeting\ndate: 2026-03-17T12:00:00-07:00\nduration: 5m\nstatus: complete\n---\n\n## Transcript\n\nHello.\n";
+        let (fm, body) = split_frontmatter(input);
+        let frontmatter: Frontmatter = serde_yaml::from_str(fm).unwrap();
+        assert!(frontmatter.recording_health.is_none());
+
+        let yaml = serde_yaml::to_string(&frontmatter).unwrap();
+        let output = format!("---\n{}---\n{}", yaml, body);
+
+        assert!(!yaml.contains("recording_health"));
+        assert_eq!(split_frontmatter(&output).1.as_bytes(), body.as_bytes());
+    }
+
+    #[test]
+    fn recording_health_populated_roundtrips_structurally() {
+        let input = "---\ntitle: Test Meeting\ntype: meeting\ndate: 2026-03-17T12:00:00-07:00\nduration: 5m\nrecording_health:\n  voice_stem_active_ratio: 0.31\n  system_stem_active_ratio: 0.0\n  system_dominant_ratio: 0.12\n  capture_warnings:\n    - kind: silent\n      source: system\n      message: System audio was silent during capture.\n      diagnostic_confidence: inferred\n  diarization_path: ml-bleed-degraded\n---\n\n## Transcript\n\nHello.\n";
+        let (fm, body) = split_frontmatter(input);
+        let frontmatter: Frontmatter = serde_yaml::from_str(fm).unwrap();
+        let health = frontmatter.recording_health.as_ref().unwrap();
+
+        assert_eq!(health.voice_stem_active_ratio, Some(0.31));
+        assert_eq!(health.system_stem_active_ratio, Some(0.0));
+        assert_eq!(health.system_dominant_ratio, Some(0.12));
+        assert_eq!(
+            health.diarization_path,
+            Some(DiarizationPath::MlBleedDegraded)
+        );
+        assert_eq!(health.capture_warnings.len(), 1);
+        assert_eq!(
+            health.capture_warnings[0].kind,
+            crate::diarize::FailureKind::Silent
+        );
+        assert_eq!(
+            health.capture_warnings[0].source,
+            crate::diarize::CaptureSource::System
+        );
+        assert_eq!(
+            health.capture_warnings[0].diagnostic_confidence,
+            crate::diarize::DiagnosticConfidence::Inferred
+        );
+
+        let yaml = serde_yaml::to_string(&frontmatter).unwrap();
+        let output = format!("---\n{}---\n{}", yaml, body);
+        let reparsed: Frontmatter = serde_yaml::from_str(split_frontmatter(&output).0).unwrap();
+
+        assert_eq!(reparsed.recording_health, frontmatter.recording_health);
+        assert_eq!(split_frontmatter(&output).1.as_bytes(), body.as_bytes());
     }
 
     #[test]

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -208,6 +208,8 @@ fn attribution_source_label(source: diarize::AttributionSource) -> String {
         diarize::AttributionSource::Llm => "llm".into(),
         diarize::AttributionSource::Enrollment => "enrollment".into(),
         diarize::AttributionSource::Manual => "manual".into(),
+        diarize::AttributionSource::MlBleedDegraded => "ml-bleed-degraded".into(),
+        diarize::AttributionSource::StemRecovery => "stem-recovery".into(),
     }
 }
 
@@ -1005,6 +1007,7 @@ pub fn write_transcript_artifact(
         recorded_by: config.identity.name.clone(),
         visibility: None,
         speaker_map: vec![],
+        recording_health: None,
         template: context.template.as_ref().map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
             Some(filter_stats.diagnosis())
@@ -1815,6 +1818,7 @@ where
         recorded_by: config.identity.name.clone(),
         visibility: None,
         speaker_map,
+        recording_health: None,
         template: template.map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
             Some(filter_stats.diagnosis())
@@ -2276,10 +2280,10 @@ fn title_from_transcript(transcript: &str) -> Option<String> {
     if !alpha_chars.is_empty() {
         let latin_count = alpha_chars
             .iter()
-            .filter(|c| {
+            .filter(|&&c| {
                 c.is_ascii_alphabetic()
-                    || ('\u{00C0}'..='\u{024F}').contains(c) // Latin-1 Supplement + Extended-A/B
-                    || ('\u{1E00}'..='\u{1EFF}').contains(c) // Latin Extended Additional
+                    || ('\u{00C0}'..='\u{024F}').contains(&c) // Latin-1 Supplement + Extended-A/B
+                    || ('\u{1E00}'..='\u{1EFF}').contains(&c) // Latin Extended Additional
             })
             .count();
         let latin_ratio = latin_count as f64 / alpha_chars.len() as f64;
@@ -3809,6 +3813,7 @@ mod tests {
             recorded_by: Some("Mat".into()),
             visibility: None,
             speaker_map: vec![],
+            recording_health: None,
             template: None,
             filter_diagnosis: None,
         };
@@ -5139,6 +5144,7 @@ mod tests {
                 confidence: diarize::Confidence::Medium,
                 source: diarize::AttributionSource::Llm,
             }],
+            recording_health: None,
             template: None,
             filter_diagnosis: None,
         };

--- a/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
+++ b/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
@@ -1,0 +1,491 @@
+---
+source: crates/core/src/markdown.rs
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Frontmatter",
+  "description": "Frontmatter for a meeting/memo markdown file.",
+  "type": "object",
+  "properties": {
+    "action_items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ActionItem"
+      }
+    },
+    "attendees": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "attendees_raw": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "calendar_event": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "captured_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "context": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "decisions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Decision"
+      }
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "duration": {
+      "type": "string"
+    },
+    "entities": {
+      "$ref": "#/$defs/EntityLinks"
+    },
+    "intents": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Intent"
+      }
+    },
+    "people": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "recorded_by": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "recording_health": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RecordingHealth"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "source": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "speaker_map": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/SpeakerAttribution"
+      }
+    },
+    "status": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OutputStatus"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "template": {
+      "description": "Slug of the template applied to this recording, if any.\nRecorded so a Phase 2 reprocessor knows which template produced the\nsummary. `None` means no template was passed (legacy / default flow).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "type": {
+      "$ref": "#/$defs/ContentType"
+    },
+    "visibility": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Visibility"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "title",
+    "type",
+    "date",
+    "duration"
+  ],
+  "$defs": {
+    "ActionItem": {
+      "description": "A structured action item extracted from a meeting.\nQueryable via MCP tools: filter by assignee, status, due date.",
+      "type": "object",
+      "properties": {
+        "assignee": {
+          "type": "string"
+        },
+        "due": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "assignee",
+        "task",
+        "status"
+      ]
+    },
+    "AttributionSource": {
+      "description": "How the attribution was determined.",
+      "type": "string",
+      "enum": [
+        "deterministic",
+        "llm",
+        "enrollment",
+        "manual",
+        "ml-bleed-degraded",
+        "stem-recovery"
+      ]
+    },
+    "CaptureSource": {
+      "type": "string",
+      "enum": [
+        "voice",
+        "system",
+        "both",
+        "backend"
+      ]
+    },
+    "CaptureWarning": {
+      "type": "object",
+      "properties": {
+        "diagnostic_confidence": {
+          "$ref": "#/$defs/DiagnosticConfidence"
+        },
+        "kind": {
+          "$ref": "#/$defs/FailureKind"
+        },
+        "message": {
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/CaptureSource"
+        }
+      },
+      "required": [
+        "kind",
+        "source",
+        "message",
+        "diagnostic_confidence"
+      ]
+    },
+    "Confidence": {
+      "description": "How confident we are that a speaker label maps to a real person.",
+      "type": "string",
+      "enum": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "ContentType": {
+      "description": "Content types for output files.",
+      "type": "string",
+      "enum": [
+        "meeting",
+        "memo",
+        "dictation"
+      ]
+    },
+    "Decision": {
+      "description": "A structured decision extracted from a meeting.\nQueryable via MCP tools: search across all meetings for decision history.\n\nFrontmatter v2 fields (optional, backward compatible):\n- `authority`: \"high\" | \"medium\" | \"low\" — the decision's weight. A CEO\n  commitment is high; a drive-by aside is low. Consumers can use this to\n  rank conflicting decisions or surface the authoritative one.\n- `supersedes`: free-text reference to the earlier decision this one\n  replaces. When set, the consistency report treats the topic conflict as\n  a documented supersession rather than an unresolved contradiction.",
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "supersedes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "text": {
+          "type": "string"
+        },
+        "topic": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "text"
+      ]
+    },
+    "DiagnosticConfidence": {
+      "type": "string",
+      "enum": [
+        "high",
+        "inferred"
+      ]
+    },
+    "DiarizationPath": {
+      "type": "string",
+      "enum": [
+        "stem-energy",
+        "ml",
+        "ml-bleed-degraded",
+        "none"
+      ]
+    },
+    "EntityLinks": {
+      "type": "object",
+      "properties": {
+        "people": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EntityRef"
+          }
+        },
+        "projects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EntityRef"
+          }
+        }
+      }
+    },
+    "EntityRef": {
+      "type": "object",
+      "properties": {
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "label": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "slug",
+        "label"
+      ]
+    },
+    "FailureKind": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "silent",
+            "sparse",
+            "missing",
+            "backend-unavailable",
+            "stream-error",
+            "source-starved",
+            "unsupported-format",
+            "misconfigured-route",
+            "permission-denied",
+            "route-unavailable"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "other": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "code"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "other"
+          ]
+        }
+      ]
+    },
+    "Intent": {
+      "type": "object",
+      "properties": {
+        "by_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "$ref": "#/$defs/IntentKind"
+        },
+        "status": {
+          "type": "string"
+        },
+        "what": {
+          "type": "string"
+        },
+        "who": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "kind",
+        "what",
+        "status"
+      ]
+    },
+    "IntentKind": {
+      "type": "string",
+      "enum": [
+        "action-item",
+        "decision",
+        "open-question",
+        "commitment"
+      ]
+    },
+    "OutputStatus": {
+      "description": "Output status markers.",
+      "type": "string",
+      "enum": [
+        "complete",
+        "no-speech",
+        "transcript-only"
+      ]
+    },
+    "RecordingHealth": {
+      "type": "object",
+      "properties": {
+        "capture_warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CaptureWarning"
+          }
+        },
+        "diarization_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DiarizationPath"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "system_dominant_ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        },
+        "system_stem_active_ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        },
+        "voice_stem_active_ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        }
+      }
+    },
+    "SpeakerAttribution": {
+      "description": "A mapping from an anonymous speaker label to a real person.",
+      "type": "object",
+      "properties": {
+        "confidence": {
+          "$ref": "#/$defs/Confidence"
+        },
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/AttributionSource"
+        },
+        "speaker_label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "speaker_label",
+        "name",
+        "confidence",
+        "source"
+      ]
+    },
+    "Visibility": {
+      "type": "string",
+      "enum": [
+        "private",
+        "team"
+      ]
+    }
+  }
+}

--- a/crates/mcp/src/index.test.ts
+++ b/crates/mcp/src/index.test.ts
@@ -10,6 +10,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildLiveEventsResourcePayload,
   LIVE_EVENTS_RESOURCE_URI,
+  meetingDetailPayload,
+  meetingListItem,
+  meetingSearchItem,
   MEETING_INSIGHT_KINDS,
   parseKnowledgeConfig,
   parseLiveEventsResourceUri,
@@ -20,6 +23,62 @@ import {
 describe("meeting insight contract", () => {
   it("exports only the insight kinds the pipeline emits today", () => {
     expect(MEETING_INSIGHT_KINDS).toEqual(["decision", "commitment", "question"]);
+  });
+});
+
+describe("meeting shape contract", () => {
+  const meeting = {
+    path: "/tmp/meeting.md",
+    frontmatter: {
+      date: "2026-05-05T10:00:00-07:00",
+      title: "Capture Health Review",
+      type: "meeting",
+      duration: "12m",
+      recording_health: {
+        capture_warnings: [
+          {
+            kind: "silent",
+            source: "system",
+            message: "System audio was silent.",
+            diagnostic_confidence: "inferred",
+          },
+        ],
+        diarization_path: "ml-bleed-degraded",
+      },
+    },
+  };
+
+  it("omits recording_health from list and search results", () => {
+    expect(meetingListItem(meeting)).toEqual({
+      date: "2026-05-05T10:00:00-07:00",
+      title: "Capture Health Review",
+      content_type: "meeting",
+      path: "/tmp/meeting.md",
+      duration: "12m",
+    });
+    expect(meetingSearchItem(meeting)).toEqual({
+      date: "2026-05-05T10:00:00-07:00",
+      title: "Capture Health Review",
+      content_type: "meeting",
+      path: "/tmp/meeting.md",
+    });
+  });
+
+  it("surfaces recording_health in detail payloads", () => {
+    expect(
+      meetingDetailPayload({
+        path: meeting.path,
+        speaker_map: [],
+        recording_health: meeting.frontmatter.recording_health,
+        overlay_applied: false,
+      })
+    ).toEqual({
+      path: "/tmp/meeting.md",
+      view: "detail",
+      speaker_map: [],
+      recording_health: meeting.frontmatter.recording_health,
+      overlay_applied: false,
+    });
   });
 });
 

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -165,6 +165,66 @@ export type KnowledgeConfigStatus = {
   engine: string;
 };
 
+type MeetingLike = {
+  path: string;
+  frontmatter: {
+    date?: string;
+    title?: string;
+    type?: string;
+    duration?: string;
+    recording_health?: unknown;
+  };
+};
+
+export function meetingListItem(meeting: MeetingLike) {
+  return {
+    date: meeting.frontmatter.date,
+    title: meeting.frontmatter.title,
+    content_type: meeting.frontmatter.type,
+    path: meeting.path,
+    duration: meeting.frontmatter.duration,
+  };
+}
+
+export function meetingSearchItem(meeting: MeetingLike) {
+  return {
+    date: meeting.frontmatter.date,
+    title: meeting.frontmatter.title,
+    content_type: meeting.frontmatter.type,
+    path: meeting.path,
+  };
+}
+
+export function meetingDetailPayload(input: {
+  path: string;
+  speaker_map?: unknown;
+  recording_health?: unknown;
+  overlay_applied?: boolean;
+}) {
+  const payload: {
+    path: string;
+    view: "detail";
+    speaker_map?: unknown;
+    recording_health?: unknown;
+    overlay_applied?: boolean;
+  } = {
+    path: input.path,
+    view: "detail",
+  };
+
+  if (input.speaker_map !== undefined) {
+    payload.speaker_map = input.speaker_map;
+  }
+  if (input.recording_health !== undefined) {
+    payload.recording_health = input.recording_health;
+  }
+  if (input.overlay_applied !== undefined) {
+    payload.overlay_applied = input.overlay_applied;
+  }
+
+  return payload;
+}
+
 function toolDocsUrl(name: string): string {
   return `${MCP_TOOLS_DOCS_BASE_URL}#tool-${name}`;
 }
@@ -1596,13 +1656,7 @@ registerDocsAppTool(
         .map((m) => `${m.frontmatter.date} — ${m.frontmatter.title} [${m.frontmatter.type}]\n  ${m.path}`)
         .join("\n\n");
 
-      const meetingsJson = filtered.map((m) => ({
-        date: m.frontmatter.date,
-        title: m.frontmatter.title,
-        content_type: m.frontmatter.type,
-        path: m.path,
-        duration: m.frontmatter.duration,
-      }));
+      const meetingsJson = filtered.map(meetingListItem);
 
       return {
         content: [{ type: "text" as const, text }],
@@ -1701,12 +1755,7 @@ registerDocsAppTool(
       return {
         content: [{ type: "text" as const, text }],
         structuredContent: {
-          results: filtered.map((m) => ({
-            date: m.frontmatter.date,
-            title: m.frontmatter.title,
-            content_type: m.frontmatter.type,
-            path: m.path,
-          })),
+          results: filtered.map(meetingSearchItem),
           view: "search",
         },
         _meta: { ui: { resourceUri: UI_RESOURCE_URI }, view: "search" },
@@ -2233,12 +2282,11 @@ registerDocsAppTool(
       // disk is never mutated — the CLI just layers ~/.minutes/overlays.db on
       // top of the parsed frontmatter. If the CLI is unavailable or the call
       // fails, degrade gracefully to raw content.
-      let structured: {
-        path: string;
-        view: string;
-        speaker_map?: unknown;
-        overlay_applied?: boolean;
-      } = { path: resolved, view: "detail" };
+      const rawParsed = reader.parseFrontmatter(rawContent, resolved);
+      let structured = meetingDetailPayload({
+        path: resolved,
+        recording_health: (rawParsed?.frontmatter as any)?.recording_health,
+      });
 
       if (await isCliAvailable()) {
         try {
@@ -2246,12 +2294,12 @@ registerDocsAppTool(
           const parsed = parseJsonOutput(stdout);
           if (parsed && typeof parsed === "object" && !parsed.raw) {
             const speakerMap = parsed.frontmatter?.speaker_map;
-            structured = {
+            structured = meetingDetailPayload({
               path: resolved,
-              view: "detail",
               speaker_map: Array.isArray(speakerMap) ? speakerMap : [],
+              recording_health: parsed.frontmatter?.recording_health,
               overlay_applied: Boolean(parsed.overlay_applied),
-            };
+            });
           }
         } catch {
           // Non-fatal: fall through to raw content with no speaker_map enrichment.
@@ -2611,10 +2659,7 @@ server.resource(
   async () => {
     if (!(await isCliAvailable())) {
       const meetings = await reader.listMeetings(MEETINGS_DIR, 20);
-      const json = JSON.stringify(meetings.map((m) => ({
-        date: m.frontmatter.date, title: m.frontmatter.title,
-        content_type: m.frontmatter.type, path: m.path, duration: m.frontmatter.duration,
-      })));
+      const json = JSON.stringify(meetings.map(meetingListItem));
       return { contents: [{ uri: "minutes://meetings/recent", mimeType: "application/json", text: json }] };
     }
     const { stdout } = await runMinutes(["list", "--limit", "20"]);

--- a/crates/reader/src/parse.rs
+++ b/crates/reader/src/parse.rs
@@ -76,4 +76,50 @@ mod tests {
         assert_eq!(meeting.frontmatter.title, "Test Meeting");
         assert!(meeting.body.contains("Hello world"));
     }
+
+    #[test]
+    fn parse_meeting_preserves_recording_health() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("health.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: Test Meeting\ntype: meeting\ndate: 2026-03-17T12:00:00-07:00\nduration: 5m\nrecording_health:\n  voice_stem_active_ratio: 0.42\n  system_stem_active_ratio: 0.01\n  system_dominant_ratio: 0.2\n  capture_warnings:\n    - kind: source-starved\n      source: system\n      message: System source did not deliver frames.\n      diagnostic_confidence: inferred\n  diarization_path: stem-energy\n---\n\n## Transcript\n\nHello world.\n",
+        )
+        .unwrap();
+
+        let meeting = parse_meeting(&path).unwrap();
+        let health = meeting.frontmatter.recording_health.unwrap();
+
+        assert_eq!(health.voice_stem_active_ratio, Some(0.42));
+        assert_eq!(health.system_stem_active_ratio, Some(0.01));
+        assert_eq!(health.system_dominant_ratio, Some(0.2));
+        assert_eq!(
+            health.diarization_path,
+            Some(crate::types::DiarizationPath::StemEnergy)
+        );
+        assert_eq!(
+            health.capture_warnings[0].kind,
+            crate::types::FailureKind::SourceStarved
+        );
+        assert_eq!(
+            health.capture_warnings[0].source,
+            crate::types::CaptureSource::System
+        );
+        assert_eq!(
+            health.capture_warnings[0].diagnostic_confidence,
+            crate::types::DiagnosticConfidence::Inferred
+        );
+    }
+
+    #[test]
+    fn attribution_source_parses_new_variants() {
+        assert_eq!(
+            serde_yaml::from_str::<crate::types::AttributionSource>("ml-bleed-degraded").unwrap(),
+            crate::types::AttributionSource::MlBleedDegraded
+        );
+        assert_eq!(
+            serde_yaml::from_str::<crate::types::AttributionSource>("stem-recovery").unwrap(),
+            crate::types::AttributionSource::StemRecovery
+        );
+    }
 }

--- a/crates/reader/src/types.rs
+++ b/crates/reader/src/types.rs
@@ -59,6 +59,71 @@ pub struct Frontmatter {
     pub visibility: Option<Visibility>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub speaker_map: Vec<SpeakerAttribution>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recording_health: Option<RecordingHealth>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct RecordingHealth {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice_stem_active_ratio: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_stem_active_ratio: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_dominant_ratio: Option<f32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capture_warnings: Vec<CaptureWarning>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diarization_path: Option<DiarizationPath>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiarizationPath {
+    StemEnergy,
+    Ml,
+    MlBleedDegraded,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct CaptureWarning {
+    pub kind: FailureKind,
+    pub source: CaptureSource,
+    pub message: String,
+    pub diagnostic_confidence: DiagnosticConfidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum FailureKind {
+    Silent,
+    Sparse,
+    Missing,
+    BackendUnavailable,
+    StreamError,
+    SourceStarved,
+    UnsupportedFormat,
+    MisconfiguredRoute,
+    PermissionDenied,
+    RouteUnavailable,
+    Other { code: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum CaptureSource {
+    Voice,
+    System,
+    Both,
+    Backend,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticConfidence {
+    High,
+    Inferred,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -76,6 +141,10 @@ pub enum AttributionSource {
     Llm,
     Enrollment,
     Manual,
+    #[serde(rename = "ml-bleed-degraded")]
+    MlBleedDegraded,
+    #[serde(rename = "stem-recovery")]
+    StemRecovery,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/sdk/src/index.ts
+++ b/crates/sdk/src/index.ts
@@ -18,6 +18,13 @@ export {
   type MeetingFile,
   type SpeakerAttribution,
   type SpeakerConfirmation,
+  type AttributionSource,
+  type CaptureSource,
+  type CaptureWarning,
+  type DiagnosticConfidence,
+  type DiarizationPath,
+  type FailureKind,
+  type RecordingHealth,
 
   // Config
   defaultDir,
@@ -25,6 +32,7 @@ export {
   // Parsing
   splitFrontmatter,
   parseFrontmatter,
+  parseAttributionSource,
 
   // Query API
   listMeetings,

--- a/crates/sdk/src/reader.test.ts
+++ b/crates/sdk/src/reader.test.ts
@@ -425,19 +425,20 @@ SPEAKER_0: hello
     expect(result?.frontmatter.speaker_map).toBeUndefined();
   });
 
-  it("falls back to safe defaults for unknown confidence and rejects unknown sources", () => {
+  it("falls back to safe defaults for unknown confidence/source values", () => {
     const sketchy = MEETING_WITH_SPEAKERS.replace(
       /confidence: medium/,
       "confidence: bogus"
     ).replace(/source: llm/, "source: aliens");
     const result = parseFrontmatter(sketchy, "/t/m.md");
-    expect(result).toBeNull();
+    expect(result?.frontmatter.speaker_map?.[0].confidence).toBe("medium");
+    expect(result?.frontmatter.speaker_map?.[0].source).toBe("llm");
   });
 
   it("parses new attribution sources explicitly", () => {
     expect(parseAttributionSource("ml-bleed-degraded")).toBe("ml-bleed-degraded");
     expect(parseAttributionSource("stem-recovery")).toBe("stem-recovery");
-    expect(() => parseAttributionSource("aliens")).toThrow(/unknown speaker attribution source/);
+    expect(parseAttributionSource("aliens")).toBe("llm");
   });
 
   it("preserves recording_health enum fields", () => {

--- a/crates/sdk/src/reader.test.ts
+++ b/crates/sdk/src/reader.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os";
 import {
   splitFrontmatter,
   parseFrontmatter,
+  parseAttributionSource,
   listMeetings,
   searchMeetings,
   getMeeting,
@@ -424,14 +425,52 @@ SPEAKER_0: hello
     expect(result?.frontmatter.speaker_map).toBeUndefined();
   });
 
-  it("falls back to safe defaults for unknown confidence/source values", () => {
+  it("falls back to safe defaults for unknown confidence and rejects unknown sources", () => {
     const sketchy = MEETING_WITH_SPEAKERS.replace(
       /confidence: medium/,
       "confidence: bogus"
     ).replace(/source: llm/, "source: aliens");
     const result = parseFrontmatter(sketchy, "/t/m.md");
-    expect(result?.frontmatter.speaker_map?.[0].confidence).toBe("medium");
-    expect(result?.frontmatter.speaker_map?.[0].source).toBe("llm");
+    expect(result).toBeNull();
+  });
+
+  it("parses new attribution sources explicitly", () => {
+    expect(parseAttributionSource("ml-bleed-degraded")).toBe("ml-bleed-degraded");
+    expect(parseAttributionSource("stem-recovery")).toBe("stem-recovery");
+    expect(() => parseAttributionSource("aliens")).toThrow(/unknown speaker attribution source/);
+  });
+
+  it("preserves recording_health enum fields", () => {
+    const content = MEETING_WITH_SPEAKERS.replace(
+      "speaker_map:",
+      `recording_health:
+  voice_stem_active_ratio: 0.31
+  system_stem_active_ratio: 0
+  system_dominant_ratio: 0.12
+  capture_warnings:
+    - kind: silent
+      source: system
+      message: System audio was silent during capture.
+      diagnostic_confidence: inferred
+  diarization_path: ml-bleed-degraded
+speaker_map:`
+    );
+    const result = parseFrontmatter(content, "/t/m.md");
+
+    expect(result?.frontmatter.recording_health).toEqual({
+      voice_stem_active_ratio: 0.31,
+      system_stem_active_ratio: 0,
+      system_dominant_ratio: 0.12,
+      capture_warnings: [
+        {
+          kind: "silent",
+          source: "system",
+          message: "System audio was silent during capture.",
+          diagnostic_confidence: "inferred",
+        },
+      ],
+      diarization_path: "ml-bleed-degraded",
+    });
   });
 });
 

--- a/crates/sdk/src/reader.ts
+++ b/crates/sdk/src/reader.ts
@@ -160,7 +160,7 @@ export function parseAttributionSource(raw: string): AttributionSource {
     return raw;
   }
 
-  throw new Error(`unknown speaker attribution source: ${raw}`);
+  return "llm";
 }
 
 function parseDiagnosticConfidence(raw: unknown): DiagnosticConfidence {

--- a/crates/sdk/src/reader.ts
+++ b/crates/sdk/src/reader.ts
@@ -43,7 +43,46 @@ export interface SpeakerAttribution {
   speaker_label: string;
   name: string;
   confidence: "high" | "medium" | "low";
-  source: "deterministic" | "llm" | "enrollment" | "manual";
+  source: AttributionSource;
+}
+
+export type AttributionSource =
+  | "deterministic"
+  | "llm"
+  | "enrollment"
+  | "manual"
+  | "ml-bleed-degraded"
+  | "stem-recovery";
+
+export type DiagnosticConfidence = "high" | "inferred";
+export type CaptureSource = "voice" | "system" | "both" | "backend";
+export type DiarizationPath = "stem-energy" | "ml" | "ml-bleed-degraded" | "none";
+export type FailureKind =
+  | "silent"
+  | "sparse"
+  | "missing"
+  | "backend-unavailable"
+  | "stream-error"
+  | "source-starved"
+  | "unsupported-format"
+  | "misconfigured-route"
+  | "permission-denied"
+  | "route-unavailable"
+  | { other: { code: string } };
+
+export interface CaptureWarning {
+  kind: FailureKind;
+  source: CaptureSource;
+  message: string;
+  diagnostic_confidence: DiagnosticConfidence;
+}
+
+export interface RecordingHealth {
+  voice_stem_active_ratio?: number;
+  system_stem_active_ratio?: number;
+  system_dominant_ratio?: number;
+  capture_warnings: CaptureWarning[];
+  diarization_path?: DiarizationPath;
 }
 
 /**
@@ -80,6 +119,7 @@ export interface Frontmatter {
   decisions: Decision[];
   intents: Intent[];
   speaker_map?: SpeakerAttribution[];
+  recording_health?: RecordingHealth;
 }
 
 export interface MeetingFile {
@@ -106,6 +146,94 @@ function parseRawAttendees(raw?: string): string[] {
   }
 
   return attendees;
+}
+
+export function parseAttributionSource(raw: string): AttributionSource {
+  if (
+    raw === "deterministic" ||
+    raw === "llm" ||
+    raw === "enrollment" ||
+    raw === "manual" ||
+    raw === "ml-bleed-degraded" ||
+    raw === "stem-recovery"
+  ) {
+    return raw;
+  }
+
+  throw new Error(`unknown speaker attribution source: ${raw}`);
+}
+
+function parseDiagnosticConfidence(raw: unknown): DiagnosticConfidence {
+  if (raw === "high" || raw === "inferred") return raw;
+  throw new Error(`unknown diagnostic confidence: ${String(raw)}`);
+}
+
+function parseCaptureSource(raw: unknown): CaptureSource {
+  if (raw === "voice" || raw === "system" || raw === "both" || raw === "backend") {
+    return raw;
+  }
+  throw new Error(`unknown capture source: ${String(raw)}`);
+}
+
+function parseDiarizationPath(raw: unknown): DiarizationPath {
+  if (raw === "stem-energy" || raw === "ml" || raw === "ml-bleed-degraded" || raw === "none") {
+    return raw;
+  }
+  throw new Error(`unknown diarization path: ${String(raw)}`);
+}
+
+function parseFailureKind(raw: unknown): FailureKind {
+  if (
+    raw === "silent" ||
+    raw === "sparse" ||
+    raw === "missing" ||
+    raw === "backend-unavailable" ||
+    raw === "stream-error" ||
+    raw === "source-starved" ||
+    raw === "unsupported-format" ||
+    raw === "misconfigured-route" ||
+    raw === "permission-denied" ||
+    raw === "route-unavailable"
+  ) {
+    return raw;
+  }
+
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "other" in raw &&
+    (raw as any).other &&
+    typeof (raw as any).other === "object"
+  ) {
+    return { other: { code: String((raw as any).other.code || "") } };
+  }
+
+  throw new Error(`unknown capture failure kind: ${String(raw)}`);
+}
+
+function optionalNumber(raw: unknown): number | undefined {
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+}
+
+function parseRecordingHealth(raw: any): RecordingHealth | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  return {
+    voice_stem_active_ratio: optionalNumber(raw.voice_stem_active_ratio),
+    system_stem_active_ratio: optionalNumber(raw.system_stem_active_ratio),
+    system_dominant_ratio: optionalNumber(raw.system_dominant_ratio),
+    capture_warnings: Array.isArray(raw.capture_warnings)
+      ? raw.capture_warnings.map((warning: any) => ({
+          kind: parseFailureKind(warning?.kind),
+          source: parseCaptureSource(warning?.source),
+          message: String(warning?.message || ""),
+          diagnostic_confidence: parseDiagnosticConfidence(warning?.diagnostic_confidence),
+        }))
+      : [],
+    diarization_path: raw.diarization_path
+      ? parseDiarizationPath(raw.diarization_path)
+      : undefined,
+  };
 }
 
 // ── Parsing ──────────────────────────────────────────────────
@@ -198,14 +326,10 @@ export function parseFrontmatter(
               s.confidence === "low"
               ? s.confidence
               : "medium") as "high" | "medium" | "low",
-            source: (s.source === "deterministic" ||
-              s.source === "llm" ||
-              s.source === "enrollment" ||
-              s.source === "manual"
-              ? s.source
-              : "llm") as "deterministic" | "llm" | "enrollment" | "manual",
+            source: parseAttributionSource(String(s.source || "")),
           }))
         : undefined,
+      recording_health: parseRecordingHealth(parsed.recording_health),
     };
 
     return { frontmatter: fm, body, path: filePath };
@@ -509,12 +633,7 @@ export async function getMeetingWithOverlays(
             attr.confidence === "low"
             ? attr.confidence
             : "medium") as "high" | "medium" | "low",
-          source: (attr.source === "deterministic" ||
-            attr.source === "llm" ||
-            attr.source === "enrollment" ||
-            attr.source === "manual"
-            ? attr.source
-            : "llm") as "deterministic" | "llm" | "enrollment" | "manual",
+          source: parseAttributionSource(String(attr.source || "")),
         })),
       },
     };

--- a/docs/frontmatter-schema.md
+++ b/docs/frontmatter-schema.md
@@ -53,6 +53,7 @@ schema version bump. Additive fields do not.
 | `recorded_by` | string | User identity slug (matches `people[]` if the user is in the corpus). |
 | `visibility` | enum | `private` (default) or `team`. Informational; Minutes does not enforce ACLs. |
 | `calendar_event` | string | Calendar event id (Google Calendar, Outlook) when matched. |
+| `recording_health` | object | Optional capture/diarization diagnostics. See [Recording health](#recording-health) below. Omitted when no warnings or capture-health metadata are present. |
 
 ### Participants
 
@@ -177,7 +178,7 @@ Each entry has four fields:
 | `speaker_label` | string | ✓ | Diarizer-produced label, e.g. `SPEAKER_0`. |
 | `name` | string | ✓ | The real person this speaker is. Matches a slug in `people[]` when possible. |
 | `confidence` | enum | ✓ | `high` / `medium` / `low`. |
-| `source` | enum | ✓ | `deterministic` / `llm` / `enrollment` / `manual`. Tells consumers how the attribution was derived. |
+| `source` | enum | ✓ | `deterministic` / `llm` / `enrollment` / `manual` / `ml-bleed-degraded` / `stem-recovery`. Tells consumers how the attribution was derived. |
 
 Produced by Minutes' diarization + attribution pipeline. Four confidence
 levels (L0-L3):
@@ -190,11 +191,53 @@ levels (L0-L3):
   `~/.minutes/voices.db`. High when the match is strong.
 - **L3** (user-confirmed): the user explicitly confirmed this attribution.
   Highest trust once set.
+- **Degraded-capture recovery** (`ml-bleed-degraded`): ML diarization over a
+  voice stem after the primary system-audio stem was degraded. Confidence is
+  normally low until a user confirms the attribution.
+- **Stem recovery** (`stem-recovery`): post-hoc rewrite from a recovery flow
+  that revisits stem-derived speaker labels.
 
 High-confidence attributions can be used by renderers and graph projections as
 the speaker's real name. The raw transcript remains valid even when it keeps
 `SPEAKER_N` tokens; later user confirmations are layered through the overlay
 contract below instead of rewriting historical files.
+
+### Recording health
+
+`recording_health` records capture and diarization diagnostics that should be
+visible to tools reading meeting files. It is backend-agnostic: `cpal`,
+Core Audio Process Tap, or future capture backends can all report through the
+same shape. Minutes omits the field entirely when no health metadata exists.
+
+```yaml
+recording_health:
+  voice_stem_active_ratio: 0.31
+  system_stem_active_ratio: 0.00
+  system_dominant_ratio: 0.12
+  capture_warnings:
+    - kind: silent
+      source: system
+      message: System audio was silent during capture.
+      diagnostic_confidence: inferred
+  diarization_path: ml-bleed-degraded
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `voice_stem_active_ratio` | number | Optional fraction of sampled windows where the voice stem was active. |
+| `system_stem_active_ratio` | number | Optional fraction of sampled windows where the system stem was active. |
+| `system_dominant_ratio` | number | Optional fraction of active stem-energy windows dominated by system audio. |
+| `capture_warnings` | list&lt;CaptureWarning&gt; | Structured capture warnings. Empty lists are omitted. |
+| `diarization_path` | enum | `stem-energy`, `ml`, `ml-bleed-degraded`, or `none`. |
+
+#### CaptureWarning
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `kind` | enum | ✓ | `silent`, `sparse`, `missing`, `backend-unavailable`, `stream-error`, `source-starved`, `unsupported-format`, `misconfigured-route`, `permission-denied`, `route-unavailable`, or `other: { code: string }`. |
+| `source` | enum | ✓ | `voice`, `system`, `both`, or `backend`. |
+| `message` | string | ✓ | Human-readable warning text. Render at the edge; do not parse for logic. |
+| `diagnostic_confidence` | enum | ✓ | `high` for confirmed backend/permission errors, `inferred` for signal-derived diagnoses. |
 
 ### Overlay contract
 

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 947;
+export const MINUTES_TEST_COUNT = 955;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary
- add backend-agnostic capture-health primitives and wire recording_health into markdown frontmatter with serde omission/default behavior
- extend attribution source enums for ml-bleed-degraded and stem-recovery across core, reader, SDK, MCP, and docs
- surface recording_health in MCP detail payloads while keeping list/search result shapes slim
- add structural round-trip tests, reader/SDK/MCP contract tests, and a frontmatter JSON schema snapshot

## Scope guard
This is PR-2a schema/contract only. It does not implement the bounded probe, DiarizationOutcome, ML fallback behavior, health probes, capture backend migration, or redo-diarization.

## Verification
- cargo fmt
- cargo clippy --all --no-default-features -- -D warnings
- cargo test -p minutes-core recording_health --no-default-features
- cargo test -p minutes-core speaker_attribution_roundtrips_yaml --no-default-features
- cargo test -p minutes-core markdown::tests::json_schema_generates_valid_schema --no-default-features
- cargo test -p minutes-reader --no-default-features
- npm test in crates/sdk
- npm run build in crates/sdk
- npm run test:unit in crates/mcp
- npm run build in crates/mcp
- npm test in crates/mcp
- git diff --check

Note: I also attempted the full cargo test -p minutes-core --no-default-features. In the normal sandbox it failed on PID/sqlite temp-file permissions; rerunning outside the sandbox cleared those but then stalled in hardware/device-enumeration tests, so I terminated that hung run and relied on the focused schema tests plus clippy for this slice.