### PR TITLE
fix(tauri): recover from dangling or stale meetings symlink

### DIFF
--- a/tauri/src-tauri/src/context.rs
+++ b/tauri/src-tauri/src/context.rs
@@ -178,10 +178,35 @@ pub fn create_workspace(config: &Config) -> Result<PathBuf, String> {
     fs::create_dir_all(&workspace).map_err(|e| format!("Failed to create workspace: {}", e))?;
 
     let meetings_link = workspace.join("meetings");
-    if !meetings_link.exists() {
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&config.output_dir, &meetings_link)
-            .map_err(|e| format!("Failed to symlink meetings dir: {}", e))?;
+    #[cfg(unix)]
+    {
+        // Path::exists() follows symlinks, so a dangling or stale symlink
+        // reports as nonexistent and the unconditional symlink() below
+        // would then fail with EEXIST. Inspect link metadata directly and
+        // replace the link if it is dangling or points away from the
+        // current output_dir (e.g. after the user moved their meetings
+        // directory in config, or after a cross-machine state restore).
+        let needs_create = match fs::symlink_metadata(&meetings_link) {
+            Ok(meta) if meta.file_type().is_symlink() => match fs::read_link(&meetings_link) {
+                Ok(target) if target == config.output_dir => false,
+                _ => {
+                    fs::remove_file(&meetings_link)
+                        .map_err(|e| format!("Failed to remove stale meetings symlink: {}", e))?;
+                    true
+                }
+            },
+            Ok(_) => {
+                return Err(format!(
+                    "{} exists but is not a symlink; refusing to overwrite",
+                    meetings_link.display()
+                ));
+            }
+            Err(_) => true,
+        };
+        if needs_create {
+            std::os::unix::fs::symlink(&config.output_dir, &meetings_link)
+                .map_err(|e| format!("Failed to symlink meetings dir: {}", e))?;
+        }
     }
 
     // Refresh assistant-local skill mirrors from the generated portable


### PR DESCRIPTION
## Summary

`create_workspace` in `tauri/src-tauri/src/context.rs` used `Path::exists()` to decide whether to create the `~/.minutes/assistant/meetings` symlink. `exists()` follows symlinks, so a dangling link (or one whose target was deleted/renamed) reports as nonexistent. The unconditional `symlink()` then fails with `EEXIST`, which surfaces in the Recall pane as:

> Could not start: Failed to symlink meetings dir: File exists (os error 17)

Two real ways to land in this state:

- The user changes `output_dir` in `config.toml`. The existing symlink keeps pointing at the old location and is now stale (still resolvable until the old dir is removed, but eventually dangling).
- The user restores `~/.minutes/` from another machine (cross-machine sync, dotfile restore, manual SSH copy). The symlink target is an absolute path that doesn't exist on the new host.

## What changed

Inspect the existing entry via `fs::symlink_metadata` + `fs::read_link` instead of `Path::exists`:

- If a symlink already exists and its target equals `config.output_dir`, do nothing.
- If a symlink exists but its target is wrong or unreachable, remove and recreate it.
- If a non-symlink (regular file or directory) sits at that path, refuse to overwrite — surface a clear error instead of clobbering user data.
- Otherwise create the symlink.

The whole block stays `#[cfg(unix)]`.

## Test plan

- [x] `cargo fmt -p minutes-app -- --check` passes
- [x] `cargo check -p minutes-app` passes
- [x] `cargo clippy -p minutes-app --no-deps` clean
- [ ] Manual: launch the dev app with a dangling `~/.minutes/assistant/meetings` symlink, open Recall, confirm it recovers and the symlink is recreated with the correct target
- [ ] Manual: change `output_dir` in `~/.config/minutes/config.toml` to a different existing directory, restart the app, confirm the assistant workspace symlink now points at the new directory
- [ ] Manual: replace the symlink with a regular file at the same path, confirm the app surfaces the "refusing to overwrite" error instead of silently doing something unexpected