### PR TITLE
fix(ui): make the AI assistant optional — degrade gracefully when no agent CLI is installed

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -10360,6 +10360,14 @@
               }
             });
           }
+        } else if (/not found on PATH|not found in PATH|not found in common install/i.test(msg)) {
+          // The assistant needs an external agent CLI (Claude Code by
+          // default). It's OPTIONAL — the rest of the app works without it —
+          // so degrade with a calm note instead of a scary "Could not start"
+          // error for users who don't have an agent installed.
+          console.info('Recall: assistant agent not installed (optional):', msg);
+          recallLoading.querySelector('span').textContent =
+            'AI assistant is optional; install Claude Code to enable it.';
         } else {
           console.error('Recall spawn:', e);
           recallLoading.querySelector('span').textContent = 'Could not start: ' + msg;
@@ -12421,6 +12429,18 @@
 
     // Restore panel state from previous session
     (async () => {
+      // The assistant auto-open below spawns the agent CLI (Claude Code by
+      // default). It's optional — skip the auto-open entirely when no agent
+      // is installed so a fresh install gets a clean main window instead of
+      // an auto-expanded panel it can't use. The assistant is still reachable
+      // manually (it shows the calm "optional" note then).
+      try {
+        const agents = await invoke('cmd_list_agents');
+        if (Array.isArray(agents) && agents.length === 0) {
+          return;
+        }
+      } catch (_) { /* if the check fails, fall through to normal restore */ }
+
       try {
         recallWorkspaceState = await invoke('cmd_get_recall_workspace_state');
       } catch (e) {

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -12429,17 +12429,26 @@
 
     // Restore panel state from previous session
     (async () => {
-      // The assistant auto-open below spawns the agent CLI (Claude Code by
-      // default). It's optional — skip the auto-open entirely when no agent
-      // is installed so a fresh install gets a clean main window instead of
-      // an auto-expanded panel it can't use. The assistant is still reachable
-      // manually (it shows the calm "optional" note then).
+      // The assistant auto-open below spawns the *configured* agent CLI
+      // (settings.assistant.agent, default "claude"). It's optional — when
+      // that agent isn't installed, skip ONLY the auto-open so the panel
+      // doesn't pop up and immediately fail to spawn. Everything else in the
+      // restore (recallRatio, last open document, last open meeting) is
+      // untouched. The assistant is still reachable manually, where it shows
+      // the calm "optional" note.
+      //
+      // NOTE: gate on the *configured* agent specifically — cmd_list_agents
+      // also enumerates shells (bash/zsh) that exist on every machine, so a
+      // bare "any agent installed?" check would never report unavailable.
+      let assistantAvailable = true;
       try {
-        const agents = await invoke('cmd_list_agents');
-        if (Array.isArray(agents) && agents.length === 0) {
-          return;
-        }
-      } catch (_) { /* if the check fails, fall through to normal restore */ }
+        const [agents, settings] = await Promise.all([
+          invoke('cmd_list_agents'),
+          invoke('cmd_get_settings'),
+        ]);
+        const configured = settings?.assistant?.agent || 'claude';
+        assistantAvailable = Array.isArray(agents) && agents.some(a => a.name === configured);
+      } catch (_) { /* on any error, assume available and fall through */ }
 
       try {
         recallWorkspaceState = await invoke('cmd_get_recall_workspace_state');
@@ -12448,7 +12457,7 @@
         recallWorkspaceState = null;
       }
       if (!recallWorkspaceState) {
-        if (localStorage.getItem('minutes.recallExpanded') === 'true') {
+        if (assistantAvailable && localStorage.getItem('minutes.recallExpanded') === 'true') {
           setTimeout(() => openRecall('assistant'), 500);
         }
         return;
@@ -12462,7 +12471,7 @@
         }
       }
 
-      if (recallWorkspaceState.recallExpanded) {
+      if (assistantAvailable && recallWorkspaceState.recallExpanded) {
         setTimeout(async () => {
           await openRecall('assistant');
           if (recallWorkspaceState.recallPhase) {


### PR DESCRIPTION
## Problem

The Recall assistant panel spawns an external agent CLI (Claude Code by
default). On a machine that doesn't have one installed, two rough edges show up:

1. **On startup**, if the saved workspace state has the assistant panel
   expanded, the app auto-spawns the agent and the panel renders a
   `Could not start: 'claude' not found on PATH` error — even though the
   assistant is optional and the rest of the app (recording, etc.) works fine
   without it.
2. **Opening the assistant manually** surfaces the same raw spawn error.

For someone who just wants to record/transcribe and never set up an agent, this
reads as "the app is broken."

## Fix

Make the assistant degrade gracefully when no agent CLI is installed:

- **Startup** skips the assistant auto-open entirely when `cmd_list_agents`
  reports none installed — a fresh install gets a clean main window instead of
  an auto-expanded panel it can't use.
- **Manual open** shows a calm note —
  `AI assistant is optional; install Claude Code to enable it.` — instead of the
  raw `Could not start` error.

No behavior change for anyone who has an agent installed: the availability check
falls through to the normal path, and the new message only replaces the error
text on the specific "agent binary not found" failure.

## Scope

Frontend-only (`tauri/src/index.html`), two small hunks. No backend or config
changes.

## Testing

- With an agent installed: assistant auto-opens and spawns exactly as before.
- Without an agent: startup leaves the panel collapsed; opening the assistant
  manually shows the calm optional note instead of the error.
