### PR TITLE
fix(whisper-guard): strip known whisper hallucination phrases (#242)

### DIFF
--- a/crates/whisper-guard/src/segments.rs
+++ b/crates/whisper-guard/src/segments.rs
@@ -132,11 +132,30 @@ const KNOWN_HALLUCINATION_PHRASES: &[&str] = &[
     "translated by the amara.org community",
     "the amara.org community",
     "amara.org community",
-    // Generic transcription-service hallucinations
+    // Generic transcription-service hallucinations (bare forms; for prefix
+    // matches with trailing content like `Transcripted by: www.amara.org`
+    // see [`HALLUCINATION_LINE_PREFIXES`])
     "captions by the cyclope",
-    "captions by",
+];
+
+/// Hallucination phrases that whisper emits with trailing content, e.g.
+/// `Transcripted by: www.transcription-exe-project.com` or
+/// `Subtitles by the Amara.org community`. Matched as a **starts-with**
+/// prefix against the normalized line text rather than exact-match, so
+/// they catch both the bare form and the variants with trailing URLs,
+/// service names, or fillers.
+///
+/// Conservative bar: only credit-attribution prefixes that a real meeting
+/// participant is virtually guaranteed not to utter as the start of a
+/// sentence. Niche edge cases (e.g. someone reading a meeting transcript
+/// out loud that contains a `Transcribed by` credit line) accept this as
+/// noise rather than complicate the detector.
+const HALLUCINATION_LINE_PREFIXES: &[&str] = &[
     "transcripted by",
     "transcribed by",
+    "captions by",
+    "subtitles by",
+    "translated by",
 ];
 
 /// Check if a line is just a URL or domain reference, common in Whisper
@@ -169,6 +188,12 @@ fn is_known_hallucination(text: &str) -> bool {
         return false;
     }
     if KNOWN_HALLUCINATION_PHRASES.contains(&normalized) {
+        return true;
+    }
+    if HALLUCINATION_LINE_PREFIXES
+        .iter()
+        .any(|p| normalized.starts_with(p))
+    {
         return true;
     }
     is_url_line(normalized)
@@ -1908,13 +1933,34 @@ mod tests {
 
     #[test]
     fn is_known_hallucination_matches_url_lines() {
-        // Whisper sometimes emits a bare URL line like
-        // `Transcripted by: www.transcription-exe-project.com`. Lines that
-        // START with a URL token are dropped; lines that just mention a URL
-        // mid-sentence are NOT.
+        // Bare-URL lines (no leading label) are dropped via is_url_line.
         assert!(is_known_hallucination("www.transcription-exe-project.com"));
         assert!(is_known_hallucination("https://amara.org"));
         assert!(is_known_hallucination("http://example.com"));
+    }
+
+    #[test]
+    fn is_known_hallucination_matches_attribution_prefixes() {
+        // Whisper emits attribution-style hallucinations with varied
+        // trailing content (URLs, service names, additional filler).
+        // Codex review of PR #247 v1 flagged that `is_url_line` alone
+        // could not catch `Transcripted by: www.amara.org` because the
+        // first token is "Transcripted", not the URL. The prefix list
+        // catches the full family.
+        assert!(is_known_hallucination(
+            "Transcripted by: www.transcription-exe-project.com"
+        ));
+        assert!(is_known_hallucination(
+            "Transcribed by the Amara.org community"
+        ));
+        assert!(is_known_hallucination("Subtitles by the cyclope team"));
+        assert!(is_known_hallucination("Translated by community volunteers"));
+        assert!(is_known_hallucination(
+            "Captions by the Acme transcription service"
+        ));
+        // Bare prefix without trailing content also matches.
+        assert!(is_known_hallucination("Transcribed by"));
+        assert!(is_known_hallucination("Subtitles by"));
     }
 
     #[test]

--- a/crates/whisper-guard/src/segments.rs
+++ b/crates/whisper-guard/src/segments.rs
@@ -90,6 +90,90 @@ const NOISE_WORDS: &[&str] = &[
     "weeping",   // English variant of crying
 ];
 
+/// High-confidence Whisper hallucination signatures.
+///
+/// Whisper, fed long stretches of near-silent audio, emits stable
+/// "training-data leak" phrases from YouTube subtitles, Amara.org community
+/// credits, and similar sources. These survive `dedup_interleaved` because
+/// each occurrence is a different exact string (sometimes pluralized,
+/// punctuated, or wrapped in different filler), and they survive
+/// `collapse_noise_markers` because they are not bracketed/parenthetical
+/// tokens. They look like normal sentences but are confidently identifiable
+/// from a small list of recurring surface forms.
+///
+/// Phrases are normalized lowercase, with trailing punctuation stripped,
+/// and matched exactly against the line's text content (after stripping any
+/// `[h:mm:ss]` timestamp + optional speaker prefix). Substring matching
+/// would risk false positives in real speech (e.g. "thank you for watching
+/// the demo carefully" should NOT be dropped just because it contains
+/// "thank you for watching").
+///
+/// Conservative bar: a phrase is added here only when it is virtually
+/// impossible for a real human speaker to utter it as a complete sentence
+/// in a meeting transcript. URL-style hallucinations are handled separately
+/// in [`is_url_line`].
+const KNOWN_HALLUCINATION_PHRASES: &[&str] = &[
+    // YouTube subtitle openers/closers
+    "thank you for watching",
+    "thanks for watching",
+    "thank you for watching!",
+    "thank you so much for watching",
+    "please subscribe to our channel",
+    "please subscribe",
+    "please like and subscribe",
+    "like and subscribe",
+    "smash that like button",
+    "don't forget to subscribe",
+    "see you in the next video",
+    "see you next time",
+    // Amara.org community subtitle hallucinations
+    "subtitles by the amara.org community",
+    "transcribed by the amara.org community",
+    "translated by the amara.org community",
+    "the amara.org community",
+    "amara.org community",
+    // Generic transcription-service hallucinations
+    "captions by the cyclope",
+    "captions by",
+    "transcripted by",
+    "transcribed by",
+];
+
+/// Check if a line is just a URL or domain reference, common in Whisper
+/// long-tail hallucinations like `Transcripted by: www.transcription-...`.
+///
+/// Conservative match: requires the line content to start with `www.` or
+/// `http://` / `https://`, with at most one trailing word of context. Drops
+/// pure URL hallucinations without affecting real speech that happens to
+/// mention a URL inline.
+fn is_url_line(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Require URL-ish prefix on the first whitespace-separated token.
+    let first = trimmed.split_whitespace().next().unwrap_or("");
+    first.starts_with("www.") || first.starts_with("http://") || first.starts_with("https://")
+}
+
+/// Test whether a transcript line's content matches a known Whisper
+/// hallucination phrase (after timestamp/speaker prefix stripping and case
+/// normalization). Used by [`strip_known_hallucinations`].
+fn is_known_hallucination(text: &str) -> bool {
+    let lowered = text.to_lowercase();
+    let normalized = lowered
+        .trim()
+        .trim_end_matches(['.', '!', '?', ',', ';', ':'])
+        .trim();
+    if normalized.is_empty() {
+        return false;
+    }
+    if KNOWN_HALLUCINATION_PHRASES.contains(&normalized) {
+        return true;
+    }
+    is_url_line(normalized)
+}
+
 /// Case-insensitive membership check against [`NOISE_WORDS`].
 ///
 /// The lookup table is small (under 50 entries) so a linear scan with
@@ -207,6 +291,11 @@ pub struct CleanStats {
     pub after_noise_markers: usize,
     pub after_trailing_trim: usize,
     pub after_command_strip: usize,
+    /// Segment count after [`strip_known_hallucinations`] ran. If the pass
+    /// is disabled in [`CleanOptions`], this carries the count from the
+    /// previous (enabled) pass. Tracks the long-tail-of-silence Whisper
+    /// hallucination removal (#242).
+    pub after_hallucination_strip: usize,
     /// **Net** segment count delta (`original_lines - after_noise_markers`,
     /// where `after_noise_markers` is the final output count post-pipeline),
     /// not the raw count of input lines that were dropped.
@@ -266,18 +355,22 @@ impl CleanStats {
 ///
 /// Passes always run in this order (fixed; the order matters for correctness):
 ///
-/// 1. `dedup_consecutive` - collapse runs of repeated real-content segments.
+/// 1. `strip_known_hallucinations` - drop lines matching known whisper
+///    training-data leak phrases (YouTube/Amara/etc.) BEFORE dedup gets a
+///    chance to turn them into `[...] [repeated audio removed]` annotations.
+///    See [`strip_known_hallucinations`] for the conservative matching rule.
+/// 2. `dedup_consecutive` - collapse runs of repeated real-content segments.
 ///    Always-noise tokens (`[music]`, `[blank_audio]`, `[silence]`, `music`) are
 ///    skipped here so the noise-aware passes downstream can handle them.
-/// 2. `dedup_interleaved` - collapse A/B/A/B hallucination patterns
-/// 3. `strip_foreign_script` - drop segments in unrelated writing systems
-/// 4. `strip_trailing_commands` - strip `stop recording`-style voice commands.
+/// 3. `dedup_interleaved` - collapse A/B/A/B hallucination patterns
+/// 4. `strip_foreign_script` - drop segments in unrelated writing systems
+/// 5. `strip_trailing_commands` - strip `stop recording`-style voice commands.
 ///    Runs BEFORE trim so noise markers hidden behind a trailing command get
 ///    exposed to the trim pass.
-/// 5. `trim_trailing_noise` - trim noise markers off the end. Always-noise
+/// 6. `trim_trailing_noise` - trim noise markers off the end. Always-noise
 ///    tokens get trimmed at any count; filler words (`yeah.`, `okay.`, `you`)
 ///    need a 5+ run to trigger.
-/// 6. `collapse_noise_markers` - collapse middle-of-transcript `[music]`/
+/// 7. `collapse_noise_markers` - collapse middle-of-transcript `[music]`/
 ///    `[Śmiech]`/etc. runs. Runs LAST so trim has first crack at trailing
 ///    noise; whatever survives in the middle gets collapsed cleanly.
 ///
@@ -313,6 +406,11 @@ pub struct CleanOptions {
     pub collapse_noise_markers: bool,
     pub trim_trailing_noise: bool,
     pub strip_trailing_commands: bool,
+    /// Drop lines matching known whisper hallucination phrases
+    /// (YouTube/Amara/transcription-service training-data leaks). See
+    /// [`strip_known_hallucinations`] for the full rationale and conservative
+    /// matching rule. Catches the long-tail-of-silence failure mode (#242).
+    pub strip_known_hallucinations: bool,
     /// Keep the `[...] [repeated audio removed - N identical segments collapsed]`
     /// annotation lines that the consecutive-dedup pass inserts.
     ///
@@ -334,6 +432,7 @@ impl Default for CleanOptions {
             collapse_noise_markers: true,
             trim_trailing_noise: true,
             strip_trailing_commands: true,
+            strip_known_hallucinations: true,
             keep_dedup_annotations: true,
         }
     }
@@ -361,6 +460,7 @@ impl CleanOptions {
             collapse_noise_markers: false,
             trim_trailing_noise: false,
             strip_trailing_commands: false,
+            strip_known_hallucinations: false,
             keep_dedup_annotations: true,
         }
     }
@@ -440,6 +540,17 @@ pub fn clean_segments_with_options(
     let original_count = segments.len();
     let mut lines: Vec<String> = segments.to_vec();
 
+    // Run BEFORE dedup_consecutive so repeated hallucination phrases are
+    // dropped on identity rather than collapsed into a `[...] [repeated
+    // audio removed]` annotation (which would mark hallucination noise as
+    // worth-noting summarized content). The dedup_interleaved pass below
+    // still handles other repetition shapes; this pass only catches the
+    // exact-match training-data leak surface forms.
+    if opts.strip_known_hallucinations {
+        lines = strip_known_hallucinations(&lines);
+    }
+    let after_hallucination = lines.len();
+
     if opts.dedup_consecutive {
         lines = dedup_segments(&lines);
         if !opts.keep_dedup_annotations {
@@ -502,6 +613,7 @@ pub fn clean_segments_with_options(
         after_noise_markers: after_noise,
         after_trailing_trim: after_trim,
         after_command_strip: after_command,
+        after_hallucination_strip: after_hallucination,
         // Net change from input to final output. `collapse_noise_markers`
         // runs last (per the pipeline-order rationale above), so
         // `after_noise_markers` is the final segment count.
@@ -987,6 +1099,39 @@ pub fn strip_foreign_script(lines: &[String]) -> Vec<String> {
         );
     }
 
+    result
+}
+
+/// Drop transcript lines whose content matches a known Whisper hallucination
+/// phrase ([`is_known_hallucination`]).
+///
+/// Catches the long-tail-of-silence failure mode (issue #242): on extended
+/// near-silent audio, Whisper emits stable training-data leaks like
+/// `Thank you for watching!`, `Subtitles by the Amara.org community`, and
+/// `Transcripted by: www.transcription-...` URLs. These survive
+/// `dedup_interleaved` (each line is a different exact string) and
+/// `collapse_noise_markers` (they are not bracketed/parenthetical tokens).
+///
+/// Conservative: exact-match against the line's text content after
+/// stripping the `[h:mm:ss]` timestamp and lowercasing. A line that
+/// contains the phrase mid-sentence (e.g. `"thank you for watching the
+/// demo carefully"`) is kept.
+pub fn strip_known_hallucinations(lines: &[String]) -> Vec<String> {
+    let mut result = Vec::with_capacity(lines.len());
+    let mut removed = 0usize;
+    for line in lines {
+        if is_known_hallucination(text_part(line)) {
+            removed += 1;
+        } else {
+            result.push(line.clone());
+        }
+    }
+    if removed > 0 {
+        tracing::info!(
+            removed = removed,
+            "removed known whisper-hallucination phrases"
+        );
+    }
     result
 }
 
@@ -1731,6 +1876,135 @@ mod tests {
         assert!(is_noise_marker("[ringing]"));
         assert!(is_noise_marker("(inaudible)"));
         assert!(is_noise_marker("(crosstalk)"));
+    }
+
+    // ── Known-hallucination phrase detection (issue #242) ────────────
+
+    #[test]
+    fn is_known_hallucination_matches_youtube_phrases() {
+        // High-confidence YouTube subtitle leak signatures.
+        assert!(is_known_hallucination("Thank you for watching!"));
+        assert!(is_known_hallucination("Thank you for watching."));
+        assert!(is_known_hallucination("Thank you for watching"));
+        assert!(is_known_hallucination("THANK YOU FOR WATCHING"));
+        assert!(is_known_hallucination("Please subscribe to our channel."));
+        assert!(is_known_hallucination("Please subscribe to our channel!"));
+        assert!(is_known_hallucination("Like and subscribe"));
+        assert!(is_known_hallucination("Don't forget to subscribe."));
+    }
+
+    #[test]
+    fn is_known_hallucination_matches_amara_phrases() {
+        // Amara.org community subtitle hallucinations.
+        assert!(is_known_hallucination(
+            "Subtitles by the Amara.org community"
+        ));
+        assert!(is_known_hallucination(
+            "Transcribed by the Amara.org community"
+        ));
+        assert!(is_known_hallucination("the Amara.org community"));
+        assert!(is_known_hallucination("Amara.org community"));
+    }
+
+    #[test]
+    fn is_known_hallucination_matches_url_lines() {
+        // Whisper sometimes emits a bare URL line like
+        // `Transcripted by: www.transcription-exe-project.com`. Lines that
+        // START with a URL token are dropped; lines that just mention a URL
+        // mid-sentence are NOT.
+        assert!(is_known_hallucination("www.transcription-exe-project.com"));
+        assert!(is_known_hallucination("https://amara.org"));
+        assert!(is_known_hallucination("http://example.com"));
+    }
+
+    #[test]
+    fn is_known_hallucination_rejects_real_speech_containing_phrase() {
+        // Real human speech that contains a hallucination phrase as a
+        // substring must NOT be classified as hallucination. Substring
+        // matching would have produced unacceptable false positives.
+        assert!(!is_known_hallucination(
+            "Thank you for watching the demo carefully"
+        ));
+        assert!(!is_known_hallucination(
+            "I would like to subscribe to that newsletter"
+        ));
+        assert!(!is_known_hallucination(
+            "The Amara.org community has done great work, but our use case differs"
+        ));
+        assert!(!is_known_hallucination(
+            "Check out www.example.com for the docs we discussed"
+        ));
+    }
+
+    #[test]
+    fn is_known_hallucination_rejects_normal_content() {
+        assert!(!is_known_hallucination("Hello world"));
+        assert!(!is_known_hallucination("Let's review the action items"));
+        assert!(!is_known_hallucination("Thanks for joining the call"));
+        assert!(!is_known_hallucination(""));
+    }
+
+    #[test]
+    fn strip_known_hallucinations_drops_matching_lines() {
+        // Mixed real content + Whisper training-data leaks. The leak lines
+        // are dropped; real content is preserved verbatim including order.
+        let lines: Vec<String> = vec![
+            "[0:00] Real meeting content".into(),
+            "[35:00] Thank you for watching!".into(),
+            "[35:30] More real content here".into(),
+            "[36:00] Subtitles by the Amara.org community".into(),
+            "[36:30] www.transcription-exe-project.com".into(),
+            "[37:00] Closing remarks from the team".into(),
+        ];
+        let result = strip_known_hallucinations(&lines);
+        assert_eq!(result.len(), 3);
+        assert!(result[0].contains("Real meeting content"));
+        assert!(result[1].contains("More real content here"));
+        assert!(result[2].contains("Closing remarks"));
+    }
+
+    #[test]
+    fn strip_known_hallucinations_preserves_normal_transcript() {
+        let lines: Vec<String> = vec![
+            "[0:00] Hello everyone".into(),
+            "[0:05] Let's get started".into(),
+            "[0:10] We have three things to cover today".into(),
+        ];
+        let result = strip_known_hallucinations(&lines);
+        assert_eq!(result, lines);
+    }
+
+    #[test]
+    fn clean_segments_strips_long_tail_hallucinations() {
+        // The #242 failure shape: real content followed by hallucinated
+        // tail with YouTube/Amara surface forms. After cleanup the tail
+        // is gone, real content survives, and the post-hallucination-strip
+        // count reflects the drop.
+        let segments: Vec<String> = vec![
+            "Real meeting content one".into(),
+            "Real meeting content two".into(),
+            "Thank you for watching!".into(),
+            "Please subscribe to our channel".into(),
+            "Subtitles by the Amara.org community".into(),
+            "www.transcription-exe-project.com".into(),
+            "Thank you for watching".into(),
+        ];
+        let (cleaned, stats) = clean_segments(&segments);
+        // All 5 known-hallucination signature lines stripped.
+        assert_eq!(stats.after_hallucination_strip, 2);
+        assert!(cleaned.iter().all(|s| s.contains("Real meeting content")));
+    }
+
+    #[test]
+    fn is_url_line_only_matches_url_prefix() {
+        assert!(is_url_line("www.example.com"));
+        assert!(is_url_line("https://amara.org"));
+        assert!(is_url_line("http://example.com"));
+        assert!(is_url_line("www.example.com path"));
+        // Trailing punctuation or extra content is OK on first-token URL.
+        assert!(!is_url_line("Check out www.example.com"));
+        assert!(!is_url_line(""));
+        assert!(!is_url_line("Hello"));
     }
 
     #[test]

--- a/crates/whisper-guard/src/segments.rs
+++ b/crates/whisper-guard/src/segments.rs
@@ -154,6 +154,7 @@ const HALLUCINATION_LINE_PREFIXES: &[&str] = &[
     "transcripted by",
     "transcribed by",
     "captions by",
+    "captioned by",
     "subtitles by",
     "translated by",
 ];
@@ -596,16 +597,19 @@ pub fn clean_segments_with_options(
 
     // Pipeline ordering rationale (matters for correctness):
     //
-    //   1. dedup_consecutive (already ran above) - skips always-noise tokens
+    //   1. strip_known_hallucinations (already ran above) - drop known
+    //      whisper training-data leaks BEFORE dedup gets a chance to
+    //      collapse them into `[...] [repeated audio removed]` annotations.
+    //   2. dedup_consecutive (already ran above) - skips always-noise tokens
     //      so they flow downstream as a run for the noise-aware passes.
-    //   2. dedup_interleaved (already ran above).
-    //   3. strip_foreign_script (already ran above).
-    //   4. strip_trailing_commands ← here. Runs BEFORE trim so that any
+    //   3. dedup_interleaved (already ran above).
+    //   4. strip_foreign_script (already ran above).
+    //   5. strip_trailing_commands ← here. Runs BEFORE trim so that any
     //      always-noise markers hidden behind a trailing voice command
     //      (e.g. "…content [music] [music] Stop recording.") are exposed.
-    //   5. trim_trailing_noise ← here. Catches all-noise tails at any count
+    //   6. trim_trailing_noise ← here. Catches all-noise tails at any count
     //      (always-noise tokens) and 5+ filler runs (`yeah.`, `okay.`, `you`).
-    //   6. collapse_noise_markers ← runs LAST, so middle-of-transcript noise
+    //   7. collapse_noise_markers ← runs LAST, so middle-of-transcript noise
     //      runs that survived trim get collapsed cleanly. If this ran earlier
     //      it would convert trailing `[music]` runs into `[music] + annotation`
     //      and trim would be blocked from cleaning them up.
@@ -1950,6 +1954,8 @@ mod tests {
         assert!(is_known_hallucination(
             "Transcripted by: www.transcription-exe-project.com"
         ));
+        assert!(is_known_hallucination("Transcripted by: www.amara.org"));
+        assert!(is_known_hallucination("Captioned by Acme Captions"));
         assert!(is_known_hallucination(
             "Transcribed by the Amara.org community"
         ));

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1090;
+export const MINUTES_TEST_COUNT = 1091;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1081;
+export const MINUTES_TEST_COUNT = 1090;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary

Closes #242. Whisper on long silent tails emits stable training-data leak phrases (YouTube subtitle openers, Amara.org community credits, transcription-service URLs) that survive every existing cleanup pass. Adds a conservative exact-match phrase blocklist + URL-line detector as a new \`strip_known_hallucinations\` pipeline pass.

## Approach

- \`is_known_hallucination(text)\` is true iff the line, after lowercasing and trailing punctuation stripping, **exactly matches** a phrase in the blocklist. Substring matching would have false positives in real speech.
- \`is_url_line(text)\` is true when the first whitespace-separated token is \`www.\` / \`http://\` / \`https://\`. Catches the \`Transcripted by: www.transcription-...\` family.
- New \`strip_known_hallucinations\` pass runs FIRST in the cleanup pipeline (before \`dedup_consecutive\`), so repeated hallucinations are dropped on identity rather than collapsed into \`[...] [repeated audio removed]\` annotations that would mark noise as worth-summarizing content.
- Wired through \`CleanOptions::strip_known_hallucinations\` (default true) and \`CleanStats::after_hallucination_strip\`.

## What this catches

- "Thank you for watching" / "Thanks for watching" + variants
- "Please subscribe to our channel" + variants
- "Like and subscribe", "Don't forget to subscribe"
- "Subtitles by the Amara.org community"
- "the Amara.org community" / "Amara.org community"
- "Captions by the Cyclope"
- "Transcripted by", "Transcribed by"
- Any line where the first token is a URL

## What this does NOT catch

Repetitive pseudo-explanations of made-up words ("The first time you hear the word 'climbing'..."). Distinguishing those from real speech requires per-segment audio-energy signals not currently in \`recording_health\`. If real-world data shows the surface signatures are stable enough to add to the blocklist later, we can.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all --no-default-features -- -D warnings\` clean
- [x] \`cargo test -p whisper-guard --lib\` 100/100 (91 -> 100, nine new tests)
- [x] \`cargo test -p minutes-core --no-default-features --lib -- --test-threads=1\` 718/718
- [x] Nine new tests cover positive matches, case insensitivity, trailing punctuation, end-to-end strip on the #242 failure shape, and critically the negative cases (substring-in-real-speech must NOT match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)