### PR TITLE
fix(summarize): use Stdio::null() for agents that use --file args (pi, opencode)

### DIFF
--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -1083,9 +1083,17 @@ fn summarize_with_agent_impl_timeout(
     let invocation = prepare_agent_invocation(&agent_cmd, &prompt)?;
     let cleanup_path = invocation.cleanup_path.clone();
 
+    // AIDEV-NOTE: Use Stdio::null() when no stdin payload is needed (e.g. pi, opencode
+    // which use --file args). Keeping a piped stdin open without writing/closing it causes
+    // agents that read stdin to block indefinitely waiting for EOF.
+    let stdin_stdio = if invocation.stdin_payload.is_some() {
+        std::process::Stdio::piped()
+    } else {
+        std::process::Stdio::null()
+    };
     let mut child = std::process::Command::new(&invocation.cmd)
         .args(&invocation.args)
-        .stdin(std::process::Stdio::piped())
+        .stdin(stdin_stdio)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()


### PR DESCRIPTION
## Problem

Agents like `pi` and `opencode` use a prompt file (`--file` / `@file`) rather than reading from stdin. The summarization pipeline opened a piped stdin unconditionally and never wrote to or closed it, causing those agents to block indefinitely waiting for EOF — manifesting as a consistent 300s timeout on every summarization attempt.

## Root cause

In `summarize_with_agent_impl_timeout` (`crates/core/src/summarize.rs`), `Stdio::piped()` was used regardless of whether a `stdin_payload` existed. For `pi` and `opencode`, `stdin_payload` is `None` (they use `--file` args), so the child process sat waiting for input that never came.

## Fix

Use `Stdio::null()` when `stdin_payload` is `None`, so file-based agents receive a closed stdin immediately and proceed normally. Agents that do use stdin (`claude -p -`, `codex`, etc.) are unaffected.

## Testing

Verified with `pi` as `agent_command`: summarization completes in ~19s on a 21-minute meeting transcript instead of timing out at 300s.