### PR TITLE
feat(diarize): recover degraded capture with ML fallback

### DIFF
--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -114,6 +114,7 @@ type StemEnergyWindows = (Vec<EnergyWindow>, Vec<EnergyWindow>);
 const STEM_PROBE_SECS: usize = 5;
 const STEM_PROBE_RMS_FLOOR: f32 = 0.001;
 const PRIMARY_DEGRADED_MIN_DURATION_SECS: f64 = 60.0;
+const DEGRADED_ML_FALLBACK_MIN_DURATION_SECS: f64 = 120.0;
 
 // ── Speaker attribution ──────────────────────────────────────
 
@@ -1549,6 +1550,67 @@ fn degraded_capture_for_primary_result(
     Some(degraded_reason)
 }
 
+fn should_attempt_degraded_ml_fallback(audio_path: &Path, ctx: DiarizationContext<'_>) -> bool {
+    if ctx.purpose != DiarizationPurpose::PrimaryMeeting {
+        return false;
+    }
+
+    // If the duration probe fails, stay conservative: this path only runs
+    // after the primary degraded-capture guard already decided the source-aware
+    // result is unsafe, so unknown duration should not block recovery.
+    let duration_secs = audio_duration_secs(audio_path).unwrap_or(f64::INFINITY);
+    duration_secs > DEGRADED_ML_FALLBACK_MIN_DURATION_SECS
+}
+
+fn degraded_voice_stem_ml_fallback_with_runner(
+    audio_path: &Path,
+    voice_stem: &Path,
+    config: &Config,
+    resolved_engine: Option<&str>,
+    reason: &DegradedCapture,
+    ctx: DiarizationContext<'_>,
+    mut run_engine: impl FnMut(&Path, &Config, &str) -> Option<DiarizationResult>,
+) -> Option<DiarizationResult> {
+    let resolved_engine = resolved_engine?;
+    if !should_attempt_degraded_ml_fallback(audio_path, ctx) {
+        return None;
+    }
+
+    let mut result = run_engine(voice_stem, config, resolved_engine)?;
+    result.degraded_capture = Some(reason.clone());
+    result.from_stems = false;
+    result.source_aware = false;
+
+    tracing::warn!(
+        failure_kind = ?reason.failure_kind,
+        voice_stem = %voice_stem.display(),
+        speakers = result.num_speakers,
+        segments = result.segments.len(),
+        "source-aware diarization degraded; recovered with low-confidence voice-stem ML diarization"
+    );
+
+    Some(result)
+}
+
+fn degraded_voice_stem_ml_fallback(
+    audio_path: &Path,
+    voice_stem: &Path,
+    config: &Config,
+    resolved_engine: Option<&str>,
+    reason: &DegradedCapture,
+    ctx: DiarizationContext<'_>,
+) -> Option<DiarizationResult> {
+    degraded_voice_stem_ml_fallback_with_runner(
+        audio_path,
+        voice_stem,
+        config,
+        resolved_engine,
+        reason,
+        ctx,
+        run_diarization_engine,
+    )
+}
+
 /// Run speaker diarization on an audio file.
 /// Returns None if diarization is disabled or models are not available.
 ///
@@ -1587,6 +1649,16 @@ pub fn diarize_with_context(
                     if let Some(reason) =
                         degraded_capture_for_primary_result(audio_path, &result, ctx)
                     {
+                        if let Some(recovered) = degraded_voice_stem_ml_fallback(
+                            audio_path,
+                            &stems.voice,
+                            config,
+                            resolved_engine,
+                            &reason,
+                            ctx,
+                        ) {
+                            return DiarizationOutcome::Result(recovered);
+                        }
                         tracing::warn!(
                             failure_kind = ?reason.failure_kind,
                             system_dominant_ratio = result.system_dominant_ratio,
@@ -1629,6 +1701,16 @@ pub fn diarize_with_context(
                 if let Some(reason) =
                     degraded_capture_for_silent_system_stem(audio_path, &stems.system, ctx)
                 {
+                    if let Some(recovered) = degraded_voice_stem_ml_fallback(
+                        audio_path,
+                        &stems.voice,
+                        config,
+                        resolved_engine,
+                        &reason,
+                        ctx,
+                    ) {
+                        return DiarizationOutcome::Result(recovered);
+                    }
                     tracing::warn!(
                         failure_kind = ?reason.failure_kind,
                         voice = %stems.voice.display(),
@@ -3651,6 +3733,104 @@ mod tests {
         );
         assert!(!transcript.contains("[UNKNOWN"));
         assert!(!transcript.contains("[SPEAKER_0"));
+    }
+
+    #[test]
+    fn degraded_voice_stem_ml_fallback_marks_result_backend_agnostic_and_degraded() {
+        let dir = tempfile::tempdir().unwrap();
+        let audio = dir.path().join("call.wav");
+        let voice = dir.path().join("call.voice.wav");
+        let system = dir.path().join("call.system.wav");
+        let sample_rate = 1_000;
+        let frames = 121_000;
+        write_i16_wav(&audio, sample_rate, 1, frames, |_, _| 0);
+        write_i16_wav(&voice, sample_rate, 1, frames, |_, _| 3_000);
+        write_i16_wav(&system, sample_rate, 1, frames, |_, _| 0);
+
+        let reason = silent_system_stem_degraded_capture(&system);
+        let config = Config::default();
+        let windows = vec![TranscriptWindow {
+            start_secs: 0.0,
+            end_secs: 8.0,
+        }];
+        let mut attempted_paths = Vec::new();
+        let recovered = degraded_voice_stem_ml_fallback_with_runner(
+            &audio,
+            &voice,
+            &config,
+            Some("test-engine"),
+            &reason,
+            DiarizationContext {
+                purpose: DiarizationPurpose::PrimaryMeeting,
+                transcript_windows: Some(&windows),
+            },
+            |path, _config, _engine| {
+                attempted_paths.push(path.to_path_buf());
+                Some(DiarizationResult {
+                    segments: vec![
+                        SpeakerSegment {
+                            speaker: "SPEAKER_0".into(),
+                            start: 0.0,
+                            end: 10.0,
+                        },
+                        SpeakerSegment {
+                            speaker: "SPEAKER_1".into(),
+                            start: 10.0,
+                            end: 20.0,
+                        },
+                    ],
+                    num_speakers: 2,
+                    system_dominant_ratio: 0.0,
+                    voice_dominant_ratio: 0.0,
+                    degraded_capture: None,
+                    from_stems: true,
+                    source_aware: true,
+                    speaker_embeddings: std::collections::HashMap::new(),
+                })
+            },
+        )
+        .expect("expected degraded capture to recover through voice-stem ML");
+
+        assert_eq!(attempted_paths, vec![voice]);
+        assert!(!recovered.from_stems);
+        assert!(!recovered.source_aware);
+        assert_eq!(recovered.num_speakers, 2);
+        assert_eq!(recovered.degraded_capture, Some(reason));
+    }
+
+    #[test]
+    fn degraded_voice_stem_ml_fallback_respects_two_minute_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let audio = dir.path().join("call.wav");
+        let voice = dir.path().join("call.voice.wav");
+        let system = dir.path().join("call.system.wav");
+        let sample_rate = 1_000;
+        let frames = 90_000;
+        write_i16_wav(&audio, sample_rate, 1, frames, |_, _| 0);
+        write_i16_wav(&voice, sample_rate, 1, frames, |_, _| 3_000);
+        write_i16_wav(&system, sample_rate, 1, frames, |_, _| 0);
+
+        let reason = silent_system_stem_degraded_capture(&system);
+        let config = Config::default();
+        let mut attempted = false;
+        let recovered = degraded_voice_stem_ml_fallback_with_runner(
+            &audio,
+            &voice,
+            &config,
+            Some("test-engine"),
+            &reason,
+            DiarizationContext {
+                purpose: DiarizationPurpose::PrimaryMeeting,
+                transcript_windows: None,
+            },
+            |_path, _config, _engine| {
+                attempted = true;
+                Some(DiarizationResult::default())
+            },
+        );
+
+        assert!(recovered.is_none());
+        assert!(!attempted);
     }
 
     #[test]

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -65,14 +65,39 @@ pub struct CaptureWarning {
 
 impl From<crate::diarize::DegradedCapture> for RecordingHealth {
     fn from(reason: crate::diarize::DegradedCapture) -> Self {
+        RecordingHealth::from_degraded_capture(reason, DiarizationPath::None)
+    }
+}
+
+impl RecordingHealth {
+    pub fn from_degraded_capture(
+        reason: crate::diarize::DegradedCapture,
+        diarization_path: DiarizationPath,
+    ) -> Self {
         let message = match &reason.failure_kind {
             crate::diarize::FailureKind::Silent => {
-                "System audio was silent during capture; transcript was left unlabeled.".to_string()
+                if diarization_path == DiarizationPath::MlBleedDegraded {
+                    "System audio was silent during capture; speaker labels were recovered from degraded mic bleed with low confidence.".to_string()
+                } else {
+                    "System audio was silent during capture; transcript was left unlabeled."
+                        .to_string()
+                }
             }
             crate::diarize::FailureKind::Sparse => {
-                "System audio did not contain sustained transcript-aligned remote speech; transcript was left unlabeled.".to_string()
+                if diarization_path == DiarizationPath::MlBleedDegraded {
+                    "System audio did not contain sustained transcript-aligned remote speech; speaker labels were recovered from degraded mic bleed with low confidence.".to_string()
+                } else {
+                    "System audio did not contain sustained transcript-aligned remote speech; transcript was left unlabeled.".to_string()
+                }
             }
-            _ => "Capture health degraded diarization; transcript was left unlabeled.".to_string(),
+            _ => {
+                if diarization_path == DiarizationPath::MlBleedDegraded {
+                    "Capture health degraded diarization; speaker labels were recovered from degraded mic bleed with low confidence.".to_string()
+                } else {
+                    "Capture health degraded diarization; transcript was left unlabeled."
+                        .to_string()
+                }
+            }
         };
 
         RecordingHealth {
@@ -85,7 +110,7 @@ impl From<crate::diarize::DegradedCapture> for RecordingHealth {
                 message,
                 diagnostic_confidence: reason.diagnostic_confidence,
             }],
-            diarization_path: Some(DiarizationPath::None),
+            diarization_path: Some(diarization_path),
         }
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -263,6 +263,62 @@ fn debug_speaker_map(speaker_map: &[diarize::SpeakerAttribution]) -> Vec<Speaker
         .collect()
 }
 
+fn is_degraded_ml_fallback_result(result: &diarize::DiarizationResult) -> bool {
+    result.degraded_capture.is_some() && !result.from_stems && !result.source_aware
+}
+
+fn degraded_ml_recording_health(reason: diarize::DegradedCapture) -> markdown::RecordingHealth {
+    markdown::RecordingHealth::from_degraded_capture(
+        reason,
+        markdown::DiarizationPath::MlBleedDegraded,
+    )
+}
+
+fn mark_degraded_ml_attributions(speaker_map: &mut [diarize::SpeakerAttribution]) {
+    for attribution in speaker_map {
+        attribution.confidence = diarize::Confidence::Low;
+        attribution.source = diarize::AttributionSource::MlBleedDegraded;
+    }
+}
+
+fn log_rendered_label_collapse_diagnostic(
+    audio_path: &Path,
+    result: &diarize::DiarizationResult,
+    transcript: &str,
+) {
+    if result.num_speakers <= 1 {
+        return;
+    }
+
+    let rendered_labels = extract_effective_transcript_speaker_labels(transcript);
+    let rendered_speaker_labels = rendered_labels
+        .iter()
+        .filter(|label| label.as_str() != "UNKNOWN")
+        .count();
+    if rendered_speaker_labels > 1 {
+        return;
+    }
+
+    tracing::warn!(
+        diarization_speakers = result.num_speakers,
+        rendered_speaker_labels,
+        degraded_capture = result.degraded_capture.is_some(),
+        audio = %audio_path.display(),
+        "diarization found multiple speakers but transcript rendered one or fewer speaker labels"
+    );
+    logging::log_step(
+        "diarize_rendered_label_collapse",
+        &audio_path.display().to_string(),
+        0,
+        serde_json::json!({
+            "diagnostic": true,
+            "diarization_speakers": result.num_speakers,
+            "rendered_speaker_labels": rendered_speaker_labels,
+            "degraded_capture": result.degraded_capture.is_some(),
+        }),
+    );
+}
+
 fn expected_voice_stem_path(audio_path: &Path) -> Option<std::path::PathBuf> {
     let stem = audio_path.file_stem()?.to_str()?;
     let dir = audio_path.parent()?;
@@ -518,6 +574,7 @@ fn attribute_meeting_speakers(
     llm_attendees: &[String],
     diarization_num_speakers: usize,
     diarization_from_stems: bool,
+    degraded_ml_fallback: bool,
     diarization_embeddings: &std::collections::HashMap<String, Vec<f32>>,
     transcript: String,
 ) -> AttributionProcessingResult {
@@ -627,6 +684,10 @@ fn attribute_meeting_speakers(
 
         let effective_transcript_speaker_labels =
             extract_effective_transcript_speaker_labels(&transcript);
+
+        if degraded_ml_fallback {
+            mark_degraded_ml_attributions(&mut speaker_map);
+        }
 
         if speaker_map
             .iter()
@@ -1060,6 +1121,7 @@ where
     let mut transcript = artifact.transcript.clone();
     let mut diarization_num_speakers = 0usize;
     let mut diarization_from_stems = false;
+    let mut degraded_ml_fallback = false;
     let mut diarization_embeddings: std::collections::HashMap<String, Vec<f32>> =
         std::collections::HashMap::new();
     let mut recording_health: Option<markdown::RecordingHealth> = None;
@@ -1079,6 +1141,12 @@ where
                 let diarize_ms = diarize_start.elapsed().as_millis() as u64;
                 diarization_num_speakers = result.num_speakers;
                 diarization_from_stems = result.source_aware;
+                degraded_ml_fallback = is_degraded_ml_fallback_result(&result);
+                if degraded_ml_fallback {
+                    if let Some(reason) = result.degraded_capture.clone() {
+                        recording_health = Some(degraded_ml_recording_health(reason));
+                    }
+                }
                 diarization_embeddings = result.speaker_embeddings.clone();
                 logging::log_step(
                     "diarize",
@@ -1092,6 +1160,7 @@ where
                     }),
                 );
                 transcript = diarize::apply_speakers(&transcript, &result);
+                log_rendered_label_collapse_diagnostic(audio_path, &result, &transcript);
             }
             diarize::DiarizationOutcome::Skipped { reason } => {
                 let diarize_ms = diarize_start.elapsed().as_millis() as u64;
@@ -1248,6 +1317,7 @@ where
         &attendees,
         diarization_num_speakers,
         diarization_from_stems,
+        degraded_ml_fallback,
         &diarization_embeddings,
         transcript,
     );
@@ -1549,6 +1619,7 @@ where
     // Step 2: Diarize (optional — depends on config.diarization.engine)
     let mut diarization_num_speakers: usize = 0;
     let mut diarization_from_stems = false;
+    let mut degraded_ml_fallback = false;
     let mut diarization_embeddings: std::collections::HashMap<String, Vec<f32>> =
         std::collections::HashMap::new();
     let mut recording_health: Option<markdown::RecordingHealth> = None;
@@ -1568,8 +1639,16 @@ where
             diarize::DiarizationOutcome::Result(result) => {
                 diarization_num_speakers = result.num_speakers;
                 diarization_from_stems = result.source_aware;
+                degraded_ml_fallback = is_degraded_ml_fallback_result(&result);
+                if degraded_ml_fallback {
+                    if let Some(reason) = result.degraded_capture.clone() {
+                        recording_health = Some(degraded_ml_recording_health(reason));
+                    }
+                }
                 diarization_embeddings = result.speaker_embeddings.clone();
-                diarize::apply_speakers(&transcript, &result)
+                let transcript = diarize::apply_speakers(&transcript, &result);
+                log_rendered_label_collapse_diagnostic(audio_path, &result, &transcript);
+                transcript
             }
             diarize::DiarizationOutcome::Skipped { reason } => {
                 recording_health = Some(reason.into());
@@ -1744,6 +1823,7 @@ where
         &attendees,
         diarization_num_speakers,
         diarization_from_stems,
+        degraded_ml_fallback,
         &diarization_embeddings,
         transcript,
     );
@@ -4349,6 +4429,7 @@ mod tests {
             &["Mat".into(), "Alex".into()],
             2,
             true,
+            false,
             &std::collections::HashMap::new(),
             "[SPEAKER_0 0:00] hello\n[SPEAKER_1 0:01] hi\n".into(),
         );
@@ -4358,6 +4439,62 @@ mod tests {
             .speaker_map
             .iter()
             .all(|entry| entry.confidence == diarize::Confidence::Medium));
+    }
+
+    #[test]
+    fn degraded_ml_fallback_attribution_is_low_confidence_and_marked() {
+        let mut config = Config::default();
+        config.identity.name = Some("Mat".into());
+
+        let result = attribute_meeting_speakers(
+            Path::new("/fake.wav"),
+            ContentType::Meeting,
+            None,
+            &config,
+            &["Mat".into(), "Alex".into()],
+            &["Mat".into(), "Alex".into()],
+            2,
+            false,
+            true,
+            &std::collections::HashMap::new(),
+            "[SPEAKER_0 0:00] hello\n[SPEAKER_1 0:01] hi\n".into(),
+        );
+
+        assert_eq!(result.speaker_map.len(), 2);
+        assert!(result.speaker_map.iter().all(|entry| {
+            entry.confidence == diarize::Confidence::Low
+                && entry.source == diarize::AttributionSource::MlBleedDegraded
+        }));
+    }
+
+    #[test]
+    fn degraded_ml_recording_health_sets_recovery_path() {
+        let health = degraded_ml_recording_health(diarize::DegradedCapture {
+            failure_kind: diarize::FailureKind::Silent,
+            capture_backend: "cpal".into(),
+            capture_source: diarize::CaptureSource::System,
+            voice_active_ratio: Some(0.9),
+            system_active_ratio: Some(0.0),
+            observed_signal: diarize::ObservedSignal {
+                frames_captured: 120,
+                max_rms: 0.0,
+                avg_rms: 0.0,
+            },
+            diagnostic_confidence: diarize::DiagnosticConfidence::Inferred,
+        });
+
+        assert_eq!(
+            health.diarization_path,
+            Some(markdown::DiarizationPath::MlBleedDegraded)
+        );
+        assert_eq!(health.capture_warnings.len(), 1);
+        assert_eq!(
+            health.capture_warnings[0].source,
+            diarize::CaptureSource::System
+        );
+        assert!(health.capture_warnings[0]
+            .message
+            .contains("low confidence"));
     }
 
     #[test]
@@ -4455,6 +4592,7 @@ mod tests {
             &[],
             2,
             true,
+            false,
             &std::collections::HashMap::new(),
             "[SPEAKER_1 0:00] hi\n[SPEAKER_0 0:01] hello\n".into(),
         );

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 970;
+export const MINUTES_TEST_COUNT = 974;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary
- add PR-2b voice-stem ML recovery when PR-1 degraded-capture guards would otherwise skip a primary meeting over two minutes
- force recovered results to backend-agnostic diarization semantics: from_stems=false, source_aware=false, degraded_capture preserved
- surface recording_health.diarization_path=ml-bleed-degraded and downgrade generated speaker_map entries to low-confidence ml-bleed-degraded attribution
- add diagnostic logging when diarization finds multiple speakers but rendered transcript labels collapse to one or fewer labels

## Adversarial scope check
- no PR-3 system-audio readiness probe
- no PR-4-pre SystemAudioBackend trait or capture refactor
- no PR-4 Core Audio Process Tap backend
- no CLI/MCP skip-audio-probe behavior
- fallback trigger is only structured degraded-capture evidence from PR-1, not rendered-label collapse by itself

## Tests
- cargo test -p minutes-core degraded_voice_stem_ml_fallback --no-default-features
- cargo test -p minutes-core degraded_ml --no-default-features
- cargo test -p minutes-core primary_zero_system_stem_skips_without_unknown_spam_and_sets_health --no-default-features
- cargo test -p minutes-core diarize::tests --no-default-features
- cargo test -p minutes-core pipeline::tests --no-default-features
- cargo fmt --all -- --check
- cargo clippy --all --no-default-features -- -D warnings
- git diff --check

## Local full-suite note
A sandboxed cargo test -p minutes-core --no-default-features failed on PID/temp SQLite permissions. Those specific tests passed outside the sandbox. A later full unsandboxed minutes-core run progressed past those failures but hung in existing local hardware/device-enumeration tests, so I stopped it after it stayed wedged. CI should provide the clean matrix signal.