### PR TITLE
refactor(capture): add system audio backend trait

### DIFF
--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -947,6 +947,8 @@ fn record_to_wav_dual_source(
     plan: DualCapturePlan,
     started_context: Option<RecordingStartedContext>,
 ) -> Result<(), CaptureError> {
+    use crate::system_audio_backend::SystemAudioBackend;
+
     crate::pid::check_and_clear_sentinel();
     // Refresh the in-process mic-mute flag from the sentinel. The CLI
     // `--mute-mic` flag writes the sentinel before getting here, and the
@@ -960,14 +962,21 @@ fn record_to_wav_dual_source(
     let (live_tx, sidecar_handle) = start_live_sidecar(config, &stop_flag);
 
     let mut voice_stream = Some(AudioStream::start(plan.voice_override.as_deref())?);
-    let mut system_stream = Some(AudioStream::start(Some(&plan.call_override))?);
+    let (system_tx, system_backend_rx) = crossbeam_channel::bounded(64);
+    let mut system_backend =
+        crate::system_audio_backend::CpalSystemAudioBackend::new(plan.call_override.clone());
+    let mut system_stream = Some(system_backend.start(system_tx.clone())?);
+    let system_device_name = system_stream
+        .as_ref()
+        .and_then(|stream| stream.route().device_name)
+        .unwrap_or_else(|| plan.call_device_name.clone());
     // Call side is always a pinned override; voice side is pinned iff the caller
     // supplied an explicit override. Pinned sides skip default-device-change polling.
     let voice_pinned = plan.voice_override.is_some();
     let mut device_monitor = crate::device_monitor::MultiDeviceMonitor::with_pinned(
         &voice_stream.as_ref().expect("voice stream").device_name,
         voice_pinned,
-        &system_stream.as_ref().expect("system stream").device_name,
+        &system_device_name,
         true,
     );
 
@@ -977,11 +986,11 @@ fn record_to_wav_dual_source(
     );
     eprintln!(
         "[minutes] Using system audio device: {}",
-        system_stream.as_ref().expect("system stream").device_name
+        system_device_name
     );
     tracing::info!(
         voice = %voice_stream.as_ref().expect("voice stream").device_name,
-        system = %system_stream.as_ref().expect("system stream").device_name,
+        system = %system_device_name,
         "using dual-source audio input devices"
     );
     emit_recording_started(started_context);
@@ -1079,7 +1088,7 @@ fn record_to_wav_dual_source(
             .is_some_and(crate::streaming::AudioStream::has_error)
             || system_stream
                 .as_ref()
-                .is_some_and(crate::streaming::AudioStream::has_error)
+                .is_some_and(|stream| stream.has_error())
             || device_monitor.check_changes().is_some()
         {
             tracing::warn!("dual-source stream issue detected — attempting restart");
@@ -1088,17 +1097,21 @@ fn record_to_wav_dual_source(
 
             match (
                 AudioStream::start(plan.voice_override.as_deref()),
-                AudioStream::start(Some(&plan.call_override)),
+                system_backend.start(system_tx.clone()),
             ) {
                 (Ok(new_voice), Ok(new_system)) => {
+                    let new_system_name = new_system
+                        .route()
+                        .device_name
+                        .unwrap_or_else(|| plan.call_device_name.clone());
                     eprintln!(
                         "[minutes] Dual-source capture reconnected: {} + {}",
-                        new_voice.device_name, new_system.device_name
+                        new_voice.device_name, new_system_name
                     );
                     device_monitor = crate::device_monitor::MultiDeviceMonitor::with_pinned(
                         &new_voice.device_name,
                         voice_pinned,
-                        &new_system.device_name,
+                        &new_system_name,
                         true,
                     );
                     slot_base = max_voice_slot
@@ -1129,9 +1142,8 @@ fn record_to_wav_dual_source(
             .clone();
         let system_rx = system_stream
             .as_ref()
-            .expect("system stream should stay active")
-            .receiver
-            .clone();
+            .map(|_| system_backend_rx.clone())
+            .expect("system stream should stay active");
 
         // Drain all available chunks from both channels before flushing.
         // The old code used select! to grab ONE chunk per iteration, which

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod screen;
 pub mod search;
 pub mod search_index;
 pub mod summarize;
+pub mod system_audio_backend;
 pub mod template;
 pub mod transcribe;
 pub mod transcription_coordinator;

--- a/crates/core/src/system_audio_backend.rs
+++ b/crates/core/src/system_audio_backend.rs
@@ -1,0 +1,313 @@
+use crate::diarize::{DiagnosticConfidence, FailureKind, ObservedSignal};
+use crate::error::CaptureError;
+
+#[cfg(feature = "streaming")]
+use crate::streaming::{AudioChunk, AudioStream, SourceRole};
+
+/// Receives system-audio chunks from a backend.
+#[cfg(feature = "streaming")]
+pub type AudioSink = crossbeam_channel::Sender<AudioChunk>;
+
+/// Placeholder sink when streaming support is not compiled in.
+#[cfg(not(feature = "streaming"))]
+#[derive(Debug, Clone)]
+pub struct AudioSink;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDescription {
+    pub capture_backend: String,
+    pub device_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionStatus {
+    Granted,
+    Denied,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeResult {
+    pub observed_signal: ObservedSignal,
+    pub failure_kind: Option<FailureKind>,
+    pub diagnostic_confidence: DiagnosticConfidence,
+}
+
+pub trait SystemAudioBackend {
+    fn probe(&self, secs: u32) -> Result<ProbeResult, CaptureError>;
+    fn start(&mut self, sink: AudioSink) -> Result<StreamHandle, CaptureError>;
+    fn current_route(&self) -> RouteDescription;
+    fn permission_status(&self) -> Option<PermissionStatus>;
+}
+
+trait SystemAudioStreamHandle: Send {
+    fn has_error(&self) -> bool;
+    fn route(&self) -> RouteDescription;
+}
+
+pub struct StreamHandle {
+    inner: Box<dyn SystemAudioStreamHandle>,
+}
+
+impl StreamHandle {
+    fn new(inner: impl SystemAudioStreamHandle + 'static) -> Self {
+        Self {
+            inner: Box::new(inner),
+        }
+    }
+
+    pub fn has_error(&self) -> bool {
+        self.inner.has_error()
+    }
+
+    pub fn route(&self) -> RouteDescription {
+        self.inner.route()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CpalSystemAudioBackend {
+    device_override: String,
+    current_route: RouteDescription,
+}
+
+impl CpalSystemAudioBackend {
+    pub fn new(device_override: String) -> Self {
+        Self {
+            current_route: RouteDescription {
+                capture_backend: "cpal".into(),
+                device_name: Some(device_override.clone()),
+            },
+            device_override,
+        }
+    }
+}
+
+impl SystemAudioBackend for CpalSystemAudioBackend {
+    fn probe(&self, secs: u32) -> Result<ProbeResult, CaptureError> {
+        cpal_probe(&self.device_override, secs)
+    }
+
+    fn start(&mut self, sink: AudioSink) -> Result<StreamHandle, CaptureError> {
+        let handle = cpal_start_stream(&self.device_override, sink)?;
+        self.current_route = handle.route();
+        Ok(StreamHandle::new(handle))
+    }
+
+    fn current_route(&self) -> RouteDescription {
+        self.current_route.clone()
+    }
+
+    fn permission_status(&self) -> Option<PermissionStatus> {
+        None
+    }
+}
+
+#[cfg(feature = "streaming")]
+struct CpalSystemAudioStreamHandle {
+    stream: AudioStream,
+    stop_forwarding: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    forward_thread: Option<std::thread::JoinHandle<()>>,
+    route: RouteDescription,
+}
+
+#[cfg(feature = "streaming")]
+impl SystemAudioStreamHandle for CpalSystemAudioStreamHandle {
+    fn has_error(&self) -> bool {
+        self.stream.has_error()
+    }
+
+    fn route(&self) -> RouteDescription {
+        self.route.clone()
+    }
+}
+
+#[cfg(feature = "streaming")]
+impl Drop for CpalSystemAudioStreamHandle {
+    fn drop(&mut self) {
+        self.stop_forwarding
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.stream.stop();
+        if let Some(handle) = self.forward_thread.take() {
+            handle.join().ok();
+        }
+    }
+}
+
+#[cfg(feature = "streaming")]
+fn cpal_start_stream(
+    device_override: &str,
+    sink: AudioSink,
+) -> Result<CpalSystemAudioStreamHandle, CaptureError> {
+    let stream = AudioStream::start(Some(device_override))?;
+    let receiver = stream.receiver.clone();
+    let stop_forwarding = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_thread = std::sync::Arc::clone(&stop_forwarding);
+    let forward_thread = std::thread::Builder::new()
+        .name("system-audio-backend-cpal".into())
+        .spawn(move || {
+            while !stop_thread.load(std::sync::atomic::Ordering::Relaxed) {
+                match receiver.recv_timeout(std::time::Duration::from_millis(50)) {
+                    Ok(mut chunk) => {
+                        chunk.source = SourceRole::Call;
+                        let _ = sink.send_timeout(chunk, std::time::Duration::from_millis(50));
+                    }
+                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+        })
+        .map_err(|e| CaptureError::Io(std::io::Error::other(e.to_string())))?;
+
+    let route = RouteDescription {
+        capture_backend: "cpal".into(),
+        device_name: Some(stream.device_name.clone()),
+    };
+
+    Ok(CpalSystemAudioStreamHandle {
+        stream,
+        stop_forwarding,
+        forward_thread: Some(forward_thread),
+        route,
+    })
+}
+
+#[cfg(not(feature = "streaming"))]
+struct UnsupportedSystemAudioStreamHandle {
+    route: RouteDescription,
+}
+
+#[cfg(not(feature = "streaming"))]
+impl SystemAudioStreamHandle for UnsupportedSystemAudioStreamHandle {
+    fn has_error(&self) -> bool {
+        true
+    }
+
+    fn route(&self) -> RouteDescription {
+        self.route.clone()
+    }
+}
+
+#[cfg(not(feature = "streaming"))]
+fn cpal_start_stream(
+    device_override: &str,
+    _sink: AudioSink,
+) -> Result<UnsupportedSystemAudioStreamHandle, CaptureError> {
+    Err(CaptureError::Io(std::io::Error::other(format!(
+        "system audio backend requires the streaming feature for '{}'",
+        device_override
+    ))))
+}
+
+#[cfg(feature = "streaming")]
+fn cpal_probe(device_override: &str, secs: u32) -> Result<ProbeResult, CaptureError> {
+    let stream = AudioStream::start(Some(device_override))?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs as u64);
+    let mut frames_captured = 0usize;
+    let mut sum_square = 0.0f64;
+    let mut max_rms = 0.0f32;
+
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let timeout = remaining.min(std::time::Duration::from_millis(100));
+        match stream.receiver.recv_timeout(timeout) {
+            Ok(chunk) => {
+                frames_captured += chunk.samples.len();
+                max_rms = max_rms.max(chunk.rms);
+                sum_square += chunk
+                    .samples
+                    .iter()
+                    .map(|sample| (*sample as f64) * (*sample as f64))
+                    .sum::<f64>();
+            }
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    drop(stream);
+
+    let avg_rms = if frames_captured > 0 {
+        (sum_square / frames_captured as f64).sqrt() as f32
+    } else {
+        0.0
+    };
+    let observed_signal = ObservedSignal {
+        frames_captured,
+        max_rms,
+        avg_rms,
+    };
+    let failure_kind = if frames_captured == 0 {
+        Some(FailureKind::SourceStarved)
+    } else if max_rms <= 0.001 {
+        Some(FailureKind::Silent)
+    } else {
+        None
+    };
+
+    Ok(ProbeResult {
+        observed_signal,
+        failure_kind,
+        diagnostic_confidence: DiagnosticConfidence::High,
+    })
+}
+
+#[cfg(not(feature = "streaming"))]
+fn cpal_probe(_device_override: &str, _secs: u32) -> Result<ProbeResult, CaptureError> {
+    Ok(ProbeResult {
+        observed_signal: ObservedSignal {
+            frames_captured: 0,
+            max_rms: 0.0,
+            avg_rms: 0.0,
+        },
+        failure_kind: Some(FailureKind::BackendUnavailable),
+        diagnostic_confidence: DiagnosticConfidence::Inferred,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpal_backend_reports_configured_route_without_permission_api() {
+        let backend = CpalSystemAudioBackend::new("BlackHole 2ch".into());
+
+        assert_eq!(
+            backend.current_route(),
+            RouteDescription {
+                capture_backend: "cpal".into(),
+                device_name: Some("BlackHole 2ch".into()),
+            }
+        );
+        assert_eq!(backend.permission_status(), None);
+    }
+
+    #[test]
+    fn probe_result_preserves_backend_agnostic_signal_fields() {
+        let result = ProbeResult {
+            observed_signal: ObservedSignal {
+                frames_captured: 1600,
+                max_rms: 0.02,
+                avg_rms: 0.01,
+            },
+            failure_kind: None,
+            diagnostic_confidence: DiagnosticConfidence::High,
+        };
+
+        assert_eq!(result.observed_signal.frames_captured, 1600);
+        assert_eq!(result.failure_kind, None);
+        assert_eq!(result.diagnostic_confidence, DiagnosticConfidence::High);
+    }
+
+    #[cfg(not(feature = "streaming"))]
+    #[test]
+    fn cpal_probe_reports_unavailable_without_streaming_feature() {
+        let backend = CpalSystemAudioBackend::new("BlackHole 2ch".into());
+        let result = backend.probe(1).unwrap();
+
+        assert_eq!(result.observed_signal.frames_captured, 0);
+        assert_eq!(result.failure_kind, Some(FailureKind::BackendUnavailable));
+        assert_eq!(result.diagnostic_confidence, DiagnosticConfidence::Inferred);
+    }
+}

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 974;
+export const MINUTES_TEST_COUNT = 977;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary
- Add a backend-agnostic `SystemAudioBackend` trait plus `ProbeResult`, `RouteDescription`, `PermissionStatus`, `AudioSink`, and `StreamHandle` in `minutes-core`.
- Wrap the existing CPAL system-audio capture path in `CpalSystemAudioBackend` while keeping the dual-source voice stream and mixer behavior unchanged.
- Provide the future probe contract using the PR-2a health fields (`ObservedSignal`, `FailureKind`, `DiagnosticConfidence`) without wiring startup health behavior yet.

## Scope guardrails
- No Core Audio Process Tap / `cidre` backend.
- No `NSAudioCaptureUsageDescription` or macOS permission UI change.
- No PR-3 readiness probe wiring, `check_system_audio_capture`, or `--skip-audio-probe`.
- No config flag or backend selector.
- No desktop/MCP warning behavior changes.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p minutes-core system_audio_backend --no-default-features`
- `cargo test -p minutes-core system_audio_backend --features streaming --no-default-features`
- `cargo test -p minutes-core capture::tests --features streaming --no-default-features`
- `cargo test -p minutes-core capture::tests --no-default-features`
- `cargo clippy --all --no-default-features -- -D warnings`
- `git diff --check`
- Scope grep for PR-3/PR-4 forbidden surfaces: no new `cidre`, Process Tap implementation, readiness probe, skip flag, or permission plist wiring.