### PR TITLE
feat(macos): add Core Audio Process Tap backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cidre"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c903ff1729987d29e07295d2c5841993db25ff86cca43bee04505878d3ec1a7"
+dependencies = [
+ "cc",
+ "cidre-macros",
+]
+
+[[package]]
+name = "cidre-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6facfeffa8b9792dc014bb4e65e364d13518b74e06783d56249810a3e48cfad7"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,6 +3217,7 @@ version = "0.16.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "cidre",
  "cpal",
  "crossbeam-channel",
  "dirs 6.0.0",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -55,6 +55,7 @@ tempfile = "3"
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+cidre = { version = "0.15.0", default-features = false, features = ["at", "av", "cat", "cf", "cm", "core_audio", "macos_14_4", "ns"] }
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSRunningApplication", "NSWorkspace", "libc"] }
 objc2-av-foundation = { version = "0.3.2", default-features = false, features = ["AVCaptureDevice", "AVMediaFormat"] }

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -497,6 +497,8 @@ fn resolve_capture_plan(config: &Config) -> Result<CapturePlan, CaptureError> {
 }
 
 pub fn resolve_system_audio_probe_device(config: &Config) -> Result<Option<String>, String> {
+    let use_core_audio_tap = crate::system_audio_backend::configured_capture_backend(config)?
+        == crate::system_audio_backend::CaptureBackendKind::CoreAudioTap;
     let Some(call_override) = config
         .recording
         .sources
@@ -507,6 +509,19 @@ pub fn resolve_system_audio_probe_device(config: &Config) -> Result<Option<Strin
     else {
         return Ok(None);
     };
+
+    if use_core_audio_tap {
+        if crate::system_audio_backend::core_audio_tap_source_is_supported(call_override) {
+            return Ok(Some(
+                crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND.to_string(),
+            ));
+        }
+        return Err(format!(
+            "recording.capture_backend = '{}' captures the default system output; set [recording.sources] call = \"auto\" instead of '{}'",
+            crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND,
+            call_override
+        ));
+    }
 
     if call_override.eq_ignore_ascii_case("auto") {
         detect_loopback_device()
@@ -546,6 +561,24 @@ fn resolve_capture_plan_with_host(
     #[cfg(feature = "streaming")]
     if let Some(call_override) = call_override {
         let (_, voice_name) = select_device_with_override(host, voice_override.as_deref())?;
+        let use_core_audio_tap = crate::system_audio_backend::configured_capture_backend(config)
+            .map_err(|error| CaptureError::Io(std::io::Error::other(error)))?
+            == crate::system_audio_backend::CaptureBackendKind::CoreAudioTap;
+        if use_core_audio_tap {
+            if !crate::system_audio_backend::core_audio_tap_source_is_supported(call_override) {
+                return Err(CaptureError::Io(std::io::Error::other(format!(
+                    "recording.capture_backend = '{}' captures the default system output; set [recording.sources] call = \"auto\" instead of '{}'",
+                    crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND,
+                    call_override
+                ))));
+            }
+            return Ok(CapturePlan::Dual(DualCapturePlan {
+                voice_override,
+                voice_device_name: voice_name,
+                call_override: crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND.into(),
+                call_device_name: crate::system_audio_backend::CORE_AUDIO_TAP_ROUTE_NAME.into(),
+            }));
+        }
         let resolved_call = if call_override.eq_ignore_ascii_case("auto") {
             detect_loopback_device().ok_or_else(|| {
                 CaptureError::Io(std::io::Error::other(MISSING_DUAL_SOURCE_LOOPBACK_MESSAGE))
@@ -968,8 +1001,6 @@ fn record_to_wav_dual_source(
     plan: DualCapturePlan,
     started_context: Option<RecordingStartedContext>,
 ) -> Result<(), CaptureError> {
-    use crate::system_audio_backend::SystemAudioBackend;
-
     crate::pid::check_and_clear_sentinel();
     // Refresh the in-process mic-mute flag from the sentinel. The CLI
     // `--mute-mic` flag writes the sentinel before getting here, and the
@@ -984,8 +1015,10 @@ fn record_to_wav_dual_source(
 
     let mut voice_stream = Some(AudioStream::start(plan.voice_override.as_deref())?);
     let (system_tx, system_backend_rx) = crossbeam_channel::bounded(64);
-    let mut system_backend =
-        crate::system_audio_backend::CpalSystemAudioBackend::new(plan.call_override.clone());
+    let mut system_backend = crate::system_audio_backend::system_audio_backend_for_config(
+        config,
+        plan.call_override.clone(),
+    )?;
     let mut system_stream = Some(system_backend.start(system_tx.clone())?);
     let system_device_name = system_stream
         .as_ref()
@@ -2035,6 +2068,7 @@ pub fn is_system_audio_device_name(name: &str) -> bool {
         "stereo mix",
         "multi-output",
         "aggregate",
+        "core audio process tap",
         // macOS app-installed virtual drivers (verified 2026-04-06)
         "mmaudio",
         "loomaudio",
@@ -2728,6 +2762,46 @@ mod tests {
             false, // not pipewire
         );
         assert_eq!(category, DeviceCategory::SystemAudio);
+    }
+
+    #[test]
+    fn core_audio_process_tap_route_counts_as_system_audio() {
+        assert!(is_system_audio_device_name(
+            crate::system_audio_backend::CORE_AUDIO_TAP_ROUTE_NAME
+        ));
+    }
+
+    #[test]
+    fn core_audio_tap_probe_route_does_not_require_loopback_device() {
+        let mut config = Config::default();
+        config.recording.capture_backend =
+            crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND.into();
+        config.recording.sources = Some(crate::config::SourcesConfig {
+            voice: Some("default".into()),
+            call: Some("auto".into()),
+        });
+
+        let route = resolve_system_audio_probe_device(&config).unwrap();
+
+        assert_eq!(
+            route.as_deref(),
+            Some(crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND)
+        );
+    }
+
+    #[test]
+    fn core_audio_tap_rejects_named_loopback_call_source() {
+        let mut config = Config::default();
+        config.recording.capture_backend =
+            crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND.into();
+        config.recording.sources = Some(crate::config::SourcesConfig {
+            voice: Some("default".into()),
+            call: Some("BlackHole 2ch".into()),
+        });
+
+        let error = resolve_system_audio_probe_device(&config).unwrap_err();
+
+        assert!(error.contains("call = \"auto\""));
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -449,6 +449,9 @@ pub struct RecordingConfig {
     /// Allow Minutes to start a call capture even when the selected input
     /// looks like a plain microphone rather than a system-audio route.
     pub allow_degraded_call_capture: bool,
+    /// System-audio capture backend. "cpal" keeps the current loopback-device
+    /// path. "core-audio-tap" opts into Apple's macOS Process Tap backend.
+    pub capture_backend: String,
     /// Multi-source capture: explicit voice + call device names.
     /// When set, `device` is ignored. CLI `--source` flags override this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -476,6 +479,7 @@ impl Default for RecordingConfig {
             device: None,
             auto_call_intent: false,
             allow_degraded_call_capture: false,
+            capture_backend: "cpal".into(),
             sources: None,
         }
     }
@@ -1227,6 +1231,7 @@ mod tests {
         assert!(!config.watch.extensions.is_empty());
         assert!(!config.recording.auto_call_intent);
         assert!(!config.recording.allow_degraded_call_capture);
+        assert_eq!(config.recording.capture_backend, "cpal");
     }
 
     #[test]

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -16,9 +16,7 @@
 use crate::config::Config;
 use crate::diarize::{CaptureSource, DiagnosticConfidence, FailureKind};
 use crate::markdown::{CaptureWarning, DiarizationPath, RecordingHealth};
-use crate::system_audio_backend::{
-    CpalSystemAudioBackend, ProbeResult, RouteDescription, SystemAudioBackend,
-};
+use crate::system_audio_backend::{system_audio_backend_for_config, ProbeResult, RouteDescription};
 use serde::{Deserialize, Serialize};
 
 const SYSTEM_AUDIO_PROBE_SECS: u32 = 5;
@@ -60,7 +58,8 @@ pub fn probe_system_audio_capture(
         return Ok(None);
     };
 
-    let backend = CpalSystemAudioBackend::new(device_override);
+    let backend = system_audio_backend_for_config(config, device_override)
+        .map_err(|error| error.to_string())?;
     let route = backend.current_route();
     backend
         .probe(SYSTEM_AUDIO_PROBE_SECS)

--- a/crates/core/src/system_audio_backend.rs
+++ b/crates/core/src/system_audio_backend.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::diarize::{DiagnosticConfidence, FailureKind, ObservedSignal};
 use crate::error::CaptureError;
 
@@ -31,6 +32,110 @@ pub struct ProbeResult {
     pub observed_signal: ObservedSignal,
     pub failure_kind: Option<FailureKind>,
     pub diagnostic_confidence: DiagnosticConfidence,
+}
+
+pub const CPAL_CAPTURE_BACKEND: &str = "cpal";
+pub const CORE_AUDIO_TAP_CAPTURE_BACKEND: &str = "core-audio-tap";
+pub const CORE_AUDIO_TAP_ROUTE_NAME: &str = "Core Audio Process Tap";
+pub const CORE_AUDIO_TAP_MIN_MACOS: MacOsVersion = MacOsVersion {
+    major: 14,
+    minor: 4,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureBackendKind {
+    Cpal,
+    CoreAudioTap,
+}
+
+impl CaptureBackendKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpal => CPAL_CAPTURE_BACKEND,
+            Self::CoreAudioTap => CORE_AUDIO_TAP_CAPTURE_BACKEND,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MacOsVersion {
+    pub major: u32,
+    pub minor: u32,
+}
+
+pub fn parse_macos_version(version: &str) -> Option<MacOsVersion> {
+    let mut parts = version.trim().split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    Some(MacOsVersion { major, minor })
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn current_macos_version() -> Option<MacOsVersion> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_macos_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+pub fn configured_capture_backend(config: &Config) -> Result<CaptureBackendKind, String> {
+    parse_capture_backend(&config.recording.capture_backend)
+}
+
+pub fn parse_capture_backend(value: &str) -> Result<CaptureBackendKind, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "cpal" => Ok(CaptureBackendKind::Cpal),
+        "core-audio-tap" | "core_audio_tap" | "coreaudio-tap" | "process-tap" => {
+            Ok(CaptureBackendKind::CoreAudioTap)
+        }
+        other => Err(format!(
+            "unknown recording.capture_backend '{other}'; expected 'cpal' or 'core-audio-tap'"
+        )),
+    }
+}
+
+pub fn core_audio_tap_source_is_supported(source: &str) -> bool {
+    let normalized = source.trim().to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "auto" | "" | CORE_AUDIO_TAP_CAPTURE_BACKEND | "core_audio_tap" | "coreaudio-tap"
+    )
+}
+
+pub fn system_audio_backend_for_config(
+    config: &Config,
+    route_hint: String,
+) -> Result<Box<dyn SystemAudioBackend>, CaptureError> {
+    match configured_capture_backend(config).map_err(capture_config_error)? {
+        CaptureBackendKind::Cpal => Ok(Box::new(CpalSystemAudioBackend::new(route_hint))),
+        CaptureBackendKind::CoreAudioTap => {
+            if !core_audio_tap_source_is_supported(&route_hint) {
+                return Err(capture_config_error(format!(
+                    "recording.capture_backend = '{}' captures the default system output; set [recording.sources] call = \"auto\" instead of '{route_hint}'",
+                    CORE_AUDIO_TAP_CAPTURE_BACKEND
+                )));
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                Ok(Box::new(CoreAudioTapSystemAudioBackend::new()))
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                Err(capture_config_error(
+                    "recording.capture_backend = 'core-audio-tap' is only available on macOS",
+                ))
+            }
+        }
+    }
+}
+
+fn capture_config_error(message: impl Into<String>) -> CaptureError {
+    CaptureError::Io(std::io::Error::other(message.into()))
 }
 
 pub trait SystemAudioBackend {
@@ -100,6 +205,52 @@ impl SystemAudioBackend for CpalSystemAudioBackend {
 
     fn permission_status(&self) -> Option<PermissionStatus> {
         None
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone)]
+pub struct CoreAudioTapSystemAudioBackend {
+    current_route: RouteDescription,
+}
+
+#[cfg(target_os = "macos")]
+impl CoreAudioTapSystemAudioBackend {
+    pub fn new() -> Self {
+        Self {
+            current_route: RouteDescription {
+                capture_backend: CORE_AUDIO_TAP_CAPTURE_BACKEND.into(),
+                device_name: Some(CORE_AUDIO_TAP_ROUTE_NAME.into()),
+            },
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Default for CoreAudioTapSystemAudioBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl SystemAudioBackend for CoreAudioTapSystemAudioBackend {
+    fn probe(&self, secs: u32) -> Result<ProbeResult, CaptureError> {
+        core_audio_tap_probe(secs)
+    }
+
+    fn start(&mut self, sink: AudioSink) -> Result<StreamHandle, CaptureError> {
+        let handle = core_audio_tap_start_stream(sink)?;
+        self.current_route = handle.route();
+        Ok(StreamHandle::new(handle))
+    }
+
+    fn current_route(&self) -> RouteDescription {
+        self.current_route.clone()
+    }
+
+    fn permission_status(&self) -> Option<PermissionStatus> {
+        Some(PermissionStatus::Unknown)
     }
 }
 
@@ -265,6 +416,407 @@ fn cpal_probe(_device_override: &str, _secs: u32) -> Result<ProbeResult, Capture
     })
 }
 
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+struct CoreAudioTapSystemAudioStreamHandle {
+    _started_device: cidre::core_audio::hardware::StartedDevice<cidre::core_audio::AggregateDevice>,
+    _tap: cidre::core_audio::TapGuard,
+    _ctx: Box<CoreAudioTapCallbackContext>,
+    err_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    route: RouteDescription,
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+impl SystemAudioStreamHandle for CoreAudioTapSystemAudioStreamHandle {
+    fn has_error(&self) -> bool {
+        self.err_flag.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn route(&self) -> RouteDescription {
+        self.route.clone()
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+struct CoreAudioTapCallbackContext {
+    sink: AudioSink,
+    err_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ratio: f64,
+    channels: usize,
+    interleaved: bool,
+    resample_pos: f64,
+    input_samples: Vec<f32>,
+    chunk_index: u64,
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+impl CoreAudioTapCallbackContext {
+    fn new(
+        sink: AudioSink,
+        err_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        asbd: cidre::cat::AudioStreamBasicDesc,
+    ) -> Self {
+        Self {
+            sink,
+            err_flag,
+            ratio: asbd.sample_rate / 16_000.0,
+            channels: asbd.channels_per_frame.max(1) as usize,
+            interleaved: asbd.is_interleaved(),
+            resample_pos: 0.0,
+            input_samples: Vec::new(),
+            chunk_index: 0,
+        }
+    }
+
+    fn ingest(&mut self, input_data: &cidre::cat::AudioBufList<1>) {
+        let Some(mono) = mono_f32_samples(input_data, self.channels, self.interleaved) else {
+            self.err_flag
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            return;
+        };
+        self.input_samples.extend(mono);
+
+        let mut resampled = Vec::new();
+        while self.resample_pos < self.input_samples.len() as f64 {
+            let idx = self.resample_pos as usize;
+            if let Some(sample) = self.input_samples.get(idx) {
+                resampled.push(*sample);
+            }
+            self.resample_pos += self.ratio;
+        }
+
+        let consumed = (self.resample_pos as usize).min(self.input_samples.len());
+        if consumed > 0 {
+            self.input_samples.drain(..consumed);
+            self.resample_pos -= consumed as f64;
+        }
+
+        if resampled.is_empty() {
+            return;
+        }
+
+        let rms = (resampled
+            .iter()
+            .map(|sample| (*sample as f64) * (*sample as f64))
+            .sum::<f64>()
+            / resampled.len() as f64)
+            .sqrt() as f32;
+        let index = self.chunk_index;
+        self.chunk_index += 1;
+        let _ = self.sink.try_send(AudioChunk {
+            samples: resampled,
+            rms,
+            timestamp: std::time::Instant::now(),
+            index,
+            source: SourceRole::Call,
+        });
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn mono_f32_samples(
+    input_data: &cidre::cat::AudioBufList<1>,
+    channels: usize,
+    interleaved: bool,
+) -> Option<Vec<f32>> {
+    let buffer_count = input_data.number_buffers as usize;
+    if buffer_count == 0 {
+        return Some(Vec::new());
+    }
+    let buffers = unsafe { std::slice::from_raw_parts(input_data.buffers.as_ptr(), buffer_count) };
+
+    if interleaved {
+        let buffer = buffers.first()?;
+        if buffer.data.is_null() || buffer.data_bytes_size == 0 {
+            return Some(Vec::new());
+        }
+        let channels = (buffer.number_channels as usize).max(channels).max(1);
+        let sample_count = buffer.data_bytes_size as usize / std::mem::size_of::<f32>();
+        let samples =
+            unsafe { std::slice::from_raw_parts(buffer.data as *const f32, sample_count) };
+        let mut mono = Vec::with_capacity(sample_count / channels);
+        for frame in samples.chunks(channels) {
+            mono.push(frame.iter().copied().sum::<f32>() / frame.len() as f32);
+        }
+        return Some(mono);
+    }
+
+    let frame_count = buffers
+        .iter()
+        .filter(|buffer| !buffer.data.is_null())
+        .map(|buffer| buffer.data_bytes_size as usize / std::mem::size_of::<f32>())
+        .min()
+        .unwrap_or(0);
+    let mut mono = Vec::with_capacity(frame_count);
+    for frame in 0..frame_count {
+        let mut sum = 0.0f32;
+        let mut count = 0usize;
+        for buffer in buffers {
+            if buffer.data.is_null() {
+                continue;
+            }
+            let samples = unsafe {
+                std::slice::from_raw_parts(
+                    buffer.data as *const f32,
+                    buffer.data_bytes_size as usize / std::mem::size_of::<f32>(),
+                )
+            };
+            if let Some(sample) = samples.get(frame) {
+                sum += *sample;
+                count += 1;
+            }
+        }
+        if count > 0 {
+            mono.push(sum / count as f32);
+        }
+    }
+    Some(mono)
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+extern "C" fn core_audio_tap_io_proc(
+    _device: cidre::core_audio::Device,
+    _now: &cidre::cat::AudioTimeStamp,
+    input_data: &cidre::cat::AudioBufList<1>,
+    _input_time: &cidre::cat::AudioTimeStamp,
+    _output_data: &mut cidre::cat::AudioBufList<1>,
+    _output_time: &cidre::cat::AudioTimeStamp,
+    ctx: Option<&mut CoreAudioTapCallbackContext>,
+) -> cidre::os::Status {
+    if let Some(ctx) = ctx {
+        ctx.ingest(input_data);
+    }
+    Default::default()
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn core_audio_tap_start_stream(
+    sink: AudioSink,
+) -> Result<CoreAudioTapSystemAudioStreamHandle, CaptureError> {
+    use cidre::{cf, core_audio as ca, ns};
+
+    ensure_core_audio_tap_runtime()?;
+
+    let output_device = default_core_audio_output_device()?;
+    let output_uid = output_device
+        .uid()
+        .map_err(|error| core_audio_error("default output device UID", error))?;
+    let output_name = output_device
+        .name()
+        .ok()
+        .map(|name| name.to_string())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| "default output".into());
+
+    let sub_device = cf::DictionaryOf::with_keys_values(
+        &[ca::sub_device_keys::uid()],
+        &[output_uid.as_type_ref()],
+    );
+
+    let mut tap_desc = ca::TapDesc::with_stereo_global_tap_excluding_processes(&ns::Array::new());
+    tap_desc.set_name(Some(ns::str!(c"Minutes System Audio")));
+    tap_desc.set_private(true);
+    tap_desc.set_mute_behavior(ca::TapMuteBehavior::Unmuted);
+    let tap = tap_desc
+        .create_process_tap()
+        .map_err(|error| core_audio_error("create process tap", error))?;
+    let asbd = tap
+        .asbd()
+        .map_err(|error| core_audio_error("read process tap format", error))?;
+    if !tap_asbd_is_supported(&asbd) {
+        return Err(capture_config_error(format!(
+            "Core Audio Process Tap returned unsupported format: {asbd:?}"
+        )));
+    }
+
+    let sub_tap = cf::DictionaryOf::with_keys_values(
+        &[ca::sub_device_keys::uid()],
+        &[tap
+            .uid()
+            .map_err(|error| core_audio_error("process tap UID", error))?
+            .as_type_ref()],
+    );
+    let aggregate_desc = cf::DictionaryOf::with_keys_values(
+        &[
+            ca::aggregate_device_keys::is_private(),
+            ca::aggregate_device_keys::is_stacked(),
+            ca::aggregate_device_keys::tap_auto_start(),
+            ca::aggregate_device_keys::name(),
+            ca::aggregate_device_keys::main_sub_device(),
+            ca::aggregate_device_keys::uid(),
+            ca::aggregate_device_keys::sub_device_list(),
+            ca::aggregate_device_keys::tap_list(),
+        ],
+        &[
+            cf::Boolean::value_true().as_type_ref(),
+            cf::Boolean::value_false(),
+            cf::Boolean::value_true(),
+            cf::str!(c"Minutes Process Tap"),
+            &output_uid,
+            &cf::Uuid::new().to_cf_string(),
+            &cf::ArrayOf::from_slice(&[sub_device.as_ref()]),
+            &cf::ArrayOf::from_slice(&[sub_tap.as_ref()]),
+        ],
+    );
+    let aggregate_device = ca::AggregateDevice::with_desc(&aggregate_desc)
+        .map_err(|error| core_audio_error("create private aggregate tap device", error))?;
+
+    let err_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let mut ctx = Box::new(CoreAudioTapCallbackContext::new(
+        sink,
+        std::sync::Arc::clone(&err_flag),
+        asbd,
+    ));
+    let proc_id = aggregate_device
+        .create_io_proc_id(core_audio_tap_io_proc, Some(ctx.as_mut()))
+        .map_err(|error| core_audio_error("create process tap IOProc", error))?;
+    let started_device = ca::device_start(aggregate_device, Some(proc_id))
+        .map_err(|error| core_audio_error("start process tap device", error))?;
+
+    Ok(CoreAudioTapSystemAudioStreamHandle {
+        _started_device: started_device,
+        _tap: tap,
+        _ctx: ctx,
+        err_flag,
+        route: RouteDescription {
+            capture_backend: CORE_AUDIO_TAP_CAPTURE_BACKEND.into(),
+            device_name: Some(format!("{CORE_AUDIO_TAP_ROUTE_NAME} ({output_name})")),
+        },
+    })
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn core_audio_tap_probe(secs: u32) -> Result<ProbeResult, CaptureError> {
+    let (tx, rx) = crossbeam_channel::bounded(64);
+    let handle = core_audio_tap_start_stream(tx)?;
+    let route = handle.route();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs as u64);
+    let mut frames_captured = 0usize;
+    let mut sum_square = 0.0f64;
+    let mut max_rms = 0.0f32;
+
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let timeout = remaining.min(std::time::Duration::from_millis(100));
+        match rx.recv_timeout(timeout) {
+            Ok(chunk) => {
+                frames_captured += chunk.samples.len();
+                max_rms = max_rms.max(chunk.rms);
+                sum_square += chunk
+                    .samples
+                    .iter()
+                    .map(|sample| (*sample as f64) * (*sample as f64))
+                    .sum::<f64>();
+            }
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    drop(handle);
+
+    let avg_rms = if frames_captured > 0 {
+        (sum_square / frames_captured as f64).sqrt() as f32
+    } else {
+        0.0
+    };
+    let observed_signal = ObservedSignal {
+        frames_captured,
+        max_rms,
+        avg_rms,
+    };
+    let failure_kind = if frames_captured == 0 {
+        Some(FailureKind::SourceStarved)
+    } else if max_rms <= 0.001 {
+        Some(FailureKind::Silent)
+    } else {
+        None
+    };
+    tracing::debug!(route = ?route, ?observed_signal, "Core Audio Process Tap probe completed");
+
+    Ok(ProbeResult {
+        observed_signal,
+        failure_kind,
+        diagnostic_confidence: DiagnosticConfidence::High,
+    })
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn tap_asbd_is_supported(asbd: &cidre::cat::AudioStreamBasicDesc) -> bool {
+    asbd.format == cidre::cat::AudioFormat::LINEAR_PCM
+        && asbd.frames_per_packet == 1
+        && asbd
+            .format_flags
+            .contains(cidre::cat::AudioFormatFlags::IS_FLOAT)
+        && asbd.bits_per_channel == 32
+        && asbd.sample_rate > 0.0
+        && asbd.channels_per_frame > 0
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn ensure_core_audio_tap_runtime() -> Result<(), CaptureError> {
+    let Some(version) = current_macos_version() else {
+        return Err(capture_config_error(
+            "could not determine macOS version for Core Audio Process Tap",
+        ));
+    };
+    if version < CORE_AUDIO_TAP_MIN_MACOS {
+        return Err(capture_config_error(format!(
+            "Core Audio Process Tap requires macOS {}.{} or newer; this Mac reports {}.{}",
+            CORE_AUDIO_TAP_MIN_MACOS.major,
+            CORE_AUDIO_TAP_MIN_MACOS.minor,
+            version.major,
+            version.minor
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn default_core_audio_output_device() -> Result<cidre::core_audio::Device, CaptureError> {
+    use cidre::core_audio as ca;
+
+    if let Ok(device) = ca::System::default_output_device() {
+        if !device.is_unknown() {
+            return Ok(device);
+        }
+    }
+    if let Ok(device) = ca::System::default_sys_output_device() {
+        if !device.is_unknown() {
+            return Ok(device);
+        }
+    }
+
+    Err(capture_config_error(
+        "Core Audio Process Tap requires a default macOS output device, but none is available",
+    ))
+}
+
+#[cfg(all(target_os = "macos", feature = "streaming"))]
+fn core_audio_error(context: &str, error: impl std::fmt::Display) -> CaptureError {
+    CaptureError::Io(std::io::Error::other(format!("{context}: {error}")))
+}
+
+#[cfg(any(not(target_os = "macos"), not(feature = "streaming")))]
+fn core_audio_tap_probe(_secs: u32) -> Result<ProbeResult, CaptureError> {
+    Ok(ProbeResult {
+        observed_signal: ObservedSignal {
+            frames_captured: 0,
+            max_rms: 0.0,
+            avg_rms: 0.0,
+        },
+        failure_kind: Some(FailureKind::BackendUnavailable),
+        diagnostic_confidence: DiagnosticConfidence::Inferred,
+    })
+}
+
+#[cfg(all(target_os = "macos", not(feature = "streaming")))]
+fn core_audio_tap_start_stream(
+    _sink: AudioSink,
+) -> Result<UnsupportedSystemAudioStreamHandle, CaptureError> {
+    Err(capture_config_error(
+        "Core Audio Process Tap backend requires the streaming feature",
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,6 +833,61 @@ mod tests {
             }
         );
         assert_eq!(backend.permission_status(), None);
+    }
+
+    #[test]
+    fn capture_backend_parser_accepts_default_and_core_audio_tap_aliases() {
+        assert_eq!(parse_capture_backend(""), Ok(CaptureBackendKind::Cpal));
+        assert_eq!(parse_capture_backend("cpal"), Ok(CaptureBackendKind::Cpal));
+        assert_eq!(
+            parse_capture_backend("core-audio-tap"),
+            Ok(CaptureBackendKind::CoreAudioTap)
+        );
+        assert_eq!(
+            parse_capture_backend("core_audio_tap"),
+            Ok(CaptureBackendKind::CoreAudioTap)
+        );
+        assert!(parse_capture_backend("screencapturekit").is_err());
+    }
+
+    #[test]
+    fn parses_macos_major_minor_versions() {
+        assert_eq!(
+            parse_macos_version("14.4.1"),
+            Some(MacOsVersion {
+                major: 14,
+                minor: 4
+            })
+        );
+        assert_eq!(
+            parse_macos_version("15"),
+            Some(MacOsVersion {
+                major: 15,
+                minor: 0
+            })
+        );
+        assert_eq!(parse_macos_version("not-a-version"), None);
+    }
+
+    #[test]
+    fn core_audio_tap_source_requires_auto_style_route() {
+        assert!(core_audio_tap_source_is_supported("auto"));
+        assert!(core_audio_tap_source_is_supported("core-audio-tap"));
+        assert!(!core_audio_tap_source_is_supported("BlackHole 2ch"));
+    }
+
+    #[test]
+    fn backend_factory_defaults_to_cpal_route() {
+        let config = Config::default();
+        let backend = system_audio_backend_for_config(&config, "BlackHole 2ch".into()).unwrap();
+
+        assert_eq!(
+            backend.current_route(),
+            RouteDescription {
+                capture_backend: "cpal".into(),
+                device_name: Some("BlackHole 2ch".into()),
+            }
+        );
     }
 
     #[test]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -106,6 +106,7 @@ server compatibility.
 | `min_disk_space_mb` | `500` | Auto-stop when free disk space drops below this; 0 = off |
 | `auto_call_intent` | `false` | Infer call intent from process detection (high false-positive rate) |
 | `allow_degraded_call_capture` | `false` | Allow call capture when selected input isn't a system-audio route |
+| `capture_backend` | `"cpal"` | System-audio backend: `"cpal"` for loopback devices, or opt-in `"core-audio-tap"` on macOS 14.4+ |
 
 ### `[recording.sources]` — multi-source capture
 
@@ -113,6 +114,10 @@ server compatibility.
 |---|---|---|
 | `voice` | unset | Voice (mic) device name, or `"default"` |
 | `call` | unset | Call (system audio) device name, or `"auto"` to detect loopback |
+
+When `capture_backend = "core-audio-tap"`, set `call = "auto"`. The backend
+captures the default macOS system output via Core Audio Process Tap instead of
+opening a named loopback input device.
 
 ### `[identity]` — who you are (for attribution)
 

--- a/docs/CORE-AUDIO-PROCESS-TAP.md
+++ b/docs/CORE-AUDIO-PROCESS-TAP.md
@@ -1,0 +1,49 @@
+# Core Audio Process Tap Backend
+
+Minutes can opt into Apple's Core Audio Process Tap API for macOS system-audio
+capture with:
+
+```toml
+[recording]
+capture_backend = "core-audio-tap"
+
+[recording.sources]
+voice = "default"
+call = "auto"
+```
+
+This backend is intentionally opt-in while the existing `cpal` loopback-device
+path remains the default.
+
+## Runtime Target
+
+The code gates Process Tap startup to macOS 14.4 or newer. Apple's
+`AudioHardwareCreateProcessTap` header is available as of macOS 14.2, but the
+Rust binding and community examples target the 14.4 generation, so 14.4 is the
+minimum supported runtime for this backend.
+
+The app bundle deployment target stays lower for now. Older macOS releases can
+still run Minutes and use the `cpal` backend; only the explicit
+`core-audio-tap` backend returns unavailable below macOS 14.4.
+
+## Permissions
+
+The macOS bundle includes:
+
+- `NSAudioCaptureUsageDescription` for Process Tap system-audio access
+- `NSMicrophoneUsageDescription` for mic capture
+- `NSScreenCaptureUsageDescription` for the older ScreenCaptureKit helper and
+  optional screenshot context
+
+There is no reliable permission-status shortcut in this PR. A Process Tap can
+be created but still deliver silence, so the readiness probe remains the source
+of truth: startup health must observe non-zero frames and non-silent RMS before
+the system-audio route is treated as healthy.
+
+## Entitlements and Notarization
+
+No new hardened-runtime entitlement was added for Process Tap in this slice.
+The existing Tauri entitlements already include microphone audio input and
+user-selected file access. Release notarization should not need a new entitlement
+for the tap backend, but signed builds must carry the updated Info.plist string
+so macOS can present the correct privacy prompt.

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 983;
+export const MINUTES_TEST_COUNT = 990;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/Info.plist
+++ b/tauri/src-tauri/Info.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>Minutes needs microphone access to record meetings, voice memos, and your side of call audio.</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>Minutes needs system audio access to capture the other side of calls without requiring a virtual loopback device.</string>
     <key>NSScreenCaptureUsageDescription</key>
     <string>Minutes uses screen and system-audio capture for call recording and can optionally capture screenshots for visual context during recordings.</string>
     <key>NSCalendarsFullAccessUsageDescription</key>


### PR DESCRIPTION
## Summary
- add opt-in `recording.capture_backend = "core-audio-tap"` for macOS system-audio capture while keeping `cpal` as the default
- wire the backend into capture planning and health probing, with `call = "auto"` required for Process Tap
- add `NSAudioCaptureUsageDescription` and document the macOS 14.4+ runtime target, permission behavior, and config

## Verification
- `cargo test -p minutes-core system_audio_backend::tests --no-default-features`
- `cargo test -p minutes-core system_audio_backend::tests --no-default-features --features streaming`
- `cargo test -p minutes-core capture::tests::core_audio --no-default-features`
- `cargo test -p minutes-core config::tests --no-default-features`
- `cargo test -p minutes-core health::tests --no-default-features`
- `HOME=/private/tmp/minutes-pr4-test-home USERPROFILE=/private/tmp/minutes-pr4-test-home cargo test -p minutes-core --no-default-features --lib -- --test-threads=1`
- `HOME=/private/tmp/minutes-pr4-test-home USERPROFILE=/private/tmp/minutes-pr4-test-home cargo test -p minutes-core --features streaming --lib -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo clippy --all --no-default-features -- -D warnings`
- `git diff --check`
- `MINUTES_DEV_SIGNING_IDENTITY=... ./scripts/install-dev-app.sh --no-open`
- verified installed `~/Applications/Minutes Dev.app` includes `NSAudioCaptureUsageDescription` and is signed by Developer ID team `63TMLKT8HN`
- ran signed sidecar `minutes health --json` with opt-in Process Tap config; this shell has no Core Audio devices, so the probe correctly reports the explicit no-default-output-device attention state instead of the earlier raw `!obj` Core Audio error