### PR TITLE
docs(plans): consent layer v1 spec trio + Phase 2 plan

### DIFF
--- a/docs/plans/consent-layer-addendum-2026-06-04.md
+++ b/docs/plans/consent-layer-addendum-2026-06-04.md
@@ -1,0 +1,141 @@
+# Build Spec Addendum — Consent in Tauri Settings + fix broken --no-default-features
+
+Author: Claude (handed to Codex). Builds on docs/plans/consent-layer-spec-2026-06-04.md
+(already implemented). Repo: ~/Sites/minutes (work here).
+
+Same hard constraints as the base spec apply, especially: **copy discipline** (no
+"legal/compliant/lawful/no consent required" claims anywhere, including UI strings;
+frame as "disclosure aid, not legal advice"), 100% doc comments on new pub items, fmt +
+clippy clean.
+
+## Part 1 — Surface consent in the Tauri Settings panel (config parity)
+
+The desktop app shares `Config` with the CLI but does not yet expose the new `[consent]`
+section. Add it, mirroring exactly how `privacy.hide_from_screen_share` and the
+`transcription` selects are wired today.
+
+### 1a. Backend setter — `tauri/src-tauri/src/commands.rs`, `cmd_set_setting` (~line 8207)
+
+`cmd_set_setting` is match-gated on `(section, key)`. Add a `// Consent` block with three arms:
+
+```rust
+("consent", "mode") => {
+    let mode = match value.as_str() {
+        "off" => ConsentMode::Off,
+        "remind" => ConsentMode::Remind,
+        "require" => ConsentMode::Require,
+        other => return Err(format!("unknown consent mode '{}'. Valid: off, remind, require", other)),
+    };
+    config.consent.mode = mode;
+}
+("consent", "disclosure_script") => config.consent.disclosure_script = value.clone(),
+("consent", "default_basis") => {
+    config.consent.default_basis = parse_optional_string_setting(&value);
+}
+```
+(Import `ConsentMode` if not already in scope. `parse_optional_string_setting` already exists.)
+
+### 1b. Backend getter — `cmd_get_settings` (~line 7927)
+
+Add a `consent` object to the returned JSON, alongside the existing `privacy` block:
+```json
+"consent": {
+  "mode": <"off"|"remind"|"require">,
+  "disclosure_script": <string>,
+  "default_basis": <string|null>
+}
+```
+Serialize `ConsentMode` to its lowercase string. Match the construction style already
+used in that function.
+
+### 1c. Frontend — `tauri/src/index.html` Settings overlay
+
+In the **privacy `settings-section`** (the one containing `#settings-screen-share`,
+markup ~line 5336), add a consent control group. A `<select>` for mode + a text field
+for the disclosure script, matching the existing `.settings-field` / toggle styling:
+
+```html
+<!-- Recording consent (disclosure aid; not legal advice) -->
+<label class="settings-field-label" for="settings-consent-mode">Recording consent reminder</label>
+<select id="settings-consent-mode" class="settings-field">
+  <option value="off">Off</option>
+  <option value="remind">Remind me (default)</option>
+  <option value="require">Require acknowledgment</option>
+</select>
+<p class="settings-hint">Shows a local-transcription disclosure before recording a
+meeting. A disclosure aid, not legal advice — obtain all-party consent where required.</p>
+<label class="settings-field-label" for="settings-consent-disclosure">Disclosure script</label>
+<input type="text" id="settings-consent-disclosure" class="settings-field" spellcheck="false">
+```
+(Use whatever the existing label/hint classes are in that section — match siblings, do
+not invent new CSS unless a class is missing.)
+
+**Load** (in the settings-load fn, next to `setSettingsToggle('settings-screen-share', …)` ~line 8628):
+```js
+const consentMode = s.consent?.mode || 'remind';
+const sel = document.getElementById('settings-consent-mode');
+if (sel) sel.value = consentMode;
+const disc = document.getElementById('settings-consent-disclosure');
+if (disc) disc.value = s.consent?.disclosure_script || '';
+```
+
+**Onchange handlers** (next to the other `cmd_set_setting` select handlers ~line 9148):
+```js
+document.getElementById('settings-consent-mode')?.addEventListener('change', async (e) => {
+  try { await invoke('cmd_set_setting', { section: 'consent', key: 'mode', value: e.target.value }); }
+  catch (err) { console.error('consent mode:', err); }
+});
+document.getElementById('settings-consent-disclosure')?.addEventListener('change', async (e) => {
+  try { await invoke('cmd_set_setting', { section: 'consent', key: 'disclosure_script', value: e.target.value }); }
+  catch (err) { console.error('consent disclosure:', err); }
+});
+```
+
+### 1d. Make the setting non-misleading in the app record flow (non-blocking only)
+
+The desktop record-start path (the `cmd_start_recording`-family commands ~line 4906 and
+their frontend caller) must surface the SAME non-blocking disclosure the CLI shows in
+`Remind`/`Require` mode, so the setting is not a no-op in the app:
+- When a **meeting** recording starts and `config.consent.mode` is `remind` or `require`,
+  emit the local-transcribe indicator + the disclosure script to the user via the app's
+  EXISTING notification/toast/log surface (find how the app already surfaces transient
+  record-start messages — reuse it; do NOT add a new modal/overlay).
+- **Do NOT build a blocking confirmation modal.** In the app, `require` behaves like
+  `remind` for now. Add a `// TODO(phase 2): blocking require confirmation modal` note.
+- Only for meeting captures (not memos/quick-thought), same gating as the CLI.
+
+If wiring 1d cleanly requires a new modal/overlay, STOP and leave a TODO instead — the
+settings UI (1a–1c) is the must-have; 1d is best-effort non-blocking only.
+
+## Part 2 — Fix the broken `cargo test -p minutes-core --no-default-features`
+
+The auto-discovered example `crates/core/examples/dogfood_vad_engines.rs` uses
+`minutes_core::live_transcript`, which is gated `#[cfg(all(feature="streaming", feature="whisper"))]`.
+There are no `[[example]]` declarations in `crates/core/Cargo.toml`, so it compiles under
+all feature sets and breaks `--no-default-features`.
+
+Add to `crates/core/Cargo.toml`:
+```toml
+[[example]]
+name = "dogfood_vad_engines"
+required-features = ["streaming", "whisper"]
+```
+Check whether `build_parity_fixtures.rs` (the other example referencing streaming) also
+needs gating; if it references gated modules, give it the matching `required-features`.
+After this, `cargo test -p minutes-core --no-default-features` must skip the example(s)
+and pass cleanly.
+
+## Verification (must all pass; report results)
+
+```
+cargo fmt --all
+cargo clippy --all --no-default-features -- -D warnings
+cargo clippy --all -- -D warnings
+cargo test -p minutes-core --no-default-features      # MUST now pass (was broken)
+cargo build -p minutes-cli
+cargo build -p minutes-app   # confirm the Tauri backend compiles with the new command arms
+```
+- Do NOT commit.
+- UI render verification (dev-app build + click-test of the new settings controls) is a
+  SEPARATE manual step handled outside this task — note that it is still required.
+- Report the diff (files + insertions/deletions) for review.

--- a/docs/plans/consent-layer-fixes-2026-06-04.md
+++ b/docs/plans/consent-layer-fixes-2026-06-04.md
@@ -1,0 +1,78 @@
+# FIX SPEC — consent layer (adversarial-review fixes)
+
+Two independent reviews (Codex + a fresh reviewer) both returned FIX-FIRST and converged
+on these. Implement in ~/Sites/minutes. Do NOT commit. Same constraints as the prior
+specs (no legal-conclusion copy; never block non-interactive callers; back-compat).
+
+## Fix 1 — fabricated consent_notice + Remind skips reminder (flagged by BOTH; high confidence)
+
+File: crates/cli/src/main.rs, `prepare_recording_consent` (~line 192).
+
+Problem: `notice` falls back to `config.consent.disclosure_script`, and the fn early-
+`return`s for `--consent` (~206) and `default_basis` (~215) BEFORE `match config.consent.mode`
+(~223). Effects: (a) `minutes record --consent na` (or any explicit/default basis with no
+`--consent-notice`) stamps `consent_notice = "Heads up — I'm using Minutes…"`, a disclosure
+the user never gave — a false attestation; (b) Remind mode prints no reminder when a basis
+is present.
+
+Fix — remove the early-return-on-basis; resolve, then switch on mode:
+1. `resolved_basis`: parse `--consent` if Some, else parse `config.consent.default_basis`
+   if set, else None. Parse error → return Err (unchanged).
+2. `explicit_notice`: `--consent-notice` trimmed; Some if non-empty else None.
+   **`consent_notice` must ONLY ever be `explicit_notice`. NEVER fall back to
+   `disclosure_script` in any mode** — recording the script as the notice-given fabricates
+   an attestation. (Spec: "the exact disclosure the user gave/used, if any".)
+3. `match config.consent.mode`:
+   - Off → basis = resolved_basis.unwrap_or(Unattested); notice = explicit_notice; no reminder; no warning.
+   - Remind → reminder = Some(disclosure_script) ALWAYS (even if a basis was supplied);
+     basis = resolved_basis.unwrap_or(Unattested); notice = explicit_notice.
+   - Require & !stdin_is_tty → basis = resolved_basis.unwrap_or(Unattested);
+     reminder = Some(disclosure_script); warning = "consent gate skipped: non-interactive
+     session; recording as unattested"; NEVER block.
+   - Require & stdin_is_tty → if resolved_basis is Some, use it (no prompt); else prompt;
+     "yes" → VerbalAllParties; "no" → bail with the existing helpful message.
+     notice = explicit_notice.
+Tests: extend the existing consent unit tests to assert (a) `--consent na` with no
+`--consent-notice` → `consent_notice == None` (NOT the script); (b) Remind + explicit basis
+still produces a reminder.
+
+## Fix 2 — stale consent sidecar leaks to the wrong artifact (treat as MAJOR; cheap)
+
+Files: crates/core/src/pipeline.rs (~2096, `process_with_progress_and_sidecar`);
+tauri/src-tauri/src/commands.rs (~3628 `maybe_save_and_show_recording_consent`, ~5246 finalize).
+
+Problem: `process_with_progress_and_sidecar` unconditionally calls `notes::load_consent()`
+(global ~/.minutes/current-consent.json). That fn also backs manual `minutes process <file>`
+(main.rs:4254). A stale sidecar (crashed/aborted recording, or a concurrent live session)
+gets stamped onto an unrelated processed file — a wrong consent attestation (worse than absent).
+
+Fix — establish the invariant: **consent attaches ONLY to the recording it was captured
+for; any uncertainty → absent/Unattested, never another meeting's consent.**
+- The generic pipeline must NOT read the global consent sidecar. Consent must arrive only
+  via the recording's own context/job. The queue path already carries it by value
+  (pipeline.rs:1592 `context.consent`). Prefer the SMALLEST change: have
+  `process_with_progress_and_sidecar` take consent from the passed context/params and
+  delete the global `notes::load_consent()` at ~2096. `minutes process` passes None.
+- Clear the consent sidecar at record START (before writing the new one) so a crashed
+  prior session can't leave stale data, AND on finalize/cleanup (mirror how the live path
+  already removes the notes/context sidecars).
+- Desktop (Fix 2b): in `maybe_save_and_show_recording_consent`, if `save_consent` fails,
+  do NOT fall through to a stale on-disk read at finalize — clear the sidecar (finalize
+  then reads None = Unattested, safe) or carry consent in memory into the queued job.
+
+## Not fixing (leave as-is)
+- notes.md — pre-existing unrelated dirt; will be excluded from the commit.
+- CLI hard-errors vs Tauri silently-Unattested on an invalid hand-edited `default_basis` —
+  acceptable; Unattested is the safe default.
+
+## Verify (all must pass; report results + diff)
+```
+cargo fmt --all
+cargo clippy --all --no-default-features -- -D warnings
+cargo clippy --all -- -D warnings
+cargo test -p minutes-core --no-default-features
+cargo test -p minutes-cli --no-default-features          # consent tests
+cargo build -p minutes-cli
+cargo build -p minutes-app
+```
+Do NOT commit. Report the diff for a final review.

--- a/docs/plans/consent-layer-phase2-2026-06-10.md
+++ b/docs/plans/consent-layer-phase2-2026-06-10.md
@@ -1,0 +1,113 @@
+# Plan — Consent Layer Phase 2: Sensitive Meetings + Agent-Layer Enforcement
+
+Author: Claude (strategic rescope, 2026-06-10)
+Builds on: `consent-layer-spec-2026-06-04.md` (v1, shipped in #276 at `0322c64`),
+`consent-layer-addendum-2026-06-04.md` (Tauri settings), `consent-layer-fixes-2026-06-04.md`
+(adversarial-review fixes).
+
+## Why now (June 2026 context)
+
+Two curves are moving at different speeds:
+
+- **Adoption**: default-on workplace recording is normalizing (ambient notetakers,
+  meeting bots, wearables). a16z's "Everything is Recorded Now" (Torenberg, June 2026)
+  is the category's bull case, and it names the gap itself: governance gets
+  "retrofitted on top" after the fact.
+- **Governance demand**: lags adoption but is steeper when it kicks. EU AI Act
+  transparency obligations phase in from August 2026; two-party-consent law isn't
+  going anywhere; the first "recorded meeting corpus subpoenaed in discovery" story
+  is a when, not an if. Medical/regulated users (RFC 0001's `medical-fr` family,
+  HDS/RGPD context) already ask for this.
+
+Nearly every product in the category is built for the first curve and will retrofit
+the second. Minutes builds the second curve into the architecture. That is a moat
+timed to a predictable shock, and it is also simply the right way to build it.
+
+## The two objections the bull case can't answer (our wedge)
+
+1. **Discovery/subpoena risk.** The only coherent answers are local-first custody,
+   retention policy, and selective capture. Cloud-processed competitors structurally
+   cannot offer the first; we can offer all three.
+2. **The non-consenting participant.** Everyone in a recorded meeting enters the
+   corpus, consenting or not. Minutes' graph models people as entities, so per-person
+   exclusion/redaction is architecturally possible here in a way it is not elsewhere.
+   (Explicitly v3 / out of scope below — on the map, not in this phase.)
+
+## The core reframe
+
+In an agent-first product, the transcript's primary consumer is not a human reading
+markdown. It is the agent layer: MCP search, the knowledge graph, ingest, skills.
+Therefore consent/sensitivity metadata is not documentation — it is an
+**enforcement contract for agents**. A meeting designated sensitive must be
+invisible-by-default to every agent surface, not just labeled in YAML. This turns
+the consent layer into the policy gate of the audio→agent bridge, which is the
+product's positioning expressed as architecture.
+
+## Scope — two waves
+
+### Wave 1 (target 0.18.8) — the designation
+
+1. **Desktop Require modal.** Close the gap behind the v1 label
+   ("Require confirmation (CLI blocks; app reminds for now)"). A real blocking
+   confirmation before desktop recording starts; Cancel cancels. TODO marker:
+   `tauri/src-tauri/src/commands.rs` (`TODO(phase 2)` in
+   `maybe_save_and_show_recording_consent`). Small, UI render verification via
+   dev app required.
+2. **Sensitive Meeting designation + no-capture mode.** A first-class meeting
+   artifact with NO audio capture:
+   - Designate ahead (calendar match or manual) or at start ("record nothing").
+   - **Quick typed markers** during: timestamped, no recorder running. Markers MUST
+     ride the event bus (RFC #194 event types, append-only discipline) rather than a
+     parallel notes path. This makes sensitive mode the first real consumer of the
+     mid-meeting typed-semantic-events surface identified as empty competitive real
+     estate (April 2026 snapshot) — territory cloud notetakers without webhooks
+     cannot follow into.
+   - **Guided debrief** after: structured human-written summary into standard
+     frontmatter, provenance marked no-capture (e.g. `capture: none`,
+     `sensitivity:` field).
+   - Output is a normal meeting file for the human; sensitivity governs the agent
+     layer (Wave 2).
+
+### Wave 2 (target 0.18.9) — the enforcement
+
+3. **Retention policy.** Per-sensitivity auto-delete: audio after N days, optionally
+   transcript too. Prerequisite: audit current audio retention behavior in code
+   (what is kept where, after which pipeline) before speccing the delta. This is the
+   concrete thing legal/medical users request.
+4. **Agent-layer enforcement.** Sensitivity respected by MCP tools, graph fact
+   extraction, search, and ingest: restricted meetings excluded by default from all
+   agent surfaces, with explicit, logged override. The genuinely novel piece; no
+   competitor has an equivalent because none of them separate the artifact from the
+   agent surface.
+
+## Hard constraints (carry over from v1, plus new)
+
+- **Copy discipline (non-negotiable):** no string anywhere may say "legal",
+  "compliant/compliance", "lawful", or "no consent required". Allowed framing:
+  "audio stays on your device", "disclosure aid, not legal advice",
+  "ensure everyone present consents where required", "provenance you can show".
+- **Never block non-interactive callers.** Headless/hook/automation paths degrade
+  gracefully exactly as v1's `require` does (warn + unattested), including the new
+  modal path.
+- **Agents never mutate human frontmatter** (RFC #194). Markers and debrief
+  annotations are append-only attributed events.
+- **No enterprise land-grab.** Retention + agent-gating are single-user, local-first
+  features valuable to one operator today. Pure-OSS direction (April 2026 decision)
+  stands; this phase is product depth + positioning, not a pivot.
+- 100% doc comments on new pub items; fmt + clippy clean; tests per surface
+  (CLI gate, pipeline stamping, MCP exclusion, Tauri modal via dev-app click-test).
+
+## Explicitly OUT of scope (v3+, do not build)
+
+- Per-person redaction / "right to be forgotten" per attendee (on the map; needs
+  graph-wide redaction design).
+- Org policy distribution, admin consoles, anything multi-tenant.
+- Video/screen capture governance.
+- Telemetry, hosted anything.
+
+## Process
+
+Same pipeline that shipped v1: this plan → detailed build spec per wave → Codex
+implements → two-pass adversarial review (Codex + fresh-Claude) → dev-app click-test
+for any UI → merge. Release notes for 0.18.7 frame v1 as "governance built in, not
+retrofitted"; the Wave 2 release carries the "controls your agents must obey" story.

--- a/docs/plans/consent-layer-spec-2026-06-04.md
+++ b/docs/plans/consent-layer-spec-2026-06-04.md
@@ -1,0 +1,231 @@
+# Build Spec — Consent Layer (Phase 1 of privacy/sensitive-meeting work)
+
+Author: Claude (handed to Codex for implementation)
+Date: 2026-06-04
+Repo: ~/Sites/minutes  (cd here first — do NOT work in ~/.minutes/assistant)
+
+## Why
+
+Minutes records full local transcripts. That is the hero feature and stays the hero.
+But in all-party-consent jurisdictions (e.g. California PC §632), capturing others'
+confidential speech needs consent. Every shipping competitor (Granola, Otter, Gong,
+Circleback) handles this with a lightweight consent affordance — it is table stakes,
+not a product-killer. This phase adds that affordance to Minutes and records the
+consent basis in the meeting artifact.
+
+The compliance *story* leads with data-residency (audio stays on device), NOT with
+any claim that local transcription removes the consent requirement. It does not.
+
+## Scope (do ONLY this)
+
+1. A `[consent]` config section.
+2. A visible recording/transcribing indicator at `minutes record` start.
+3. A consent acknowledgment gate (off / remind / require) that is **non-interactive-safe**.
+4. A reusable disclosure script (config-driven, surfaced to the user).
+5. Two new frontmatter fields: `consent` and `consent_notice`, written through the pipeline.
+6. Tests + docs.
+
+## Explicitly OUT of scope (Phase 2 — do NOT build now)
+
+- The no-capture "Sensitive Meeting" mode (prep panel, quick markers, guided debrief).
+- Any Tauri/desktop UI work beyond what compiles.
+- Telemetry, Stripe, Discord, hosted anything.
+- Video/screen capture.
+
+## Hard constraints (read before coding)
+
+- **Never block non-interactive callers.** `minutes record` is invoked by hooks, the
+  desktop app, and automation. The `require` gate may only block when stdin is a TTY.
+  When stdin is NOT a TTY, downgrade to `remind` behavior, print a warning, and record
+  the basis as `unattested`. Never hang a headless run.
+- **Copy discipline — non-negotiable.** No string in code, help text, or docs may say
+  "no consent required", "legal", "compliant/compliance", or assert that local
+  transcription exempts the user from consent law. Allowed framing only:
+  "audio stays on your device", "Minutes transcribes locally",
+  "ensure everyone present consents where required". Do NOT render legal conclusions.
+- **Back-compat.** Existing meeting files have no `consent` field. New frontmatter
+  fields must be `Option`, `#[serde(default, skip_serializing_if = "Option::is_none")]`,
+  so old files still deserialize and clean runs emit no extra noise.
+- Cross-platform (macOS/Linux/Windows). Gate TTY detection behind `std::io::IsTerminal`.
+- 100% doc comments on new `pub` items (repo rule).
+- Follow the existing `context` plumbing exactly (see §"Data flow").
+
+## Data model
+
+### Config — `crates/core/src/config.rs`
+
+Add, mirroring `PrivacyConfig` (line ~306) and its `Default` impl (line ~355):
+
+```rust
+/// Consent affordance for meeting capture. Minutes records full local
+/// transcripts; in all-party-consent jurisdictions capturing others' speech
+/// requires consent. This config controls the pre-record reminder/gate and the
+/// disclosure script. It is a privacy aid, NOT legal advice and NOT a
+/// determination of legality.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ConsentConfig {
+    /// off | remind | require. Default `remind`.
+    pub mode: ConsentMode,
+    /// One-line script the user can read aloud / paste to disclose recording.
+    pub disclosure_script: String,
+    /// Optional default basis stamped into frontmatter when the user does not
+    /// pass one (e.g. a team with notice baked into every calendar invite).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_basis: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsentMode { Off, Remind, Require }
+```
+
+- `impl Default for ConsentConfig`: mode = `Remind`, default_basis = `None`,
+  disclosure_script = (honest, no legal claim):
+  `"Heads up — I'm using Minutes to transcribe this conversation locally on my device for my own notes. Let me know if you'd prefer I didn't."`
+- `impl Default for ConsentMode { fn default() -> Self { Self::Remind } }`
+- Add `pub consent: ConsentConfig,` to `Config` (struct at line ~18; it is `#[serde(default)]`
+  so no other change needed).
+
+### Frontmatter — `crates/core/src/markdown.rs`
+
+Add to `Frontmatter` (struct at line 145), after `recorded_by` (line 187):
+
+```rust
+    /// How consent to capture was obtained, if attested. Privacy metadata only —
+    /// not a legal determination. See [`crate::config::ConsentConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consent: Option<ConsentBasis>,
+    /// The exact disclosure the user gave/used, if any. Free text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consent_notice: Option<String>,
+```
+
+New enum in markdown.rs:
+
+```rust
+/// Attested basis for capturing a conversation. Privacy metadata, NOT a legal
+/// determination of whether recording was lawful.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsentBasis {
+    VerbalAllParties,   // verbal_all_parties
+    NoticeInInvite,     // notice_in_invite
+    RecordedDisclosed,  // recorded_disclosed
+    NotApplicable,      // na  -> use #[serde(rename = "na")]
+    Unattested,         // unattested
+}
+```
+(Use `#[serde(rename = "na")]` on `NotApplicable`.)
+
+`Frontmatter` has NO `Default` impl and is built via explicit struct literals. You MUST
+add `consent: None, consent_notice: None` to every construction site, or it won't
+compile. Known sites (grep `Frontmatter {` to confirm you got all):
+- `crates/core/src/pid.rs` ~832 and ~884
+- `crates/core/src/daily_notes.rs` ~299
+- `crates/core/src/dictation.rs` ~1125
+- `crates/core/src/pipeline.rs` (the main meeting build site)
+- any test fixtures
+
+## Data flow (mirror `context` exactly)
+
+`minutes record` persists pre-meeting context at start via
+`minutes_core::notes::save_context`, and the pipeline reads it back when building
+`Frontmatter.context` at finalize (a separate `minutes stop` process does the
+processing, so consent MUST be persisted to disk at record start, not held in memory).
+
+Do the same for consent:
+1. Add `notes::save_consent(basis: Option<ConsentBasis>, notice: Option<&str>)` that
+   writes a small sidecar in the recording session dir (mirror `save_context`).
+2. Add `notes::load_consent() -> (Option<ConsentBasis>, Option<String>)`.
+3. In the pipeline, where `context` is loaded into the Frontmatter, also load consent
+   and set `consent` / `consent_notice`. Clear the sidecar on finalize like context.
+
+## CLI — `crates/cli/src/main.rs`
+
+### New args on `Commands::Record` (struct at line 195)
+
+```rust
+/// Attested consent basis for this capture: verbal_all_parties | notice_in_invite |
+/// recorded_disclosed | na. Stamped into the meeting's frontmatter.
+#[arg(long, value_name = "BASIS")]
+consent: Option<String>,
+/// Free-text note describing the disclosure you gave.
+#[arg(long, value_name = "TEXT")]
+consent_notice: Option<String>,
+```
+Thread them into `cmd_record(...)` (signature at line 1957; call site in
+`Commands::Record` handler ~1266).
+
+### Behavior in `cmd_record` (inject around line 2035, before the "Recording meeting..." prints)
+
+Only for capture that records other people — i.e. `CaptureMode::Meeting` (and call/room
+intents). Skip the indicator/gate for `QuickThought` and memo/solo dictation.
+
+1. **Indicator (always, for Meeting):** print to stderr:
+   `🔴 Recording + transcribing locally — audio stays on your device.`
+2. **Resolve basis:** `--consent` flag → else `config.consent.default_basis` → else None.
+   Parse the string to `ConsentBasis`; reject unknown values with a clear error.
+3. **Gate by `config.consent.mode`:**
+   - `Off`: no extra output. basis = resolved (may be None → store `Unattested`).
+   - `Remind` (default): print `eprintln!` with the reminder + the configured
+     `disclosure_script`. Do not block. basis = resolved or `Unattested`.
+   - `Require`:
+     - if a basis was provided via flag/default → proceed with it.
+     - else if `std::io::stdin().is_terminal()` → interactively prompt:
+       `Has everyone present been notified and do they consent? [y/N] `
+       (read line; `y`/`yes` → basis = `VerbalAllParties`; anything else → abort with a
+       non-judgmental message telling them how to proceed: pass `--consent` or set
+       `[consent] mode = "remind"`).
+     - else (NOT a TTY) → print a warning ("consent gate skipped: non-interactive
+       session; recording as unattested"), basis = `Unattested`, DO NOT block.
+4. Call `notes::save_consent(basis, consent_notice.as_deref())`.
+
+Use `use std::io::IsTerminal;`.
+
+## Tests
+
+`crates/core` (`--no-default-features` must pass):
+- `ConsentConfig::default()` → mode == Remind, disclosure_script non-empty,
+  default_basis None.
+- `ConsentMode` and `ConsentBasis` serde round-trip to the exact snake_case strings
+  (`verbal_all_parties`, `notice_in_invite`, `recorded_disclosed`, `na`, `unattested`,
+  and mode `off`/`remind`/`require`).
+- Frontmatter: serialize with `consent: Some(VerbalAllParties)` → YAML contains
+  `consent: verbal_all_parties`; with `None` → key absent.
+- Frontmatter: deserialize a legacy YAML block with NO consent key → `consent: None`
+  (back-compat).
+- `notes::save_consent` then `load_consent` round-trips.
+
+CLI (`crates/cli`):
+- `--consent verbal_all_parties` ends up in the written frontmatter (can assert via the
+  pipeline/notes seam used by existing record tests).
+- `require` mode + non-TTY path does not block and yields `Unattested` + a warning.
+- unknown `--consent xyz` → clean error, non-zero exit.
+
+## Docs
+
+- README: short `[consent]` subsection + the two frontmatter fields. Lead with
+  "audio stays local"; include the explicit disclaimer: "This is a disclosure aid, not
+  legal advice; obtain all-party consent where the law requires it."
+- Document the `[consent]` TOML in whatever config reference the repo keeps
+  (search docs/ for the existing `[transcription]`/`[retention]` reference and match it).
+
+## Verification before you call it done (CLAUDE.md PRE-COMMIT)
+
+```
+command -v cargo && rustup which cargo   # must match (toolchain pin)
+cargo fmt --all
+cargo clippy --all --no-default-features -- -D warnings
+cargo clippy --all -- -D warnings
+cargo test -p minutes-core --no-default-features
+cargo build -p minutes-cli
+```
+- Confirm no feature-stub parity breakage and no Unix-only API used unguarded.
+- No Tauri/dev-app build needed (no UI surface touched). If you find yourself editing
+  `tauri/src/index.html` or adding a `cmd_*`, STOP — that's out of scope for this phase.
+
+## Done = 
+Config section + indicator + non-blocking gate + disclosure script + `consent`/
+`consent_notice` frontmatter written through the pipeline, all tests green, docs updated,
+zero legal-conclusion copy. Report the diff back for review before committing.


### PR DESCRIPTION
Commits the three build docs behind the shipped v1 consent layer (#276) per the docs/plans convention, plus the Phase 2 plan: June 2026 context, the agent-enforcement reframe, two-wave scope, carried constraints, explicit v3+ non-goals.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)