### PR TITLE
fix(watch): accept audio containers without n_frames metadata (#231)

### DIFF
--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -189,8 +189,46 @@ fn is_icloud_stub(path: &Path) -> bool {
         .is_some_and(|n| n.starts_with('.') && n.ends_with(".icloud"))
 }
 
-/// Probe audio duration from container metadata using symphonia.
-/// Returns None if the file can't be probed (corrupt, unsupported, etc.).
+/// Check if a file is a probable audio container by running symphonia's probe.
+/// Returns true if symphonia can identify the file as a supported audio
+/// container with at least one track.
+///
+/// Deliberately does NOT require `n_frames` or `sample_rate` in the codec
+/// params, because some encoders produce fully-decodable audio without writing
+/// total-frame metadata in the moov box (notably iPhone Voice Memos exports,
+/// see #231). The downstream decode path validates real decodability and
+/// surfaces a clearer error than this gate would.
+fn is_audio_container(path: &Path) -> bool {
+    use symphonia::core::io::MediaSourceStream;
+    use symphonia::core::probe::Hint;
+
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+
+    match symphonia::default::get_probe().format(
+        &hint,
+        mss,
+        &Default::default(),
+        &Default::default(),
+    ) {
+        Ok(probed) => probed.format.tracks().iter().any(|track| {
+            track.codec_params.codec != symphonia::core::codecs::CODEC_TYPE_NULL
+        }),
+        Err(_) => false,
+    }
+}
+
+/// Probe audio duration from container metadata using symphonia. Returns None
+/// if the file can't be probed OR if the container does not record total
+/// frame count and sample rate. Used for duration-based content routing
+/// (memo vs meeting); validity gating goes through `is_audio_container`.
 fn audio_duration(path: &Path) -> Option<std::time::Duration> {
     use symphonia::core::io::MediaSourceStream;
     use symphonia::core::probe::Hint;
@@ -691,13 +729,20 @@ fn build_candidate(path: &Path, settle_delay: u64, config: &Config) -> Option<Wa
         return None;
     }
 
-    if audio_duration(path).is_none() {
+    // The audio-container gate is intentionally permissive: it accepts any
+    // file symphonia can probe into a non-null-codec track, regardless of
+    // duration metadata. See #231 (iPhone Voice Memos exports with
+    // `ftyp -> mdat -> moov` and missing total-frame counts were previously
+    // rejected here). TODO(#231): once we have a real Voice Memos fixture
+    // we can add a regression test for the no-n_frames path; today's gate
+    // tests only cover happy path and clear non-audio bytes.
+    if !is_audio_container(path) {
         let is_wav = path
             .extension()
             .and_then(|e| e.to_str())
             .is_some_and(|e| e.eq_ignore_ascii_case("wav"));
         if !is_wav {
-            tracing::warn!(path = %path.display(), "file failed audio probe — not a valid audio container, skipping");
+            tracing::warn!(path = %path.display(), "file failed audio probe, not a valid audio container, skipping");
             return None;
         }
     }
@@ -918,5 +963,34 @@ mod tests {
             .unwrap()
             .to_string_lossy();
         assert_eq!(parent_name, "processed");
+    }
+
+    /// Regression for #231: the audio-probe gate must accept any file whose
+    /// container symphonia recognizes, even when the codec params lack frame
+    /// counts. The previous implementation required `n_frames` and rejected
+    /// otherwise-valid Voice Memos exports.
+    #[test]
+    fn is_audio_container_accepts_real_wav_fixture() {
+        let wav = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("assets")
+            .join("demo.wav");
+        assert!(wav.exists(), "fixture missing: {}", wav.display());
+        assert!(is_audio_container(&wav));
+    }
+
+    #[test]
+    fn is_audio_container_rejects_random_bytes() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("noise.wav");
+        fs::write(&path, b"this is not an audio container").unwrap();
+        assert!(!is_audio_container(&path));
+    }
+
+    #[test]
+    fn is_audio_container_rejects_missing_file() {
+        assert!(!is_audio_container(Path::new(
+            "/definitely/does/not/exist/file.m4a"
+        )));
     }
 }

--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -218,9 +218,11 @@ fn is_audio_container(path: &Path) -> bool {
         &Default::default(),
         &Default::default(),
     ) {
-        Ok(probed) => probed.format.tracks().iter().any(|track| {
-            track.codec_params.codec != symphonia::core::codecs::CODEC_TYPE_NULL
-        }),
+        Ok(probed) => probed
+            .format
+            .tracks()
+            .iter()
+            .any(|track| track.codec_params.codec != symphonia::core::codecs::CODEC_TYPE_NULL),
         Err(_) => false,
     }
 }

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 50;
-export const MINUTES_TEST_COUNT = 1045;
+export const MINUTES_TEST_COUNT = 1048;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Closes #231.

## Summary

iPhone Voice Memos exports `.m4a` files with `ftyp -> mdat -> moov` layout (Apple's default, not faststart) that do not write a complete total-frame count in the moov sample table. The watcher's audio-probe gate previously required `n_frames` and `sample_rate` to be present and rejected the file otherwise, routing valid recordings to `failed/` with a "file failed audio probe" warning. Both symphonia and ffmpeg can decode these files cleanly; the rejection is purely on missing duration metadata, not container validity.

Reported by @jmh1313 against v0.17.2 with a complete diagnosis, repro recipe, and ffmpeg-faststart workaround.

## Fix

Split the symphonia probe logic in `crates/core/src/watch.rs` into two functions with different contracts:

* **`is_audio_container(path) -> bool`** (new): used by the validity gate. Returns true if symphonia probe succeeds AND at least one track has a non-null codec. Does not require duration metadata. Accepts the previously-rejected Voice Memos case.
* **`audio_duration(path) -> Option<Duration>`** (unchanged signature and behavior): used only for memo-vs-meeting routing in `determine_content_type`. When None on a probe-OK file, routing falls back to the configured default type, which is the existing behavior.

Three new tests cover the happy path (real WAV fixture from `crates/assets/demo.wav`), random-bytes rejection, and missing-file rejection. The exact no-n_frames regression case awaits an anonymized Voice Memos fixture from the reporter; a TODO at the gate references #231 for the missing coverage.

## Codex adversarial review

Ran two rounds of `/codex` adversarial review on the plan and then the diff.

* Round 1 (plan): pushed back on a permissive "drop the probe" approach because it opened a DoS vector through `decode_with_ffmpeg`'s unbounded subprocess. Recommended either a bounded `ffprobe` fallback or a tighter symphonia gate. Adopted the tighter gate.
* Round 2 (diff): caught that the first version was too loose. An mp4 with only a video track and a `.m4a` extension would have passed because `tracks().is_empty()` is false. Tightened to require `codec_params.codec != CODEC_TYPE_NULL` on at least one track. Also flagged the test-coverage gap on the no-n_frames case, addressed with the TODO comment.

The pre-existing `decode_with_ffmpeg` DoS angle (no subprocess timeout) is unchanged from v0.17.2 and not in scope for this PR; it should be its own follow-up because it predates this issue.

## Verification

* 707 core lib tests pass (was 704 in v0.17.2, +3 new from this PR)
* `cargo clippy --workspace --all-targets -- -D warnings` clean
* `cargo fmt --check` clean
* Site `release.ts` test count synced to 1048 (was 1045)
* `llms.txt` regenerated

Bundling into v0.17.3 once @jmh1313 confirms the fix against his actual files.