### PR TITLE
fix(windows): release pty_manager lock before PTY teardown + kill process tree on End Session (#274)

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -7884,8 +7884,13 @@ pub fn cmd_pty_resize(
 
 #[tauri::command]
 pub fn cmd_pty_kill(state: tauri::State<AppState>, session_id: String) -> Result<(), String> {
-    let mut manager = state.pty_manager.lock().map_err(|_| "Lock failed")?;
-    manager.kill_session(&session_id);
+    let session = {
+        let mut manager = state.pty_manager.lock().map_err(|_| "Lock failed")?;
+        manager.take_session(&session_id)
+    };
+    if let Some(session) = session {
+        crate::pty::kill_session(session);
+    }
     Ok(())
 }
 

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -39,11 +39,17 @@ static CLEAN_EXIT_STARTED: AtomicBool = AtomicBool::new(false);
 static MACOS_TERMINATE_APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
 
 fn cleanup_before_process_exit(app: &tauri::AppHandle) {
-    if let Some(state) = app.try_state::<commands::AppState>() {
-        if let Ok(mut mgr) = state.pty_manager.lock() {
-            mgr.kill_all();
-        }
-    }
+    let sessions = app
+        .try_state::<commands::AppState>()
+        .and_then(|state| {
+            state
+                .pty_manager
+                .lock()
+                .ok()
+                .map(|mut mgr| mgr.take_all_sessions())
+        })
+        .unwrap_or_default();
+    crate::pty::kill_all(sessions);
     minutes_core::parakeet_sidecar::shutdown_global_parakeet_sidecar();
 }
 

--- a/tauri/src-tauri/src/pty.rs
+++ b/tauri/src-tauri/src/pty.rs
@@ -8,6 +8,20 @@ use tauri::Emitter;
 pub const ASSISTANT_SESSION_ID: &str = "assistant";
 const MAX_SESSIONS: usize = 1;
 
+#[cfg(windows)]
+fn terminate_process_tree(process_id: Option<u32>) {
+    let Some(process_id) = process_id else {
+        return;
+    };
+    let process_id = process_id.to_string();
+    let _ = std::process::Command::new("taskkill")
+        .args(["/T", "/F", "/PID", process_id.as_str()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}
+
 pub struct PtySession {
     pub master: Box<dyn portable_pty::MasterPty + Send>,
     pub writer: Box<dyn Write + Send>,
@@ -238,53 +252,54 @@ impl PtyManager {
             .map_err(|e| format!("Resize failed: {}", e))
     }
 
-    pub fn kill_session(&mut self, session_id: &str) -> Option<PathBuf> {
-        if let Some(mut session) = self.sessions.remove(session_id) {
-            session.child.kill().ok();
-            if let Some(handle) = session.reader_handle.take() {
-                // The reader thread blocks on `reader.read()` of the PTY
-                // master and only breaks on EOF / error. On Windows ConPTY,
-                // killing the child process does NOT deliver EOF to the
-                // master — the pseudoconsole keeps the pipe open — so the
-                // read never returns and an unconditional `join()` here hangs
-                // forever. Because every quit path runs
-                // `cleanup_before_process_exit` -> `kill_all` -> `kill_session`,
-                // that wedges the whole app on exit (window hides, process
-                // never dies, "Not Responding" — Task Manager required).
-                //
-                // On macOS/Unix killing the child closes the slave PTY, the
-                // master read returns Ok(0), and the thread exits immediately,
-                // so the join is instant there (which is why this only bites
-                // on Windows).
-                //
-                // Bounded wait, then detach: give the reader a brief window to
-                // exit cleanly (it does wherever EOF is delivered), otherwise
-                // drop the handle. The reader holds no lock the rest of the
-                // app needs and dies with the process on exit, so detaching is
-                // safe and shutdown can never wedge on it.
-                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(300);
-                while !handle.is_finished() && std::time::Instant::now() < deadline {
-                    std::thread::sleep(std::time::Duration::from_millis(5));
-                }
-                if handle.is_finished() {
-                    let _ = handle.join();
-                }
-                // else: detach — never block on a ConPTY reader that won't see EOF.
-            }
-            Some(session.context_dir)
-        } else {
-            None
-        }
+    pub fn take_session(&mut self, session_id: &str) -> Option<PtySession> {
+        self.sessions.remove(session_id)
     }
 
-    pub fn kill_all(&mut self) -> Vec<PathBuf> {
-        let ids: Vec<String> = self.sessions.keys().cloned().collect();
-        let mut dirs = Vec::new();
-        for id in ids {
-            if let Some(dir) = self.kill_session(&id) {
-                dirs.push(dir);
-            }
-        }
-        dirs
+    pub fn take_all_sessions(&mut self) -> Vec<PtySession> {
+        self.sessions.drain().map(|(_, session)| session).collect()
     }
+}
+
+pub fn kill_session(mut session: PtySession) -> PathBuf {
+    #[cfg(windows)]
+    let process_id = session.child.process_id();
+    session.child.kill().ok();
+    #[cfg(windows)]
+    terminate_process_tree(process_id);
+    if let Some(handle) = session.reader_handle.take() {
+        // The reader thread blocks on `reader.read()` of the PTY
+        // master and only breaks on EOF / error. On Windows ConPTY,
+        // killing the child process does NOT deliver EOF to the
+        // master — the pseudoconsole keeps the pipe open — so the
+        // read never returns and an unconditional `join()` here hangs
+        // forever. Because every quit path runs
+        // `cleanup_before_process_exit` -> `kill_all` -> `kill_session`,
+        // that wedges the whole app on exit (window hides, process
+        // never dies, "Not Responding" — Task Manager required).
+        //
+        // On macOS/Unix killing the child closes the slave PTY, the
+        // master read returns Ok(0), and the thread exits immediately,
+        // so the join is instant there (which is why this only bites
+        // on Windows).
+        //
+        // Bounded wait, then detach: give the reader a brief window to
+        // exit cleanly (it does wherever EOF is delivered), otherwise
+        // drop the handle. The reader holds no lock the rest of the
+        // app needs and dies with the process on exit, so detaching is
+        // safe and shutdown can never wedge on it.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(300);
+        while !handle.is_finished() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        if handle.is_finished() {
+            let _ = handle.join();
+        }
+        // else: detach — never block on a ConPTY reader that won't see EOF.
+    }
+    session.context_dir
+}
+
+pub fn kill_all(sessions: Vec<PtySession>) -> Vec<PathBuf> {
+    sessions.into_iter().map(kill_session).collect()
 }

--- a/tauri/src-tauri/src/pty.rs
+++ b/tauri/src-tauri/src/pty.rs
@@ -262,11 +262,16 @@ impl PtyManager {
 }
 
 pub fn kill_session(mut session: PtySession) -> PathBuf {
+    // Kill the full process tree FIRST on Windows: `taskkill /T /F` walks the
+    // tree from the live leader PID, so it must run before `child.kill()` reaps
+    // the leader. Otherwise a dead or reused PID could orphan the node / npx
+    // minutes-mcp grandchildren (thanks @mquinn614). `child.kill()` below is the
+    // real kill on Unix and a harmless no-op on Windows.
     #[cfg(windows)]
     let process_id = session.child.process_id();
-    session.child.kill().ok();
     #[cfg(windows)]
     terminate_process_tree(process_id);
+    session.child.kill().ok();
     if let Some(handle) = session.reader_handle.take() {
         // The reader thread blocks on `reader.read()` of the PTY
         // master and only breaks on EOF / error. On Windows ConPTY,


### PR DESCRIPTION
## What
Recall "End Session" (`cmd_pty_kill`) freezes the desktop app on Windows: force-kill required, no session-end event written. Reported on v0.18.5 (#274).

## Why
`cmd_pty_kill` held the `pty_manager` mutex across `child.kill()` and the bounded reader wait. If ConPTY teardown blocks on Windows, the lock wedges every other PTY command (the xterm UI issues writes/resizes constantly) and the panel freezes. The #262 fix bounded the reader-thread join for the quit path, but did not address the lock-held-across-kill, nor the agent process tree.

## Changes (Windows behavior; Unix unchanged)
- **Drop the lock before teardown.** Lock only long enough to `take_session` (map removal), drop it, then run `child.kill()` plus the existing 300ms bounded-wait-then-detach outside the lock. Same for shutdown (`take_all_sessions`, drop, `kill_all`).
- **Kill the full process tree on Windows.** A `#[cfg(windows)]` best-effort, non-blocking `taskkill /T /F /PID` after `child.kill()`, since terminating the ConPTY leader leaves agent grandchildren holding the pipe open with no EOF.

## Testing
- macOS: `cargo fmt`, clippy (default and `--no-default-features`), `cargo build -p minutes-app` all pass.
- This path is Windows-ConPTY-specific and cannot be reproduced on macOS. Relying on CI's Windows build for the compile gate and on a Windows tester to confirm the runtime fix before closing #274.

Refs #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
