### PR TITLE
fix(summarize): extend #288 stdin fix to title refinement and speaker mapping

### DIFF
--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -1931,9 +1931,17 @@ fn run_title_refinement_via_agent(
 
     let invocation = prepare_agent_invocation(agent_cmd, prompt)?;
     let cleanup_path = invocation.cleanup_path.clone();
+    // Same fix as summarize_with_agent_impl_timeout (#288): file-arg agents
+    // (pi, opencode) have no stdin payload, and an unclosed piped stdin makes
+    // them block until the timeout. Null stdin closes it immediately.
+    let stdin_stdio = if invocation.stdin_payload.is_some() {
+        std::process::Stdio::piped()
+    } else {
+        std::process::Stdio::null()
+    };
     let mut child = std::process::Command::new(&invocation.cmd)
         .args(&invocation.args)
-        .stdin(std::process::Stdio::piped())
+        .stdin(stdin_stdio)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -2243,9 +2251,17 @@ fn run_speaker_mapping_via_agent(
     let agent_cmd = resolve_agent_path(&agent_cmd);
     let invocation = prepare_agent_invocation(&agent_cmd, prompt)?;
     let cleanup_path = invocation.cleanup_path.clone();
+    // Same fix as summarize_with_agent_impl_timeout (#288): file-arg agents
+    // (pi, opencode) have no stdin payload, and an unclosed piped stdin makes
+    // them block until the timeout. Null stdin closes it immediately.
+    let stdin_stdio = if invocation.stdin_payload.is_some() {
+        std::process::Stdio::piped()
+    } else {
+        std::process::Stdio::null()
+    };
     let mut child = std::process::Command::new(&invocation.cmd)
         .args(&invocation.args)
-        .stdin(std::process::Stdio::piped())
+        .stdin(stdin_stdio)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -3026,5 +3042,64 @@ EOF
         assert_eq!(summary.decisions, vec!["decision ok"]);
         assert_eq!(summary.action_items, vec!["@mat: verify fix"]);
         assert_eq!(summary.participants, vec!["Mat"]);
+    }
+
+    /// Write a fake `pi` binary (a file-arg agent: `stdin_payload` is None)
+    /// that reads stdin to EOF before answering. With a null stdin it gets
+    /// EOF immediately; with the pre-#288 unclosed pipe it blocks until the
+    /// 120s internal timeout, so a regression shows up as a slow test failure.
+    #[cfg(unix)]
+    fn write_stdin_draining_pi(dir: &Path, reply: &str) -> std::path::PathBuf {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let script_path = dir.join("pi");
+        fs::write(
+            &script_path,
+            format!("#!/bin/sh\ncat >/dev/null\nprintf '%s' \"{}\"\n", reply),
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+        script_path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn title_refinement_with_file_arg_agent_does_not_block_on_stdin() {
+        let dir = tempfile::tempdir().unwrap();
+        let script_path = write_stdin_draining_pi(dir.path(), "refined title");
+
+        let start = std::time::Instant::now();
+        let result =
+            run_title_refinement_via_agent("refine this title", &script_path.display().to_string())
+                .expect("file-arg agent should not block on an unclosed stdin pipe");
+
+        assert_eq!(result, "refined title");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(30),
+            "stdin pipe regression: file-arg agent blocked waiting for EOF"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn speaker_mapping_with_file_arg_agent_does_not_block_on_stdin() {
+        let dir = tempfile::tempdir().unwrap();
+        let script_path = write_stdin_draining_pi(dir.path(), "SPEAKER_0: Mat");
+
+        let mut config = Config::default();
+        config.summarization.agent_command = script_path.display().to_string();
+
+        let start = std::time::Instant::now();
+        let result = run_speaker_mapping_via_agent("map these speakers", &config)
+            .expect("file-arg agent should not block on an unclosed stdin pipe");
+
+        assert_eq!(result, "SPEAKER_0: Mat");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(30),
+            "stdin pipe regression: file-arg agent blocked waiting for EOF"
+        );
     }
 }

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1131;
+export const MINUTES_TEST_COUNT = 1133;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Extends gtheys' fix from #288 to the two sibling agent-spawn sites with the identical unconditional piped-stdin pattern: `run_title_refinement_via_agent` and `run_speaker_mapping_via_agent`. With pi/opencode configured, both would hit the same stdin-EOF deadlock (120s timeouts).

Adds Unix regression tests using a fake stdin-draining `pi` agent. The tests were verified to hang against the pre-fix code (reintroduced the bug locally; test blocked until killed) and complete in ~0.2s with the fix.

Credit to @gtheys for the root-cause diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)