### PR TITLE
docs+cli(parakeet): make the missing --features parakeet failure mode loud

### DIFF
--- a/.agents/skills/minutes/minutes-record/SKILL.md
+++ b/.agents/skills/minutes/minutes-record/SKILL.md
@@ -81,7 +81,7 @@ This downloads a ~466MB model. For faster but lower quality: `--model tiny` (75M
 minutes setup --parakeet                           # English (tdt-ctc-110m, ~220MB)
 minutes setup --parakeet --parakeet-model tdt-600m  # Multilingual v3 (~1.2GB)
 ```
-Requires parakeet.cpp installed. See `docs/PARAKEET.md` for full setup.
+Requires both parakeet.cpp installed AND a Minutes CLI compiled with `--features parakeet`. The downloadable DMG and tagged CLI release binaries include the feature; the Homebrew Formula CLI (`brew install silverstein/tap/minutes`) and bare `cargo install minutes-cli` do not. If `minutes setup --parakeet` reports `WARNING: this minutes binary was compiled WITHOUT the parakeet feature`, rebuild from source with the flag. See `docs/PARAKEET.md` for the full walkthrough.
 
 ## Gotchas
 

--- a/.claude/plugins/minutes/skills/minutes-record/SKILL.md
+++ b/.claude/plugins/minutes/skills/minutes-record/SKILL.md
@@ -73,7 +73,7 @@ This downloads a ~466MB model. For faster but lower quality: `--model tiny` (75M
 minutes setup --parakeet                           # English (tdt-ctc-110m, ~220MB)
 minutes setup --parakeet --parakeet-model tdt-600m  # Multilingual v3 (~1.2GB)
 ```
-Requires parakeet.cpp installed. See `docs/PARAKEET.md` for full setup.
+Requires both parakeet.cpp installed AND a Minutes CLI compiled with `--features parakeet`. The downloadable DMG and tagged CLI release binaries include the feature; the Homebrew Formula CLI (`brew install silverstein/tap/minutes`) and bare `cargo install minutes-cli` do not. If `minutes setup --parakeet` reports `WARNING: this minutes binary was compiled WITHOUT the parakeet feature`, rebuild from source with the flag. See `docs/PARAKEET.md` for the full walkthrough.
 
 ## Gotchas
 

--- a/.opencode/skills/minutes-record/SKILL.md
+++ b/.opencode/skills/minutes-record/SKILL.md
@@ -82,7 +82,7 @@ This downloads a ~466MB model. For faster but lower quality: `--model tiny` (75M
 minutes setup --parakeet                           # English (tdt-ctc-110m, ~220MB)
 minutes setup --parakeet --parakeet-model tdt-600m  # Multilingual v3 (~1.2GB)
 ```
-Requires parakeet.cpp installed. See `docs/PARAKEET.md` for full setup.
+Requires both parakeet.cpp installed AND a Minutes CLI compiled with `--features parakeet`. The downloadable DMG and tagged CLI release binaries include the feature; the Homebrew Formula CLI (`brew install silverstein/tap/minutes`) and bare `cargo install minutes-cli` do not. If `minutes setup --parakeet` reports `WARNING: this minutes binary was compiled WITHOUT the parakeet feature`, rebuild from source with the flag. See `docs/PARAKEET.md` for the full walkthrough.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -883,7 +883,11 @@ brew install ffmpeg           # macOS
 minutes setup --diarization
 
 # Alternative: use Parakeet engine (opt-in, local GPU via parakeet.cpp)
-# Requires parakeet.cpp installed: https://github.com/Frikallo/parakeet.cpp
+# Requires (1) parakeet.cpp installed (https://github.com/Frikallo/parakeet.cpp)
+# AND (2) a Minutes CLI compiled with `--features parakeet`. The downloadable
+# DMG and tagged CLI release binaries include the feature; the Homebrew Formula
+# CLI (`brew install silverstein/tap/minutes`) and bare `cargo install minutes-cli`
+# do not. See docs/PARAKEET.md for the source-build walkthrough.
 minutes setup --parakeet                          # Multilingual v3 (tdt-600m, ~1.2GB)
 minutes setup --parakeet --parakeet-model tdt-ctc-110m  # English-only compact model (~220MB)
 # Also installs native Silero VAD weights for the parakeet.cpp --vad path
@@ -940,7 +944,7 @@ brew install --cask silverstein/tap/minutes
 # macOS — build from source
 export CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1"
 export MACOSX_DEPLOYMENT_TARGET=11.0
-cargo tauri build --bundles app
+cargo tauri build --bundles app --features parakeet,metal
 
 # macOS — local desktop development with stable permissions
 ./scripts/install-dev-app.sh

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5393,6 +5393,55 @@ fn cmd_setup_parakeet(model: &str) -> Result<()> {
     eprintln!("  engine = \"parakeet\"");
     eprintln!("  parakeet_model = \"{}\"", model);
     eprintln!("  parakeet_vocab = \"{}\"", dest_vocab_name);
+    // Print parakeet_binary too. Users who installed parakeet.cpp from
+    // source typically land at ~/.local/bin/parakeet, which is reachable
+    // from a Terminal-launched CLI but NOT from a Finder/Spotlight/Dock-
+    // launched desktop app (different PATH). Spelling the binary out in
+    // the config footer prevents the "minutes works in terminal, app
+    // says binary-not-found" class of issue.
+    eprintln!("  parakeet_binary = \"<absolute path to parakeet, e.g. /Users/you/.local/bin/parakeet>\"");
+
+    // Feature-flag visibility check. If this binary was compiled without
+    // `--features parakeet`, every config key above is silently inert at
+    // runtime and the engine falls back to whisper. The setup command
+    // itself runs to completion because download + binary resolution don't
+    // require the feature, so without this warning a user can follow every
+    // step successfully and still wonder why parakeet isn't transcribing.
+    //
+    // Tagged release artifacts (the DMG and the per-platform CLI binaries
+    // built by .github/workflows/release-{macos,cli}.yml) ship WITH the
+    // feature. The paths that don't are the Homebrew Formula CLI
+    // (`brew install silverstein/tap/minutes`, which runs bare
+    // `cargo install --path crates/cli`) and any source `cargo install`
+    // without `--features parakeet`.
+    //
+    // Confirmed reachable: this function is not feature-gated, so the
+    // warning fires correctly on a whisper-only binary.
+    if !cfg!(feature = "parakeet") {
+        eprintln!();
+        eprintln!(
+            "WARNING: this minutes binary was compiled WITHOUT the parakeet feature."
+        );
+        eprintln!(
+            "The model and helper binary above are installed, but the runtime will fall"
+        );
+        eprintln!(
+            "back to whisper regardless of the config keys you just set. To actually use"
+        );
+        eprintln!("parakeet, rebuild the CLI with the feature enabled, e.g.:");
+        eprintln!();
+        eprintln!(
+            "  cargo install --path crates/cli --features parakeet --root ~/.cargo --force"
+        );
+        eprintln!();
+        eprintln!(
+            "The downloadable DMG and tagged CLI release binaries do include parakeet."
+        );
+        eprintln!(
+            "The Homebrew Formula CLI (`brew install silverstein/tap/minutes`) and bare"
+        );
+        eprintln!("`cargo install minutes-cli` runs are the install paths that omit it.");
+    }
 
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5399,7 +5399,9 @@ fn cmd_setup_parakeet(model: &str) -> Result<()> {
     // launched desktop app (different PATH). Spelling the binary out in
     // the config footer prevents the "minutes works in terminal, app
     // says binary-not-found" class of issue.
-    eprintln!("  parakeet_binary = \"<absolute path to parakeet, e.g. /Users/you/.local/bin/parakeet>\"");
+    eprintln!(
+        "  parakeet_binary = \"<absolute path to parakeet, e.g. /Users/you/.local/bin/parakeet>\""
+    );
 
     // Feature-flag visibility check. If this binary was compiled without
     // `--features parakeet`, every config key above is silently inert at
@@ -5419,27 +5421,15 @@ fn cmd_setup_parakeet(model: &str) -> Result<()> {
     // warning fires correctly on a whisper-only binary.
     if !cfg!(feature = "parakeet") {
         eprintln!();
-        eprintln!(
-            "WARNING: this minutes binary was compiled WITHOUT the parakeet feature."
-        );
-        eprintln!(
-            "The model and helper binary above are installed, but the runtime will fall"
-        );
-        eprintln!(
-            "back to whisper regardless of the config keys you just set. To actually use"
-        );
+        eprintln!("WARNING: this minutes binary was compiled WITHOUT the parakeet feature.");
+        eprintln!("The model and helper binary above are installed, but the runtime will fall");
+        eprintln!("back to whisper regardless of the config keys you just set. To actually use");
         eprintln!("parakeet, rebuild the CLI with the feature enabled, e.g.:");
         eprintln!();
-        eprintln!(
-            "  cargo install --path crates/cli --features parakeet --root ~/.cargo --force"
-        );
+        eprintln!("  cargo install --path crates/cli --features parakeet --root ~/.cargo --force");
         eprintln!();
-        eprintln!(
-            "The downloadable DMG and tagged CLI release binaries do include parakeet."
-        );
-        eprintln!(
-            "The Homebrew Formula CLI (`brew install silverstein/tap/minutes`) and bare"
-        );
+        eprintln!("The downloadable DMG and tagged CLI release binaries do include parakeet.");
+        eprintln!("The Homebrew Formula CLI (`brew install silverstein/tap/minutes`) and bare");
         eprintln!("`cargo install minutes-cli` runs are the install paths that omit it.");
     }
 

--- a/docs/PARAKEET.md
+++ b/docs/PARAKEET.md
@@ -93,6 +93,10 @@ cd parakeet.cpp
 make build
 mkdir -p ~/.local/bin
 cp build/bin/parakeet ~/.local/bin/
+# Also copy the warm-sidecar binary. Without this, live mode (minutes live
+# and the recording sidecar) falls back to spawning a fresh subprocess for
+# every utterance — visibly slow because the model has to reload each time.
+cp build/bin/example-server ~/.local/bin/
 
 # 2. Build the Minutes CLI WITH the parakeet feature, then install it
 cd <path/to/your/minutes/checkout>     # e.g. ~/Sites/minutes
@@ -115,6 +119,9 @@ engine = "parakeet"
 parakeet_model = "tdt-600m"
 parakeet_binary = "/Users/<you>/.local/bin/parakeet"
 parakeet_vocab = "tdt-600m.tokenizer.vocab"
+# Reuse the warm example-server socket for live mode instead of spawning
+# a fresh subprocess per utterance. Requires step 1's example-server copy.
+parakeet_sidecar_enabled = true
 ```
 
 That gives you the validated multilingual path:
@@ -276,8 +283,11 @@ make build
 # Replace the check_cxx_source_compiles block with an Apple arm64 short-circuit.
 # See: https://github.com/google/highway/issues/XXXX
 
-# Install the binary
+# Install the binaries
 cp build/bin/parakeet ~/.local/bin/
+# Warm-sidecar binary: required for live mode to reuse a single loaded
+# model across utterances instead of spawning a fresh subprocess each time.
+cp build/bin/example-server ~/.local/bin/
 ```
 
 ## Install Models
@@ -325,6 +335,7 @@ Edit `~/.config/minutes/config.toml`:
 engine = "parakeet"              # "whisper" (default) or "parakeet"
 parakeet_model = "tdt-600m"      # "tdt-ctc-110m" (English) or "tdt-600m" (multilingual v3)
 parakeet_binary = "/Users/you/.local/bin/parakeet"  # Prefer an absolute path for desktop app launches
+parakeet_sidecar_enabled = true  # Reuse warm example-server socket for live mode (requires example-server copied above)
 parakeet_boost_limit = 25        # Experimental: top graph-derived boost phrases (0 disables)
 parakeet_boost_score = 2.0       # Experimental tuning for parakeet.cpp --boost-score
 parakeet_fp16 = true             # Default on macOS Apple Silicon: ~35% faster transcription with lower GPU memory (see docs/designs/parakeet-perf-2026-04-14.md)

--- a/tooling/skills/sources/minutes-record/skill.md
+++ b/tooling/skills/sources/minutes-record/skill.md
@@ -100,7 +100,7 @@ This downloads a ~466MB model. For faster but lower quality: `--model tiny` (75M
 minutes setup --parakeet                           # English (tdt-ctc-110m, ~220MB)
 minutes setup --parakeet --parakeet-model tdt-600m  # Multilingual v3 (~1.2GB)
 ```
-Requires parakeet.cpp installed. See `docs/PARAKEET.md` for full setup.
+Requires both parakeet.cpp installed AND a Minutes CLI compiled with `--features parakeet`. The downloadable DMG and tagged CLI release binaries include the feature; the Homebrew Formula CLI (`brew install silverstein/tap/minutes`) and bare `cargo install minutes-cli` do not. If `minutes setup --parakeet` reports `WARNING: this minutes binary was compiled WITHOUT the parakeet feature`, rebuild from source with the flag. See `docs/PARAKEET.md` for the full walkthrough.
 
 ## Gotchas
 


### PR DESCRIPTION
Follow-up to the audit work that came out of [#163's diagnosis thread](https://github.com/silverstein/minutes/issues/163) and an instance of the same silent failure I just hit on my own machine while debugging that thread.

## The failure mode

Install minutes via a path that does not include `--features parakeet`. Run `minutes setup --parakeet`. See success messages, a model on disk, a resolved binary, and a "to use parakeet, add to ~/.config/minutes/config.toml" footer. Wire `engine = "parakeet"` in config. Watch every transcript silently land via the whisper fallback.

`minutes setup --parakeet` never warned. The skill files and README never mentioned the feature flag. The "Build parakeet.cpp" section copied only `parakeet`, omitting `example-server` (so live mode falls back to per-utterance subprocess spawn even on a parakeet-enabled binary).

## What changed

- **`crates/cli/src/main.rs::cmd_setup_parakeet`**: append `parakeet_binary` to the printed config footer with an absolute-path placeholder, and emit a loud `cfg!(feature = "parakeet")`-gated warning at the end of setup when the running binary lacks the feature. The warning includes the exact rebuild command and an accurate description of which install paths ship parakeet.
- **`docs/PARAKEET.md`**: add `cp build/bin/example-server ~/.local/bin/` next to the existing parakeet binary copy in both fastest-path and full-install sections, plus `parakeet_sidecar_enabled = true` to both config blocks so the recommended-for-live setting appears in the copy-paste text instead of only in prose.
- **`tooling/skills/sources/minutes-record/skill.md`** + the three compiled host surfaces (`.claude`, `.opencode`, `.agents`): expand the parakeet block to name the `--features parakeet` requirement, distinguish which install paths satisfy it, and forward-reference the exact CLI warning string.
- **`README.md`**: replace the one-line "Requires parakeet.cpp installed" comment with a three-line callout. Align the macOS source-build command at the Install section to include `--features parakeet,metal`, consistent with the upgrade-from-source command later in the file.

## Codex adversarial review

Two rounds. Round 1 found five issues:

1. `cfg!(feature = "parakeet")` macro semantics on a non-feature-gated function. **Verified compile-time evaluation correct, fires at runtime on whisper-only binary.** Confirmed by reading the fn declaration and compiling both feature configs.
2. Cross-references in PARAKEET.md needed the same example-server + sidecar additions in the later "Build parakeet.cpp" section. **Fixed.**
3. The originally-drafted warning text incorrectly claimed "Homebrew cask and DMG releases ship without parakeet." **False per the release workflows** (`.github/workflows/release-macos.yml:115` runs `cargo tauri build --features parakeet,metal`; `.github/workflows/release-cli.yml` passes parakeet features for all three platforms). **Removed and replaced with the accurate description**: the omit-feature paths are the Homebrew Formula CLI (`brew install silverstein/tap/minutes`, which runs bare `cargo install --path crates/cli`) and any bare `cargo install minutes-cli` from crates.io.
4. README.md had an inconsistent source-build command at line 946 versus line 1025. **Aligned.**
5. No other skill files reference `minutes setup --parakeet`, so the three host surfaces are the complete set.

Round 2 verdict: ship with the tweaks above. All applied.

## Verification

- `cargo build -p minutes-cli` (default features, no parakeet): clean
- `cargo build -p minutes-cli --features parakeet`: clean
- `cargo fmt --check`: clean (after one rustfmt fixup commit)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- The three compiled SKILL.md files carry the new text byte-for-byte (verified via grep)

## Slated for v0.17.4

Bundles naturally with the other v0.17.4 work (PR #235 macOS 26 .mov dual-track fix in flight from jmh1313, PR #237 rescue threshold + stopCapture timing).