### PR TITLE
docs(release): revive crates.io publishing for minutes-core/cli (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/silverstein/minutes?style=social)](https://github.com/silverstein/minutes)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![crates.io](https://img.shields.io/crates/v/minutes-cli.svg)](https://crates.io/crates/minutes-cli)
 
 **Open-source conversation memory.** &nbsp; [useminutes.app](https://useminutes.app)
 

--- a/docs/PRE-RELEASE-CHECKLIST.md
+++ b/docs/PRE-RELEASE-CHECKLIST.md
@@ -229,21 +229,16 @@ Anyone running `brew install --cask silverstein/tap/minutes` is silently stuck o
 - `GGML_CCACHE=OFF` — whisper.cpp's CMakeLists has `GGML_CCACHE=ON` by default; if a user has ccache installed (e.g. via Homebrew), `find_program()` locates it at cmake-configure time but the resulting `RULE_LAUNCH_COMPILE` fails at make-time inside Homebrew's sanitized superenv PATH (silverstein/minutes#89). `whisper-rs-sys` forwards any `GGML_*`, `WHISPER_*`, or `CMAKE_*` env var to cmake as `-D<KEY>=<VALUE>`, which is how this disable propagates.
 - Windows desktop release builds must set `GGML_NATIVE=OFF`, keep `GGML_AVX=ON` / `GGML_AVX2=ON`, and force all `GGML_AVX512*` flags `OFF` — otherwise the GitHub Windows runner can enable AVX-512 code paths in ggml/whisper.cpp that crash on normal consumer CPUs with `STATUS_ILLEGAL_INSTRUCTION` (silverstein/minutes#106)
 
-### 9.3 crates.io: not currently published
+### 9.3 crates.io: published again (revived in #79)
 
-`minutes-cli` and `minutes-core` are at v0.9.4 on crates.io and have NOT been published since. Reasons we are not reviving the publish:
+`minutes-core` and `minutes-cli` are published to crates.io again as of #79, which cleared the last git dependencies that had blocked `cargo publish`:
 
-- `minutes-core` has a git dependency on a forked `pyannote-rs`, which `cargo publish` rejects.
-- Reviving requires either feature-stripping or vendoring/replacing the git dep, which is out of scope for a normal release.
-- The crates.io README badge was removed in this same cleanup.
+- `pyannote-rs` moved from the forked git dep to crates.io 0.3.4.
+- `cpal` moved from the git rev pin to crates.io 0.18.1 (with `windows-core` pinned to 0.61.2 in the lockfile; see RustAudio/cpal#1242).
 
-If you ever decide to revive crates.io publishing, you will need to:
+Publishing is a manual release step, consistent with how whisper-guard and the npm packages are published: see **RELEASE.md Step 11.6** (publish `minutes-core`, then `minutes-cli`, in dependency order). The crates.io README badge is restored.
 
-1. Resolve the `pyannote-rs` git dep (vendor or upstream the fork)
-2. Add `cargo publish` steps to `release-cli.yml` after the tag fires
-3. Re-add the README badge
-
-Until then, treat crates.io as not part of the release surface.
+History: the crates sat at v0.9.4 and were unpublishable from ~v0.10 onward because the forked pyannote-rs and the cpal git rev are git dependencies, which `cargo publish` rejects. Both are now crates.io releases, so the next tagged release should republish at the main version (currently 0.18.5).
 
 ### 9.4 `manifest.mcpb.json`
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -117,6 +117,32 @@ sleep 30 && curl -s https://crates.io/api/v1/crates/whisper-guard | jq '.crate.m
 ```
 whisper-guard is a standalone MIT crate consumed outside this repo (currently 277+ downloads). Bump independently of the main release; do NOT couple to the Minutes version. If you skip the publish, the crates.io users miss the fix and you create silent drift between repo state and published artifact.
 
+### 11.6. Publish minutes-core and minutes-cli to crates.io
+
+As of #79 the workspace has no git dependencies (cpal is on crates.io 0.18.1 with `windows-core` pinned to 0.61.2; pyannote-rs is on crates.io 0.3.4), so these crates can be published again. They were last on crates.io at v0.9.4 and now publish at the main release version (currently 0.18.5).
+
+Publish in dependency order, `minutes-core` before `minutes-cli`, because `minutes-cli` depends on the crates.io version of `minutes-core`. whisper-guard (Step 11.5) must already be published at the version `minutes-core` requires.
+
+```bash
+# core first; cli depends on it. dry-run each before the real publish.
+cd crates/core
+cargo publish --dry-run
+cargo publish
+# wait for the index to pick up core so cli can resolve it
+sleep 45 && curl -s https://crates.io/api/v1/crates/minutes-core | jq '.crate.max_stable_version'
+
+cd ../cli
+cargo publish --dry-run
+cargo publish
+sleep 30 && curl -s https://crates.io/api/v1/crates/minutes-cli | jq '.crate.max_stable_version'
+```
+
+Notes:
+- `cargo publish` reads each crate's `version =` dependency fields (not the local `path =`), which already point at the crates.io versions, so no manifest edits are needed.
+- Publishing is irreversible: you can only yank, never replace a version. Always run the `--dry-run` first.
+- This revives `cargo install minutes-cli` for users who do not use Homebrew.
+- If `minutes-core` fails to publish with a missing-dependency error, confirm whisper-guard at the required version is already indexed (Step 11.5).
+
 ### 12. Refresh the landing page copy, then redeploy
 Before deploying, make sure the site matches what just shipped:
 


### PR DESCRIPTION
## What
Revives crates.io publishing for `minutes-core` and `minutes-cli`, now that #79's git-dependency blockers are cleared (cpal on crates.io 0.18.1 + windows-core pin, pyannote-rs on crates.io 0.3.4).

## Why now
The crates were last on crates.io at v0.9.4 and got shelved around v0.10 only because the forked pyannote-rs and the cpal git rev were git dependencies, which `cargo publish` rejects. Both are now crates.io releases. Verified empirically: `cargo publish --dry-run -p minutes-core` packages (70 files) and verifies cleanly, no git-dep rejection.

## Changes (docs/process only, no code)
- **RELEASE.md**: new Step 11.6 to publish `minutes-core` then `minutes-cli` in dependency order (cli depends on the crates.io version of core), with dry-runs and an index wait.
- **README**: restore the crates.io version badge.
- **PRE-RELEASE-CHECKLIST**: flip 9.3 from "not published" to "published again (revived)."

## Design choice: manual, not CI-auto
Publishing is a manual maintainer release step (run `cargo publish` locally), matching how whisper-guard and the npm packages (sdk, mcp) are already published. I deliberately did **not** add auto-publish-on-tag to `release-cli.yml`: crates.io publishing is irreversible (yank-only), and an auto-publish job would require a crates.io token sitting in CI that could publish anything. If you'd prefer the CI-auto approach instead, that's a follow-up.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
