### PR TITLE
fix(app): throttle recording status polling

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -6279,7 +6279,11 @@
     }
 
     // ── Status polling ──
+    let statusCheckInFlight = false;
+
     async function checkStatus() {
+      if (statusCheckInFlight) return;
+      statusCheckInFlight = true;
       try {
         const status = await invoke('cmd_status');
         const wasRecording = isRecording;
@@ -6456,12 +6460,14 @@
         }
       } catch (e) {
         console.error('Status:', e);
+      } finally {
+        statusCheckInFlight = false;
       }
     }
 
     function startFastPoll() {
       stopFastPoll();
-      pollInterval = setInterval(checkStatus, 150);
+      pollInterval = setInterval(checkStatus, 1000);
     }
 
     function stopFastPoll() {


### PR DESCRIPTION
## Summary
- prevent overlapping desktop status polls from piling up on the Tauri/WebKit bridge
- reduce recording fast-poll cadence from 150ms to 1000ms to avoid starving CoreAudio during capture

## Evidence
- observed production Minutes.app v0.16.2 non-responsive at ~90-100% CPU while recording
- stack sample showed main-thread WebKit URL-scheme task handling; unified logs showed repeated URL-scheme tasks alongside CoreAudio overload warnings

## Tests
- cargo test -p minutes-app update_ui_tests
- cargo fmt --check
- cargo check -p minutes-app
- git diff --check

Note: signed dev-app install compiled but hit an existing local signing-script timestamp failure while re-signing system_audio_record, so I did not use it as the verification surface yet.