### PR TITLE
fix(summarize): bypass codex + gemini workspace-trust gates so summaries don't degrade

### DIFF
--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -932,18 +932,34 @@ fn prepare_agent_invocation(
     }
 
     if matches_agent_binary(agent_cmd, "codex") {
+        // `--skip-git-repo-check`: summarization runs read-only in the meeting /
+        // job directory, which is not a git repo. Without this, Codex refuses to
+        // start ("not inside a trusted directory") and the summary silently
+        // degrades. The sandbox stays `-s read-only`, so the bypass grants no
+        // write access.
         return Ok(AgentInvocation {
             cmd: agent_cmd.to_string(),
-            args: vec!["exec".into(), "-".into(), "-s".into(), "read-only".into()],
+            args: vec![
+                "exec".into(),
+                "-".into(),
+                "-s".into(),
+                "read-only".into(),
+                "--skip-git-repo-check".into(),
+            ],
             stdin_payload: Some(prompt.as_bytes().to_vec()),
             cleanup_path: None,
         });
     }
 
     if matches_agent_binary(agent_cmd, "gemini") {
+        // `--skip-trust`: same class of failure as Codex above. Gemini refuses
+        // to run in a directory it does not trust ("not running in a trusted
+        // directory"), so a summary launched from the non-repo job directory
+        // degrades unless the workspace-trust gate is bypassed for this
+        // non-interactive, read-only run.
         return Ok(AgentInvocation {
             cmd: agent_cmd.to_string(),
-            args: vec!["-p".into(), "-".into()],
+            args: vec!["-p".into(), "-".into(), "--skip-trust".into()],
             stdin_payload: Some(prompt.as_bytes().to_vec()),
             cleanup_path: None,
         });
@@ -2786,6 +2802,38 @@ PARTICIPANTS:
     fn map_speakers_empty_when_no_attendees() {
         let config = Config::default();
         assert!(map_speakers("[SPEAKER_1 0:00] hi", &[], &config, None).is_empty());
+    }
+
+    #[test]
+    fn prepare_agent_invocation_for_codex_skips_git_repo_check() {
+        // Regression: summaries run in a non-repo job dir; without the bypass
+        // Codex refuses to start and the summary degrades.
+        let invocation = prepare_agent_invocation("codex", "sensitive prompt").unwrap();
+        assert_eq!(invocation.cmd, "codex");
+        assert_eq!(
+            invocation.args,
+            vec!["exec", "-", "-s", "read-only", "--skip-git-repo-check"]
+        );
+        assert_eq!(
+            invocation.stdin_payload.as_deref(),
+            Some("sensitive prompt".as_bytes())
+        );
+        assert!(invocation.cleanup_path.is_none());
+    }
+
+    #[test]
+    fn prepare_agent_invocation_for_gemini_skips_workspace_trust() {
+        // Regression (#280-adjacent): Gemini refuses to run in an untrusted
+        // workspace ("not running in a trusted directory"), so the non-repo
+        // job dir degraded summaries until --skip-trust was passed.
+        let invocation = prepare_agent_invocation("gemini", "sensitive prompt").unwrap();
+        assert_eq!(invocation.cmd, "gemini");
+        assert_eq!(invocation.args, vec!["-p", "-", "--skip-trust"]);
+        assert_eq!(
+            invocation.stdin_payload.as_deref(),
+            Some("sensitive prompt".as_bytes())
+        );
+        assert!(invocation.cleanup_path.is_none());
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1129;
+export const MINUTES_TEST_COUNT = 1131;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What
Agent-based summarization runs read-only from the meeting / job directory, which is not a git repo. Two supported agent CLIs refuse to start in a non-trusted directory, so the summary silently degrades (the "summarization via agent produced no output" degraded badge we have been seeing on recent recordings):

- **codex**: refuses outside a trusted git directory, fixed with `--skip-git-repo-check`
- **gemini**: refuses in an untrusted workspace ("not running in a trusted directory"), fixed with `--skip-trust`

## Why both
A Codex agent first spotted and fixed the codex case. Checking the other configured agents showed gemini has the identical gate. Verified empirically: `gemini -p -` in a non-repo dir fails with `Gemini CLI is not running in a trusted directory ... use --skip-trust`, and succeeds with the flag. So the codex-only fix was half of it.

Agent coverage:
| Agent | Gates on trust in a non-repo dir? | Change |
| --- | --- | --- |
| codex | yes | `--skip-git-repo-check` |
| gemini | yes (confirmed) | `--skip-trust` |
| claude | no, trust dialog auto-skipped in `-p` / piped mode (per `claude --help`) | none |
| opencode | no gate flag exposed | none |
| pi | no gate flag exposed, already sandboxed | none |

## Safety
Both runs stay non-interactive and read-only (codex keeps `-s read-only`); the bypass only skips the directory-trust gate, granting no write access.

## Tests
Adds regression tests asserting the exact invocation args for codex and gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
