### PR TITLE
feat(health): add system audio readiness probe

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -214,6 +214,11 @@ enum Commands {
         #[arg(long)]
         allow_degraded: bool,
 
+        /// Skip the system-audio readiness probe for this run. Requires a
+        /// reason, which is written into recording_health.
+        #[arg(long, value_name = "REASON")]
+        skip_audio_probe: Option<String>,
+
         /// Transcription language (e.g. "en", "ur", "es"). Overrides config.toml setting.
         #[arg(short, long)]
         language: Option<String>,
@@ -1220,6 +1225,7 @@ fn main() -> Result<()> {
             mode,
             intent,
             allow_degraded,
+            skip_audio_probe,
             language,
             device,
             source,
@@ -1285,6 +1291,7 @@ fn main() -> Result<()> {
                     &mode,
                     effective_intent,
                     allow_degraded,
+                    skip_audio_probe.as_deref(),
                     template,
                     &config,
                 )
@@ -1830,12 +1837,78 @@ fn cmd_preflight_record(
     Ok(())
 }
 
+fn check_meeting_system_audio_probe(
+    capture_mode: CaptureMode,
+    skip_audio_probe: Option<&str>,
+    config: &Config,
+) -> Result<Option<minutes_core::markdown::RecordingHealth>> {
+    if capture_mode != CaptureMode::Meeting {
+        return Ok(None);
+    }
+
+    if minutes_core::capture::resolve_system_audio_probe_device(config)
+        .map_err(|error| anyhow::anyhow!("{}", error))?
+        .is_none()
+    {
+        if skip_audio_probe.is_some() {
+            anyhow::bail!("--skip-audio-probe was provided, but no system-audio source is configured for this recording");
+        }
+        return Ok(None);
+    }
+
+    if let Some(reason) = skip_audio_probe {
+        let reason = reason.trim();
+        if reason.is_empty() {
+            anyhow::bail!("--skip-audio-probe requires a non-empty reason");
+        }
+        eprintln!(
+            "[minutes] System-audio readiness probe skipped for this recording: {}",
+            reason
+        );
+        return Ok(Some(
+            minutes_core::health::recording_health_for_skipped_system_audio_probe(reason),
+        ));
+    }
+
+    match minutes_core::health::probe_system_audio_capture(config)
+        .map_err(|error| anyhow::anyhow!("{}", error))?
+    {
+        None => Ok(None),
+        Some((route, result)) if result.failure_kind.is_none() => {
+            if let Some(device) = route.device_name.as_deref() {
+                eprintln!(
+                    "[minutes] System-audio readiness probe passed on '{}'.",
+                    device
+                );
+            }
+            Ok(None)
+        }
+        Some((route, result)) => {
+            let health = minutes_core::health::recording_health_for_system_audio_probe_failure(
+                Some(&route),
+                &result,
+            );
+            let detail = health
+                .capture_warnings
+                .first()
+                .map(|warning| warning.message.as_str())
+                .unwrap_or("System-audio readiness probe failed.");
+            anyhow::bail!(
+                "{} Use --skip-audio-probe \"<reason>\" for this run only if you intentionally want to record despite this degraded system-audio signal.",
+                detail
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn cmd_record(
     title: Option<String>,
     context: Option<String>,
     mode: &str,
     intent: &str,
     allow_degraded: bool,
+    skip_audio_probe: Option<&str>,
     template_slug: Option<String>,
     config: &Config,
 ) -> Result<()> {
@@ -1857,6 +1930,9 @@ fn cmd_record(
     for warning in &preflight.warnings {
         eprintln!("[minutes] {}", warning);
     }
+
+    let startup_recording_health =
+        check_meeting_system_audio_probe(capture_mode, skip_audio_probe, config)?;
 
     // Check for conflicting live transcript session
     let lt_pid = minutes_core::pid::live_transcript_pid_path();
@@ -1961,7 +2037,7 @@ fn cmd_record(
     // The pipeline already falls back to events_overlapping_now() during background processing.
     let calendar_event = None;
     let queued = (|| -> Result<(minutes_core::jobs::ProcessingJob, String)> {
-        let job = minutes_core::jobs::queue_live_capture(
+        let job = minutes_core::jobs::queue_live_capture_with_recording_health(
             capture_mode,
             title.clone(),
             &wav_path,
@@ -1972,6 +2048,7 @@ fn cmd_record(
             context_session_id.clone(),
             calendar_event,
             template_slug.clone(),
+            startup_recording_health.clone(),
         )?;
 
         let queued_result = serde_json::to_string_pretty(&serde_json::json!({

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -496,6 +496,27 @@ fn resolve_capture_plan(config: &Config) -> Result<CapturePlan, CaptureError> {
     resolve_capture_plan_with_host(host, config)
 }
 
+pub fn resolve_system_audio_probe_device(config: &Config) -> Result<Option<String>, String> {
+    let Some(call_override) = config
+        .recording
+        .sources
+        .as_ref()
+        .and_then(|sources| sources.call.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    if call_override.eq_ignore_ascii_case("auto") {
+        detect_loopback_device()
+            .map(Some)
+            .ok_or_else(|| MISSING_DUAL_SOURCE_LOOPBACK_MESSAGE.to_string())
+    } else {
+        Ok(Some(call_override.to_string()))
+    }
+}
+
 fn resolve_capture_plan_with_host(
     host: &cpal::Host,
     config: &Config,

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -14,7 +14,14 @@
 //! ```
 
 use crate::config::Config;
+use crate::diarize::{CaptureSource, DiagnosticConfidence, FailureKind};
+use crate::markdown::{CaptureWarning, DiarizationPath, RecordingHealth};
+use crate::system_audio_backend::{
+    CpalSystemAudioBackend, ProbeResult, RouteDescription, SystemAudioBackend,
+};
 use serde::{Deserialize, Serialize};
+
+const SYSTEM_AUDIO_PROBE_SECS: u32 = 5;
 
 /// A single health check result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,11 +40,133 @@ pub fn check_all(config: &Config) -> Vec<HealthItem> {
         ffmpeg_status(),
         diarization_status(config),
         mic_status(),
+        check_system_audio_capture(config),
         calendar_status(config),
         watcher_status(config),
         output_dir_status(config),
         disk_space(config),
     ]
+}
+
+/// Probe the configured system-audio capture route, if any.
+///
+/// A missing route is not itself unhealthy: room meetings and memos are
+/// deliberately mic-only. A configured route that captures no signal is
+/// unhealthy because source-aware diarization depends on this stem.
+pub fn probe_system_audio_capture(
+    config: &Config,
+) -> Result<Option<(RouteDescription, ProbeResult)>, String> {
+    let Some(device_override) = crate::capture::resolve_system_audio_probe_device(config)? else {
+        return Ok(None);
+    };
+
+    let backend = CpalSystemAudioBackend::new(device_override);
+    let route = backend.current_route();
+    backend
+        .probe(SYSTEM_AUDIO_PROBE_SECS)
+        .map(|result| Some((route, result)))
+        .map_err(|error| error.to_string())
+}
+
+pub fn check_system_audio_capture(config: &Config) -> HealthItem {
+    match probe_system_audio_capture(config) {
+        Ok(None) => HealthItem {
+            label: "System audio capture".into(),
+            state: "ready".into(),
+            detail: "No system-audio source configured. Room and memo recordings use microphone capture only.".into(),
+            optional: true,
+        },
+        Ok(Some((route, result))) => health_item_for_system_audio_probe(Some(&route), &result),
+        Err(error) => HealthItem {
+            label: "System audio capture".into(),
+            state: "attention".into(),
+            detail: format!("System-audio probe could not start: {error}"),
+            optional: true,
+        },
+    }
+}
+
+pub fn health_item_for_system_audio_probe(
+    route: Option<&RouteDescription>,
+    result: &ProbeResult,
+) -> HealthItem {
+    let route_label = route
+        .and_then(|route| route.device_name.as_deref())
+        .unwrap_or("configured system-audio route");
+    let observed = &result.observed_signal;
+    let detail = if let Some(kind) = &result.failure_kind {
+        format!(
+            "Probe on '{route_label}' found {:?}: {} frame(s), max RMS {:.4}, avg RMS {:.4}.",
+            kind, observed.frames_captured, observed.max_rms, observed.avg_rms
+        )
+    } else {
+        format!(
+            "Probe on '{route_label}' captured signal: {} frame(s), max RMS {:.4}, avg RMS {:.4}.",
+            observed.frames_captured, observed.max_rms, observed.avg_rms
+        )
+    };
+
+    HealthItem {
+        label: "System audio capture".into(),
+        state: if result.failure_kind.is_none() {
+            "ready"
+        } else {
+            "attention"
+        }
+        .into(),
+        detail,
+        optional: true,
+    }
+}
+
+pub fn recording_health_for_skipped_system_audio_probe(reason: &str) -> RecordingHealth {
+    RecordingHealth {
+        voice_stem_active_ratio: None,
+        system_stem_active_ratio: None,
+        system_dominant_ratio: None,
+        capture_warnings: vec![CaptureWarning {
+            kind: FailureKind::Other {
+                code: "system-audio-probe-skipped".into(),
+            },
+            source: CaptureSource::System,
+            message: format!(
+                "System-audio readiness probe was skipped before recording. Operator reason: {}",
+                reason.trim()
+            ),
+            diagnostic_confidence: DiagnosticConfidence::Inferred,
+        }],
+        diarization_path: Some(DiarizationPath::None),
+    }
+}
+
+pub fn recording_health_for_system_audio_probe_failure(
+    route: Option<&RouteDescription>,
+    result: &ProbeResult,
+) -> RecordingHealth {
+    let kind = result.failure_kind.clone().unwrap_or(FailureKind::Other {
+        code: "probe-failed".into(),
+    });
+    let route_label = route
+        .and_then(|route| route.device_name.as_deref())
+        .unwrap_or("configured system-audio route");
+    RecordingHealth {
+        voice_stem_active_ratio: None,
+        system_stem_active_ratio: None,
+        system_dominant_ratio: None,
+        capture_warnings: vec![CaptureWarning {
+            kind,
+            source: CaptureSource::System,
+            message: format!(
+                "System-audio readiness probe failed before recording on '{}': {} frame(s), max RMS {:.4}, avg RMS {:.4}.",
+                route_label,
+                result.observed_signal.frames_captured,
+                result.observed_signal.max_rms,
+                result.observed_signal.avg_rms
+            ),
+            diagnostic_confidence: result.diagnostic_confidence,
+        }],
+        diarization_path: Some(DiarizationPath::None),
+    }
 }
 
 /// Check if the whisper model is downloaded and ready.
@@ -386,7 +515,7 @@ mod tests {
     fn test_check_all_returns_items() {
         let config = Config::default();
         let items = check_all(&config);
-        assert!(items.len() >= 5, "should have at least 5 health checks");
+        assert!(items.len() >= 6, "should have at least 6 health checks");
         for item in &items {
             assert!(!item.label.is_empty());
             assert!(
@@ -395,6 +524,75 @@ mod tests {
                 item.state
             );
         }
+    }
+
+    #[test]
+    fn system_audio_health_is_ready_when_no_route_configured() {
+        let config = Config::default();
+        let item = check_system_audio_capture(&config);
+
+        assert_eq!(item.label, "System audio capture");
+        assert_eq!(item.state, "ready");
+        assert!(item.optional);
+        assert!(item.detail.contains("No system-audio source configured"));
+    }
+
+    #[test]
+    fn system_audio_health_reports_probe_signal() {
+        let route = RouteDescription {
+            capture_backend: "cpal".into(),
+            device_name: Some("BlackHole 2ch".into()),
+        };
+        let result = ProbeResult {
+            observed_signal: crate::diarize::ObservedSignal {
+                frames_captured: 1_600,
+                max_rms: 0.02,
+                avg_rms: 0.01,
+            },
+            failure_kind: None,
+            diagnostic_confidence: DiagnosticConfidence::High,
+        };
+
+        let item = health_item_for_system_audio_probe(Some(&route), &result);
+
+        assert_eq!(item.state, "ready");
+        assert!(item.detail.contains("BlackHole 2ch"));
+        assert!(item.detail.contains("captured signal"));
+    }
+
+    #[test]
+    fn system_audio_health_reports_silent_probe() {
+        let result = ProbeResult {
+            observed_signal: crate::diarize::ObservedSignal {
+                frames_captured: 1_600,
+                max_rms: 0.0,
+                avg_rms: 0.0,
+            },
+            failure_kind: Some(FailureKind::Silent),
+            diagnostic_confidence: DiagnosticConfidence::Inferred,
+        };
+
+        let item = health_item_for_system_audio_probe(None, &result);
+
+        assert_eq!(item.state, "attention");
+        assert!(item.detail.contains("Silent"));
+        assert!(item.detail.contains("max RMS 0.0000"));
+    }
+
+    #[test]
+    fn skipped_system_audio_probe_health_records_reason() {
+        let health = recording_health_for_skipped_system_audio_probe("hotel Wi-Fi call");
+
+        assert_eq!(health.diarization_path, Some(DiarizationPath::None));
+        assert_eq!(health.capture_warnings.len(), 1);
+        assert_eq!(health.capture_warnings[0].source, CaptureSource::System);
+        assert!(matches!(
+            health.capture_warnings[0].kind,
+            FailureKind::Other { ref code } if code == "system-audio-probe-skipped"
+        ));
+        assert!(health.capture_warnings[0]
+            .message
+            .contains("hotel Wi-Fi call"));
     }
 
     #[test]

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -81,6 +81,8 @@ pub struct ProcessingJob {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub template_slug: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recording_health: Option<crate::markdown::RecordingHealth>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub word_count: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -108,6 +110,35 @@ pub fn queue_live_capture(
     calendar_event: Option<CalendarEvent>,
     template_slug: Option<String>,
 ) -> std::io::Result<ProcessingJob> {
+    queue_live_capture_with_recording_health(
+        mode,
+        title,
+        current_wav,
+        user_notes,
+        pre_context,
+        recording_started_at,
+        recording_finished_at,
+        context_session_id,
+        calendar_event,
+        template_slug,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn queue_live_capture_with_recording_health(
+    mode: CaptureMode,
+    title: Option<String>,
+    current_wav: &Path,
+    user_notes: Option<String>,
+    pre_context: Option<String>,
+    recording_started_at: Option<DateTime<Local>>,
+    recording_finished_at: Option<DateTime<Local>>,
+    context_session_id: Option<String>,
+    calendar_event: Option<CalendarEvent>,
+    template_slug: Option<String>,
+    recording_health: Option<crate::markdown::RecordingHealth>,
+) -> std::io::Result<ProcessingJob> {
     let job_id = next_job_id();
     let old_screen_dir = crate::screen::screens_dir_for(current_wav);
     let audio_path = move_capture_into_job(&job_id, current_wav)?;
@@ -131,6 +162,7 @@ pub fn queue_live_capture(
         pre_context,
         calendar_event,
         template_slug,
+        recording_health,
         word_count: None,
         error: None,
         owner_pid: None,
@@ -289,6 +321,7 @@ pub fn enqueue_capture_job(
         pre_context,
         calendar_event,
         template_slug,
+        recording_health: None,
         word_count: None,
         error: None,
         owner_pid: None,
@@ -684,6 +717,7 @@ fn job_context(job: &ProcessingJob) -> BackgroundPipelineContext {
         calendar_event: job.calendar_event.clone(),
         recorded_at: job.recording_started_at.or(job.recording_finished_at),
         requested_title: job.title.clone(),
+        recording_health: job.recording_health.clone(),
         template,
     }
 }
@@ -982,6 +1016,38 @@ mod tests {
     }
 
     #[test]
+    fn queue_live_capture_persists_recording_health() {
+        with_temp_home(|_| {
+            let current_wav = pid::current_wav_path();
+            if let Some(parent) = current_wav.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&current_wav, b"fake-wav").unwrap();
+            let health = crate::health::recording_health_for_skipped_system_audio_probe(
+                "operator accepted mic-only call",
+            );
+
+            let job = queue_live_capture_with_recording_health(
+                CaptureMode::Meeting,
+                Some("Probe skipped".into()),
+                &current_wav,
+                None,
+                None,
+                Some(Local::now()),
+                Some(Local::now()),
+                None,
+                None,
+                None,
+                Some(health.clone()),
+            )
+            .unwrap();
+
+            let loaded = load_job(&job.id).unwrap();
+            assert_eq!(loaded.recording_health, Some(health));
+        });
+    }
+
+    #[test]
     fn preserve_audio_alongside_output_moves_stems_too() {
         with_temp_home(|tmp| {
             let jobs_root = jobs_dir();
@@ -1016,6 +1082,7 @@ mod tests {
                 pre_context: None,
                 calendar_event: None,
                 template_slug: None,
+                recording_health: None,
                 word_count: None,
                 error: None,
                 owner_pid: None,
@@ -1102,6 +1169,7 @@ mod tests {
                 pre_context: None,
                 calendar_event: None,
                 template_slug: None,
+                recording_health: None,
                 word_count: None,
                 error: None,
                 owner_pid: Some(99_999_999),
@@ -1139,6 +1207,7 @@ mod tests {
                 pre_context: None,
                 calendar_event: None,
                 template_slug: None,
+                recording_health: None,
                 word_count: Some(42),
                 error: Some("boom".into()),
                 owner_pid: None,
@@ -1180,6 +1249,7 @@ mod tests {
                 pre_context: None,
                 calendar_event: None,
                 template_slug: None,
+                recording_health: None,
                 word_count: Some(42),
                 error: None,
                 owner_pid: None,
@@ -1218,6 +1288,7 @@ mod tests {
                 pre_context: None,
                 calendar_event: None,
                 template_slug: None,
+                recording_health: None,
                 word_count: None,
                 error: None,
                 owner_pid: None,
@@ -1241,6 +1312,7 @@ mod tests {
                 pre_context: None,
                 calendar_event: None,
                 template_slug: None,
+                recording_health: None,
                 word_count: None,
                 error: None,
                 owner_pid: None,

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -274,6 +274,35 @@ fn degraded_ml_recording_health(reason: diarize::DegradedCapture) -> markdown::R
     )
 }
 
+fn merge_recording_health(
+    primary: Option<markdown::RecordingHealth>,
+    existing: Option<markdown::RecordingHealth>,
+) -> Option<markdown::RecordingHealth> {
+    match (primary, existing) {
+        (Some(mut primary), Some(existing)) => {
+            primary.voice_stem_active_ratio = primary
+                .voice_stem_active_ratio
+                .or(existing.voice_stem_active_ratio);
+            primary.system_stem_active_ratio = primary
+                .system_stem_active_ratio
+                .or(existing.system_stem_active_ratio);
+            primary.system_dominant_ratio = primary
+                .system_dominant_ratio
+                .or(existing.system_dominant_ratio);
+            if primary.diarization_path.is_none() {
+                primary.diarization_path = existing.diarization_path;
+            }
+            let mut warnings = existing.capture_warnings;
+            warnings.extend(primary.capture_warnings);
+            primary.capture_warnings = warnings;
+            Some(primary)
+        }
+        (Some(primary), None) => Some(primary),
+        (None, Some(existing)) => Some(existing),
+        (None, None) => None,
+    }
+}
+
 fn mark_degraded_ml_attributions(speaker_map: &mut [diarize::SpeakerAttribution]) {
     for attribution in speaker_map {
         attribution.confidence = diarize::Confidence::Low;
@@ -757,6 +786,7 @@ pub struct BackgroundPipelineContext {
     pub calendar_event: Option<crate::calendar::CalendarEvent>,
     pub recorded_at: Option<DateTime<Local>>,
     pub requested_title: Option<String>,
+    pub recording_health: Option<crate::markdown::RecordingHealth>,
     /// Optional template applied to summarization. Recorded in frontmatter
     /// so Phase 2 reprocessing knows which template produced this file.
     pub template: Option<crate::template::Template>,
@@ -1068,7 +1098,7 @@ pub fn write_transcript_artifact(
         recorded_by: config.identity.name.clone(),
         visibility: None,
         speaker_map: vec![],
-        recording_health: None,
+        recording_health: context.recording_health.clone(),
         template: context.template.as_ref().map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
             Some(filter_stats.diagnosis())
@@ -1391,7 +1421,8 @@ where
     frontmatter.decisions = structured_decisions;
     frontmatter.intents = structured_intents;
     frontmatter.speaker_map = speaker_map;
-    frontmatter.recording_health = recording_health.or(frontmatter.recording_health);
+    frontmatter.recording_health =
+        merge_recording_health(recording_health, frontmatter.recording_health);
 
     on_progress(PipelineStage::Saving);
     let mut result = markdown::rewrite_with_retry_path(

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -1313,9 +1313,14 @@ registerTool(
       .default(false)
       .describe("Allow a mic-only capture to continue even if Minutes detects a call but no system-audio route is configured."),
     language: z.string().optional().describe("Transcription language code (e.g. 'en', 'ur', 'es', 'zh'). Overrides config.toml setting."),
+    skip_audio_probe_reason: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Per-call reason to skip the system-audio readiness probe. This is not persisted and is written into recording_health."),
   },
   { title: "Start Recording", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
-  async ({ title, mode, intent, allow_degraded, language }) => {
+  async ({ title, mode, intent, allow_degraded, language, skip_audio_probe_reason }) => {
     if (!(await isCliAvailable())) {
       return { content: [{ type: "text" as const, text: CLI_INSTALL_MSG }] };
     }
@@ -1342,6 +1347,17 @@ registerTool(
     // For non-extension mode, still delegate call recordings to the desktop app
     // (it has system audio capture that the CLI can't do).
     if (isExtensionRuntime || preflight.intent === "call") {
+      if (skip_audio_probe_reason) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: "skip_audio_probe_reason cannot be honored for desktop-delegated recordings yet. Start the recording from the CLI with --skip-audio-probe \"<reason>\" if you intentionally want to bypass the system-audio readiness probe.",
+          }],
+          structuredContent: { preflight },
+          isError: true,
+        };
+      }
+
       let response: DesktopControlResponse | null;
       try {
         response = await delegateRecordingToDesktop({
@@ -1435,6 +1451,7 @@ registerTool(
     if (title) args.push("--title", title);
     if (intent) args.push("--intent", intent);
     if (allow_degraded) args.push("--allow-degraded");
+    if (skip_audio_probe_reason) args.push("--skip-audio-probe", skip_audio_probe_reason);
     if (language) args.push("--language", language);
 
     const child = spawn(MINUTES_BIN, args, {

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 977;
+export const MINUTES_TEST_COUNT = 982;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary
- add a system-audio health probe backed by `SystemAudioBackend::probe()` and include it in `minutes health`/`check_all`
- block meeting recordings with configured system-audio sources when the readiness probe observes silence/starvation/backend failure
- add per-run `--skip-audio-probe <reason>` and carry that reason into queued job metadata so final markdown can preserve it in `recording_health.capture_warnings`
- expose a reason-shaped MCP argument for direct CLI recordings while rejecting silent skip attempts on desktop-delegated recordings

## Scope guard
- no Core Audio Process Tap backend
- no macOS permission UI or `NSAudioCaptureUsageDescription` wiring
- no redo-diarization tooling
- no sticky config flag for probe bypass

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p minutes-cli --no-default-features`
- `cargo clippy --all --no-default-features -- -D warnings`
- `cargo test -p minutes-core health::tests --no-default-features`
- `cargo test -p minutes-core jobs::tests --no-default-features`
- `cargo test -p minutes-core pipeline::tests --no-default-features`
- `cargo test -p minutes-core capture::tests --no-default-features`
- `cargo test -p minutes-core system_audio_backend --no-default-features`
- `cargo test -p minutes-core system_audio_backend --features streaming --no-default-features`
- `npm test` in `crates/mcp`
- `npm run build` in `crates/mcp`
- `node scripts/sync_site_release_version.mjs --check`
- `git diff --check`

Note: broad `cargo test -p minutes-cli` currently fails on pre-existing `DecodeHintEvalTranscriptMetrics` test fixtures missing the newer `text` field. I did not expand this PR into that unrelated CLI test-fixture repair.