### PR TITLE
chore(deps): move pyannote-rs to crates.io 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,8 @@ dependencies = [
 [[package]]
 name = "knf-rs"
 version = "0.3.2"
-source = "git+https://github.com/gregoire22enpc/pyannote-rs?rev=ae9fbc1#ae9fbc1f6c605dfec020fe26aad765ce7026bcac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ebe7cf9eae245a44ab76cabdd06c0b3769972fd06050ed9aea6a22ff0d682f"
 dependencies = [
  "eyre",
  "knf-rs-sys",
@@ -2829,7 +2830,8 @@ dependencies = [
 [[package]]
 name = "knf-rs-sys"
 version = "0.3.2"
-source = "git+https://github.com/gregoire22enpc/pyannote-rs?rev=ae9fbc1#ae9fbc1f6c605dfec020fe26aad765ce7026bcac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9aa7679fdc0ecdaab1f4e7c9603413f303765f33c8e34e6ca4f26e7d61d6023"
 dependencies = [
  "bindgen 0.69.5",
  "cmake",
@@ -4471,7 +4473,8 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 [[package]]
 name = "pyannote-rs"
 version = "0.3.4"
-source = "git+https://github.com/gregoire22enpc/pyannote-rs?rev=ae9fbc1#ae9fbc1f6c605dfec020fe26aad765ce7026bcac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fff2b00fa0b4bd7e5d415eaedd9a5f0aefe58c08758ddbd945dc85dffae328"
 dependencies = [
  "eyre",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,9 +77,14 @@ nnnoiseless = "0.5"
 # Channels (for streaming audio)
 crossbeam-channel = "0.5"
 
-# Speaker diarization (native, no Python) — patched fork fixes i16→f32
-# normalization bug and trailing speech flush in get_segments
-pyannote-rs = { git = "https://github.com/gregoire22enpc/pyannote-rs", rev = "ae9fbc1" }
+# Speaker diarization (native, no Python). Use the crates.io release so the
+# manifest stays `cargo publish`-able. The only known upstream bug (i16→f32
+# normalization + trailing-speech flush in get_segments) lives in a function we
+# deliberately bypass: diarize.rs runs its own ONNX segmentation via `ort` and
+# only consumes pyannote-rs's EmbeddingExtractor, which is byte-identical between
+# 0.3.4 and the old patched fork. See diarize.rs `segment_speech` / `get_segments`
+# comments. (Previously pinned to gregoire22enpc/pyannote-rs@ae9fbc1.)
+pyannote-rs = "0.3.4"
 
 # ONNX Runtime + ndarray (used directly for segmentation model — pyannote-rs
 # has a normalisation bug so we bypass get_segments for the segmentation step)


### PR DESCRIPTION
Re-check of the two `cargo publish` blockers tracked in #79. Removes the pyannote-rs half.

## pyannote-rs: drop the git fork, use crates.io 0.3.4
The pinned fork (`gregoire22enpc/pyannote-rs@ae9fbc1`) turned out to be redundant. It is crates.io `pyannote-rs 0.3.4` plus a single patch to `src/segment.rs::get_segments`, a function we deliberately bypass. `diarize.rs` runs its own ONNX segmentation via `ort` (`segment_speech`) and only consumes `pyannote_rs::EmbeddingExtractor`.

Verified behavior-identical:
- `diff -rq` of fork vs crates.io 0.3.4 src: only `segment.rs` differs.
- `embedding.rs` (EmbeddingExtractor), `knf-rs`, and `knf-rs-sys` are byte-identical between the fork and crates.io.
- No code path in the repo reaches `pyannote_rs::get_segments` (the only import is `EmbeddingExtractor`).
- Runtime diarization runs clean against 0.3.4; lockfile unifies `pyannote-rs 0.3.4`, `ort 2.0.0-rc.10`, and `ndarray 0.16`.
- Independent Codex adversarial review: no P1.

## cpal: unchanged in this PR
An earlier revision bumped the cpal git pin to pick up the PipeWire init-timeout fix, but cpal's current master fails to compile on Windows (`windows-core 0.62` in its WASAPI backend). That bump was dropped. cpal stays on the existing pin and moves to crates.io when v0.18 ships.

## Result
cpal is the only remaining external git dependency in the workspace, and it is self-resolving: v0.18 is imminent on crates.io. When it lands, flip that one line and `cargo publish` is unblocked. Closes the pyannote half of #79.

Generated with Claude Code
