### PR TITLE
fix(app): make meeting note text selectable and draft pickers float above modal

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -1818,7 +1818,9 @@
       justify-content: center;
       background: rgba(7, 8, 10, 0.64);
       backdrop-filter: blur(12px);
-      z-index: 90;
+      /* Must sit above .detail-overlay (z-index 120) — the picker is launched
+         from the meeting note overlay and would otherwise render behind it. */
+      z-index: 130;
       padding: 20px;
     }
 
@@ -2289,6 +2291,8 @@
     .detail-scroll {
       overflow-y: auto;
       padding: 0 20px 20px;
+      -webkit-user-select: text;
+      user-select: text;
     }
 
     .detail-bottom-cta {
@@ -11996,6 +12000,12 @@
       rerenderOpenArtifact(markdownText);
       mdViewerEditor.value = kind === 'json' ? formatJsonSource(markdownText) : markdownText;
       mdViewer.classList.add('active');
+      // The detail overlay is a fixed full-screen layer (z-index 120) — leaving it
+      // open would render the draft behind the meeting note. Close it so the
+      // newly-active md-viewer is actually visible.
+      if (detailOverlay.classList.contains('active')) {
+        detailOverlay.classList.remove('active');
+      }
       meetingsScroll.style.display = 'none';
       mdSearchWrap.style.display = 'none';
       footer.style.display = 'none';
@@ -12087,7 +12097,9 @@
           editable: true,
         });
         if (!shown) return;
-        showDetailFeedback(`Created ${draft.templateKind.replaceAll('-', ' ')} draft`, 'success');
+        // The detail overlay is closed by showMdViewer, so showDetailFeedback would
+        // render into a hidden element. The md-viewer opening with the draft contents
+        // is itself the confirmation that the draft was created.
       } catch (e) {
         console.error('Create artifact:', e);
         showDetailFeedback(`Could not create draft: ${e}`, 'error');


### PR DESCRIPTION
## Summary

Closes #221.

Two UI issues in the meeting note overlay (`.detail-overlay`):

1. **Text was unselectable** in the body: action items, decisions, transcript. The body's `user-select: none` leaked into `.detail-scroll` because nothing re-enabled it for the meeting view. Added `user-select: text` on `.detail-scroll`.
2. **CREATE DRAFT opened windows behind the meeting note**. Two layers were involved:
   - The artifact template picker (`Pick the artifact you want...`) sat at `z-index: 90`, but the meeting note is at `z-index: 120`, so the picker rendered underneath. Bumped it to `130`.
   - The draft md-viewer is an in-flow panel inside the left pane, not a fixed overlay. With the meeting note still active, it was occluded. `showMdViewer` now closes `.detail-overlay` when activating. Centralized in `showMdViewer` so all 7 callers behave consistently.

Also drops the now-invisible success toast in `createArtifactFromMeetingPath` (it was being written into the just-closed overlay; the md-viewer opening with the draft contents is itself the confirmation).

Adversarial review via codex caught the dead toast; the diff reflects that.

## Test plan

- [x] Build dev app via `./scripts/install-dev-app.sh` (ad-hoc signed)
- [x] Open a meeting; drag-select text in the transcript: selects
- [x] Click CREATE DRAFT; template picker appears in front of the meeting note
- [x] Pick a template; draft editor appears in front (meeting note closes)

Generated with [Claude Code](https://claude.com/claude-code)