### PR TITLE
fix(app): persist dismissed processing notices

### DIFF
--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -64,6 +64,8 @@ pub struct ProcessingJob {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finished_at: Option<DateTime<Local>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notice_dismissed_at: Option<DateTime<Local>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recording_started_at: Option<DateTime<Local>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recording_finished_at: Option<DateTime<Local>>,
@@ -155,6 +157,7 @@ pub fn queue_live_capture_with_recording_health(
         created_at: Local::now(),
         started_at: None,
         finished_at: None,
+        notice_dismissed_at: None,
         recording_started_at,
         recording_finished_at,
         context_session_id,
@@ -314,6 +317,7 @@ pub fn enqueue_capture_job(
         created_at: Local::now(),
         started_at: None,
         finished_at: None,
+        notice_dismissed_at: None,
         recording_started_at,
         recording_finished_at,
         context_session_id,
@@ -540,6 +544,7 @@ pub fn requeue_job(job_id: &str) -> std::io::Result<Option<ProcessingJob>> {
         job.stage = JobState::Queued.default_stage();
         job.started_at = None;
         job.finished_at = None;
+        job.notice_dismissed_at = None;
         job.error = None;
         job.owner_pid = None;
     })?
@@ -553,6 +558,14 @@ pub fn requeue_job(job_id: &str) -> std::io::Result<Option<ProcessingJob>> {
 
     sync_processing_status();
     Ok(Some(requeued))
+}
+
+pub fn dismiss_job_notice(job_id: &str) -> std::io::Result<Option<ProcessingJob>> {
+    update_job_state(job_id, |job| {
+        if matches!(job.state, JobState::Failed | JobState::NeedsReview) {
+            job.notice_dismissed_at = Some(Local::now());
+        }
+    })
 }
 
 pub fn processing_summary() -> Option<ProcessingJob> {
@@ -1075,6 +1088,7 @@ mod tests {
                 created_at: Local::now(),
                 started_at: None,
                 finished_at: None,
+                notice_dismissed_at: None,
                 recording_started_at: None,
                 recording_finished_at: None,
                 context_session_id: None,
@@ -1162,6 +1176,7 @@ mod tests {
                 created_at: Local::now(),
                 started_at: Some(Local::now()),
                 finished_at: None,
+                notice_dismissed_at: None,
                 recording_started_at: None,
                 recording_finished_at: None,
                 context_session_id: None,
@@ -1200,6 +1215,7 @@ mod tests {
                 created_at: Local::now(),
                 started_at: Some(Local::now()),
                 finished_at: Some(Local::now()),
+                notice_dismissed_at: None,
                 recording_started_at: None,
                 recording_finished_at: None,
                 context_session_id: None,
@@ -1225,6 +1241,49 @@ mod tests {
     }
 
     #[test]
+    fn dismiss_job_notice_marks_retryable_job_and_requeue_clears_it() {
+        with_temp_home(|dir| {
+            let audio_path = dir.path().join("fake.wav");
+            fs::write(&audio_path, b"fake-wav").unwrap();
+
+            let job = ProcessingJob {
+                id: "job-dismissed".into(),
+                mode: CaptureMode::Meeting,
+                content_type: ContentType::Meeting,
+                title: Some("dismiss me".into()),
+                audio_path: audio_path.display().to_string(),
+                output_path: None,
+                state: JobState::Failed,
+                stage: Some("Processing failed".into()),
+                created_at: Local::now(),
+                started_at: Some(Local::now()),
+                finished_at: Some(Local::now()),
+                notice_dismissed_at: None,
+                recording_started_at: None,
+                recording_finished_at: None,
+                context_session_id: None,
+                user_notes: None,
+                pre_context: None,
+                calendar_event: None,
+                template_slug: None,
+                recording_health: None,
+                word_count: None,
+                error: Some("boom".into()),
+                owner_pid: None,
+            };
+            write_job(&job).unwrap();
+
+            let dismissed = dismiss_job_notice(&job.id).unwrap().unwrap();
+            assert!(dismissed.notice_dismissed_at.is_some());
+
+            let requeued = requeue_job(&job.id).unwrap().unwrap();
+            assert_eq!(requeued.state, JobState::Queued);
+            assert_eq!(requeued.notice_dismissed_at, None);
+            assert_eq!(requeued.error, None);
+        });
+    }
+
+    #[test]
     fn requeue_job_rejects_non_retryable_state() {
         with_temp_home(|dir| {
             let audio_path = dir.path().join("fake.wav");
@@ -1242,6 +1301,7 @@ mod tests {
                 created_at: Local::now(),
                 started_at: Some(Local::now()),
                 finished_at: Some(Local::now()),
+                notice_dismissed_at: None,
                 recording_started_at: None,
                 recording_finished_at: None,
                 context_session_id: None,
@@ -1281,6 +1341,7 @@ mod tests {
                 created_at: Local::now() - chrono::Duration::minutes(5),
                 started_at: Some(Local::now() - chrono::Duration::minutes(4)),
                 finished_at: None,
+                notice_dismissed_at: None,
                 recording_started_at: None,
                 recording_finished_at: None,
                 context_session_id: None,
@@ -1305,6 +1366,7 @@ mod tests {
                 created_at: Local::now(),
                 started_at: None,
                 finished_at: None,
+                notice_dismissed_at: None,
                 recording_started_at: None,
                 recording_finished_at: None,
                 context_session_id: None,

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 990;
+export const MINUTES_TEST_COUNT = 991;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3007,7 +3007,7 @@ fn latest_retryable_output_notice() -> Option<OutputNotice> {
             matches!(
                 job.state,
                 minutes_core::jobs::JobState::Failed | minutes_core::jobs::JobState::NeedsReview
-            )
+            ) && job.notice_dismissed_at.is_none()
         })
         .collect::<Vec<_>>();
 
@@ -5775,6 +5775,19 @@ pub fn cmd_clear_open_artifact(state: tauri::State<AppState>) -> Result<(), Stri
 
 #[tauri::command]
 pub fn cmd_clear_latest_output(state: tauri::State<AppState>) {
+    let dismissed_job_id = state
+        .latest_output
+        .lock()
+        .ok()
+        .and_then(|current| current.as_ref().and_then(|notice| notice.job_id.clone()));
+    if let Some(job_id) = dismissed_job_id {
+        if let Err(error) = minutes_core::jobs::dismiss_job_notice(&job_id) {
+            eprintln!(
+                "[minutes] failed to persist dismissed processing notice for {}: {}",
+                job_id, error
+            );
+        }
+    }
     set_latest_output(&state.latest_output, None);
 }
 
@@ -9051,6 +9064,7 @@ mod tests {
             created_at: chrono::Local::now(),
             started_at: None,
             finished_at: Some(chrono::Local::now()),
+            notice_dismissed_at: None,
             recording_started_at: None,
             recording_finished_at: None,
             context_session_id: None,
@@ -9084,6 +9098,7 @@ mod tests {
             created_at: chrono::Local::now(),
             started_at: None,
             finished_at: Some(chrono::Local::now()),
+            notice_dismissed_at: None,
             recording_started_at: None,
             recording_finished_at: None,
             context_session_id: None,
@@ -9108,6 +9123,108 @@ mod tests {
             "Previous processing failed. Raw capture is preserved and can be retried."
         );
         assert!(!startup_notice.detail.contains("parakeet"));
+    }
+
+    #[test]
+    fn latest_retryable_notice_skips_dismissed_jobs_after_restart() {
+        with_temp_home(|_| {
+            let now = chrono::Local::now();
+            let dismissed_job = minutes_core::jobs::ProcessingJob {
+                id: "job-dismissed".into(),
+                title: Some("Already handled".into()),
+                mode: CaptureMode::Meeting,
+                content_type: ContentType::Meeting,
+                state: minutes_core::jobs::JobState::Failed,
+                stage: minutes_core::jobs::JobState::Failed.default_stage(),
+                output_path: None,
+                audio_path: "/tmp/dismissed.wav".into(),
+                error: Some("old failure".into()),
+                created_at: now - chrono::Duration::minutes(1),
+                started_at: None,
+                finished_at: Some(now),
+                notice_dismissed_at: Some(now),
+                recording_started_at: None,
+                recording_finished_at: None,
+                context_session_id: None,
+                user_notes: None,
+                pre_context: None,
+                calendar_event: None,
+                template_slug: None,
+                word_count: Some(0),
+                owner_pid: None,
+                recording_health: None,
+            };
+
+            minutes_core::jobs::write_job(&dismissed_job).unwrap();
+            assert!(
+                latest_retryable_output_notice().is_none(),
+                "dismissed startup notices should stay hidden after restart"
+            );
+        });
+    }
+
+    #[test]
+    fn latest_retryable_notice_falls_back_to_older_undismissed_job() {
+        with_temp_home(|_| {
+            let now = chrono::Local::now();
+            let dismissed_job = minutes_core::jobs::ProcessingJob {
+                id: "job-new-dismissed".into(),
+                title: Some("New dismissed".into()),
+                mode: CaptureMode::Meeting,
+                content_type: ContentType::Meeting,
+                state: minutes_core::jobs::JobState::Failed,
+                stage: minutes_core::jobs::JobState::Failed.default_stage(),
+                output_path: None,
+                audio_path: "/tmp/new-dismissed.wav".into(),
+                error: Some("new failure".into()),
+                created_at: now - chrono::Duration::minutes(1),
+                started_at: None,
+                finished_at: Some(now),
+                notice_dismissed_at: Some(now),
+                recording_started_at: None,
+                recording_finished_at: None,
+                context_session_id: None,
+                user_notes: None,
+                pre_context: None,
+                calendar_event: None,
+                template_slug: None,
+                word_count: Some(0),
+                owner_pid: None,
+                recording_health: None,
+            };
+            let older_job = minutes_core::jobs::ProcessingJob {
+                id: "job-old-visible".into(),
+                title: Some("Still retryable".into()),
+                mode: CaptureMode::Meeting,
+                content_type: ContentType::Meeting,
+                state: minutes_core::jobs::JobState::Failed,
+                stage: minutes_core::jobs::JobState::Failed.default_stage(),
+                output_path: None,
+                audio_path: "/tmp/old-visible.wav".into(),
+                error: Some("older failure".into()),
+                created_at: now - chrono::Duration::minutes(10),
+                started_at: None,
+                finished_at: Some(now - chrono::Duration::minutes(9)),
+                notice_dismissed_at: None,
+                recording_started_at: None,
+                recording_finished_at: None,
+                context_session_id: None,
+                user_notes: None,
+                pre_context: None,
+                calendar_event: None,
+                template_slug: None,
+                word_count: Some(0),
+                owner_pid: None,
+                recording_health: None,
+            };
+
+            minutes_core::jobs::write_job(&dismissed_job).unwrap();
+            minutes_core::jobs::write_job(&older_job).unwrap();
+
+            let notice = latest_retryable_output_notice().expect("older retryable notice");
+            assert_eq!(notice.job_id.as_deref(), Some("job-old-visible"));
+            assert_eq!(notice.path, "/tmp/old-visible.wav");
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- persist dismissal timestamps for retryable failed/needs-review processing job notices
- skip dismissed retryable notices during startup seeding
- clear dismissal when a job is retried so a fresh failure can surface again

## Verification
- cargo test -p minutes-core jobs::tests::
- cargo test -p minutes-app retryable
- cargo test -p minutes-app
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --all --no-default-features -- -D warnings
- cargo test -p minutes-core -- --test-threads=1 (outside workspace sandbox; 683 passed, 1 ignored; integration + doc tests passed)