### PR TITLE
fix(258): detect Windows mandatory-lock PID files so live transcript stays visible

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1986,9 +1986,12 @@ fn cmd_record(
     let startup_recording_health =
         check_meeting_system_audio_probe(capture_mode, skip_audio_probe, config)?;
 
-    // Check for conflicting live transcript session
+    // Check for conflicting live transcript session. `inspect_pid_file` so a
+    // standalone session holding the PID under a mandatory Windows lock is seen —
+    // otherwise a recording could start alongside it and clobber the shared
+    // `live-transcript.jsonl`. See #258.
     let lt_pid = minutes_core::pid::live_transcript_pid_path();
-    if let Ok(Some(_)) = minutes_core::pid::check_pid_file(&lt_pid) {
+    if minutes_core::pid::inspect_pid_file(&lt_pid).is_active() {
         anyhow::bail!("live transcript in progress — run `minutes stop` first");
     }
 
@@ -2161,7 +2164,7 @@ fn cmd_record(
 }
 
 fn spawn_queue_worker() -> Result<()> {
-    if minutes_core::jobs::current_worker_pid().is_some() {
+    if minutes_core::jobs::worker_active() {
         return Ok(());
     }
 
@@ -2279,40 +2282,43 @@ fn cmd_stop(config: &Config) -> Result<()> {
             Ok(())
         }
         Ok(None) => {
-            // No batch recording — check for live transcript session
+            // No batch recording — check for live transcript session.
+            // `inspect_pid_file` so a session holding the PID under a mandatory
+            // Windows lock is detected (the PID is unreadable there, but the stop
+            // sentinel — polled inline by the live loop — stops it on any
+            // platform). See #258.
             let lt_pid_path = minutes_core::pid::live_transcript_pid_path();
-            match minutes_core::pid::check_pid_file(&lt_pid_path) {
-                Ok(Some(pid)) => {
-                    eprintln!("Stopping live transcript (PID {})...", pid);
-                    minutes_core::pid::write_stop_sentinel()
-                        .map_err(|e| anyhow::anyhow!("failed to write stop sentinel: {}", e))?;
-                    #[cfg(unix)]
-                    {
-                        let rc = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
-                        if rc != 0 {
-                            tracing::warn!("SIGTERM failed for live transcript PID {}", pid);
-                        }
-                    }
-                    // Poll for PID removal
-                    let start = std::time::Instant::now();
-                    eprint!("Finalizing live transcript");
-                    while lt_pid_path.exists()
-                        && start.elapsed() < std::time::Duration::from_secs(30)
-                    {
-                        std::thread::sleep(std::time::Duration::from_millis(500));
-                        eprint!(".");
-                    }
-                    eprintln!();
-                    if lt_pid_path.exists() {
-                        anyhow::bail!("live transcript process did not stop within 30 seconds");
-                    }
-                    eprintln!("Live transcript stopped.");
-                    Ok(())
+            let lt_state = minutes_core::pid::inspect_pid_file(&lt_pid_path);
+            if lt_state.is_active() {
+                match lt_state.pid() {
+                    Some(pid) => eprintln!("Stopping live transcript (PID {})...", pid),
+                    None => eprintln!("Stopping live transcript..."),
                 }
-                _ => {
-                    eprintln!("No recording or live transcript in progress.");
-                    Ok(())
+                minutes_core::pid::write_stop_sentinel()
+                    .map_err(|e| anyhow::anyhow!("failed to write stop sentinel: {}", e))?;
+                #[cfg(unix)]
+                if let Some(pid) = lt_state.pid() {
+                    let rc = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+                    if rc != 0 {
+                        tracing::warn!("SIGTERM failed for live transcript PID {}", pid);
+                    }
                 }
+                // Poll for PID removal
+                let start = std::time::Instant::now();
+                eprint!("Finalizing live transcript");
+                while lt_pid_path.exists() && start.elapsed() < std::time::Duration::from_secs(30) {
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    eprint!(".");
+                }
+                eprintln!();
+                if lt_pid_path.exists() {
+                    anyhow::bail!("live transcript process did not stop within 30 seconds");
+                }
+                eprintln!("Live transcript stopped.");
+                Ok(())
+            } else {
+                eprintln!("No recording or live transcript in progress.");
+                Ok(())
             }
         }
         Err(e) => Err(anyhow::anyhow!("{}", e)),

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -231,9 +231,10 @@ where
         return Err(DictationError::RecordingActive.into());
     }
 
-    // Check for conflicts: live transcript must not be active
+    // Check for conflicts: live transcript must not be active. `inspect_pid_file`
+    // so a session holding the PID under a mandatory Windows lock is detected. #258.
     let lt_pid = pid::live_transcript_pid_path();
-    if let Ok(Some(_)) = pid::check_pid_file(&lt_pid) {
+    if pid::inspect_pid_file(&lt_pid).is_active() {
         return Err(DictationError::LiveTranscriptActive.into());
     }
 

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -280,8 +280,19 @@ pub fn create_worker_guard() -> Result<PidGuard, crate::error::PidError> {
     pid::create_pid_guard(&worker_pid_path())
 }
 
+/// The worker PID when readable. NOTE: this cannot detect a `LockedAlive` worker
+/// on Windows (the lock makes the PID unreadable). For a presence check, prefer
+/// [`worker_active`], which is correct on every platform.
 pub fn current_worker_pid() -> Option<u32> {
     pid::check_pid_file(&worker_pid_path()).ok().flatten()
+}
+
+/// Whether a background worker is currently running. Uses `inspect_pid_file` so a
+/// worker holding its PID file under a mandatory Windows lock is still detected —
+/// `current_worker_pid` would read the locked file as absent and let a duplicate
+/// worker spawn. See #258 and `pid::PidFileState`.
+pub fn worker_active() -> bool {
+    pid::inspect_pid_file(&worker_pid_path()).is_active()
 }
 
 pub fn move_capture_into_job(job_id: &str, current_wav: &Path) -> std::io::Result<PathBuf> {

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -1992,9 +1992,12 @@ fn run_sidecar_inner_mpsc(
     stop_flag: Arc<AtomicBool>,
     config: &Config,
 ) -> Result<(), MinutesError> {
-    // Guard: don't clobber a standalone live transcript session's JSONL
+    // Guard: don't clobber a standalone live transcript session's JSONL.
+    // `inspect_pid_file` (not `check_pid_file`) so a standalone session holding
+    // the PID file under a mandatory Windows lock is detected — otherwise the
+    // sidecar would write the same `live-transcript.jsonl` concurrently. See #258.
     let lt_pid = pid::live_transcript_pid_path();
-    if let Ok(Some(_)) = pid::check_pid_file(&lt_pid) {
+    if pid::inspect_pid_file(&lt_pid).is_active() {
         tracing::info!("standalone live transcript active — skipping recording sidecar");
         return Ok(());
     }
@@ -2346,26 +2349,35 @@ pub fn read_since_duration(duration_ms: u64) -> Result<Vec<TranscriptLine>, Minu
 /// Detects both standalone live transcript sessions (via live-transcript.pid)
 /// and recording sidecar sessions (recording active + sidecar status file exists).
 pub fn session_status() -> SessionStatus {
-    // Check standalone live transcript PID
+    // Standalone live-transcript PID. Use `inspect_pid_file` rather than
+    // `check_pid_file` so a session that holds the PID file under a mandatory
+    // Windows lock is still detected as active: the in-app reader and the lock
+    // holder are the same process, and a plain read of the locked file fails on
+    // Windows. See `pid::PidFileState` and issue #258.
     let lt_pid = pid::live_transcript_pid_path();
-    let lt_process_pid = pid::check_pid_file(&lt_pid).ok().flatten();
+    let lt_pid_state = pid::inspect_pid_file(&lt_pid);
 
     let recording_pid = pid::check_recording().ok().flatten();
     let status_path = pid::live_transcript_status_path();
     let jsonl_path = pid::live_transcript_jsonl_path();
 
-    derive_session_status(lt_process_pid, recording_pid, &status_path, &jsonl_path)
+    derive_session_status(lt_pid_state, recording_pid, &status_path, &jsonl_path)
 }
 
 fn derive_session_status(
-    lt_process_pid: Option<u32>,
+    lt_pid_state: pid::PidFileState,
     recording_pid: Option<u32>,
     status_path: &Path,
     jsonl_path: &Path,
 ) -> SessionStatus {
     let live_status = read_live_status(status_path);
     let now = Local::now();
-    let standalone_active = lt_process_pid.is_some();
+    // A held PID file (readable on Unix, or lock-detected on Windows) proves the
+    // standalone session is alive. Liveness is NOT gated on heartbeat freshness:
+    // the heartbeat is written inline by the live loop, so a long utterance or
+    // model load can stall it past the staleness window while the session is
+    // perfectly healthy — gating on it would re-introduce the #258 flicker.
+    let standalone_active = lt_pid_state.is_active();
 
     let (sidecar_active, diagnostic) = if recording_pid.is_some() {
         evaluate_recording_sidecar_status(live_status.as_ref(), now)
@@ -2375,7 +2387,9 @@ fn derive_session_status(
 
     let active = standalone_active || sidecar_active;
     let pid = if standalone_active {
-        lt_process_pid
+        // `None` when the session is alive but the PID is unreadable (Windows
+        // locked file) — we report active without fabricating a PID.
+        lt_pid_state.pid()
     } else if sidecar_active {
         recording_pid
     } else {
@@ -3591,7 +3605,7 @@ mod tests {
     fn sidecar_missing_status_is_inactive_with_diagnostic() {
         let dir = tempdir().unwrap();
         let status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &dir.path().join("live-status.json"),
             &dir.path().join("live.jsonl"),
@@ -3615,7 +3629,7 @@ mod tests {
         std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
 
         let status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &status_path,
             &dir.path().join("live.jsonl"),
@@ -3638,7 +3652,7 @@ mod tests {
         std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
 
         let status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &status_path,
             &dir.path().join("live.jsonl"),
@@ -3836,7 +3850,7 @@ mod tests {
         std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
 
         let status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &status_path,
             &dir.path().join("live.jsonl"),
@@ -3859,7 +3873,7 @@ mod tests {
         std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
 
         let status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &status_path,
             &dir.path().join("live.jsonl"),
@@ -3880,7 +3894,7 @@ mod tests {
         std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
 
         let status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &status_path,
             &dir.path().join("live.jsonl"),
@@ -3901,8 +3915,12 @@ mod tests {
         let status = live_status_with_state(LiveStatusState::Failed);
         std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
 
-        let status =
-            derive_session_status(None, None, &status_path, &dir.path().join("live.jsonl"));
+        let status = derive_session_status(
+            pid::PidFileState::Inactive,
+            None,
+            &status_path,
+            &dir.path().join("live.jsonl"),
+        );
 
         assert!(!status.active);
         assert_eq!(status.line_count, 0);
@@ -3920,7 +3938,7 @@ mod tests {
         std::fs::write(&status_path, serde_json::to_string(&healthy).unwrap()).unwrap();
 
         let healthy_status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &status_path,
             &dir.path().join("live.jsonl"),
@@ -3940,7 +3958,7 @@ mod tests {
         std::fs::write(&status_path, serde_json::to_string(&failed).unwrap()).unwrap();
 
         let failed_status = derive_session_status(
-            None,
+            pid::PidFileState::Inactive,
             Some(std::process::id()),
             &status_path,
             &dir.path().join("live.jsonl"),
@@ -3956,5 +3974,112 @@ mod tests {
         assert!(healthy_status.active);
         assert!(!failed_status.active);
         assert_eq!(failed_status.diagnostic.as_deref(), Some("sidecar failed"));
+    }
+
+    /// #258: a standalone session whose PID file is held under a Windows mandatory
+    /// lock (`LockedAlive`, PID unreadable) must report active with real stats and
+    /// `source = Standalone`. The PID is `None` (we don't fabricate it) and no
+    /// "sidecar …" diagnostic leaks onto the standalone path.
+    #[cfg(all(feature = "whisper", feature = "streaming"))]
+    #[test]
+    fn standalone_locked_alive_reports_active_with_stats() {
+        let dir = tempdir().unwrap();
+        let status_path = dir.path().join("live-status.json");
+        let status = live_status_with_state(LiveStatusState::Healthy);
+        std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
+
+        let result = derive_session_status(
+            pid::PidFileState::LockedAlive,
+            None,
+            &status_path,
+            &dir.path().join("live.jsonl"),
+        );
+
+        assert!(result.active);
+        assert_eq!(result.source, Some(TranscriptSource::Standalone));
+        assert_eq!(
+            result.pid, None,
+            "locked PID is unreadable, must not be faked"
+        );
+        assert_eq!(result.line_count, 3);
+        assert_eq!(
+            result.diagnostic, None,
+            "no sidecar diagnostic on standalone"
+        );
+    }
+
+    /// Regression guard for the heartbeat-flicker hazard: standalone liveness comes
+    /// from the held lock, NOT the heartbeat. A `LockedAlive` session with a *stale*
+    /// healthy heartbeat (loop busy on a long utterance) must still report active
+    /// and keep reporting its last-known stats rather than dropping back to 0/0.
+    #[cfg(all(feature = "whisper", feature = "streaming"))]
+    #[test]
+    fn standalone_locked_alive_stays_active_with_stale_heartbeat() {
+        let dir = tempdir().unwrap();
+        let status_path = dir.path().join("live-status.json");
+        let mut status = live_status_with_state(LiveStatusState::Healthy);
+        status.updated_at =
+            Local::now() - ChronoDuration::seconds(SIDECAR_HEALTH_STALE_AFTER_SECS + 5);
+        std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
+
+        let result = derive_session_status(
+            pid::PidFileState::LockedAlive,
+            None,
+            &status_path,
+            &dir.path().join("live.jsonl"),
+        );
+
+        assert!(
+            result.active,
+            "lock proves liveness independent of heartbeat"
+        );
+        assert_eq!(result.source, Some(TranscriptSource::Standalone));
+        assert_eq!(result.line_count, 3);
+    }
+
+    /// The readable-PID standalone path (Unix, or Windows when not self-locked)
+    /// reports the real PID alongside `source = Standalone`.
+    #[cfg(all(feature = "whisper", feature = "streaming"))]
+    #[test]
+    fn standalone_active_pid_reports_pid_and_source() {
+        let dir = tempdir().unwrap();
+        let status_path = dir.path().join("live-status.json");
+        let status = live_status_with_state(LiveStatusState::Healthy);
+        std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
+
+        let result = derive_session_status(
+            pid::PidFileState::Active(4321),
+            None,
+            &status_path,
+            &dir.path().join("live.jsonl"),
+        );
+
+        assert!(result.active);
+        assert_eq!(result.source, Some(TranscriptSource::Standalone));
+        assert_eq!(result.pid, Some(4321));
+        assert_eq!(result.line_count, 3);
+    }
+
+    /// An inactive standalone PID with no recording reports nothing — unchanged
+    /// behavior, guarding against the fallback over-triggering.
+    #[cfg(all(feature = "whisper", feature = "streaming"))]
+    #[test]
+    fn standalone_inactive_with_no_recording_is_idle() {
+        let dir = tempdir().unwrap();
+        let status_path = dir.path().join("live-status.json");
+        let status = live_status_with_state(LiveStatusState::Healthy);
+        std::fs::write(&status_path, serde_json::to_string(&status).unwrap()).unwrap();
+
+        let result = derive_session_status(
+            pid::PidFileState::Inactive,
+            None,
+            &status_path,
+            &dir.path().join("live.jsonl"),
+        );
+
+        assert!(!result.active);
+        assert_eq!(result.source, None);
+        assert_eq!(result.line_count, 0);
+        assert_eq!(result.duration_secs, 0.0);
     }
 }

--- a/crates/core/src/pid.rs
+++ b/crates/core/src/pid.rs
@@ -251,6 +251,106 @@ pub fn check_pid_file(path: &Path) -> Result<Option<u32>, PidError> {
     }
 }
 
+/// Outcome of inspecting a PID file that may be held under an exclusive lock.
+///
+/// [`check_pid_file`] reads the PID bytes to decide liveness, which is defeated
+/// on Windows by the very lock that proves liveness: `fs2` locks are *mandatory*
+/// there (`LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK`), so a read from any other
+/// handle of a file held by [`create_pid_guard`] fails with `ERROR_LOCK_VIOLATION`
+/// and `check_pid_file` collapses a live session to `None`. A held mandatory lock,
+/// however, *proves* the owner is alive — Windows releases file locks when the
+/// owning process exits — so the lock violation is positive liveness evidence
+/// even though the PID value itself is unreadable. On Unix `fs2` uses advisory
+/// `flock`, so the read succeeds and this distinction never arises.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PidFileState {
+    /// PID file present, readable, and the process is alive.
+    Active(u32),
+    /// PID file present but unreadable because the owner holds an exclusive lock
+    /// (Windows mandatory lock). The owner is alive; the PID value is unknown.
+    LockedAlive,
+    /// PID file absent, stale (dead PID — cleaned up), or unreadable for any
+    /// reason other than a lock/sharing violation.
+    Inactive,
+}
+
+impl PidFileState {
+    /// True when a live process holds the PID file, whether the PID was readable
+    /// (`Active`) or the file was locked by its live owner (`LockedAlive`).
+    pub fn is_active(self) -> bool {
+        matches!(self, PidFileState::Active(_) | PidFileState::LockedAlive)
+    }
+
+    /// The owning PID when it could be read. `None` for `LockedAlive` (the lock
+    /// proves liveness but hides the value) and `Inactive`.
+    pub fn pid(self) -> Option<u32> {
+        match self {
+            PidFileState::Active(pid) => Some(pid),
+            _ => None,
+        }
+    }
+}
+
+/// Inspect a PID file, distinguishing a live-but-locked owner (Windows mandatory
+/// lock) from a genuinely absent or stale file. Use this instead of
+/// [`check_pid_file`] for any reader of a PID file held under a persistent
+/// [`create_pid_guard`] lock (e.g. the live-transcript or worker PID), so the
+/// reader is not fooled by Windows file locking. Stale PID files (dead PID) are
+/// cleaned up automatically, mirroring [`check_pid_file`].
+pub fn inspect_pid_file(path: &Path) -> PidFileState {
+    if !path.exists() {
+        return PidFileState::Inactive;
+    }
+
+    match fs::read_to_string(path) {
+        Ok(contents) => match contents.trim().parse::<u32>() {
+            Ok(pid) if is_process_alive(pid) => PidFileState::Active(pid),
+            Ok(pid) => {
+                tracing::warn!(
+                    "stale PID file found at {} (PID {pid} is dead). Cleaning up.",
+                    path.display()
+                );
+                fs::remove_file(path).ok();
+                PidFileState::Inactive
+            }
+            // Present but unparseable (empty/corrupt): treat as not active rather
+            // than guessing a PID.
+            Err(_) => PidFileState::Inactive,
+        },
+        // The read failed. On Windows a mandatory-lock violation means the owner
+        // is alive and holding the lock; any other error is treated conservatively
+        // as inactive (we never claim a live owner without positive evidence).
+        Err(err) if is_lock_violation(&err) => PidFileState::LockedAlive,
+        Err(_) => PidFileState::Inactive,
+    }
+}
+
+/// Whether an I/O error is a Windows byte-range lock violation
+/// (`ERROR_LOCK_VIOLATION` = 33) — the precise way a read of a region held under
+/// `LockFileEx` surfaces. `create_pid_guard` opens the file with shared read
+/// access, so our reader's open succeeds and only the `ReadFile` over the locked
+/// range fails with 33; that is positive proof a live owner holds the lock.
+///
+/// We deliberately do NOT treat `ERROR_SHARING_VIOLATION` (32) as a live owner:
+/// it signals an unrelated incompatible-share opener (antivirus, indexer, backup)
+/// rather than the PID owner's lock, and since this gates start/stop/update
+/// decisions, treating it as "alive" could falsely block recording or stall
+/// `minutes stop`. A bare sharing violation degrades to the safe `Inactive`
+/// default instead. On non-Windows targets `fs2` locks are advisory and reads
+/// never fail this way, so this is always `false`.
+fn is_lock_violation(err: &std::io::Error) -> bool {
+    #[cfg(windows)]
+    {
+        // ERROR_LOCK_VIOLATION
+        err.raw_os_error() == Some(33)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = err;
+        false
+    }
+}
+
 fn read_locked_pid(file: &mut fs::File) -> Result<Option<u32>, PidError> {
     file.seek(SeekFrom::Start(0))?;
 
@@ -848,5 +948,72 @@ mod tests {
 
         remove_pid_file(&pid_path).unwrap();
         assert!(!pid_path.exists());
+    }
+
+    #[test]
+    fn inspect_pid_file_absent_is_inactive() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("live-transcript.pid");
+        assert_eq!(inspect_pid_file(&path), PidFileState::Inactive);
+        assert!(!inspect_pid_file(&path).is_active());
+        assert_eq!(inspect_pid_file(&path).pid(), None);
+    }
+
+    #[test]
+    fn inspect_pid_file_live_self_is_active() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("live-transcript.pid");
+        std::fs::write(&path, std::process::id().to_string()).unwrap();
+
+        let state = inspect_pid_file(&path);
+        assert!(state.is_active());
+        assert_eq!(state, PidFileState::Active(std::process::id()));
+        assert_eq!(state.pid(), Some(std::process::id()));
+    }
+
+    #[test]
+    fn inspect_pid_file_stale_dead_pid_is_inactive_and_cleaned() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("live-transcript.pid");
+        // A high PID that almost certainly isn't a live process (matches the
+        // value used by is_process_alive_returns_false_for_dead_pid). PID 0 is
+        // unusable here: `kill(0, 0)` targets the caller's process group.
+        std::fs::write(&path, "99999999").unwrap();
+
+        assert_eq!(inspect_pid_file(&path), PidFileState::Inactive);
+        assert!(!path.exists(), "stale PID file should be cleaned up");
+    }
+
+    #[test]
+    fn inspect_pid_file_corrupt_is_inactive() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("live-transcript.pid");
+        std::fs::write(&path, "not-a-pid").unwrap();
+        assert_eq!(inspect_pid_file(&path), PidFileState::Inactive);
+    }
+
+    /// The fix for #258: a PID file held under a live `create_pid_guard` lock must
+    /// report active. On Unix the read succeeds (`Active`); on Windows the read
+    /// hits the mandatory lock (`LockedAlive`). Either way `is_active()` is true —
+    /// that is the platform-independent invariant the live-transcript readers rely
+    /// on.
+    #[test]
+    fn inspect_pid_file_reports_active_while_guard_is_held() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("live-transcript.pid");
+
+        let guard = create_pid_guard(&path).unwrap();
+        let state = inspect_pid_file(&path);
+        assert!(
+            state.is_active(),
+            "a held guard must read as active, got {state:?}"
+        );
+        #[cfg(windows)]
+        assert_eq!(state, PidFileState::LockedAlive);
+        #[cfg(not(windows))]
+        assert_eq!(state, PidFileState::Active(std::process::id()));
+
+        drop(guard);
+        assert_eq!(inspect_pid_file(&path), PidFileState::Inactive);
     }
 }

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 29;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1120;
+export const MINUTES_TEST_COUNT = 1129;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/src/cli_setup.rs
+++ b/tauri/src-tauri/src/cli_setup.rs
@@ -716,9 +716,10 @@ pub fn cli_recording_active() -> bool {
         pid::dictation_pid_path(),
         pid::live_transcript_pid_path(),
     ];
-    paths
-        .iter()
-        .any(|p| matches!(pid::check_pid_file(p), Ok(Some(_))))
+    // `inspect_pid_file` so the live-transcript PID — held under a mandatory
+    // Windows lock — isn't misread as inactive, which would let an update install
+    // mid-session. See #258.
+    paths.iter().any(|p| pid::inspect_pid_file(p).is_active())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3724,7 +3724,7 @@ pub fn spawn_processing_worker(
     completion_notifications_enabled: Arc<AtomicBool>,
 ) {
     std::thread::spawn(move || {
-        if minutes_core::jobs::current_worker_pid().is_some() {
+        if minutes_core::jobs::worker_active() {
             sync_processing_indicator(&processing, &processing_stage);
             return;
         }
@@ -11664,14 +11664,20 @@ pub fn cmd_stop_live_transcript(state: tauri::State<AppState>) -> Result<(), Str
             .store(true, Ordering::Relaxed);
         return Ok(());
     }
-    // Check for external live transcript (started from CLI)
+    // Check for external live transcript (started from CLI). `inspect_pid_file`
+    // so a session holding the PID under a mandatory Windows lock is detected; the
+    // stop sentinel (polled inline by the live loop) stops it on any platform, and
+    // the Unix SIGTERM is sent only when the PID is readable. See #258.
     let lt_pid = minutes_core::pid::live_transcript_pid_path();
-    if let Ok(Some(pid)) = minutes_core::pid::check_pid_file(&lt_pid) {
+    let lt_state = minutes_core::pid::inspect_pid_file(&lt_pid);
+    if lt_state.is_active() {
         minutes_core::pid::write_stop_sentinel()
             .map_err(|e| format!("failed to write stop sentinel: {}", e))?;
         #[cfg(unix)]
-        unsafe {
-            libc::kill(pid as i32, libc::SIGTERM);
+        if let Some(pid) = lt_state.pid() {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGTERM);
+            }
         }
         return Ok(());
     }

--- a/tauri/src-tauri/src/context.rs
+++ b/tauri/src-tauri/src/context.rs
@@ -502,12 +502,11 @@ pub fn write_assistant_context(workspace: &Path, config: &Config) -> Result<(), 
     let assistant_md = generate_assistant_context(config)?;
 
     // Preserve live transcript markers only if a session is actually active (V3).
-    // Don't trust stale markers in the file — verify via PID.
+    // Don't trust stale markers in the file — verify via PID. `inspect_pid_file`
+    // so a session holding the PID under a mandatory Windows lock isn't misread as
+    // inactive (which would strip the live markers mid-session). See #258.
     let lt_pid = minutes_core::pid::live_transcript_pid_path();
-    let live_actually_active = minutes_core::pid::check_pid_file(&lt_pid)
-        .ok()
-        .flatten()
-        .is_some();
+    let live_actually_active = minutes_core::pid::inspect_pid_file(&lt_pid).is_active();
 
     let content = if live_actually_active {
         let marker_start = "<!-- LIVE_TRANSCRIPT_START -->";

--- a/tauri/src-tauri/src/palette_dispatch.rs
+++ b/tauri/src-tauri/src/palette_dispatch.rs
@@ -222,11 +222,11 @@ pub(crate) fn backend_flags(state: &AppState) -> StateFlags {
     }
 
     let live_in_app = state.live_transcript_active.load(Ordering::Relaxed);
+    // `inspect_pid_file` so a CLI-started session holding the PID under a mandatory
+    // Windows lock still sets the LIVE_TRANSCRIPT flag. See #258.
     let standalone_live_pid =
-        minutes_core::pid::check_pid_file(&minutes_core::pid::live_transcript_pid_path())
-            .ok()
-            .flatten()
-            .is_some();
+        minutes_core::pid::inspect_pid_file(&minutes_core::pid::live_transcript_pid_path())
+            .is_active();
     if live_in_app || standalone_live_pid {
         f = f.union(StateFlags::LIVE_TRANSCRIPT);
     }


### PR DESCRIPTION
Closes #258. Thanks to **Quinn (@mquinn614)** for the report and for an unusually precise root-cause diagnosis.

## Root cause
`fs2` file locks are mandatory on Windows (`LockFileEx`) but advisory on Unix (`flock`). A standalone live-transcript session holds its PID file under a persistent exclusive lock (`create_pid_guard`). On Windows, any other read of that file fails with `ERROR_LOCK_VIOLATION`, so `check_pid_file().ok().flatten()` collapsed a healthy session to `None`. In the in-app (Tauri) case the reader and the lock holder are the same process, so `session_status()` reported `line_count: 0` / `duration_secs: 0.0` for the whole session, freezing the Live timer and line count at 0:00. macOS was unaffected.

The key insight: a held mandatory lock proves the owner is alive (Windows releases locks on process exit), so the lock violation is positive liveness evidence even though the PID bytes are unreadable.

## Fix (root-cause contained)
New `pid::inspect_pid_file() -> PidFileState { Active(pid) | LockedAlive | Inactive }`, keying `LockedAlive` specifically on `ERROR_LOCK_VIOLATION` (33), not `SHARING_VIOLATION` (32) which would false-positive on AV/indexer share conflicts. Every reader of a persistently-locked PID file (live-transcript + jobs worker) now routes through it:

- #258 itself: `session_status`/`derive_session_status` report active plus real stats, and liveness is NOT gated on the heartbeat (the heartbeat is written inline, so a long transcription must not flip stats back to 0).
- Data-safety: the recording-sidecar skip guard now detects a locked live session, so a Windows `minutes record` can't clobber the shared `live-transcript.jsonl`.
- record-start block, CLI + Tauri stop (sentinel-based; no PID to `kill` on Windows), CLAUDE.md live markers, palette LIVE flag, dictation conflict check, the update guard (`cli_recording_active`, which would have let an update install mid-session), and the jobs worker (which would have spawned a duplicate).

`check_pid_file` is unchanged; readers of non-persistently-locked PID files (recording, dictation, where the lock is released at function return) are correctly left alone.

## Verification
- Reviewed in two adversarial Codex passes (diagnosis and diff); the diff pass drove the 32-vs-33 tightening.
- 745 core lib tests (no-default-features) plus 9 new tests, including a held-guard test (active on both platforms) and a stale-heartbeat regression guard. fmt and clippy (`--all --no-default-features`) clean.

Generated with [Claude Code](https://claude.com/claude-code)