### PR TITLE
docs(audio): desktop app uses native call capture (no BlackHole); fix [capture] typo (#239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ minutes record --template standup                 # Apply a summary template
 minutes stop                                      # Stop from another terminal
 ```
 
-**Recording calls (Zoom, Meet, Teams, Webex):** macOS does not let apps capture system audio directly, so the default mic-only recording only picks up your own voice. To capture the other side of the call too, install BlackHole and route the call through a Multi-Output Device. Full setup in [`docs/audio-devices.md`](docs/audio-devices.md).
+**Recording calls (Zoom, Meet, Teams, Webex):** the desktop app captures both your mic and the call's audio natively (ScreenCaptureKit, macOS 15+, no extra software). Grant Screen Recording + Microphone permission and start from the "Call detected" banner; Google Meet and Teams-in-browser need their experimental detection toggles enabled. The CLI (`minutes record`) cannot use native capture, so for command-line call recording you route system audio through BlackHole and a Multi-Output Device. Full setup in [`docs/audio-devices.md`](docs/audio-devices.md).
 
 ### Take notes during meetings
 ```bash

--- a/docs/audio-devices.md
+++ b/docs/audio-devices.md
@@ -8,12 +8,23 @@ Minutes captures audio from whatever input device is set as the system default (
 |----------|-------------|--------------|
 | In-person meeting | Built-in Microphone | None |
 | External USB mic (Blue Yeti, Rode, etc.) | Your mic name | Plug in, select in System Settings > Sound > Input |
-| Zoom / Meet / Teams call | BlackHole 2ch | Install BlackHole + Multi-Output Device (see below) |
+| Zoom / Teams / Meet call (desktop app) | Native call capture | None. Grant Screen Recording + Microphone permission, record from the "Call detected" banner (see below) |
+| Zoom / Meet / Teams call (CLI or manual) | BlackHole 2ch | Install BlackHole + Multi-Output Device (see below) |
 | iPhone voice memo | N/A (file-based) | Configure folder watcher |
 
 ## Capturing system audio (Zoom, Meet, Teams)
 
-macOS doesn't let apps record system audio directly. You need BlackHole, a free virtual audio device.
+**Desktop app (recommended, macOS 15+): you do not need BlackHole.** The desktop app records both your microphone and the call's audio natively using ScreenCaptureKit, with no virtual audio device. To use it:
+
+1. Grant Minutes **Screen Recording** and **Microphone** permission in System Settings > Privacy & Security.
+2. Join your call. Minutes detects Zoom, Microsoft Teams (desktop), and Webex by default and shows a **"Call detected"** banner. Click **Record** on that banner to start native call capture (it writes separate mic and system stems and mixes them).
+3. **Google Meet and Teams-in-browser** are opt-in: enable the experimental Google Meet / Teams-web detection toggles in Settings. Browser detection may also prompt for Automation permission.
+
+Note: a plain recording started without the call banner captures your microphone only. Use the banner's **Record** button (call intent) for both sides of the call.
+
+**CLI or manual fallback (any macOS): BlackHole.** The command-line `minutes record` cannot use native call capture, so to record system audio there you route it through BlackHole, a free virtual audio device. The same applies if you prefer manual routing over the desktop app.
+
+### 1. Install BlackHole
 
 ### 1. Install BlackHole
 
@@ -39,7 +50,7 @@ Either set BlackHole as the system default input in System Settings > Sound > In
 
 ```toml
 # ~/.config/minutes/config.toml
-[capture]
+[recording]
 device = "BlackHole 2ch"
 ```
 


### PR DESCRIPTION
## What
Two documentation bugs surfaced in #239 (user followed the docs, got an empty/garbled recording):

1. **`[capture]` config typo.** `docs/audio-devices.md` told users to write `[capture]\ndevice = "..."`, but there is no `[capture]` config section. The real key is `[recording].device` (multi-source under `[recording.sources]`). The user wrote what the docs said and Minutes silently ignored it.

2. **"You need BlackHole" is misleading for desktop-app users.** The README and audio-devices.md both stated "macOS does not let apps capture system audio directly" and routed all call users through BlackHole + a Multi-Output Device. That is the CLI-only story. The **desktop app captures both mic and system audio natively via ScreenCaptureKit** (no virtual device, macOS 15+). The reporter was on the desktop app and got sent down the BlackHole rabbit hole unnecessarily.

## Fix
- Corrected the `[capture]` to `[recording]` typo.
- Reframed call-capture docs to lead with native call capture for the desktop app: grant Screen Recording + Microphone permission, record from the "Call detected" banner. Google Meet and Teams-in-browser are opt-in experimental detectors. BlackHole is now presented as the CLI / manual fallback.
- Same correction in the README call-recording line.

Verified against `call_capture.rs`, `system_audio_record.swift`, `call_detect.rs`, and `config.rs` (defaults: Zoom / Microsoft Teams / Webex detected; Meet + Teams-web opt-in; `auto_call_intent` false).

Refs #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
