### PR TITLE
fix(cli): bundle demo fixtures so minutes-cli can publish to crates.io

### DIFF
--- a/crates/cli/fixtures/demo/2026-02-28-pricing-strategy.md
+++ b/crates/cli/fixtures/demo/2026-02-28-pricing-strategy.md
@@ -1,0 +1,47 @@
+---
+title: Pricing Strategy — Monthly Billing Test
+type: meeting
+minutes_demo: true
+date: 2026-02-28T10:00:00-07:00
+duration: 48m
+attendees: [Mat S., Alex K., Jordan M.]
+people: [mat, alex, jordan]
+tags: [pricing, gtm, experiment]
+decisions:
+  - text: Launch monthly billing alongside annual, starting with the next three consultant signups
+    topic: pricing
+    authority: high
+action_items:
+  - assignee: jordan
+    task: Draft monthly billing landing copy
+    due: 2026-03-07
+    status: open
+  - assignee: alex
+    task: Wire monthly price into Stripe
+    due: 2026-03-10
+    status: open
+speaker_map:
+  - speaker_label: SPEAKER_0
+    name: mat
+    confidence: high
+    source: manual
+  - speaker_label: SPEAKER_1
+    name: alex
+    confidence: high
+    source: manual
+  - speaker_label: SPEAKER_2
+    name: jordan
+    confidence: high
+    source: manual
+---
+
+## Summary
+
+- Seven consultants pushed back on annual this month. Testing monthly for the segment.
+- Decision: monthly billing for the next three consultant signups. Annual stays default for enterprise.
+
+## Transcript
+
+[SPEAKER_0 0:00] Let's talk pricing. Seven consultants this month pushed back on annual.
+[SPEAKER_1 0:31] Monthly kills payback. Breakeven moves from 11 months to 14.
+[SPEAKER_0 1:02] Run it narrow. Next three consultant signups get monthly. Annual stays default for enterprise. Reassess Q2.

--- a/crates/cli/fixtures/demo/2026-03-04-northwind-call.md
+++ b/crates/cli/fixtures/demo/2026-03-04-northwind-call.md
@@ -1,0 +1,43 @@
+---
+title: Northwind Customer Call — SSO Friction
+type: meeting
+minutes_demo: true
+date: 2026-03-04T15:30:00-07:00
+duration: 31m
+attendees: [Mat S., Riley B.]
+people: [mat, riley]
+tags: [customer, northwind, onboarding, retention]
+decisions:
+  - text: Ship SSO nested-groups fix for Northwind-shaped accounts before end of Q1 (2026-03-31)
+    topic: sso
+    authority: high
+action_items:
+  - assignee: mat
+    task: Fix SSO nested-groups onboarding for Northwind
+    due: 2026-03-31
+    status: open
+    promised_to: riley
+speaker_map:
+  - speaker_label: SPEAKER_0
+    name: mat
+    confidence: high
+    source: manual
+  - speaker_label: SPEAKER_1
+    name: riley
+    confidence: high
+    source: manual
+---
+
+## Summary
+
+- Riley (Northwind, Director of Ops) frustrated. SSO nested-groups failing for their Okta setup.
+- Mat personally committed to ship the fix before 2026-03-31.
+- Riley used the word "churn" twice unprompted.
+
+## Transcript
+
+[SPEAKER_1 0:00] Half of our eighteen people bounced at SSO this month. I can't keep selling this.
+[SPEAKER_0 0:22] What's the failure point?
+[SPEAKER_1 0:29] Okta nested groups. Your product expects flat users.
+[SPEAKER_0 0:49] End of the quarter. March 31. That's a personal commitment from me.
+[SPEAKER_1 1:02] If it slips, we're going to have a different conversation in Q2.

--- a/crates/cli/fixtures/demo/2026-03-11-eng-standup.md
+++ b/crates/cli/fixtures/demo/2026-03-11-eng-standup.md
@@ -1,0 +1,37 @@
+---
+title: Eng Standup — Alex Takes SSO
+type: meeting
+minutes_demo: true
+date: 2026-03-11T09:30:00-07:00
+duration: 22m
+attendees: [Mat S., Alex K., Sam W.]
+people: [mat, alex, sam]
+tags: [engineering, sso, standup]
+decisions:
+  - text: Alex owns SSO nested-groups support, targeting ship by 2026-03-25
+    topic: sso
+    authority: high
+action_items:
+  - assignee: alex
+    task: Ship SSO nested-groups support
+    due: 2026-03-25
+    status: open
+speaker_map:
+  - speaker_label: SPEAKER_0
+    name: mat
+    confidence: high
+    source: manual
+  - speaker_label: SPEAKER_1
+    name: alex
+    confidence: high
+    source: manual
+---
+
+## Summary
+
+- Alex took SSO nested-groups. Target ship 2026-03-25, buffer before the Northwind-promised 2026-03-31.
+
+## Transcript
+
+[SPEAKER_0 0:00] I need status on SSO nested groups. Committed to Riley, March 31.
+[SPEAKER_1 0:11] I can take it. Week of work. Target March 25, gives a week of slack.

--- a/crates/cli/fixtures/demo/2026-03-25-pricing-reversal.md
+++ b/crates/cli/fixtures/demo/2026-03-25-pricing-reversal.md
@@ -1,0 +1,44 @@
+---
+title: Pricing Follow-up — Reverse the Monthly Experiment
+type: meeting
+minutes_demo: true
+date: 2026-03-25T10:00:00-07:00
+duration: 34m
+attendees: [Mat S., Alex K., Jordan M.]
+people: [mat, alex, jordan]
+tags: [pricing, gtm, decision-reversal]
+decisions:
+  - text: Revert to annual-only billing across all segments. Monthly billing experiment did not generate enough signups to justify the payback hit.
+    topic: pricing
+    authority: high
+    supersedes: "2026-02-28 monthly billing decision"
+action_items:
+  - assignee: jordan
+    task: Pull monthly billing from the landing page
+    due: 2026-03-27
+    status: open
+speaker_map:
+  - speaker_label: SPEAKER_0
+    name: mat
+    confidence: high
+    source: manual
+  - speaker_label: SPEAKER_1
+    name: alex
+    confidence: high
+    source: manual
+  - speaker_label: SPEAKER_2
+    name: jordan
+    confidence: high
+    source: manual
+---
+
+## Summary
+
+- Four monthly signups in three weeks, below the 12 threshold. Churn on the four tracking worse than baseline.
+- Decision: revert to annual-only. Explicitly supersedes the 2026-02-28 launch decision.
+
+## Transcript
+
+[SPEAKER_2 0:00] Four monthly signups in three weeks. The threshold was twelve.
+[SPEAKER_1 0:14] Churn on the four is worse than annual baseline. Two of four canceled before month two.
+[SPEAKER_0 0:47] To be clear: we are reversing the 2026-02-28 decision. Going annual-only, effective immediately.

--- a/crates/cli/fixtures/demo/2026-04-17-prioritization.md
+++ b/crates/cli/fixtures/demo/2026-04-17-prioritization.md
@@ -1,0 +1,52 @@
+---
+title: Product Prioritization — Q2 Cut Lines
+type: meeting
+minutes_demo: true
+date: 2026-04-17T13:00:00-07:00
+duration: 58m
+attendees: [Mat S., Alex K., Sam W., Jordan M.]
+people: [mat, alex, sam, jordan]
+tags: [product, prioritization, q2, roadmap]
+decisions:
+  - text: Kill the advanced analytics feature. It was on the Q2 roadmap; it is no longer.
+    topic: advanced-analytics
+    authority: high
+  - text: Keep team billing as the primary Q2 engineering investment
+    topic: team-billing
+    authority: high
+  - text: Ship a scoped reporting-exports fix in Q2. Date-ranged CSV export, no dashboard, no visualizations.
+    topic: reporting-exports
+    authority: high
+action_items:
+  - assignee: sam
+    task: Remove advanced analytics mockups from the product roadmap page
+    due: 2026-04-18
+    status: open
+  - assignee: alex
+    task: Ship scoped reporting-exports (date-ranged CSV) by 2026-05-02
+    due: 2026-05-02
+    status: open
+speaker_map:
+  - speaker_label: SPEAKER_0
+    name: mat
+    confidence: high
+    source: manual
+  - speaker_label: SPEAKER_1
+    name: alex
+    confidence: high
+    source: manual
+---
+
+## Summary
+
+- Advanced analytics cut from Q2 roadmap.
+- Team billing stays as primary Q2 investment.
+- Reporting exports get a scoped green-light: date-ranged CSV only, two weeks of engineering, ship 2026-05-02.
+
+## Transcript
+
+[SPEAKER_0 0:00] Three things on the table. Advanced analytics, team billing, reporting exports.
+[SPEAKER_1 0:08] Kill analytics. No customer pulling for it.
+[SPEAKER_0 0:34] Killed. Team billing stays, on track for April 15. Reporting exports scoped: date-ranged CSV, no dashboard.
+[SPEAKER_1 1:02] Two weeks if it's literally date filter + CSV.
+[SPEAKER_0 1:14] Scope locked. Ship by May 2.

--- a/crates/cli/src/demo_data.rs
+++ b/crates/cli/src/demo_data.rs
@@ -7,26 +7,31 @@ use std::time::Duration;
 
 const DEMO_TAG: &str = "minutes-demo-seed";
 const SNOWCRASH_TAG: &str = "snow-crash";
+// These demo fixtures live in `crates/cli/fixtures/demo/` (a copy of the shared
+// set under `crates/mcp/fixtures/demo/`). They MUST stay inside the cli crate:
+// `include_str!` of a path outside the crate root (the old `../../mcp/...`) makes
+// `cargo publish` fail to package them (#280-era publish revival). If the demo
+// content changes, update both copies.
 const MCP_DEMO_FIXTURES: &[(&str, &str)] = &[
     (
         "2026-02-28-pricing-strategy.md",
-        include_str!("../../mcp/fixtures/demo/2026-02-28-pricing-strategy.md"),
+        include_str!("../fixtures/demo/2026-02-28-pricing-strategy.md"),
     ),
     (
         "2026-03-04-northwind-call.md",
-        include_str!("../../mcp/fixtures/demo/2026-03-04-northwind-call.md"),
+        include_str!("../fixtures/demo/2026-03-04-northwind-call.md"),
     ),
     (
         "2026-03-11-eng-standup.md",
-        include_str!("../../mcp/fixtures/demo/2026-03-11-eng-standup.md"),
+        include_str!("../fixtures/demo/2026-03-11-eng-standup.md"),
     ),
     (
         "2026-03-25-pricing-reversal.md",
-        include_str!("../../mcp/fixtures/demo/2026-03-25-pricing-reversal.md"),
+        include_str!("../fixtures/demo/2026-03-25-pricing-reversal.md"),
     ),
     (
         "2026-04-17-prioritization.md",
-        include_str!("../../mcp/fixtures/demo/2026-04-17-prioritization.md"),
+        include_str!("../fixtures/demo/2026-04-17-prioritization.md"),
     ),
 ];
 


### PR DESCRIPTION
## What
Unblocks `minutes-cli` crates.io publishing. During the 0.18.6 release, `cargo publish -p minutes-cli` failed its verify step:

```
error: couldn't read `src/../../mcp/fixtures/demo/2026-02-28-pricing-strategy.md`: No such file or directory
```

`crates/cli/src/demo_data.rs` embedded 5 demo meetings via `include_str!("../../mcp/fixtures/demo/*.md")`, which are files in the *mcp* crate. `cargo publish` only packages files inside the crate, so the packaged tarball could not reach them. (minutes-core published fine; only cli hit this.)

## Fix
Copy the 5 fixtures into `crates/cli/fixtures/demo/` and point `include_str!` at the in-crate copies. `cargo publish --dry-run -p minutes-cli` now packages (17 files) and verifies cleanly.

mcp keeps its own copy (it reads them at runtime); the two must stay in sync if demo content changes (noted in demo_data.rs).

## Why now
`cargo install minutes-cli` currently installs the stale 0.9.4 (the last publishable cli). This lets cli publish at 0.18.6 so the crates.io revival is complete for both the library (minutes-core, already up) and the CLI.

No version change; no behavior change (same demo content, relocated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
