### PR TITLE
fix(worker): harden post-stop transcription against SIGABRT + bounded retry (#229)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4866,14 +4866,46 @@ fn cmd_setup(model: &str, list: bool, diarization: bool) -> Result<()> {
     std::fs::create_dir_all(model_dir)?;
 
     let dest = model_dir.join(format!("ggml-{}.bin", model));
-    if dest.exists() {
-        let size = std::fs::metadata(&dest)?.len();
-        eprintln!(
-            "Model already downloaded: {} ({:.0} MB)",
-            dest.display(),
-            size as f64 / 1_048_576.0
-        );
+    let expected_min_bytes = minutes_core::transcribe::expected_whisper_model_size_bytes(model);
+    let mb = |bytes: u64| bytes as f64 / 1_048_576.0;
+
+    // Helper: treat an existing file as truncated if it's smaller than the
+    // expected minimum for this model (issue #229 root cause: a partial
+    // download was reported as "already downloaded" and whisper-rs aborted
+    // parsing the truncated GGML header). Returns Ok(true) when the
+    // existing file should be kept, Ok(false) when it was removed and a
+    // re-download is needed.
+    let keep_existing = if dest.exists() {
+        let actual = std::fs::metadata(&dest)?.len();
+        match expected_min_bytes {
+            Some(min_bytes) if actual < min_bytes => {
+                eprintln!(
+                    "Model file at {} is {:.0} MB but the {} model should be at least {:.0} MB.",
+                    dest.display(),
+                    mb(actual),
+                    model,
+                    mb(min_bytes),
+                );
+                eprintln!(
+                    "Looks truncated, probably an interrupted download. Removing and refetching."
+                );
+                std::fs::remove_file(&dest)?;
+                false
+            }
+            _ => {
+                eprintln!(
+                    "Model already downloaded: {} ({:.0} MB)",
+                    dest.display(),
+                    mb(actual),
+                );
+                true
+            }
+        }
     } else {
+        false
+    };
+
+    if !keep_existing {
         let url = format!(
             "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{}.bin",
             model
@@ -4881,6 +4913,23 @@ fn cmd_setup(model: &str, list: bool, diarization: bool) -> Result<()> {
 
         eprintln!("Downloading whisper model: {} ...", model);
         download_file(&url, &dest)?;
+
+        // Validate the freshly downloaded file too. A partial download
+        // that ends in a successful HTTP close (rare but possible) would
+        // otherwise slip through silently.
+        if let Some(min_bytes) = expected_min_bytes {
+            let actual = std::fs::metadata(&dest)?.len();
+            if actual < min_bytes {
+                let _ = std::fs::remove_file(&dest);
+                anyhow::bail!(
+                    "downloaded model is {:.0} MB but expected at least {:.0} MB for {}; the file was truncated and has been removed. Try running `minutes setup --model {}` again on a stable connection.",
+                    mb(actual),
+                    mb(min_bytes),
+                    model,
+                    model,
+                );
+            }
+        }
 
         // Update config hint
         eprintln!("\nTo use this model, add to ~/.config/minutes/config.toml:");

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -46,6 +46,22 @@ pub enum TranscribeError {
     #[error("failed to load whisper model: {0}")]
     ModelLoadError(String),
 
+    #[error(
+        "whisper model at {path} looks truncated: file is {actual_mb:.0} MB but the {model_name} model should be at least {expected_min_mb:.0} MB. \
+         A previous download was probably interrupted. Fix: rm \"{path}\" && minutes setup --model {model_name}"
+    )]
+    ModelTruncated {
+        /// Display path of the on-disk model file.
+        path: String,
+        /// Model name as passed to `minutes setup` (e.g. `medium`, `large-v3`).
+        model_name: String,
+        /// Observed size of the file on disk, in MB.
+        actual_mb: f64,
+        /// Conservative lower bound from `expected_whisper_model_size_bytes`,
+        /// in MB. Anything below this is treated as truncated.
+        expected_min_mb: f64,
+    },
+
     #[error("audio file is empty or has zero duration")]
     EmptyAudio,
 

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -1,6 +1,6 @@
 use crate::calendar::CalendarEvent;
 use crate::config::Config;
-use crate::error::MinutesError;
+use crate::error::{MinutesError, TranscribeError};
 use crate::markdown::{ContentType, OutputStatus};
 use crate::pid::{self, CaptureMode, PidGuard};
 use crate::pipeline::{self, BackgroundPipelineContext, PipelineStage};
@@ -8,8 +8,20 @@ use chrono::{DateTime, Local};
 use serde_json::json;
 use std::fs;
 use std::io::ErrorKind;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Upper bound on automatic stale-claim retries before a job is marked
+/// permanently `Failed`. Protects against deterministic crashes (issue #229:
+/// a SIGABRT inside whisper.cpp / `__cxa_finalize_ranges` left the job
+/// orphaned with `owner_pid` set; `list_jobs()` would reset to `Queued` and
+/// the next worker would crash the same way, in a loop).
+///
+/// The counter advances each time a non-terminal job is observed with a dead
+/// `owner_pid`. A user-initiated `requeue_job` resets it so a manual retry
+/// after fixing the underlying issue always gets a fresh budget.
+pub const MAX_AUTO_RETRIES: u32 = 2;
 
 static JOB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -100,6 +112,14 @@ pub struct ProcessingJob {
     pub error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner_pid: Option<u32>,
+    /// Number of times this job has been auto-recovered from a stale
+    /// `owner_pid` claim. `list_jobs()` increments this each time it observes
+    /// a non-terminal job whose worker is dead; once it reaches
+    /// `MAX_AUTO_RETRIES` the job is demoted to `Failed` instead of being
+    /// reset to `Queued`, so a deterministic worker crash cannot loop
+    /// forever (issue #229). Reset to 0 by `requeue_job` on a manual retry.
+    #[serde(default)]
+    pub retry_count: u32,
 }
 
 fn next_job_id() -> String {
@@ -107,6 +127,19 @@ fn next_job_id() -> String {
     let pid = std::process::id();
     let counter = JOB_COUNTER.fetch_add(1, Ordering::Relaxed);
     format!("job-{}-{}-{}", ts, pid, counter)
+}
+
+/// Best-effort string form of a `catch_unwind` payload. Most panics carry a
+/// `&'static str` or a `String`; fall back to a generic label otherwise so
+/// the failed-job record still has something meaningful for the user.
+fn describe_panic_payload(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "panic payload was not a string".to_string()
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -179,6 +212,7 @@ pub fn queue_live_capture_with_recording_health(
         word_count: None,
         error: None,
         owner_pid: None,
+        retry_count: 0,
     };
     if let Err(error) = write_job(&job) {
         if audio_path.exists() {
@@ -359,6 +393,7 @@ pub fn enqueue_capture_job(
         word_count: None,
         error: None,
         owner_pid: None,
+        retry_count: 0,
     };
     write_job(&job)?;
     maybe_mark_context_session_processing(&job, Path::new(&job.audio_path));
@@ -716,31 +751,66 @@ fn move_to_archive(source: &Path, dest: &Path) -> std::io::Result<()> {
 }
 
 pub fn list_jobs() -> Vec<ProcessingJob> {
-    let mut changed = false;
-    let jobs = list_jobs_raw()
-        .into_iter()
-        .map(|mut job| {
-            if !job.state.is_terminal()
+    // Collect just the IDs that look stale in this snapshot. Recovery
+    // itself is delegated to `update_job_state`, which reloads the latest
+    // disk state inside its read-modify-write — so a worker that claimed
+    // the job between this scan and the recovery call is not silently
+    // clobbered (codex review of issue #229: two races where a stale
+    // in-memory copy could overwrite a concurrent claim or an
+    // intervening update).
+    let snapshot = list_jobs_raw();
+    let recovery_candidates: Vec<String> = snapshot
+        .iter()
+        .filter(|job| {
+            !job.state.is_terminal()
                 && job.owner_pid.is_some()
                 && !job.owner_pid.map(pid::is_process_alive).unwrap_or(false)
-            {
-                job.state = JobState::Queued;
-                job.stage = JobState::Queued.default_stage();
-                job.owner_pid = None;
-                job.started_at = None;
-                changed = true;
-            }
-            job
         })
-        .collect::<Vec<_>>();
+        .map(|job| job.id.clone())
+        .collect();
 
-    if changed {
-        for job in &jobs {
-            let _ = write_job(job);
-        }
+    for id in &recovery_candidates {
+        let _ = update_job_state(id, |current| {
+            // Re-check on the fresh disk record: a concurrent worker may
+            // have claimed it after our snapshot, or another `list_jobs`
+            // caller may have already recovered it. Both are no-ops here.
+            if current.state.is_terminal()
+                || current.owner_pid.is_none()
+                || current
+                    .owner_pid
+                    .map(pid::is_process_alive)
+                    .unwrap_or(false)
+            {
+                return;
+            }
+            current.retry_count = current.retry_count.saturating_add(1);
+            current.owner_pid = None;
+            current.started_at = None;
+            if current.retry_count > MAX_AUTO_RETRIES {
+                current.state = JobState::Failed;
+                current.stage = JobState::Failed.default_stage();
+                current.finished_at = Some(Local::now());
+                if current.error.is_none() {
+                    current.error = Some(format!(
+                        "transcription worker crashed {} times without producing output; left as Failed for manual retry",
+                        current.retry_count
+                    ));
+                }
+            } else {
+                current.state = JobState::Queued;
+                current.stage = JobState::Queued.default_stage();
+            }
+        });
     }
 
-    jobs
+    // If we recovered anything, re-read so callers see the post-recovery
+    // state. Most polls have an empty candidate list so this branch is
+    // skipped and we return the original cheap snapshot.
+    if recovery_candidates.is_empty() {
+        snapshot
+    } else {
+        list_jobs_raw()
+    }
 }
 
 pub fn display_jobs(limit: Option<usize>, include_terminal: bool) -> Vec<ProcessingJob> {
@@ -803,6 +873,10 @@ pub fn requeue_job(job_id: &str) -> std::io::Result<Option<ProcessingJob>> {
         job.notice_dismissed_at = None;
         job.error = None;
         job.owner_pid = None;
+        // Manual requeue is the user explicitly retrying after looking at
+        // the failure; give them a fresh auto-retry budget so a future
+        // transient crash doesn't get masked by leftover counter state.
+        job.retry_count = 0;
     })?
     else {
         return Ok(None);
@@ -1089,16 +1163,26 @@ where
         let audio_path = PathBuf::from(&job.audio_path);
         let context = job_context(&job);
 
-        let artifact = match pipeline::transcribe_to_artifact(
-            &audio_path,
-            job.content_type,
-            job.title.as_deref(),
-            config,
-            &context,
-            job.output_path.as_deref().map(Path::new),
-        ) {
-            Ok(artifact) => artifact,
-            Err(error) => {
+        // Run transcription inside `catch_unwind` so a Rust panic in any of
+        // the heavy native paths (whisper.cpp FFI, parakeet helper, audio
+        // decode) surfaces as a normal `Err` here instead of unwinding
+        // through the worker. The macOS `_exit` path in
+        // `tauri/src-tauri/src/main.rs` separately prevents the
+        // C++-static-teardown abort during process exit; the two together
+        // are what stop SIGABRT from reaching the UI (issue #229).
+        let transcribe_outcome = catch_unwind(AssertUnwindSafe(|| {
+            pipeline::transcribe_to_artifact(
+                &audio_path,
+                job.content_type,
+                job.title.as_deref(),
+                config,
+                &context,
+                job.output_path.as_deref().map(Path::new),
+            )
+        }));
+        let artifact = match transcribe_outcome {
+            Ok(Ok(artifact)) => artifact,
+            Ok(Err(error)) => {
                 let Some(failed_job) = update_job_state(&job.id, |job| {
                     job.state = JobState::Failed;
                     job.stage = JobState::Failed.default_stage();
@@ -1111,6 +1195,32 @@ where
                     continue;
                 };
                 maybe_mark_context_session_failed(&failed_job, &error.to_string(), None);
+                sync_processing_status();
+                on_job_update(&failed_job);
+                continue;
+            }
+            Err(payload) => {
+                let message = format!(
+                    "transcription worker panicked: {}",
+                    describe_panic_payload(payload.as_ref())
+                );
+                tracing::error!(
+                    job_id = %job.id,
+                    error = %message,
+                    "transcription worker caught panic"
+                );
+                let Some(failed_job) = update_job_state(&job.id, |job| {
+                    job.state = JobState::Failed;
+                    job.stage = JobState::Failed.default_stage();
+                    job.finished_at = Some(Local::now());
+                    job.error = Some(message.clone());
+                    job.owner_pid = None;
+                })?
+                else {
+                    sync_processing_status();
+                    continue;
+                };
+                maybe_mark_context_session_failed(&failed_job, &message, None);
                 sync_processing_status();
                 on_job_update(&failed_job);
                 continue;
@@ -1172,22 +1282,45 @@ where
         sync_processing_status();
         on_job_update(&job);
 
-        let enrich_result = pipeline::enrich_transcript_artifact(
-            &audio_path,
-            &artifact,
-            config,
-            &context,
-            |stage| {
-                let state = stage_state(stage);
-                if let Ok(Some(job)) = update_job_state(&job.id, |job| {
-                    job.state = state;
-                    job.stage = state.default_stage();
-                }) {
-                    sync_processing_status();
-                    on_job_update(&job);
-                }
-            },
-        );
+        // Same `catch_unwind` rationale as the transcribe call above: the
+        // enrich path runs the LLM summarizer, diarization, and graph
+        // updates, any of which can panic in native or third-party code.
+        // We want a clean `Failed` job, not a crashed worker (issue #229).
+        let enrich_outcome = catch_unwind(AssertUnwindSafe(|| {
+            pipeline::enrich_transcript_artifact(
+                &audio_path,
+                &artifact,
+                config,
+                &context,
+                |stage| {
+                    let state = stage_state(stage);
+                    if let Ok(Some(job)) = update_job_state(&job.id, |job| {
+                        job.state = state;
+                        job.stage = state.default_stage();
+                    }) {
+                        sync_processing_status();
+                        on_job_update(&job);
+                    }
+                },
+            )
+        }));
+        let enrich_result = match enrich_outcome {
+            Ok(result) => result,
+            Err(payload) => {
+                let message = format!(
+                    "enrichment worker panicked: {}",
+                    describe_panic_payload(payload.as_ref())
+                );
+                tracing::error!(
+                    job_id = %job.id,
+                    error = %message,
+                    "enrichment worker caught panic"
+                );
+                Err(MinutesError::Transcribe(
+                    TranscribeError::TranscriptionFailed(message),
+                ))
+            }
+        };
 
         match enrich_result {
             Ok(result) => {
@@ -1421,6 +1554,7 @@ mod tests {
                 word_count: None,
                 error: None,
                 owner_pid: None,
+                retry_count: 0,
             };
             write_job(&job).unwrap();
 
@@ -1509,6 +1643,7 @@ mod tests {
                 word_count: None,
                 error: None,
                 owner_pid: Some(99_999_999),
+                retry_count: 0,
             };
             write_job(&job).unwrap();
 
@@ -1516,6 +1651,103 @@ mod tests {
             assert_eq!(jobs.len(), 1);
             assert_eq!(jobs[0].state, JobState::Queued);
             assert_eq!(jobs[0].owner_pid, None);
+            assert_eq!(jobs[0].retry_count, 1);
+        });
+    }
+
+    #[test]
+    fn list_jobs_demotes_to_failed_when_retry_cap_exceeded() {
+        with_temp_home(|_| {
+            // Already burned every auto-retry slot. A worker that died after
+            // claiming this job should not get a fresh `Queued` chance —
+            // that's exactly the "loop forever on a deterministic crash"
+            // case from issue #229.
+            let job = ProcessingJob {
+                id: "job-burned".into(),
+                mode: CaptureMode::Meeting,
+                content_type: ContentType::Meeting,
+                title: Some("burned".into()),
+                audio_path: "/tmp/fake.wav".into(),
+                output_path: None,
+                state: JobState::Transcribing,
+                stage: Some("Transcribing meeting".into()),
+                created_at: Local::now(),
+                started_at: Some(Local::now()),
+                finished_at: None,
+                notice_dismissed_at: None,
+                recording_started_at: None,
+                recording_finished_at: None,
+                context_session_id: None,
+                user_notes: None,
+                pre_context: None,
+                calendar_event: None,
+                template_slug: None,
+                recording_health: None,
+                word_count: None,
+                error: None,
+                owner_pid: Some(99_999_999),
+                retry_count: MAX_AUTO_RETRIES,
+            };
+            write_job(&job).unwrap();
+
+            // Trigger the recovery scan. The demoted job moves into the
+            // archive so it no longer shows up in `list_jobs()` (which
+            // only walks the active dir); verify the final state by
+            // reading the archived record directly.
+            let _ = list_jobs();
+
+            let recovered = load_job(&job.id).expect("archived job should be loadable");
+            assert_eq!(recovered.state, JobState::Failed);
+            assert_eq!(recovered.owner_pid, None);
+            assert_eq!(recovered.retry_count, MAX_AUTO_RETRIES + 1);
+            assert!(recovered
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("crashed")));
+
+            // The active copy should be gone — `update_job_state` moves it
+            // across the boundary on terminal transition.
+            assert!(!job_path(&job.id).exists());
+            assert!(job_archive_path(&job.id).exists());
+        });
+    }
+
+    #[test]
+    fn manual_requeue_resets_retry_count() {
+        with_temp_home(|dir| {
+            let audio_path = dir.path().join("fake.wav");
+            let job = ProcessingJob {
+                id: "job-retry-reset".into(),
+                mode: CaptureMode::Meeting,
+                content_type: ContentType::Meeting,
+                title: Some("retry reset".into()),
+                audio_path: audio_path.display().to_string(),
+                output_path: None,
+                state: JobState::Failed,
+                stage: Some("Processing failed".into()),
+                created_at: Local::now(),
+                started_at: Some(Local::now()),
+                finished_at: Some(Local::now()),
+                notice_dismissed_at: None,
+                recording_started_at: None,
+                recording_finished_at: None,
+                context_session_id: None,
+                user_notes: None,
+                pre_context: None,
+                calendar_event: None,
+                template_slug: None,
+                recording_health: None,
+                word_count: None,
+                error: Some("crashed three times".into()),
+                owner_pid: None,
+                retry_count: MAX_AUTO_RETRIES + 1,
+            };
+            write_job(&job).unwrap();
+            fs::write(&audio_path, b"fake-wav").unwrap();
+
+            let requeued = requeue_job(&job.id).unwrap().unwrap();
+            assert_eq!(requeued.state, JobState::Queued);
+            assert_eq!(requeued.retry_count, 0);
         });
     }
 
@@ -1548,6 +1780,7 @@ mod tests {
                 word_count: Some(42),
                 error: Some("boom".into()),
                 owner_pid: None,
+                retry_count: 0,
             };
             write_job(&job).unwrap();
             fs::write(&audio_path, b"fake-wav").unwrap();
@@ -1591,6 +1824,7 @@ mod tests {
                 word_count: None,
                 error: Some("boom".into()),
                 owner_pid: None,
+                retry_count: 0,
             };
             write_job(&job).unwrap();
 
@@ -1634,6 +1868,7 @@ mod tests {
                 word_count: Some(42),
                 error: None,
                 owner_pid: None,
+                retry_count: 0,
             };
             write_job(&job).unwrap();
 
@@ -1674,6 +1909,7 @@ mod tests {
                 word_count: None,
                 error: None,
                 owner_pid: None,
+                retry_count: 0,
             };
             let queued = ProcessingJob {
                 id: "job-queued".into(),
@@ -1699,6 +1935,7 @@ mod tests {
                 word_count: None,
                 error: None,
                 owner_pid: None,
+                retry_count: 0,
             };
 
             write_job(&active).unwrap();
@@ -1739,6 +1976,7 @@ mod tests {
             word_count: None,
             error: None,
             owner_pid: None,
+            retry_count: 0,
         }
     }
 

--- a/crates/core/src/pid.rs
+++ b/crates/core/src/pid.rs
@@ -733,6 +733,7 @@ mod tests {
             word_count: None,
             error: None,
             owner_pid: Some(4242),
+            retry_count: 0,
         };
         let jobs = vec![job];
         let status = status_with_active_jobs(&jobs);
@@ -784,6 +785,7 @@ mod tests {
             word_count: None,
             error: None,
             owner_pid: None,
+            retry_count: 0,
         };
         let active = mk("job-a", crate::jobs::JobState::Transcribing, "Active job");
         let queued = mk("job-q", crate::jobs::JobState::Queued, "Queued job");

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -1402,6 +1402,86 @@ fn denoise_audio(samples: &[f32], sample_rate: u32) -> Vec<f32> {
     denoised
 }
 
+/// Conservative lower bound on the on-disk size of each whisper.cpp ggml
+/// model from `huggingface.co/ggerganov/whisper.cpp`. Used to detect
+/// truncated downloads (issue #229: an interrupted download left a
+/// `ggml-medium.bin` at 221 MB instead of ~1.5 GB; `minutes setup` happily
+/// reported it as "already downloaded" and whisper-rs aborted parsing the
+/// truncated GGML header on the next transcription).
+///
+/// Numbers are set at roughly 90% of the canonical artifact size so a
+/// legitimate file passes comfortably and only a partial download fails
+/// the check. Out of scope here: per-model SHA256 manifests, which would
+/// catch corruption as well as truncation.
+///
+/// Returns `None` for unknown / custom model names; callers should treat
+/// that as "no check available" and skip size validation.
+pub fn expected_whisper_model_size_bytes(model_name: &str) -> Option<u64> {
+    // Real Content-Length values from the canonical URL the CLI downloads
+    // (`huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{name}.bin`)
+    // as of 2026-05-11:
+    //   tiny      ~74.1 MB
+    //   base     ~141.1 MB
+    //   small    ~465.0 MB
+    //   medium  ~1462.7 MB
+    //   large-v3 ~2951.7 MB
+    // Thresholds sit roughly 5% below those numbers so a real file passes
+    // and only a meaningfully truncated file is rejected.
+    //
+    // Quantized variants (`ggml-medium-q5_0.bin` and friends) have
+    // different sizes and intentionally aren't in this table; the parser
+    // in `validate_whisper_model_size` strips only the canonical
+    // `ggml-{name}.bin` shape, so quantized files resolve to a name like
+    // `medium-q5_0` that hits the `None` arm and skips validation.
+    match model_name {
+        "tiny" | "tiny.en" => Some(70 * 1024 * 1024),
+        "base" | "base.en" => Some(135 * 1024 * 1024),
+        "small" | "small.en" => Some(440 * 1024 * 1024),
+        "medium" | "medium.en" => Some(1_400 * 1024 * 1024),
+        "large-v1" | "large-v2" | "large-v3" | "large" => Some(2_800 * 1024 * 1024),
+        _ => None,
+    }
+}
+
+/// If the resolved path looks like a known `ggml-{name}.bin` artifact,
+/// check its on-disk size against `expected_whisper_model_size_bytes` and
+/// return `Err(ModelTruncated { .. })` if it falls short. Otherwise
+/// returns `Ok(path)` unchanged.
+///
+/// We only validate when the filename matches the canonical pattern so a
+/// user-supplied custom model path (e.g. a fine-tune in a non-standard
+/// location) is never falsely rejected.
+#[cfg(feature = "whisper")]
+fn validate_whisper_model_size(path: PathBuf) -> Result<PathBuf, TranscribeError> {
+    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+        return Ok(path);
+    };
+    let model_name = match file_name
+        .strip_prefix("ggml-")
+        .and_then(|rest| rest.strip_suffix(".bin"))
+    {
+        Some(name) => name,
+        None => return Ok(path),
+    };
+    let Some(expected_min) = expected_whisper_model_size_bytes(model_name) else {
+        return Ok(path);
+    };
+    let metadata = match std::fs::metadata(&path) {
+        Ok(m) => m,
+        Err(_) => return Ok(path),
+    };
+    let actual = metadata.len();
+    if actual >= expected_min {
+        return Ok(path);
+    }
+    Err(TranscribeError::ModelTruncated {
+        path: path.display().to_string(),
+        model_name: model_name.to_string(),
+        actual_mb: actual as f64 / (1024.0 * 1024.0),
+        expected_min_mb: expected_min as f64 / (1024.0 * 1024.0),
+    })
+}
+
 /// Resolve the whisper model file path for dictation (uses dictation.model config).
 #[cfg(feature = "whisper")]
 pub fn resolve_model_path_for_dictation(config: &Config) -> Result<PathBuf, TranscribeError> {
@@ -1416,13 +1496,13 @@ pub fn resolve_model_path_for_dictation(config: &Config) -> Result<PathBuf, Tran
 
     for candidate in &candidates {
         if candidate.exists() {
-            return Ok(candidate.clone());
+            return validate_whisper_model_size(candidate.clone());
         }
     }
 
     let direct = PathBuf::from(model_name);
     if direct.exists() {
-        return Ok(direct);
+        return validate_whisper_model_size(direct);
     }
 
     Err(TranscribeError::ModelNotFound(format!(
@@ -1450,13 +1530,13 @@ pub fn resolve_model_path_by_name(
 
     for candidate in &candidates {
         if candidate.exists() {
-            return Ok(candidate.clone());
+            return validate_whisper_model_size(candidate.clone());
         }
     }
 
     let direct = PathBuf::from(model_name);
     if direct.exists() {
-        return Ok(direct);
+        return validate_whisper_model_size(direct);
     }
 
     // Fall back to dictation model with a warning
@@ -1491,14 +1571,14 @@ fn resolve_model_path(config: &Config) -> Result<PathBuf, TranscribeError> {
 
     for candidate in &candidates {
         if candidate.exists() {
-            return Ok(candidate.clone());
+            return validate_whisper_model_size(candidate.clone());
         }
     }
 
     // If model_name is an absolute path, try it directly
     let direct = PathBuf::from(model_name);
     if direct.exists() {
-        return Ok(direct);
+        return validate_whisper_model_size(direct);
     }
 
     Err(TranscribeError::ModelNotFound(format!(
@@ -2818,6 +2898,76 @@ mod tests {
             "error should include the model directory: {}",
             err
         );
+    }
+
+    #[test]
+    fn expected_whisper_model_sizes_cover_canonical_names() {
+        for name in ["tiny", "base", "small", "medium", "large-v3"] {
+            assert!(
+                expected_whisper_model_size_bytes(name).is_some(),
+                "missing expected size for {}",
+                name
+            );
+        }
+        assert!(expected_whisper_model_size_bytes("nonexistent").is_none());
+        // Sanity: medium must be greater than small (catches regressions
+        // where someone confuses the rows of the size table).
+        assert!(
+            expected_whisper_model_size_bytes("medium").unwrap()
+                > expected_whisper_model_size_bytes("small").unwrap()
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "whisper")]
+    fn validate_whisper_model_size_rejects_truncated_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("ggml-medium.bin");
+        // Reproduces issue #229: write a 221 MB file where ~1.5 GB is expected.
+        // We use a smaller stand-in (10 MB) since the validator only cares about
+        // the comparison against `expected_whisper_model_size_bytes("medium")`.
+        let truncated_bytes = 10 * 1024 * 1024;
+        std::fs::write(&path, vec![0u8; truncated_bytes]).unwrap();
+
+        let result = validate_whisper_model_size(path.clone());
+        let err = result.expect_err("a 10 MB ggml-medium.bin should be rejected");
+        match err {
+            TranscribeError::ModelTruncated {
+                model_name,
+                actual_mb,
+                expected_min_mb,
+                ..
+            } => {
+                assert_eq!(model_name, "medium");
+                assert!(actual_mb < expected_min_mb);
+            }
+            other => panic!("expected ModelTruncated, got {:?}", other),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "whisper")]
+    fn validate_whisper_model_size_accepts_full_size_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("ggml-tiny.bin");
+        // A file at or above the tiny threshold should pass through.
+        let bytes = expected_whisper_model_size_bytes("tiny").unwrap() as usize + 1024;
+        std::fs::write(&path, vec![0u8; bytes]).unwrap();
+        let validated =
+            validate_whisper_model_size(path.clone()).expect("full-size tiny should pass");
+        assert_eq!(validated, path);
+    }
+
+    #[test]
+    #[cfg(feature = "whisper")]
+    fn validate_whisper_model_size_ignores_unknown_filenames() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("custom-finetune.bin");
+        std::fs::write(&path, vec![0u8; 1024]).unwrap();
+        // No `ggml-` prefix means no expected size; the validator must not
+        // reject otherwise legitimate user files in non-standard locations.
+        let validated = validate_whisper_model_size(path.clone()).unwrap();
+        assert_eq!(validated, path);
     }
 
     #[test]

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "2026-05-11",
-  "visibleCount": 55,
+  "visibleCount": 56,
   "hiddenCount": 16,
   "groups": [
     {
@@ -88,7 +88,7 @@
     },
     {
       "enumName": "TranscribeError",
-      "count": 9,
+      "count": 10,
       "entries": [
         {
           "id": "transcribeerror-modelnotfound",
@@ -111,6 +111,17 @@
           "hidden": false,
           "anchorId": "error-transcribeerror-modelloaderror",
           "docsUrl": "https://useminutes.app/docs/errors#error-transcribeerror-modelloaderror"
+        },
+        {
+          "id": "transcribeerror-modeltruncated",
+          "enumName": "TranscribeError",
+          "variant": "ModelTruncated",
+          "cfg": null,
+          "message": "{path}\" && minutes setup --model {model_name}",
+          "sourceFile": "crates/core/src/error.rs",
+          "hidden": false,
+          "anchorId": "error-transcribeerror-modeltruncated",
+          "docsUrl": "https://useminutes.app/docs/errors#error-transcribeerror-modeltruncated"
         },
         {
           "id": "transcribeerror-emptyaudio",

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 1039;
+export const MINUTES_TEST_COUNT = 1041;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 1041;
+export const MINUTES_TEST_COUNT = 1045;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -6,7 +6,7 @@
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 
-- Visible actionable errors: 55
+- Visible actionable errors: 56
 - Hidden low-signal wrappers: 16
 
 # CaptureError
@@ -126,6 +126,18 @@ Exact message:
 Source: `crates/core/src/error.rs`
 
 Reference URL: https://useminutes.app/docs/errors#error-transcribeerror-modelloaderror
+
+<a id="error-transcribeerror-modeltruncated"></a>
+
+## `TranscribeError::ModelTruncated`
+
+Exact message:
+
+> {path}" && minutes setup --model {model_name}
+
+Source: `crates/core/src/error.rs`
+
+Reference URL: https://useminutes.app/docs/errors#error-transcribeerror-modeltruncated
 
 <a id="error-transcribeerror-emptyaudio"></a>
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3172,7 +3172,10 @@ fn startup_retryable_notice_is_recent(job: &minutes_core::jobs::ProcessingJob) -
 }
 
 fn latest_retryable_output_notice() -> Option<OutputNotice> {
-    let mut jobs = minutes_core::jobs::list_jobs()
+    // Include archive: retry-cap demotions in `list_jobs()` move Failed
+    // jobs across the active/archive boundary (issue #229), so a
+    // `list_jobs()`-only scan would silently miss them on startup.
+    let mut jobs = minutes_core::jobs::display_jobs(None, true)
         .into_iter()
         .filter(|job| {
             matches!(
@@ -9693,6 +9696,7 @@ mod tests {
             template_slug: None,
             word_count: Some(0),
             owner_pid: None,
+            retry_count: 0,
             recording_health: None,
         };
 
@@ -9727,6 +9731,7 @@ mod tests {
             template_slug: None,
             word_count: Some(0),
             owner_pid: None,
+            retry_count: 0,
             recording_health: None,
         };
 
@@ -9771,6 +9776,7 @@ mod tests {
                 template_slug: None,
                 word_count: Some(0),
                 owner_pid: None,
+                retry_count: 0,
                 recording_health: None,
             };
 
@@ -9809,6 +9815,7 @@ mod tests {
                 template_slug: None,
                 word_count: Some(0),
                 owner_pid: None,
+                retry_count: 0,
                 recording_health: None,
             };
             let older_job = minutes_core::jobs::ProcessingJob {
@@ -9834,6 +9841,7 @@ mod tests {
                 template_slug: None,
                 word_count: Some(0),
                 owner_pid: None,
+                retry_count: 0,
                 recording_health: None,
             };
 
@@ -9873,6 +9881,7 @@ mod tests {
                 template_slug: None,
                 word_count: Some(0),
                 owner_pid: None,
+                retry_count: 0,
                 recording_health: None,
             };
             minutes_core::jobs::write_job(&job).unwrap();
@@ -9913,6 +9922,7 @@ mod tests {
                 template_slug: None,
                 word_count: Some(0),
                 owner_pid: None,
+                retry_count: 0,
                 recording_health: None,
             };
             minutes_core::jobs::write_job(&job).unwrap();
@@ -9969,6 +9979,7 @@ mod tests {
                 template_slug: None,
                 word_count: Some(0),
                 owner_pid: None,
+                retry_count: 0,
                 recording_health: None,
             };
             minutes_core::jobs::write_job(&job).unwrap();

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1202,7 +1202,20 @@ fn main() {
     }
 
     if let Some(code) = maybe_run_process_queue_worker() {
-        std::process::exit(code);
+        // Worker subprocess exit: skip C++ static teardown on macOS.
+        //
+        // Letting `main` return (or calling `std::process::exit`) runs
+        // `atexit` handlers and C++ static destructors via
+        // `__cxa_finalize_ranges`. whisper.cpp / ggml / parakeet helpers
+        // register global C++ state whose destructors can call `abort()`
+        // on partially-initialized contexts (issue #229: a transcription
+        // spawn failure left a context in a bad state, then the normal
+        // exit path crashed the worker via SIGABRT inside
+        // `__cxa_finalize_ranges`). `_exit` skips that teardown
+        // entirely; we drain the sidecar manager explicitly above and
+        // rely on the OS to reclaim the rest.
+        minutes_core::parakeet_sidecar::shutdown_global_parakeet_sidecar();
+        exit_process_without_destructors(code);
     }
 
     // Load with first-run and upgrade migrations so palette defaults


### PR DESCRIPTION
## Summary

Issue #229: a post-stop transcription failure crashed the worker with SIGABRT inside `__cxa_finalize_ranges -> exit`, then left an orphan WAV in `~/.minutes/jobs/` that no automatic recovery would handle. This PR addresses Bug B (the crash) and Bug C (the missing retry policy) from that triage. Bug A (the upstream root cause: a truncated `ggml-medium.bin` on disk) will land as a follow-up commit on this branch.

### Bug B: SIGABRT on worker exit

Two complementary defenses:

1. **Worker subprocess exits via `_exit` on macOS.** The Tauri `--process-queue-worker` path used to call `std::process::exit(code)`, which runs C++ static destructors during `__cxa_finalize_ranges`. whisper.cpp / ggml register static state whose destructors can call `abort()` on partially-initialized contexts. The worker now drains the parakeet sidecar manager and calls `exit_process_without_destructors`, skipping that teardown entirely.
2. **`process_pending_jobs` wraps each transcription pass in `catch_unwind`.** A Rust panic from any of the heavy native paths (whisper FFI, parakeet helper, audio decode, LLM summarizer) is converted to `MinutesError::Transcribe(TranscriptionFailed(...))` and the job is marked `Failed` via the existing Err path, instead of unwinding through the worker.

Audited every `impl Drop` in `crates/core/src/`. None of them panic. The abort was C++ static teardown, not a Rust-side destructor.

### Bug C: bounded retry instead of infinite loop

`ProcessingJob` gains a `retry_count: u32` field (with `#[serde(default)]` so on-disk JSON stays compatible). `list_jobs()` now caps automatic stale-claim recovery at `MAX_AUTO_RETRIES = 2`. Past the cap, the job is demoted to `Failed` with an explanatory error message and moved across the active/archive boundary via `update_job_state`. A user-initiated `requeue_job` resets `retry_count` to 0 so explicit manual retry always gets a fresh budget.

The recovery loop now delegates to `update_job_state` per candidate ID (instead of mutating a `list_jobs_raw()` snapshot in memory) so a concurrent worker that re-claims a job between scan and write does not get silently clobbered. `latest_retryable_output_notice()` switches from `list_jobs()` to `display_jobs(None, true)` so retry-cap demotions remain visible on the startup recovery notice path. Both fixes came out of the codex adversarial review rounds.

## Test plan

- [x] `cargo test -p minutes-core --no-default-features --lib` (699 pass, 1 ignored)
- [x] `cargo test -p minutes-app` (188 pass)
- [x] `cargo clippy --all --no-default-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New `list_jobs_demotes_to_failed_when_retry_cap_exceeded` confirms the active to archive transition + user-facing error string
- [x] New `manual_requeue_resets_retry_count` covers the explicit fresh-budget reset
- [x] `list_jobs_recovers_stale_worker_claims` extended to assert retry_count increments
- [ ] Manual: simulate a model-load failure (point config at a missing model) and confirm the worker exits cleanly instead of aborting (target for v0.17.2 dogfood)

Refs #229.

Bug A follow-up will land on this branch before v0.17.2 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)