### PR TITLE
fix(whisper-guard): detect parenthetical noise markers + expose all_noise signal

### DIFF
--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -64,6 +64,45 @@ fn suppress_if_all_noise(
     ))
 }
 
+/// Outcome of the shared suppression decision used by BOTH the
+/// `write_transcript_artifact` background-recording path and the
+/// `minutes process <wav>` reprocess path.
+///
+/// Returning a strongly typed struct (rather than a tuple) keeps the two call
+/// sites mechanically identical and makes drift obvious in code review: if a
+/// new field is added here the compiler forces an update at every call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SuppressionOutcome {
+    /// Replacement body to write in place of the hallucinated transcript.
+    body: String,
+    /// Human-readable explanation, stored in `Frontmatter::filter_diagnosis`.
+    diagnosis: String,
+}
+
+/// Shared decision: should the transcript body be suppressed because it is
+/// almost certainly fabricated noise on near-silent audio?
+///
+/// This is the **single source of truth** for the suppression rule. Both
+/// `write_transcript_artifact` (background recording finalizer) and
+/// `process_with_progress_and_sidecar` (`minutes process <wav>` reprocess
+/// path) call this helper so users see identical behavior regardless of
+/// which entry point produced the artifact - the codex review on PR #246
+/// flagged this drift as blocker #2.
+///
+/// Returns `Some(outcome)` when [`suppress_if_all_noise`] confirms the
+/// transcript is all noise markers AND both stems are sparse; `None`
+/// otherwise.
+fn should_suppress_transcript(
+    transcript: &str,
+    recording_health: Option<&markdown::RecordingHealth>,
+) -> Option<SuppressionOutcome> {
+    let diagnosis = suppress_if_all_noise(transcript, recording_health)?;
+    Some(SuppressionOutcome {
+        body: ALL_NOISE_SUPPRESSED_BODY.to_string(),
+        diagnosis,
+    })
+}
+
 /// Result of Level 2 voice enrollment matching.
 struct VoiceMatchResult {
     /// Speaker attributions from voice matching (one per matched label).
@@ -1067,12 +1106,15 @@ pub fn write_transcript_artifact(
     // preserved on disk and `minutes process` is the canonical retry path,
     // so there is no need to round-trip the hallucinated lines through the
     // markdown output.
-    let all_noise_suppression =
-        suppress_if_all_noise(&transcript, context.recording_health.as_ref());
-    let (transcript, forced_no_speech_diagnosis) = match all_noise_suppression {
-        Some(diagnosis) => (ALL_NOISE_SUPPRESSED_BODY.to_string(), Some(diagnosis)),
-        None => (transcript, None),
-    };
+    //
+    // Decision routed through `should_suppress_transcript` so this path and
+    // `process_with_progress_and_sidecar` share the exact same gate (codex
+    // blocker #2 on PR #246).
+    let (transcript, forced_no_speech_diagnosis) =
+        match should_suppress_transcript(&transcript, context.recording_health.as_ref()) {
+            Some(outcome) => (outcome.body, Some(outcome.diagnosis)),
+            None => (transcript, None),
+        };
 
     let word_count = transcript.split_whitespace().count();
     logging::log_step(
@@ -1713,7 +1755,7 @@ where
     );
 
     // Check minimum word threshold
-    let status = if word_count < config.transcription.min_words {
+    let mut status = if word_count < config.transcription.min_words {
         tracing::warn!(
             words = word_count,
             min = config.transcription.min_words,
@@ -1771,6 +1813,31 @@ where
         transcript
     };
 
+    // Suppression gate (issue #241): if the diarized transcript is nothing
+    // but hallucinated non-speech markers AND both capture stems were sparse,
+    // replace the body with a diagnostic message and force `status: NoSpeech`.
+    // Routed through `should_suppress_transcript` so this path and
+    // `write_transcript_artifact` share the exact same gate (codex blocker
+    // #2 on PR #246) - users see identical behavior regardless of which
+    // entry point produced the artifact. The original noisy text is dropped
+    // - the source WAV is preserved and `minutes process` is the canonical
+    // retry path.
+    let (transcript, forced_no_speech_diagnosis) =
+        match should_suppress_transcript(&transcript, recording_health.as_ref()) {
+            Some(outcome) => {
+                tracing::warn!(
+                    step = "transcribe",
+                    diagnosis = %outcome.diagnosis,
+                    "all-noise suppression fired on process path — replacing transcript body"
+                );
+                // Force NoSpeech status: we know the body is fabricated even
+                // if the original `word_count` cleared `min_words`.
+                status = Some(OutputStatus::NoSpeech);
+                (outcome.body, Some(outcome.diagnosis))
+            }
+            None => (transcript, None),
+        };
+
     // Step 3: Summarize (optional — depends on config.summarization.engine)
     // Pass user notes to the summarizer as high-priority context
     // Step 3: Summarize + extract structured intent
@@ -1795,7 +1862,12 @@ where
     let summary_model = summarize::summarization_model_hint(config, !screen_files.is_empty());
 
     let mut raw_summary: Option<summarize::Summary> = None;
-    let summary: Option<String> = if config.summarization.engine != "none" {
+    // Skip summarization when the all-noise gate replaced the transcript body:
+    // the LLM has nothing to summarize, and we'd just burn tokens / surface
+    // a hallucinated summary on top of a hallucinated transcript.
+    let summary: Option<String> = if forced_no_speech_diagnosis.is_some() {
+        None
+    } else if config.summarization.engine != "none" {
         on_progress(PipelineStage::Summarizing);
         tracing::info!(step = "summarize", "generating summary");
 
@@ -2053,7 +2125,17 @@ where
         recording_health,
         template: template.map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
-            Some(filter_stats.diagnosis())
+            // Prefer the all-noise-suppression diagnosis when it fired; it
+            // describes a different failure mode (whisper produced only
+            // non-speech markers on sparse stems) than the standard
+            // min_words / no_speech filter path. Identical preference order
+            // to `write_transcript_artifact` so both entry points produce
+            // matching frontmatter.
+            Some(
+                forced_no_speech_diagnosis
+                    .clone()
+                    .unwrap_or_else(|| filter_stats.diagnosis()),
+            )
         } else {
             None
         },
@@ -4090,6 +4172,116 @@ mod tests {
         health.system_stem_active_ratio = None;
         let transcript = "[0:07] (crying)\n[1:52] [Growling]\n";
         assert!(suppress_if_all_noise(transcript, Some(&health)).is_none());
+    }
+
+    #[test]
+    fn should_suppress_transcript_wraps_decision_in_outcome() {
+        // The shared helper returns the same body+diagnosis used by BOTH
+        // `write_transcript_artifact` and the `process` path. This is the
+        // single source of truth that closes codex blocker #2 - both call
+        // sites must produce identical suppression output.
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n";
+        let health = sparse_health(0.005, 0.001);
+        let outcome = should_suppress_transcript(transcript, Some(&health))
+            .expect("expected suppression outcome");
+        assert_eq!(outcome.body, ALL_NOISE_SUPPRESSED_BODY);
+        assert!(outcome.diagnosis.contains("all-noise"));
+        assert!(outcome.diagnosis.contains("threshold"));
+    }
+
+    #[test]
+    fn should_suppress_transcript_returns_none_with_real_content() {
+        let transcript = "[0:00] Hello world\n[0:05] Goodbye\n";
+        let health = sparse_health(0.001, 0.001);
+        assert!(should_suppress_transcript(transcript, Some(&health)).is_none());
+    }
+
+    /// Simulates the branch logic the `process` path applies after
+    /// diarization: if `should_suppress_transcript` fires, the transcript
+    /// body, status, and forced filter_diagnosis are all updated together.
+    /// This mirrors lines around 1790 of `process_with_progress_and_sidecar`.
+    /// We can't run the full pipeline in a unit test (whisper model, audio
+    /// file, calendar lookup), but we CAN assert the decision-and-apply
+    /// logic produces exactly the same observable state as the
+    /// `write_transcript_artifact` path for the same input.
+    fn apply_suppression_on_process_path(
+        transcript: String,
+        recording_health: Option<&markdown::RecordingHealth>,
+        initial_status: Option<OutputStatus>,
+    ) -> (String, Option<OutputStatus>, Option<String>) {
+        let mut status = initial_status;
+        let (transcript, forced) = match should_suppress_transcript(&transcript, recording_health) {
+            Some(outcome) => {
+                status = Some(OutputStatus::NoSpeech);
+                (outcome.body, Some(outcome.diagnosis))
+            }
+            None => (transcript, None),
+        };
+        (transcript, status, forced)
+    }
+
+    #[test]
+    fn process_path_suppresses_all_noise_with_sparse_stems() {
+        // Acceptance criterion 4 (issue #241): the `minutes process <wav>`
+        // path must show the "no audible content" message and a NoSpeech
+        // status, not the raw hallucinated lines.
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n".to_string();
+        let health = sparse_health(0.005, 0.001);
+        let (body, status, forced) = apply_suppression_on_process_path(
+            transcript,
+            Some(&health),
+            // Start from `Complete` to prove the gate downgrades the status
+            // even when word_count cleared min_words.
+            Some(OutputStatus::Complete),
+        );
+        assert_eq!(body, ALL_NOISE_SUPPRESSED_BODY);
+        assert!(
+            body.contains("No audible content"),
+            "body should surface the diagnostic message, got: {}",
+            body
+        );
+        // The raw hallucinated lines must NOT appear in the rendered body.
+        assert!(
+            !body.contains("(crying)"),
+            "raw hallucination leaked: {}",
+            body
+        );
+        assert!(
+            !body.contains("[Growling]"),
+            "raw hallucination leaked: {}",
+            body
+        );
+        assert_eq!(status, Some(OutputStatus::NoSpeech));
+        let diag = forced.expect("expected forced filter_diagnosis");
+        assert!(diag.contains("all-noise"));
+        assert!(diag.contains("body suppressed"));
+    }
+
+    #[test]
+    fn process_path_leaves_real_content_alone() {
+        // Real (if brief) speech must flow through both paths unchanged.
+        let transcript = "[0:00] Hello world\n[0:05] Goodbye\n".to_string();
+        let health = sparse_health(0.001, 0.001);
+        let initial = Some(OutputStatus::Complete);
+        let (body, status, forced) =
+            apply_suppression_on_process_path(transcript.clone(), Some(&health), initial);
+        assert_eq!(body, transcript, "real content was clobbered");
+        assert_eq!(status, initial, "status was downgraded without cause");
+        assert!(forced.is_none(), "forced diagnosis set without suppression");
+    }
+
+    #[test]
+    fn process_path_holds_off_without_recording_health() {
+        // No diarization / no health captured (e.g. config.diarization.engine
+        // = "none") must NOT suppress, even on an all-noise transcript: we
+        // lack the corroborating evidence to override.
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n".to_string();
+        let initial = Some(OutputStatus::TranscriptOnly);
+        let (body, status, forced) =
+            apply_suppression_on_process_path(transcript.clone(), None, initial);
+        assert_eq!(body, transcript);
+        assert_eq!(status, initial);
+        assert!(forced.is_none());
     }
 
     fn sample_summary() -> summarize::Summary {

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -36,10 +36,12 @@ const ALL_NOISE_SUPPRESSED_BODY: &str =
 ///    `[music]` / `[Growling]` or parenthetical `(crying)` / `(applause)`)
 ///    according to [`wg_segments::is_all_noise`].
 /// 2. Both stem active ratios in `recording_health` are below
-///    [`SPARSE_STEM_ACTIVE_RATIO`]. If a stem ratio is `None` we treat that
-///    stem as inconclusive and require the other one to be sparse; if both
-///    are `None` (e.g. dictation, no health captured) the gate does NOT
-///    fire - we lack the evidence to override the transcript.
+///    [`SPARSE_STEM_ACTIVE_RATIO`]. **Both ratios must be present**: if
+///    either `voice_stem_active_ratio` or `system_stem_active_ratio` is
+///    `None` (e.g. dictation captures with no system stem, or any recording
+///    where stem-active health was not computed) the gate does NOT fire.
+///    Missing health is treated as insufficient evidence to override the
+///    transcript, not as confirmation that the stem was silent.
 ///
 /// Otherwise returns `None` and the transcript flows through unchanged.
 fn suppress_if_all_noise(

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -8,6 +8,61 @@ use crate::summarize;
 use chrono::{DateTime, Local};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
+use whisper_guard::segments as wg_segments;
+
+/// Stem active-ratio threshold below which a capture source is considered
+/// "sparse" (almost no audible energy).
+///
+/// Keep in sync with the silence detector in `diarize::active_ratio` callers
+/// (see `diarize.rs` around line 861, where the same `0.02` value classifies
+/// a stem as `FailureKind::Sparse`). Pulled into a named constant so the
+/// suppression gate below can read it without re-deriving the number.
+const SPARSE_STEM_ACTIVE_RATIO: f32 = 0.02;
+
+/// Body text we render in place of the transcript when the all-noise
+/// suppression gate fires. Kept short and pointed - the surrounding markdown
+/// already shows the diagnosis and `minutes process` retry hint, so this
+/// just labels the gap.
+const ALL_NOISE_SUPPRESSED_BODY: &str =
+    "*No audible content was captured. See capture diagnostics.*";
+
+/// Decide whether the transcript body should be suppressed because it is
+/// almost certainly fabricated.
+///
+/// Returns `Some(diagnosis)` (a short human-readable string to store in
+/// `Frontmatter::filter_diagnosis`) when **both** of these are true:
+///
+/// 1. Every non-empty line in `transcript` is a noise marker (bracketed
+///    `[music]` / `[Growling]` or parenthetical `(crying)` / `(applause)`)
+///    according to [`wg_segments::is_all_noise`].
+/// 2. Both stem active ratios in `recording_health` are below
+///    [`SPARSE_STEM_ACTIVE_RATIO`]. If a stem ratio is `None` we treat that
+///    stem as inconclusive and require the other one to be sparse; if both
+///    are `None` (e.g. dictation, no health captured) the gate does NOT
+///    fire - we lack the evidence to override the transcript.
+///
+/// Otherwise returns `None` and the transcript flows through unchanged.
+fn suppress_if_all_noise(
+    transcript: &str,
+    recording_health: Option<&markdown::RecordingHealth>,
+) -> Option<String> {
+    let lines: Vec<String> = transcript.lines().map(str::to_string).collect();
+    if !wg_segments::is_all_noise(&lines) {
+        return None;
+    }
+
+    let health = recording_health?;
+    let voice = health.voice_stem_active_ratio?;
+    let system = health.system_stem_active_ratio?;
+    if voice >= SPARSE_STEM_ACTIVE_RATIO || system >= SPARSE_STEM_ACTIVE_RATIO {
+        return None;
+    }
+
+    Some(format!(
+        "all-noise transcript on sparse stems (voice active {:.3}, system active {:.3}, threshold {:.2}); whisper produced only non-speech markers - body suppressed",
+        voice, system, SPARSE_STEM_ACTIVE_RATIO
+    ))
+}
 
 /// Result of Level 2 voice enrollment matching.
 struct VoiceMatchResult {
@@ -1003,6 +1058,22 @@ pub fn write_transcript_artifact(
     } else {
         transcript
     };
+
+    // Suppression gate (issue #241): if the cleaned transcript is nothing but
+    // hallucinated non-speech markers AND both capture stems were sparse, the
+    // body is almost certainly fabricated on near-silent audio. Replace it
+    // with a clear diagnostic message and promote `status: NoSpeech` for
+    // greppability. The original noisy text is dropped - the source WAV is
+    // preserved on disk and `minutes process` is the canonical retry path,
+    // so there is no need to round-trip the hallucinated lines through the
+    // markdown output.
+    let all_noise_suppression =
+        suppress_if_all_noise(&transcript, context.recording_health.as_ref());
+    let (transcript, forced_no_speech_diagnosis) = match all_noise_suppression {
+        Some(diagnosis) => (ALL_NOISE_SUPPRESSED_BODY.to_string(), Some(diagnosis)),
+        None => (transcript, None),
+    };
+
     let word_count = transcript.split_whitespace().count();
     logging::log_step(
         "transcribe",
@@ -1011,11 +1082,12 @@ pub fn write_transcript_artifact(
         serde_json::json!({"words": word_count, "mode": "background", "diagnosis": filter_stats.diagnosis()}),
     );
 
-    let status = if word_count < config.transcription.min_words {
-        Some(OutputStatus::NoSpeech)
-    } else {
-        Some(OutputStatus::TranscriptOnly)
-    };
+    let status =
+        if forced_no_speech_diagnosis.is_some() || word_count < config.transcription.min_words {
+            Some(OutputStatus::NoSpeech)
+        } else {
+            Some(OutputStatus::TranscriptOnly)
+        };
 
     let auto_title = title.map(String::from).unwrap_or_else(|| {
         if status == Some(OutputStatus::NoSpeech) {
@@ -1101,7 +1173,15 @@ pub fn write_transcript_artifact(
         recording_health: context.recording_health.clone(),
         template: context.template.as_ref().map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
-            Some(filter_stats.diagnosis())
+            // Prefer the all-noise-suppression diagnosis when it fired; it
+            // describes a different failure mode (whisper produced only
+            // non-speech markers on sparse stems) than the standard
+            // min_words / no_speech filter path.
+            Some(
+                forced_no_speech_diagnosis
+                    .clone()
+                    .unwrap_or_else(|| filter_stats.diagnosis()),
+            )
         } else {
             None
         },
@@ -3943,6 +4023,74 @@ pub fn run_post_record_hook(config: &Config, transcript_path: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sparse_health(voice: f32, system: f32) -> markdown::RecordingHealth {
+        markdown::RecordingHealth {
+            voice_stem_active_ratio: Some(voice),
+            system_stem_active_ratio: Some(system),
+            system_dominant_ratio: None,
+            capture_warnings: vec![],
+            diarization_path: None,
+        }
+    }
+
+    #[test]
+    fn suppress_if_all_noise_fires_on_all_noise_with_sparse_stems() {
+        // The exact failure case from issue #241.
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n";
+        let health = sparse_health(0.005, 0.001);
+        let diagnosis = suppress_if_all_noise(transcript, Some(&health));
+        assert!(diagnosis.is_some(), "expected suppression diagnosis");
+        let msg = diagnosis.unwrap();
+        assert!(msg.contains("all-noise"), "msg: {}", msg);
+        assert!(msg.contains("threshold"), "msg: {}", msg);
+    }
+
+    #[test]
+    fn suppress_if_all_noise_holds_off_when_stems_have_signal() {
+        // Stems are above the sparse threshold - we lack the corroborating
+        // capture-side evidence, so let the transcript through even if it
+        // looks all-noise. Better to surface the suspicious lines than to
+        // hide real (if brief) capture.
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n";
+        let health = sparse_health(0.5, 0.4);
+        assert!(suppress_if_all_noise(transcript, Some(&health)).is_none());
+    }
+
+    #[test]
+    fn suppress_if_all_noise_holds_off_when_only_one_stem_is_sparse() {
+        // Asymmetric capture (one side silent, one side active) is a
+        // different failure mode - we trust the active side and don't
+        // suppress here.
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n";
+        let health = sparse_health(0.001, 0.5);
+        assert!(suppress_if_all_noise(transcript, Some(&health)).is_none());
+    }
+
+    #[test]
+    fn suppress_if_all_noise_holds_off_with_real_content() {
+        // Real speech, even with a noise marker mixed in, is left alone.
+        let transcript = "[0:00] Hello world\n[0:05] (crying)\n[0:10] Goodbye\n";
+        let health = sparse_health(0.001, 0.001);
+        assert!(suppress_if_all_noise(transcript, Some(&health)).is_none());
+    }
+
+    #[test]
+    fn suppress_if_all_noise_holds_off_without_health() {
+        // No recording_health (e.g. dictation, or a test fixture) means we
+        // can't confirm the stems were sparse. Be conservative.
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n";
+        assert!(suppress_if_all_noise(transcript, None).is_none());
+    }
+
+    #[test]
+    fn suppress_if_all_noise_holds_off_with_partial_health() {
+        // Only one stem ratio captured - inconclusive, don't suppress.
+        let mut health = sparse_health(0.001, 0.001);
+        health.system_stem_active_ratio = None;
+        let transcript = "[0:07] (crying)\n[1:52] [Growling]\n";
+        assert!(suppress_if_all_noise(transcript, Some(&health)).is_none());
+    }
 
     fn sample_summary() -> summarize::Summary {
         summarize::Summary {

--- a/crates/whisper-guard/src/segments.rs
+++ b/crates/whisper-guard/src/segments.rs
@@ -23,15 +23,93 @@ fn is_always_noise(text: &str) -> bool {
     t == "[music]" || t == "[blank_audio]" || t == "[silence]" || t == "music"
 }
 
+/// Whisper non-speech tokens that legitimately appear as `(crying)` /
+/// `[laughter]` style annotations. Compared case-insensitively against each
+/// whitespace-separated word inside the parentheses or brackets.
+///
+/// Keeping this an explicit allowlist (rather than "any short parenthetical")
+/// is what stops the all-noise classifier from eating legitimate user
+/// parentheticals like `(see attached)`, `(part 1)`, `(2 of 3)`, or
+/// `(continued)` that whisper would never emit on its own.
+///
+/// Includes a handful of foreign-language whisper-emitted tokens (Polish,
+/// Spanish, German, French) so non-English captures still get the bracketed
+/// form recognized.
+const NOISE_WORDS: &[&str] = &[
+    // English non-speech events whisper labels on near-silent / noisy audio
+    "crying",
+    "laughter",
+    "laughing",
+    "applause",
+    "growling",
+    "music",
+    "sobbing",
+    "cheering",
+    "sighing",
+    "clapping",
+    "coughing",
+    "sneezing",
+    "gasping",
+    "whispering",
+    "mumbling",
+    "humming",
+    "breathing",
+    "silence",
+    "snoring",
+    "yelling",
+    "screaming",
+    // Whisper-specific synthetic tokens (typically bracketed)
+    "blank_audio",
+    // Non-English whisper noise tokens we've seen in real captures
+    "śmiech",    // Polish: laughter
+    "risas",     // Spanish: laughter
+    "musik",     // German: music
+    "musique",   // French: music
+    "musica",    // Italian/Spanish: music
+    "música",    // Spanish/Portuguese: music
+    "muzyka",    // Polish: music
+    "applaus",   // German: applause
+    "aplausos",  // Spanish: applause
+    "applausi",  // Italian: applause
+    "oklaski",   // Polish: applause
+    "ruido",     // Spanish: noise
+    "geräusch",  // German: noise
+    "stille",    // German: silence
+    "silencio",  // Spanish: silence
+    "cisza",     // Polish: silence
+    "rires",     // French: laughter
+    "rire",      // French: laughter (singular form)
+    "gelächter", // German: laughter
+    "weeping",   // English variant of crying
+];
+
+/// Case-insensitive membership check against [`NOISE_WORDS`].
+///
+/// The lookup table is small (under 50 entries) so a linear scan with
+/// `eq_ignore_ascii_case` is fine; the non-ASCII Polish / Spanish forms are
+/// matched verbatim after lowercasing the input. We lowercase here rather
+/// than at insertion so the allowlist stays readable.
+fn is_noise_word(word: &str) -> bool {
+    let lower = word.to_lowercase();
+    NOISE_WORDS.iter().any(|w| *w == lower)
+}
+
 /// Return true if the text (after timestamp) is a short non-speech marker.
 ///
 /// Matches two whisper hallucination shapes:
 /// - bracketed: `[music]`, `[Śmiech]`, `[BLANK_AUDIO]`, `[risas]`, `[Growling]`
-/// - parenthetical: `(crying)`, `(coughing)`, `(applause)`, `(silence)`
+/// - parenthetical: `(crying)`, `(coughing)`, `(applause)`, `(silence)`,
+///   `(soft music)`, `(loud applause)`
 ///
 /// Excludes timestamp-like content `[0:00]` and collapse markers from prior
 /// dedup passes `[...] [repeated ...]`. Word-count (1-4 inner words) and
 /// length (≤40 inner chars) constraints keep this conservative.
+///
+/// **Allowlist gate:** at least one whitespace-separated word inside the
+/// delimiters must match [`NOISE_WORDS`] (case-insensitive). Without this,
+/// short user-authored parentheticals like `(see attached)`, `(part 1)`,
+/// `(2 of 3)`, or `(continued)` would be misclassified as whisper
+/// hallucinations and dropped from the transcript.
 ///
 /// This is the shared classifier used by both [`collapse_noise_markers`] and
 /// the [`is_all_noise`] read-only signal.
@@ -62,7 +140,14 @@ pub fn is_noise_marker(text: &str) -> bool {
     }
     // Must be short (1-4 words, ≤40 chars) - non-speech markers are brief
     let word_count = inner.split_whitespace().count();
-    (1..=4).contains(&word_count) && inner.len() <= 40
+    if !(1..=4).contains(&word_count) || inner.len() > 40 {
+        return false;
+    }
+
+    // Allowlist gate: at least one inner word must be a known whisper
+    // non-speech token. This keeps legitimate user parentheticals like
+    // `(see attached)` or `(part 1)` out of the noise bucket.
+    inner.split_whitespace().any(is_noise_word)
 }
 
 /// Return true iff every non-empty line in `lines` is a noise marker (after
@@ -1551,6 +1636,45 @@ mod tests {
         assert!(!is_noise_marker(
             "(this is way more than four words of content)"
         ));
+    }
+
+    #[test]
+    fn is_noise_marker_rejects_user_authored_parentheticals() {
+        // Real users put short parentheticals in notes for legitimate reasons.
+        // None of these contain a whisper non-speech token, so they must NOT
+        // be classified as noise (codex blocker 1 on PR #246).
+        assert!(!is_noise_marker("(see attached)"));
+        assert!(!is_noise_marker("(part 1)"));
+        assert!(!is_noise_marker("(2 of 3)"));
+        assert!(!is_noise_marker("(continued)"));
+        assert!(!is_noise_marker("(TBD)"));
+        assert!(!is_noise_marker("(draft)"));
+        // Trailing period is normalized but the content is still not noise.
+        assert!(!is_noise_marker("(see attached)."));
+    }
+
+    #[test]
+    fn is_noise_marker_accepts_two_word_noise_forms() {
+        // Two-word parentheticals where one word is on the noise allowlist
+        // (typical whisper emission shape).
+        assert!(is_noise_marker("(soft music)"));
+        assert!(is_noise_marker("(loud applause)"));
+        assert!(is_noise_marker("(gentle music)"));
+        assert!(is_noise_marker("(background music)"));
+        // Same in brackets.
+        assert!(is_noise_marker("[soft music]"));
+        assert!(is_noise_marker("[loud applause]"));
+    }
+
+    #[test]
+    fn is_noise_marker_rejects_user_authored_brackets() {
+        // Brackets that don't contain a noise word should also pass through.
+        // (Less common in user notes than parentheticals, but the allowlist
+        // gate applies uniformly to both shapes.)
+        assert!(!is_noise_marker("[TODO]"));
+        assert!(!is_noise_marker("[draft]"));
+        assert!(!is_noise_marker("[part 1]"));
+        assert!(!is_noise_marker("[see attached]"));
     }
 
     #[test]

--- a/crates/whisper-guard/src/segments.rs
+++ b/crates/whisper-guard/src/segments.rs
@@ -60,6 +60,13 @@ const NOISE_WORDS: &[&str] = &[
     "screaming",
     // Whisper-specific synthetic tokens (typically bracketed)
     "blank_audio",
+    "inaudible",
+    "noise",
+    "crosstalk",
+    "typing",
+    "static",
+    "beep",
+    "ringing",
     // Non-English whisper noise tokens we've seen in real captures
     "śmiech",    // Polish: laughter
     "risas",     // Spanish: laughter
@@ -144,10 +151,17 @@ pub fn is_noise_marker(text: &str) -> bool {
         return false;
     }
 
-    // Allowlist gate: at least one inner word must be a known whisper
-    // non-speech token. This keeps legitimate user parentheticals like
-    // `(see attached)` or `(part 1)` out of the noise bucket.
-    inner.split_whitespace().any(is_noise_word)
+    // Allowlist gate: the LAST whitespace-separated word inside the
+    // delimiters must be a known whisper non-speech token. This dominance
+    // rule keeps legitimate phrasings like `(music director)` or
+    // `(applause sounds great)` from matching just because they happen to
+    // contain a noise word, while still recognizing whisper's compound
+    // emissions like `(soft music)` / `(loud applause)` / `(audience
+    // laughter)` where the noise word terminates the phrase.
+    inner
+        .split_whitespace()
+        .next_back()
+        .is_some_and(is_noise_word)
 }
 
 /// Return true iff every non-empty line in `lines` is a noise marker (after
@@ -1668,13 +1682,55 @@ mod tests {
 
     #[test]
     fn is_noise_marker_rejects_user_authored_brackets() {
-        // Brackets that don't contain a noise word should also pass through.
+        // Brackets that don't end with a noise word should also pass through.
         // (Less common in user notes than parentheticals, but the allowlist
-        // gate applies uniformly to both shapes.)
+        // dominance rule applies uniformly to both shapes.)
         assert!(!is_noise_marker("[TODO]"));
         assert!(!is_noise_marker("[draft]"));
         assert!(!is_noise_marker("[part 1]"));
         assert!(!is_noise_marker("[see attached]"));
+    }
+
+    #[test]
+    fn is_noise_marker_dominance_check_rejects_noise_word_with_content_suffix() {
+        // The noise allowlist used to match if ANY word inside the marker
+        // appeared in the noise list. That meant `(music director)` and
+        // `(applause sounds great)` were classified as noise just because
+        // they contained a noise word somewhere. Per codex review of PR
+        // #246: the last word must be the noise token.
+        assert!(!is_noise_marker("(music director)"));
+        assert!(!is_noise_marker("(applause sounds great)"));
+        assert!(!is_noise_marker("(noise complaint)"));
+        assert!(!is_noise_marker("(typing speed)"));
+        assert!(!is_noise_marker("[crying baby]"));
+        assert!(!is_noise_marker("[laughter therapy]"));
+    }
+
+    #[test]
+    fn is_noise_marker_dominance_check_accepts_modifier_plus_noise_word() {
+        // The complement of the previous test: when the noise word
+        // terminates the phrase (whisper's actual emission shape), the
+        // marker is still classified as noise.
+        assert!(is_noise_marker("(audience laughter)"));
+        assert!(is_noise_marker("(soft music)"));
+        assert!(is_noise_marker("(loud applause)"));
+        assert!(is_noise_marker("(background music)"));
+        assert!(is_noise_marker("[audience laughter]"));
+    }
+
+    #[test]
+    fn is_noise_marker_accepts_expanded_allowlist_tokens() {
+        // Tokens added per codex review of PR #246: real whisper outputs
+        // that were missing from the v1 allowlist.
+        assert!(is_noise_marker("[inaudible]"));
+        assert!(is_noise_marker("[crosstalk]"));
+        assert!(is_noise_marker("[typing]"));
+        assert!(is_noise_marker("[noise]"));
+        assert!(is_noise_marker("[static]"));
+        assert!(is_noise_marker("[beep]"));
+        assert!(is_noise_marker("[ringing]"));
+        assert!(is_noise_marker("(inaudible)"));
+        assert!(is_noise_marker("(crosstalk)"));
     }
 
     #[test]

--- a/crates/whisper-guard/src/segments.rs
+++ b/crates/whisper-guard/src/segments.rs
@@ -23,6 +23,73 @@ fn is_always_noise(text: &str) -> bool {
     t == "[music]" || t == "[blank_audio]" || t == "[silence]" || t == "music"
 }
 
+/// Return true if the text (after timestamp) is a short non-speech marker.
+///
+/// Matches two whisper hallucination shapes:
+/// - bracketed: `[music]`, `[Śmiech]`, `[BLANK_AUDIO]`, `[risas]`, `[Growling]`
+/// - parenthetical: `(crying)`, `(coughing)`, `(applause)`, `(silence)`
+///
+/// Excludes timestamp-like content `[0:00]` and collapse markers from prior
+/// dedup passes `[...] [repeated ...]`. Word-count (1-4 inner words) and
+/// length (≤40 inner chars) constraints keep this conservative.
+///
+/// This is the shared classifier used by both [`collapse_noise_markers`] and
+/// the [`is_all_noise`] read-only signal.
+pub fn is_noise_marker(text: &str) -> bool {
+    let t = text.trim();
+    if t.is_empty() {
+        return false;
+    }
+    // Collapse markers from prior passes are not noise
+    if t.starts_with("[...]") {
+        return false;
+    }
+    // Optionally strip a single trailing '.' (whisper sometimes adds one)
+    let t = t.strip_suffix('.').unwrap_or(t);
+
+    // Accept either bracketed `[...]` or parenthetical `(...)` shape; both
+    // collapse to the same inner substring after the outer delimiters.
+    let matched =
+        (t.starts_with('[') && t.ends_with(']')) || (t.starts_with('(') && t.ends_with(')'));
+    if !matched {
+        return false;
+    }
+    let inner = &t[1..t.len() - 1];
+
+    // Reject timestamp-like patterns (digits and colons only)
+    if inner.chars().all(|c| c.is_ascii_digit() || c == ':') {
+        return false;
+    }
+    // Must be short (1-4 words, ≤40 chars) - non-speech markers are brief
+    let word_count = inner.split_whitespace().count();
+    (1..=4).contains(&word_count) && inner.len() <= 40
+}
+
+/// Return true iff every non-empty line in `lines` is a noise marker (after
+/// stripping any leading `[h:mm:ss]`-style timestamp).
+///
+/// Empty lines are ignored. An input with zero non-empty lines returns `false`
+/// (there's nothing to call "all noise").
+///
+/// This is a read-only signal: it does not alter `lines`. Callers (notably
+/// `minutes-core`) use it together with separate capture-health signals (e.g.
+/// silent / sparse stems) to decide whether to suppress a transcript body that
+/// is almost certainly fabricated.
+pub fn is_all_noise(lines: &[String]) -> bool {
+    let mut saw_any = false;
+    for line in lines {
+        let text = text_part(line).trim();
+        if text.is_empty() {
+            continue;
+        }
+        saw_any = true;
+        if !is_noise_marker(text) {
+            return false;
+        }
+    }
+    saw_any
+}
+
 /// Statistics from transcript cleaning.
 ///
 /// Each `after_*` field records the segment count *after* that pass ran. If a pass
@@ -51,6 +118,21 @@ pub struct CleanStats {
     /// To get the cleaner "input minus output" count, suppress the annotations
     /// via [`CleanOptions::keep_dedup_annotations`] = `false`.
     pub lines_removed: usize,
+    /// `true` iff every non-empty line in the cleaned output is a noise
+    /// marker (bracketed `[music]` / `[Growling]` or parenthetical
+    /// `(crying)` / `(applause)`), and there is at least one such line.
+    ///
+    /// This is a **read-only signal** computed after the cleanup passes run.
+    /// It does not change the cleanup output itself; downstream callers can
+    /// use it (together with separate capture-health signals like sparse or
+    /// silent stems) to decide whether to suppress a transcript body that is
+    /// almost certainly fabricated on near-silent audio.
+    ///
+    /// Examples:
+    /// - `["[0:07] (crying)", "[1:52] [Growling]"]` → `true`
+    /// - `["[0:00] Hello world", "[0:03] [laughter]"]` → `false`
+    /// - `[]` → `false` (nothing to call all-noise)
+    pub all_noise: bool,
 }
 
 impl CleanStats {
@@ -325,6 +407,9 @@ pub fn clean_segments_with_options(
         // runs last (per the pipeline-order rationale above), so
         // `after_noise_markers` is the final segment count.
         lines_removed: original_count.saturating_sub(after_noise),
+        // Read-only signal: every non-empty surviving line is a noise marker.
+        // Cleanup output is unchanged - downstream callers decide what to do.
+        all_noise: is_all_noise(&lines),
     };
 
     (lines, stats)
@@ -635,34 +720,8 @@ pub fn collapse_noise_markers(lines: &[String]) -> Vec<String> {
         return lines.to_vec();
     }
 
-    /// Return true if the text (after timestamp) is a bracketed non-speech marker.
-    ///
-    /// Matches patterns like `[music]`, `[Śmiech]`, `[BLANK_AUDIO]`, `[risas]`.
-    /// Excludes timestamp-like content `[0:00]` and collapse markers from prior
-    /// dedup passes `[...] [repeated ...]`.
-    fn is_noise_marker(text: &str) -> bool {
-        let t = text.trim();
-        if t.is_empty() {
-            return false;
-        }
-        // Collapse markers from prior passes are not noise
-        if t.starts_with("[...]") {
-            return false;
-        }
-        // Must start with '[' and end with ']' (optionally with trailing '.')
-        let t = t.strip_suffix('.').unwrap_or(t);
-        if !(t.starts_with('[') && t.ends_with(']')) {
-            return false;
-        }
-        let inner = &t[1..t.len() - 1];
-        // Reject timestamp-like patterns (digits and colons only)
-        if inner.chars().all(|c| c.is_ascii_digit() || c == ':') {
-            return false;
-        }
-        // Must be short (1-4 words, ≤40 chars) - non-speech markers are brief
-        let word_count = inner.split_whitespace().count();
-        (1..=4).contains(&word_count) && inner.len() <= 40
-    }
+    // Classifier lives at module scope (`is_noise_marker`) so the `all_noise`
+    // signal in `CleanStats` can reuse it without duplicating the rules.
 
     let markers: Vec<bool> = lines
         .iter()
@@ -1455,6 +1514,106 @@ mod tests {
         let lines = vec!["[0:00] [music]".into(), "[0:03] [laughter]".into()];
         let result = collapse_noise_markers(&lines);
         assert_eq!(result, lines);
+    }
+
+    #[test]
+    fn is_noise_marker_matches_parenthetical_form() {
+        // Whisper hallucinates parenthetical non-speech tokens on near-silent
+        // audio just as readily as bracketed ones. Both shapes count.
+        assert!(is_noise_marker("(crying)"));
+        assert!(is_noise_marker("(coughing)"));
+        assert!(is_noise_marker("(applause)"));
+        assert!(is_noise_marker("(silence)"));
+        // Trailing period (whisper sometimes adds one) is tolerated.
+        assert!(is_noise_marker("(crying)."));
+    }
+
+    #[test]
+    fn is_noise_marker_matches_bracketed_form() {
+        assert!(is_noise_marker("[music]"));
+        assert!(is_noise_marker("[Growling]"));
+        assert!(is_noise_marker("[BLANK_AUDIO]"));
+        assert!(is_noise_marker("[Śmiech]"));
+        assert!(is_noise_marker("[laughter]."));
+    }
+
+    #[test]
+    fn is_noise_marker_rejects_non_markers() {
+        assert!(!is_noise_marker(""));
+        assert!(!is_noise_marker("Hello world"));
+        assert!(!is_noise_marker("[0:00]"));
+        // Collapse marker from a prior pass is not noise.
+        assert!(!is_noise_marker("[...] [repeated audio removed - 3]"));
+        // Mismatched delimiters are not a marker.
+        assert!(!is_noise_marker("(crying]"));
+        assert!(!is_noise_marker("[crying)"));
+        // Too long / too many words.
+        assert!(!is_noise_marker(
+            "(this is way more than four words of content)"
+        ));
+    }
+
+    #[test]
+    fn is_all_noise_true_for_pure_noise_transcript() {
+        // The exact 1-2 line failure case from issue #241.
+        let lines = vec!["[0:07] (crying)".into(), "[1:52] [Growling]".into()];
+        assert!(is_all_noise(&lines));
+    }
+
+    #[test]
+    fn is_all_noise_true_for_single_noise_line() {
+        let lines = vec!["[0:00] [music]".into()];
+        assert!(is_all_noise(&lines));
+    }
+
+    #[test]
+    fn is_all_noise_false_when_any_line_is_speech() {
+        let lines = vec![
+            "[0:00] Hello world".into(),
+            "[0:05] [laughter]".into(),
+            "[0:10] (crying)".into(),
+        ];
+        assert!(!is_all_noise(&lines));
+    }
+
+    #[test]
+    fn is_all_noise_false_on_empty_input() {
+        // No surviving lines → nothing to call "all noise".
+        let lines: Vec<String> = Vec::new();
+        assert!(!is_all_noise(&lines));
+    }
+
+    #[test]
+    fn is_all_noise_ignores_blank_lines() {
+        let lines = vec![
+            "".into(),
+            "[0:07] (crying)".into(),
+            "   ".into(),
+            "[1:52] [Growling]".into(),
+        ];
+        assert!(is_all_noise(&lines));
+    }
+
+    #[test]
+    fn clean_stats_all_noise_true_for_short_noise_only_input() {
+        // Two lines is below the collapse-pass threshold, so the noise lines
+        // survive cleanup unchanged. The all_noise signal must still fire.
+        let input = vec!["[0:07] (crying)".into(), "[1:52] [Growling]".into()];
+        let (cleaned, stats) = clean_segments(&input);
+        // Cleanup is read-only here: short runs are preserved.
+        assert_eq!(cleaned, input);
+        assert!(stats.all_noise, "stats: {:?}", stats);
+    }
+
+    #[test]
+    fn clean_stats_all_noise_false_with_real_content() {
+        let input = vec![
+            "[0:00] Hello world".into(),
+            "[0:05] (crying)".into(),
+            "[0:10] Goodbye".into(),
+        ];
+        let (_, stats) = clean_segments(&input);
+        assert!(!stats.all_noise, "stats: {:?}", stats);
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1078;
+export const MINUTES_TEST_COUNT = 1081;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1054;
+export const MINUTES_TEST_COUNT = 1070;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1070;
+export const MINUTES_TEST_COUNT = 1078;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary

A transcript consisting entirely of 1-2 hallucinated non-speech markers (e.g. `[0:07] (crying)\n[1:52] [Growling]`) was surviving `clean_transcript` untouched, because:

- `collapse_noise_markers` early-returns on `lines.len() < 3` (by design - short clips might legitimately be a single `[music]` annotation).
- `is_noise_marker` only matched bracketed `[...]` form, not parenthetical `(crying)` / `(coughing)` / `(applause)`.
- The `is_always_noise` allow-list is intentionally tiny.

This PR closes the gap with a read-only classifier extension in whisper-guard and a write-time suppression gate in minutes-core that only fires when corroborating capture-health evidence (sparse stems) backs up the all-noise transcript.

### whisper-guard (no cleanup behavior change)

- Promote `is_noise_marker` to module-level `pub fn`.
- Extend it to match parenthetical `(crying)` / `(coughing)` / `(applause)` with the same word-count (1-4 inner words) and length (<=40 chars) constraints as the bracketed form. Trailing period tolerated either way.
- Add `pub fn is_all_noise(&[String]) -> bool` returning true iff every non-empty line (after timestamp strip) is a noise marker.
- Add `CleanStats.all_noise: bool` computed after the cleanup passes run. **Read-only signal; cleanup output is unchanged.**

Existing tests (`noise_markers_preserves_short_runs`, `noise_markers_handles_single_line`, `noise_markers_handles_two_lines`) pass unchanged.

### minutes-core (uses the signal at write time)

Adds `suppress_if_all_noise` in `write_transcript_artifact`. Gate fires when:

1. Every non-empty line in the transcript is a noise marker (`is_all_noise` from whisper-guard).
2. Both `voice_stem_active_ratio` and `system_stem_active_ratio` are below `0.02` (the same sparse threshold used in `diarize.rs` around line 861).

When the gate fires:

- The transcript body is replaced with `*No audible content was captured. See capture diagnostics.*`
- `status` is promoted to `OutputStatus::NoSpeech`
- `filter_diagnosis` carries the gate's reason (stem ratios + threshold), surfaced by the existing NoSpeech render path

The gate holds off when health is missing, when either stem has real signal, when the transcript contains any non-noise line, or when only one stem is sparse (asymmetric captures are a different failure mode).

### Design decision: raw text preservation

The issue listed three options for preserving the original noisy text. **I picked (a) drop it entirely.** Rationale:

- The source WAV is preserved on disk and `minutes process <wav>` is the canonical retry path. Anyone triaging this can re-run whisper with different params against the actual audio - the hallucinated lines aren't load-bearing for that workflow.
- Option (b) (new serialized `raw_hallucinated_text: Option<String>` Frontmatter field) widens the schema surface for a debug field most users will never read.
- Option (c) (sidecar `.debug.md`) introduces a new file lifecycle (creation, cleanup, rename-on-move) for a small payload.

If the suppressed text turns out to be useful for triage in practice, adding it back is a minor-version bump - no precommit-side decisions get blocked by dropping it now.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all --no-default-features -- -D warnings` clean
- [x] `cargo test -p whisper-guard --lib` 85/85 pass (including 10 new tests: parenthetical-form detection, all-noise signal computation, CleanStats.all_noise integration)
- [x] `cargo test -p whisper-guard --doc` 6/6 pass
- [x] `cargo test -p minutes-core --no-default-features --lib` 713/713 pass (including 6 new pipeline tests covering the gate matrix: fires, holds off when stems have signal, holds off asymmetric, holds off real content, holds off no health, holds off partial health)
- [x] Pre-push hooks green: fmt, clippy, site release constants, agent docs consistency

## Verification of acceptance criteria

- `CleanStats.all_noise` is `true` for `["[0:07] (crying)", "[1:52] [Growling]"]` and `false` for any input containing at least one non-noise line. Covered by `clean_stats_all_noise_true_for_short_noise_only_input` and `clean_stats_all_noise_false_with_real_content`.
- All existing whisper-guard tests pass unchanged (85/85).
- Parenthetical noise markers detected with the same constraints as bracketed forms. Covered by `is_noise_marker_matches_parenthetical_form`.
- In minutes-core, a recording where both stems are below sparse threshold AND `all_noise` is true renders a "no audible content captured" message instead of the hallucinated lines. Covered by `suppress_if_all_noise_fires_on_all_noise_with_sparse_stems` plus the surrounding hold-off tests.

Closes #241