### PR TITLE
fix(243): surface summarization failures as status=degraded + processing_warnings

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -232,6 +232,12 @@ pub struct DiarizationConfig {
 pub struct SummarizationConfig {
     pub engine: String,
     pub agent_command: String,
+    /// Timeout for the `engine = "agent"` subprocess call (in seconds).
+    /// For long transcripts on local LLM agents (e.g. opencode running
+    /// against a 60k+ char input), the default 300s can be too short.
+    /// Issue #243: when this budget is exceeded the pipeline emits a
+    /// `processing_warnings` entry and promotes status to `degraded`.
+    pub agent_timeout_secs: u64,
     pub chunk_max_tokens: usize,
     pub ollama_url: String,
     pub ollama_model: String,
@@ -815,6 +821,7 @@ impl Default for SummarizationConfig {
         Self {
             engine: "none".into(),
             agent_command: "claude".into(),
+            agent_timeout_secs: 300,
             chunk_max_tokens: 4000,
             ollama_url: "http://localhost:11434".into(),
             ollama_model: "llama3.2".into(),

--- a/crates/core/src/daily_notes.rs
+++ b/crates/core/src/daily_notes.rs
@@ -300,6 +300,7 @@ mod tests {
             visibility: None,
             speaker_map: vec![],
             recording_health: None,
+            processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,
         };

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -1108,6 +1108,7 @@ fn write_dictation_file(text: &str, duration_secs: f64, config: &Config) -> Opti
         duration: duration_str,
         source: Some("dictation".into()),
         status: Some(OutputStatus::Complete),
+        processing_warnings: Vec::new(),
         tags: vec![],
         attendees: vec![],
         attendees_raw: None,

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -1603,6 +1603,7 @@ mod tests {
                 visibility: None,
                 speaker_map: vec![],
                 recording_health: None,
+                processing_warnings: Vec::new(),
                 template: None,
                 filter_diagnosis: Some("silence strip removed ALL audio".into()),
             },

--- a/crates/core/src/knowledge_extract.rs
+++ b/crates/core/src/knowledge_extract.rs
@@ -234,6 +234,7 @@ mod tests {
             visibility: None,
             speaker_map: vec![],
             recording_health: None,
+            processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,
         }

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -1057,6 +1057,56 @@ mod tests {
     }
 
     #[test]
+    fn processing_warnings_roundtrip_through_yaml() {
+        // Issue #243: degraded status + processing_warnings must serialize
+        // to YAML and round-trip back through deserialization without loss.
+        // Codex review of PR #249 v1 flagged missing end-to-end coverage.
+        let input = "---\ntitle: Failed Summary Meeting\ntype: meeting\ndate: 2026-04-01T10:00:00-07:00\nduration: 45m\nstatus: degraded\nprocessing_warnings:\n  - step: summarize\n    reason: summarize_failed\n    timeout_secs: 300\n    message: Summarization via agent `opencode` produced no output.\n---\n\n## Transcript\n\nHello.\n";
+        let (fm, body) = split_frontmatter(input);
+        let frontmatter: Frontmatter = serde_yaml::from_str(fm).unwrap();
+
+        assert_eq!(frontmatter.status, Some(OutputStatus::Degraded));
+        assert_eq!(frontmatter.processing_warnings.len(), 1);
+        let w = &frontmatter.processing_warnings[0];
+        assert_eq!(w.step, "summarize");
+        assert_eq!(w.reason, "summarize_failed");
+        assert_eq!(w.timeout_secs, Some(300));
+        assert!(w.message.as_ref().unwrap().contains("opencode"));
+
+        // Round-trip the structure through serde -> string -> serde and
+        // assert the deserialized form is identical.
+        let yaml = serde_yaml::to_string(&frontmatter).unwrap();
+        let output = format!("---\n{}---\n{}", yaml, body);
+        let (reparsed_fm, reparsed_body) = split_frontmatter(&output);
+        let reparsed: Frontmatter = serde_yaml::from_str(reparsed_fm).unwrap();
+        assert_eq!(reparsed.status, frontmatter.status);
+        assert_eq!(
+            reparsed.processing_warnings,
+            frontmatter.processing_warnings
+        );
+        assert_eq!(reparsed_body.as_bytes(), body.as_bytes());
+
+        // Verify the serialized YAML actually contains the kebab-case
+        // discriminant and the array (rather than skipping due to empty).
+        assert!(yaml.contains("status: degraded"));
+        assert!(yaml.contains("processing_warnings:"));
+        assert!(yaml.contains("step: summarize"));
+    }
+
+    #[test]
+    fn processing_warnings_omitted_when_empty() {
+        // Empty processing_warnings must not appear in the serialized
+        // YAML so successful runs don't pick up extra frontmatter noise.
+        let input = "---\ntitle: Normal Meeting\ntype: meeting\ndate: 2026-04-01T10:00:00-07:00\nduration: 5m\nstatus: complete\n---\n\n## Transcript\n\nHello.\n";
+        let (fm, _) = split_frontmatter(input);
+        let frontmatter: Frontmatter = serde_yaml::from_str(fm).unwrap();
+        assert!(frontmatter.processing_warnings.is_empty());
+
+        let yaml = serde_yaml::to_string(&frontmatter).unwrap();
+        assert!(!yaml.contains("processing_warnings"));
+    }
+
+    #[test]
     fn frontmatter_without_speaker_map_omits_field() {
         let dir = TempDir::new().unwrap();
         let config = Config {

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -30,6 +30,30 @@ pub enum OutputStatus {
     Complete,
     NoSpeech,
     TranscriptOnly,
+    /// Transcription completed but one or more summarization-side steps
+    /// fell back to empty output (e.g. agent timeout, empty summary).
+    /// Per-step failures are recorded in [`Frontmatter::processing_warnings`].
+    Degraded,
+}
+
+/// A non-fatal failure of a post-transcript pipeline step.
+///
+/// When any step degrades, the meeting's [`OutputStatus`] is promoted to
+/// [`OutputStatus::Degraded`] and the failure context is appended here so
+/// the markdown is honest about what is missing. Files are then greppable
+/// for "what needs re-running" (`status: degraded` in frontmatter).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProcessingWarning {
+    /// The pipeline step that produced the warning.
+    pub step: String,
+    /// Machine-readable failure reason (e.g. `agent_timeout`, `empty_output`).
+    pub reason: String,
+    /// For timeout reasons, the budget that was exceeded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    /// Optional human-readable detail.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -126,6 +150,11 @@ pub struct Frontmatter {
     pub source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<OutputStatus>,
+    /// Per-step failure context when [`OutputStatus::Degraded`] applies.
+    /// Skipped from serialization when empty so successful runs do not
+    /// emit extra frontmatter noise. See issue #243.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub processing_warnings: Vec<ProcessingWarning>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -879,6 +908,7 @@ mod tests {
             visibility: None,
             speaker_map: vec![],
             recording_health: None,
+            processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,
         }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -133,34 +133,50 @@ fn detect_summarization_warnings(
     engine: &str,
     agent_command: &str,
     agent_timeout_secs: u64,
+    summarization_attempted: bool,
 ) -> Vec<ProcessingWarning> {
     let mut warnings = Vec::new();
     if engine == "none" {
         return warnings;
     }
+    // If summarization was deliberately not attempted (e.g. no-speech path
+    // or all-noise suppression), an absent summary is expected behavior,
+    // not a degradation. Without this guard the helper would emit a bogus
+    // `summarize_failed` warning on every no-speech recording.
+    if !summarization_attempted {
+        return warnings;
+    }
     if summary.is_none() {
-        // We only know the engine is configured and we got nothing back.
-        // The specific reason (timeout vs error) lives in the audio.log
-        // entries today; this is a coarser signal at the file level so
-        // users see something is missing without grepping logs.
-        let (reason, timeout_secs, message) = if engine == "agent" || engine == "auto" {
-            (
+        // We know the engine ran and produced nothing. The specific reason
+        // (timeout vs error vs network failure) lives in audio.log; this is
+        // a coarser file-level signal so users see something is missing
+        // without grepping logs. Follow-up: plumb the precise reason
+        // through summarize::run_summarization's return type.
+        let (reason, timeout_secs, message) = match engine {
+            "agent" => (
                 "summarize_failed".to_string(),
                 Some(agent_timeout_secs),
                 Some(format!(
                     "Summarization via agent `{}` produced no output (timeout budget {}s, or agent error); see audio.log for the precise reason.",
                     agent_command, agent_timeout_secs
                 )),
-            )
-        } else {
-            (
+            ),
+            "auto" => (
+                "summarize_failed".to_string(),
+                Some(agent_timeout_secs),
+                Some(format!(
+                    "Summarization with `engine = \"auto\"` produced no output (auto-detect picks the first available agent CLI then runs under the {}s budget); see audio.log for which agent was selected and the precise failure.",
+                    agent_timeout_secs
+                )),
+            ),
+            other => (
                 "summarize_failed".to_string(),
                 None,
                 Some(format!(
                     "Summarization via engine `{}` produced no output; see audio.log for the precise reason.",
-                    engine
+                    other
                 )),
-            )
+            ),
         };
         warnings.push(ProcessingWarning {
             step: "summarize".to_string(),
@@ -1601,11 +1617,16 @@ where
     );
 
     let mut frontmatter = artifact.frontmatter.clone();
+    // write_transcript_artifact calls summarize unconditionally whenever
+    // engine != "none" (no all-noise gate at this site), so attempted-ness
+    // collapses to the same condition.
+    let summarization_attempted = config.summarization.engine != "none";
     let summarization_warnings = detect_summarization_warnings(
         summary.as_deref(),
         &config.summarization.engine,
         &config.summarization.agent_command,
         config.summarization.agent_timeout_secs,
+        summarization_attempted,
     );
     frontmatter.status = if !summarization_warnings.is_empty() {
         Some(OutputStatus::Degraded)
@@ -2184,11 +2205,19 @@ where
     // itself is honest about what's missing. The initial `status` set
     // above didn't yet know whether summarization would succeed; this
     // is the corrective pass.
+    //
+    // Summarization was *attempted* only when both the all-noise gate
+    // did NOT fire (forced_no_speech_diagnosis is None) AND engine is
+    // not "none". Without the all-noise guard, an empty summary on a
+    // no-speech recording would falsely look like a summarize failure.
+    let summarization_attempted =
+        forced_no_speech_diagnosis.is_none() && config.summarization.engine != "none";
     let summarization_warnings = detect_summarization_warnings(
         summary.as_deref(),
         &config.summarization.engine,
         &config.summarization.agent_command,
         config.summarization.agent_timeout_secs,
+        summarization_attempted,
     );
     let status = if !summarization_warnings.is_empty() && status == Some(OutputStatus::Complete) {
         Some(OutputStatus::Degraded)
@@ -4299,23 +4328,32 @@ mod tests {
     fn detect_summarization_warnings_returns_empty_when_engine_none() {
         // When summarization is disabled by config, an absent summary is
         // expected behavior, not a degradation.
-        let warnings = detect_summarization_warnings(None, "none", "claude", 300);
+        let warnings = detect_summarization_warnings(None, "none", "claude", 300, false);
         assert!(warnings.is_empty());
     }
 
     #[test]
     fn detect_summarization_warnings_returns_empty_when_summary_present() {
         let summary = "Some real summary content";
-        let warnings = detect_summarization_warnings(Some(summary), "agent", "opencode", 300);
+        let warnings = detect_summarization_warnings(Some(summary), "agent", "opencode", 300, true);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn detect_summarization_warnings_returns_empty_when_not_attempted() {
+        // Codex review of v1 (PR #249) caught this: when the no-speech /
+        // all-noise gate prevents summarization from running, summary is
+        // None but that is expected, not a degradation. The helper must
+        // not emit a bogus `summarize_failed` warning in that case.
+        let warnings = detect_summarization_warnings(None, "agent", "opencode", 300, false);
         assert!(warnings.is_empty());
     }
 
     #[test]
     fn detect_summarization_warnings_flags_agent_failure_with_timeout_context() {
-        // The #243 failure shape: engine = "agent", summary is None.
-        // Emit a warning that includes the agent_command and timeout_secs
-        // so the user knows where to look and which knob to raise.
-        let warnings = detect_summarization_warnings(None, "agent", "opencode", 300);
+        // The #243 failure shape: engine = "agent", summary is None,
+        // summarization was actually attempted.
+        let warnings = detect_summarization_warnings(None, "agent", "opencode", 300, true);
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].step, "summarize");
         assert_eq!(warnings[0].reason, "summarize_failed");
@@ -4326,11 +4364,27 @@ mod tests {
     }
 
     #[test]
+    fn detect_summarization_warnings_auto_engine_message_explains_indirection() {
+        // Codex review of v1 (PR #249) caught this: when engine = "auto",
+        // the warning previously printed `agent_command` even though auto
+        // detects a CLI at runtime. The message must surface the auto
+        // indirection and tell the user to check audio.log for which
+        // agent was selected.
+        let warnings = detect_summarization_warnings(None, "auto", "claude", 600, true);
+        assert_eq!(warnings.len(), 1);
+        let msg = warnings[0].message.as_ref().unwrap();
+        assert!(msg.contains("auto"));
+        assert!(msg.contains("600s"));
+        assert!(msg.contains("audio.log"));
+        assert_eq!(warnings[0].timeout_secs, Some(600));
+    }
+
+    #[test]
     fn detect_summarization_warnings_flags_non_agent_engine_without_timeout() {
         // Non-agent engines (claude, ollama, mistral, etc.) don't have a
         // single agent_timeout_secs knob, so the warning carries no
         // timeout_secs field but still flags the degradation.
-        let warnings = detect_summarization_warnings(None, "claude", "claude", 300);
+        let warnings = detect_summarization_warnings(None, "claude", "claude", 300, true);
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].step, "summarize");
         assert_eq!(warnings[0].timeout_secs, None);

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -4350,6 +4350,32 @@ mod tests {
     }
 
     #[test]
+    fn detect_summarization_warnings_write_path_no_speech_stays_quiet() {
+        // Codex review of v2 (PR #249) asked for explicit coverage of the
+        // write_transcript_artifact path's no-speech branch. The site
+        // computes `summarization_attempted = engine != "none"`, which
+        // is correct because the upstream all-noise / NoSpeech gate
+        // returns before reaching the detection call. This test pins
+        // the invariant across every engine value: a NOT-attempted call
+        // with summary = None must produce zero warnings, so no
+        // upstream branch can leak a bogus `summarize_failed` through
+        // the helper into the frontmatter.
+        for (engine, agent_cmd) in [
+            ("agent", "opencode"),
+            ("auto", "claude"),
+            ("claude", "claude"),
+        ] {
+            let warnings = detect_summarization_warnings(None, engine, agent_cmd, 300, false);
+            assert!(
+                warnings.is_empty(),
+                "engine={} produced warnings when not attempted: {:?}",
+                engine,
+                warnings
+            );
+        }
+    }
+
+    #[test]
     fn detect_summarization_warnings_flags_agent_failure_with_timeout_context() {
         // The #243 failure shape: engine = "agent", summary is None,
         // summarization was actually attempted.

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -4350,16 +4350,16 @@ mod tests {
     }
 
     #[test]
-    fn detect_summarization_warnings_write_path_no_speech_stays_quiet() {
-        // Codex review of v2 (PR #249) asked for explicit coverage of the
-        // write_transcript_artifact path's no-speech branch. The site
-        // computes `summarization_attempted = engine != "none"`, which
-        // is correct because the upstream all-noise / NoSpeech gate
-        // returns before reaching the detection call. This test pins
-        // the invariant across every engine value: a NOT-attempted call
-        // with summary = None must produce zero warnings, so no
-        // upstream branch can leak a bogus `summarize_failed` through
-        // the helper into the frontmatter.
+    fn detect_summarization_warnings_stays_silent_for_every_engine_when_not_attempted() {
+        // This is a contract test on the helper itself, not an end-to-end
+        // integration test. Both call sites (write_transcript_artifact and
+        // process_with_progress_and_sidecar) rely on this invariant when
+        // their upstream no-speech / all-noise gate fires: pass
+        // `summarization_attempted = false` and trust the helper to return
+        // zero warnings regardless of the configured engine. If any engine
+        // value leaked a warning here, the upstream short-circuit would be
+        // insufficient and the frontmatter would gain a bogus
+        // `summarize_failed` entry on no-speech recordings.
         for (engine, agent_cmd) in [
             ("agent", "opencode"),
             ("auto", "claude"),

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -2,7 +2,9 @@ use crate::config::{Config, IdentityConfig};
 use crate::diarize;
 use crate::error::MinutesError;
 use crate::logging;
-use crate::markdown::{self, ContentType, Frontmatter, OutputStatus, WriteResult};
+use crate::markdown::{
+    self, ContentType, Frontmatter, OutputStatus, ProcessingWarning, WriteResult,
+};
 use crate::notes;
 use crate::summarize;
 use chrono::{DateTime, Local};
@@ -103,6 +105,71 @@ fn should_suppress_transcript(
         body: ALL_NOISE_SUPPRESSED_BODY.to_string(),
         diagnosis,
     })
+}
+
+/// Detect post-transcript pipeline degradation and produce one
+/// [`ProcessingWarning`] per failed step. See issue #243.
+///
+/// Returns an empty `Vec` when nothing degraded. Callers should promote
+/// [`OutputStatus::Complete`] to [`OutputStatus::Degraded`] when the
+/// result is non-empty and store the warnings on
+/// [`Frontmatter::processing_warnings`] so the file itself is honest
+/// about which sections are missing or fell back to defaults.
+///
+/// Today this detects the most user-visible failure mode: the
+/// summarization engine returned `None` despite being configured to run
+/// (typically an agent-CLI timeout or unexpected error). Follow-up
+/// PRs can plumb richer per-step warnings through the LLM call sites
+/// to populate the `reason`, `timeout_secs`, and `message` fields with
+/// precise context.
+///
+/// **Single source of truth** for the suppression rule shared by both
+/// `write_transcript_artifact` and `process_with_progress_and_sidecar`.
+/// Keeping the detection here (rather than at each call site) prevents
+/// the two paths from drifting and emitting different status values
+/// for the same underlying failure.
+fn detect_summarization_warnings(
+    summary: Option<&str>,
+    engine: &str,
+    agent_command: &str,
+    agent_timeout_secs: u64,
+) -> Vec<ProcessingWarning> {
+    let mut warnings = Vec::new();
+    if engine == "none" {
+        return warnings;
+    }
+    if summary.is_none() {
+        // We only know the engine is configured and we got nothing back.
+        // The specific reason (timeout vs error) lives in the audio.log
+        // entries today; this is a coarser signal at the file level so
+        // users see something is missing without grepping logs.
+        let (reason, timeout_secs, message) = if engine == "agent" || engine == "auto" {
+            (
+                "summarize_failed".to_string(),
+                Some(agent_timeout_secs),
+                Some(format!(
+                    "Summarization via agent `{}` produced no output (timeout budget {}s, or agent error); see audio.log for the precise reason.",
+                    agent_command, agent_timeout_secs
+                )),
+            )
+        } else {
+            (
+                "summarize_failed".to_string(),
+                None,
+                Some(format!(
+                    "Summarization via engine `{}` produced no output; see audio.log for the precise reason.",
+                    engine
+                )),
+            )
+        };
+        warnings.push(ProcessingWarning {
+            step: "summarize".to_string(),
+            reason,
+            timeout_secs,
+            message,
+        });
+    }
+    warnings
 }
 
 /// Result of Level 2 voice enrollment matching.
@@ -1215,6 +1282,7 @@ pub fn write_transcript_artifact(
         visibility: None,
         speaker_map: vec![],
         recording_health: context.recording_health.clone(),
+        processing_warnings: Vec::new(),
         template: context.template.as_ref().map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
             // Prefer the all-noise-suppression diagnosis when it fired; it
@@ -1533,11 +1601,20 @@ where
     );
 
     let mut frontmatter = artifact.frontmatter.clone();
-    frontmatter.status = if config.summarization.engine != "none" {
+    let summarization_warnings = detect_summarization_warnings(
+        summary.as_deref(),
+        &config.summarization.engine,
+        &config.summarization.agent_command,
+        config.summarization.agent_timeout_secs,
+    );
+    frontmatter.status = if !summarization_warnings.is_empty() {
+        Some(OutputStatus::Degraded)
+    } else if config.summarization.engine != "none" {
         Some(OutputStatus::Complete)
     } else {
         Some(OutputStatus::TranscriptOnly)
     };
+    frontmatter.processing_warnings = summarization_warnings;
     frontmatter.attendees = attendees;
     frontmatter.people = people;
     frontmatter.entities = entities;
@@ -2102,6 +2179,23 @@ where
         &structured_intents,
     );
 
+    // Issue #243: detect post-transcript degradation (e.g. summarization
+    // failed or timed out) and promote status to `Degraded` so the file
+    // itself is honest about what's missing. The initial `status` set
+    // above didn't yet know whether summarization would succeed; this
+    // is the corrective pass.
+    let summarization_warnings = detect_summarization_warnings(
+        summary.as_deref(),
+        &config.summarization.engine,
+        &config.summarization.agent_command,
+        config.summarization.agent_timeout_secs,
+    );
+    let status = if !summarization_warnings.is_empty() && status == Some(OutputStatus::Complete) {
+        Some(OutputStatus::Degraded)
+    } else {
+        status
+    };
+
     let mut frontmatter = Frontmatter {
         title: auto_title,
         r#type: content_type,
@@ -2109,6 +2203,7 @@ where
         duration,
         source,
         status,
+        processing_warnings: summarization_warnings,
         tags,
         attendees,
         attendees_raw: None,
@@ -4198,6 +4293,54 @@ mod tests {
         assert!(should_suppress_transcript(transcript, Some(&health)).is_none());
     }
 
+    // ── Summarization-degradation detection (issue #243) ──
+
+    #[test]
+    fn detect_summarization_warnings_returns_empty_when_engine_none() {
+        // When summarization is disabled by config, an absent summary is
+        // expected behavior, not a degradation.
+        let warnings = detect_summarization_warnings(None, "none", "claude", 300);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn detect_summarization_warnings_returns_empty_when_summary_present() {
+        let summary = "Some real summary content";
+        let warnings = detect_summarization_warnings(Some(summary), "agent", "opencode", 300);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn detect_summarization_warnings_flags_agent_failure_with_timeout_context() {
+        // The #243 failure shape: engine = "agent", summary is None.
+        // Emit a warning that includes the agent_command and timeout_secs
+        // so the user knows where to look and which knob to raise.
+        let warnings = detect_summarization_warnings(None, "agent", "opencode", 300);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].step, "summarize");
+        assert_eq!(warnings[0].reason, "summarize_failed");
+        assert_eq!(warnings[0].timeout_secs, Some(300));
+        let msg = warnings[0].message.as_ref().expect("message set");
+        assert!(msg.contains("opencode"));
+        assert!(msg.contains("300s"));
+    }
+
+    #[test]
+    fn detect_summarization_warnings_flags_non_agent_engine_without_timeout() {
+        // Non-agent engines (claude, ollama, mistral, etc.) don't have a
+        // single agent_timeout_secs knob, so the warning carries no
+        // timeout_secs field but still flags the degradation.
+        let warnings = detect_summarization_warnings(None, "claude", "claude", 300);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].step, "summarize");
+        assert_eq!(warnings[0].timeout_secs, None);
+        assert!(warnings[0]
+            .message
+            .as_ref()
+            .unwrap()
+            .contains("engine `claude`"));
+    }
+
     /// Simulates the branch logic the `process` path applies after
     /// diarization: if `should_suppress_transcript` fires, the transcript
     /// body, status, and forced filter_diagnosis are all updated together.
@@ -4331,6 +4474,7 @@ mod tests {
             visibility: None,
             speaker_map: vec![],
             recording_health: None,
+            processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,
         };
@@ -5755,6 +5899,7 @@ mod tests {
                 source: diarize::AttributionSource::Llm,
             }],
             recording_health: None,
+            processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,
         };

--- a/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
+++ b/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
@@ -79,6 +79,13 @@ expression: schema
         "type": "string"
       }
     },
+    "processing_warnings": {
+      "description": "Per-step failure context when [`OutputStatus::Degraded`] applies.\nSkipped from serialization when empty so successful runs do not\nemit extra frontmatter noise. See issue #243.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ProcessingWarning"
+      }
+    },
     "recorded_by": {
       "type": [
         "string",
@@ -407,11 +414,54 @@ expression: schema
     },
     "OutputStatus": {
       "description": "Output status markers.",
-      "type": "string",
-      "enum": [
-        "complete",
-        "no-speech",
-        "transcript-only"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "complete",
+            "no-speech",
+            "transcript-only"
+          ]
+        },
+        {
+          "description": "Transcription completed but one or more summarization-side steps\nfell back to empty output (e.g. agent timeout, empty summary).\nPer-step failures are recorded in [`Frontmatter::processing_warnings`].",
+          "type": "string",
+          "const": "degraded"
+        }
+      ]
+    },
+    "ProcessingWarning": {
+      "description": "A non-fatal failure of a post-transcript pipeline step.\n\nWhen any step degrades, the meeting's [`OutputStatus`] is promoted to\n[`OutputStatus::Degraded`] and the failure context is appended here so\nthe markdown is honest about what is missing. Files are then greppable\nfor \"what needs re-running\" (`status: degraded` in frontmatter).",
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "Optional human-readable detail.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "description": "Machine-readable failure reason (e.g. `agent_timeout`, `empty_output`).",
+          "type": "string"
+        },
+        "step": {
+          "description": "The pipeline step that produced the warning.",
+          "type": "string"
+        },
+        "timeout_secs": {
+          "description": "For timeout reasons, the budget that was exceeded.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "step",
+        "reason"
       ]
     },
     "RecordingHealth": {

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -1021,12 +1021,17 @@ fn summarize_with_agent_impl(
     template: Option<&Template>,
     agent_cmd: String,
 ) -> Result<Summary, Box<dyn std::error::Error>> {
+    // Honor the user-configurable timeout. The default (300s) lives in
+    // `SummarizationConfig::default()`. Long transcripts on local agent
+    // CLIs (e.g. opencode against a 60k+ char meeting) regularly need
+    // more than five minutes; users can raise this in `config.toml`.
+    // See issue #243.
     summarize_with_agent_impl_timeout(
         transcript,
         config,
         template,
         agent_cmd,
-        std::time::Duration::from_secs(300),
+        std::time::Duration::from_secs(config.summarization.agent_timeout_secs),
     )
 }
 

--- a/crates/reader/src/types.rs
+++ b/crates/reader/src/types.rs
@@ -21,6 +21,21 @@ pub enum OutputStatus {
     Complete,
     NoSpeech,
     TranscriptOnly,
+    /// Transcription ran but one or more post-transcript steps fell back
+    /// to empty output. Details in `processing_warnings`. See issue #243.
+    Degraded,
+}
+
+/// A non-fatal failure of a post-transcript pipeline step. Mirrors the
+/// core crate's `markdown::ProcessingWarning`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProcessingWarning {
+    pub step: String,
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -33,6 +48,9 @@ pub struct Frontmatter {
     pub source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<OutputStatus>,
+    /// Per-step failure context when `status: degraded` applies (#243).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub processing_warnings: Vec<ProcessingWarning>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/schema/meeting.schema.json
+++ b/schema/meeting.schema.json
@@ -78,6 +78,12 @@
         }
       ]
     },
+    "processing_warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ProcessingWarning"
+      }
+    },
     "tags": {
       "type": "array",
       "items": {
@@ -244,8 +250,39 @@
       "enum": [
         "complete",
         "no-speech",
-        "transcript-only"
+        "transcript-only",
+        "degraded"
       ]
+    },
+    "ProcessingWarning": {
+      "description": "A non-fatal failure of a post-transcript pipeline step.",
+      "type": "object",
+      "required": [
+        "step",
+        "reason"
+      ],
+      "properties": {
+        "step": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "timeout_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "Visibility": {
       "type": "string",

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1099;
+export const MINUTES_TEST_COUNT = 1100;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1091;
+export const MINUTES_TEST_COUNT = 1095;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1095;
+export const MINUTES_TEST_COUNT = 1099;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -9693,6 +9693,7 @@ mod tests {
             template: None,
             filter_diagnosis: None,
             recording_health: None,
+            processing_warnings: Vec::new(),
         };
         let sections = vec![MeetingSection {
             heading: "Summary".into(),
@@ -9750,6 +9751,7 @@ mod tests {
             template: None,
             filter_diagnosis: None,
             recording_health: None,
+            processing_warnings: Vec::new(),
         };
         let sections = vec![MeetingSection {
             heading: "Summary".into(),
@@ -9798,6 +9800,7 @@ mod tests {
             template: None,
             filter_diagnosis: None,
             recording_health: None,
+            processing_warnings: Vec::new(),
         };
         let sections = vec![MeetingSection {
             heading: "Summary".into(),

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -6452,6 +6452,7 @@ pub fn cmd_get_meeting_detail(path: String) -> Result<MeetingDetail, String> {
             minutes_core::markdown::OutputStatus::Complete => "complete",
             minutes_core::markdown::OutputStatus::NoSpeech => "no-speech",
             minutes_core::markdown::OutputStatus::TranscriptOnly => "transcript-only",
+            minutes_core::markdown::OutputStatus::Degraded => "degraded",
         }
         .to_string()
     });


### PR DESCRIPTION
## Summary

Closes #243. When summarization fails (agent timeout, agent error), the pipeline previously emitted \`status: complete\` with empty fields and a calendar-fallback title. Users had to grep \`audio.log\` to discover the file was incomplete.

Three changes:

1. **\`status: degraded\` + \`processing_warnings: [...]\` on the frontmatter.** New \`OutputStatus::Degraded\` variant + new \`ProcessingWarning\` struct. Files are now greppable for "what needs re-running."

2. **Configurable \`summarization.agent_timeout_secs\`** (u64, default 300). The 300s budget was too short for local LLM agents against long transcripts.

3. **Shared \`detect_summarization_warnings()\` helper** so the two transcription entry points stay in sync. Same pattern as #246's \`should_suppress_transcript()\`.

## What's NOT in this PR (deferred follow-ups)

- Richer per-step reasons (\`agent_timeout\` vs \`agent_error\` vs \`network_error\`). Today v1 emits the coarse \`summarize_failed\`. Plumbing failure context through \`summarize::run_summarization\`'s return type is the follow-up.
- Dependent-step gating: \`action_items\` and \`intents\` still execute when \`summarize\` already failed, emit \`outcome: fallback\` in logs, and produce empty output. Behavior-equivalent today, just noisier.
- \`minutes resummarize\` command for replay-from-transcript.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all --no-default-features -- -D warnings\` clean
- [x] \`cargo test -p minutes-core --no-default-features --lib -- --test-threads=1\` 722/722 (was 718, +4 new detection tests)
- [x] Insta snapshot for \`Frontmatter\` JSON schema regenerated to include the new field
- [x] Match on \`OutputStatus\` in \`tauri/src-tauri/src/commands.rs\` updated for the new \`Degraded\` variant
- [ ] Manual dogfood: configure \`engine = "agent"\` with a slow agent, record a 30+ min meeting, verify resulting markdown has \`status: degraded\` + a \`processing_warnings\` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)