### PR TITLE
site: positioning, proof, governance, demo, and writing overhaul

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -151,8 +151,9 @@ Before deploying, make sure the site matches what just shipped:
    node scripts/sync_site_release_version.mjs
    ```
    The `Site Release Link Consistency` CI job runs this with `--check` on every push, so forgetting this step also blocks CI — but running it locally first saves a round-trip and surfaces drift before tagging.
-2. **Hand-update the prose** — the release banner, headline feature blurb, and pipeline description in `site/app/page.tsx`, plus `docs/frontmatter-schema.md`'s "corresponds to" footer if the schema row moved. The sync script handles numbers; it cannot rewrite copy that references last release's headline features.
-3. **Then deploy**:
+2. **Hand-update the prose** — the changelog strip and headline feature blurb in `site/app/page.tsx`, plus `docs/frontmatter-schema.md`'s "corresponds to" footer if the schema row moved. The sync script handles numbers; it cannot rewrite copy that references last release's headline features.
+3. **Refresh social proof + comparison freshness** — update `site/lib/proof.ts` (stars/forks/contributors from the GitHub API, npm monthly downloads from `api.npmjs.org`) and spot-check the homepage comparison table cells plus `/compare/*` pages against competitors' current public docs. Competitor capabilities drift; stale cells cost more credibility than they buy.
+4. **Then deploy**:
    ```bash
    npx vercel@50.38.2 build --prod
    npx vercel@50.38.2 deploy --prebuilt --yes --prod --scope evil-genius-laboratory

--- a/site/app/compare/hyprnote-vs-minutes/page.tsx
+++ b/site/app/compare/hyprnote-vs-minutes/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next";
+import { ComparePage } from "@/components/compare-page";
+
+export const metadata: Metadata = {
+  title: "Minutes vs Hyprnote",
+  description:
+    "A fit-based comparison of Minutes and Hyprnote (Anarlog) for local-first meeting notes, agent workflows, consent provenance, and inspectable markdown output.",
+  alternates: {
+    canonical: "/compare/hyprnote-vs-minutes",
+  },
+};
+
+const comparisonRows = [
+  {
+    label: "Best for",
+    competitor: "A local-first AI notepad for people who take notes during meetings",
+    minutes: "Local conversation infrastructure for agent workflows and inspectable output",
+  },
+  {
+    label: "Open source",
+    competitor: "Yes, MIT",
+    minutes: "Yes, MIT",
+  },
+  {
+    label: "Local-first processing",
+    competitor: "Core part of the product",
+    minutes: "Core part of the product",
+  },
+  {
+    label: "Product shape",
+    competitor: "Notepad app: you write, it listens and enhances your notes",
+    minutes: "Memory layer: recordings become structured markdown your agents query",
+  },
+  {
+    label: "Agent surface",
+    competitor: "Desktop app first",
+    minutes: "Files, 31 MCP tools, CLI, SDK, live transcript reads, Claude Code plugin",
+  },
+  {
+    label: "Consent provenance",
+    competitor: "Not a stated focus",
+    minutes: "Consent basis stamped into every recording's frontmatter",
+  },
+  {
+    label: "Voice memos and dictation",
+    competitor: "Meeting-centered",
+    minutes: "iPhone voice memo pipeline, dictation hotkey, daily notes",
+  },
+  {
+    label: "Cross-meeting memory",
+    competitor: "Notes organized per meeting",
+    minutes: "People, decisions, and commitments tracked across the whole corpus",
+  },
+] as const;
+
+const sources = [
+  { label: "Hyprnote / Anarlog repository", href: "https://github.com/fastrepl/anarlog" },
+  { label: "Minutes for agents", href: "https://useminutes.app/for-agents" },
+  { label: "Minutes MCP reference", href: "https://useminutes.app/docs/mcp/tools" },
+] as const;
+
+export default function HyprnoteVsMinutesPage() {
+  return (
+    <ComparePage
+      competitorName="Hyprnote"
+      competitorLabel="Hyprnote (Anarlog)"
+      markdownHref="/compare/hyprnote-vs-minutes.md"
+      heroSummary="Hyprnote and Minutes are friendly neighbors: both are open source, local-first, and serious about privacy. The honest difference is the job. Hyprnote is a notepad you write in during meetings, with AI that enhances what you wrote. Minutes is a memory layer: it turns everything you record into structured markdown that Claude, Codex, and any MCP client can query later, with consent provenance in every file."
+      quickVerdictCompetitor="you want a polished local notepad for taking and enhancing your own meeting notes, and the app itself is where you want to live."
+      quickVerdictMinutes="you want a durable, agent-readable corpus: files on your disk, MCP tools, a CLI, and consent and provenance metadata your tools can rely on."
+      comparisonRows={comparisonRows as any}
+      competitorWins={[
+        "Hyprnote's in-meeting note-taking experience is the product. If you think while writing, its enhance-my-notes flow is the better fit.",
+        "It has a larger community today and a tight focus on the notepad job.",
+        "If you only ever need meeting notes (not voice memos, dictation, or an agent surface), it is the simpler tool.",
+      ]}
+      minutesWins={[
+        "Minutes is built for what happens after the meeting: a corpus of markdown with YAML frontmatter that agents query across months of conversations.",
+        "The agent surface is broader: MCP server, CLI, SDK, live transcript reads for mid-meeting coaching, and a Claude Code plugin.",
+        "Governance lives in the data: consent basis is stamped into every recording, with sensitive no-capture meetings and agent-enforced sensitivity on the roadmap.",
+      ]}
+      workflowSection={[
+        "Both projects process audio locally, so the privacy floor is similar. The fork in the road is the output contract. Hyprnote's durable artifact is your enhanced notes. Minutes' durable artifact is a structured, diarized transcript plus extracted decisions, action items, and people, written as plain files that outlive any one app.",
+        "If your assistant should answer 'what did we decide about pricing in April', the question is whether the record it reads was designed for that. Minutes' files, MCP tools, and knowledge graph are built for exactly that query.",
+      ]}
+      chooseSection={[
+        "Pick Hyprnote if the notepad is the product you want: you write, it listens, your notes get better.",
+        "Pick Minutes if the corpus is the product you want: everything recorded becomes agent-readable memory with provenance.",
+        "Running both is coherent: they solve adjacent jobs, and neither locks your data away.",
+      ]}
+      notRightFitSection={[
+        "Minutes is not the right first choice if you mainly want to write notes during meetings and have AI clean them up. That is Hyprnote's home turf.",
+        "It is also more tool than you need if you have no interest in MCP, CLIs, or giving your AI assistants a memory of your conversations.",
+      ]}
+      evaluatedSection={[
+        "This page is based on public repository and product information, reviewed on 2026-06-10. It is a fit-based comparison between two open-source projects, not a teardown; we genuinely like that Hyprnote exists.",
+        "The Minutes side is grounded in the public agent-facing docs surface and generated MCP reference, not hand-maintained marketing copy.",
+      ]}
+      sources={sources as any}
+    />
+  );
+}

--- a/site/app/compare/page.tsx
+++ b/site/app/compare/page.tsx
@@ -29,6 +29,12 @@ const pages = [
     blurb:
       "Best if you want the honest tradeoff between a hosted meeting assistant with integrations and a local-first memory layer for agents.",
   },
+  {
+    title: "Minutes vs Hyprnote",
+    href: "/compare/hyprnote-vs-minutes",
+    blurb:
+      "Best if you are choosing between two open-source local-first tools: a notepad you write in versus a memory layer your agents query.",
+  },
 ] as const;
 
 export default function CompareHubPage() {

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,10 +1,15 @@
 import { CopyButton } from "@/components/copy-button";
+import { DemoPlayer } from "@/components/demo-player";
 import { APPLE_SILICON_DOWNLOAD_PATH } from "@/lib/downloads";
 import {
-  MINUTES_CLI_COMMAND_COUNT,
+  GITHUB_CONTRIBUTORS,
+  GITHUB_FORKS,
+  GITHUB_STARS,
+  NPM_MONTHLY_DOWNLOADS,
+} from "@/lib/proof";
+import {
   MINUTES_MCP_TOOL_COUNT,
   MINUTES_RELEASE_VERSION,
-  MINUTES_TEST_COUNT,
   WINDOWS_SETUP_EXE,
 } from "@/lib/release";
 
@@ -113,18 +118,20 @@ const capabilityColumns = [
   },
 ] as const;
 
+// Competitor cells reflect public docs as of June 2026. Refresh quarterly.
 const comparisons = [
-  ["Local transcription", "No", "No", "Yes", "Yes"],
-  ["Open source", "No", "No", "Yes", "MIT"],
-  ["Free", "$18/mo", "Freemium", "Free", "Free"],
-  ["Agent surface", "Hosted MCP/API", "Hosted integrations", "Local app", `Files + ${MINUTES_MCP_TOOL_COUNT} MCP tools`],
-  ["Cross-meeting intelligence", "No", "No", "No", "Yes"],
+  ["Local transcription", "No (cloud)", "No (cloud)", "Yes", "Yes"],
+  ["Open source", "No", "No", "MIT", "MIT"],
+  ["Free", "Freemium", "Freemium", "Free", "Free"],
+  ["Agent surface", "Hosted MCP", "Hosted integrations", "Local app", `Files + ${MINUTES_MCP_TOOL_COUNT} MCP tools`],
+  ["Cross-meeting intelligence", "Cloud chat", "Cloud chat", "No", "Local graph"],
+  ["Consent provenance", "No", "No", "No", "In every file"],
   ["Dictation mode", "No", "No", "No", "Yes"],
   ["Voice memos", "No", "No", "No", "iPhone pipeline"],
   ["People memory", "No", "No", "No", "Yes"],
   ["Data ownership", "Their servers", "Their servers", "Local", "Local"],
-  ["Data format", "Cloud DB", "Cloud DB", "Markdown", "Markdown + YAML"],
-  ["Agent-agnostic", "No", "No", "No", "Yes"],
+  ["Data format", "Cloud DB", "Cloud DB", "Local files", "Markdown + YAML"],
+  ["Agent-agnostic", "No", "No", "Partially", "Yes"],
 ] as const;
 
 function SectionLabel({ n, label }: { n: string; label: string }) {
@@ -235,6 +242,9 @@ export default function Home() {
           <a href="/proof" className="hover:text-[var(--accent)]">
             Proof
           </a>
+          <a href="/writing" className="hover:text-[var(--accent)]">
+            Writing
+          </a>
           <a href="/for-agents" className="hover:text-[var(--accent)]">
             For agents
           </a>
@@ -246,21 +256,23 @@ export default function Home() {
 
       <section className="pb-16 pt-16 text-center sm:pb-20 sm:pt-24">
         <p className="mb-5 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-          Open-source. MCP-native.
-        </p>
-        <p className="mx-auto mb-5 max-w-[720px] font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-          v{MINUTES_RELEASE_VERSION} • {MINUTES_MCP_TOOL_COUNT} MCP tools •{" "}
-          {MINUTES_CLI_COMMAND_COUNT} CLI commands • {MINUTES_TEST_COUNT}+ tests
+          Open source · Local first · MIT
         </p>
         <h1 className="mx-auto max-w-[720px] font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
-          Every meeting, memo, and voice note,
+          The conversation memory
           <br />
-          <span className="italic text-[var(--accent)]">structured and searchable.</span>
+          <span className="italic text-[var(--accent)]">your agents can actually read.</span>
         </h1>
-        <p className="mx-auto mt-5 max-w-[600px] text-[16px] leading-7 text-[var(--text-secondary)] sm:text-[17px]">
+        <p className="mx-auto mt-5 max-w-[620px] text-[16px] leading-7 text-[var(--text-secondary)] sm:text-[17px]">
           Cloud meeting tools rent your own conversations back to you. Minutes
-          captures meetings and voice memos locally, writes them as structured
-          markdown to your disk, and lets you and every AI you use read the same folder.
+          records meetings, voice memos, and dictation locally, writes structured
+          markdown to your own disk, and gives every AI you use (Claude, Codex,
+          Gemini, anything MCP) the same folder of truth.
+        </p>
+        <p className="mx-auto mt-5 max-w-[720px] font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+          {GITHUB_STARS} GitHub stars • {GITHUB_FORKS} forks •{" "}
+          {GITHUB_CONTRIBUTORS} contributors • {NPM_MONTHLY_DOWNLOADS} npm
+          installs/mo
         </p>
 
         <div className="mt-8 flex flex-wrap justify-center gap-3">
@@ -303,14 +315,9 @@ export default function Home() {
           Local, open source, free forever.
         </p>
 
-        <p className="mx-auto mt-4 max-w-[620px] text-[14px] leading-6 text-[var(--text-secondary)]">
-          v{MINUTES_RELEASE_VERSION} adds a recording consent layer: every
-          recording stamps its consent basis into the file, an optional
-          disclosure reminder shows before each meeting, and Require mode blocks
-          CLI recording until confirmed. A disclosure aid, not legal advice.
-          Also keeps live transcripts from going silent mid-meeting and fixes
-          summarization hangs for pi and opencode users.
-        </p>
+        <div className="mt-12">
+          <DemoPlayer />
+        </div>
 
         <div className="mt-12">
           <TranscriptCard />
@@ -322,9 +329,27 @@ export default function Home() {
           readable even before an assistant touches them.
         </p>
 
+        <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
+          <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
+          adds a recording consent layer and fixes live-transcript reliability.{" "}
+          <a
+            href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
+            className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+          >
+            Release notes
+          </a>
+          {" · "}
+          <a
+            href="https://github.com/silverstein/minutes/releases.atom"
+            className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+          >
+            Feed
+          </a>
+        </p>
+
         <div
           id="install"
-          className="mt-14 flex flex-wrap justify-center gap-3"
+          className="mt-12 flex flex-wrap justify-center gap-3"
         >
           <a
             href={APPLE_SILICON_DOWNLOAD_PATH}
@@ -386,6 +411,17 @@ export default function Home() {
             cmd="brew tap silverstein/tap && brew install minutes"
           />
           <CopyButton label="MCP server" cmd="npx minutes-mcp" />
+        </div>
+
+        <div className="mt-8 rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 text-[13px] leading-6 text-[var(--text-secondary)] sm:hidden">
+          Reading on your phone? Minutes installs on Mac and Windows.{" "}
+          <a
+            href="https://github.com/silverstein/minutes"
+            className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2"
+          >
+            Star the repo
+          </a>{" "}
+          so it is waiting when you are back at your desk.
         </div>
 
         <div className="mt-10 border-t border-[color:var(--border)] pt-8">
@@ -545,7 +581,7 @@ export default function Home() {
                   Otter.ai
                 </th>
                 <th className="p-3 text-left font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
-                  Meetily
+                  Hyprnote
                 </th>
                 <th className="p-3 text-left font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--accent)]">
                   minutes
@@ -581,6 +617,70 @@ export default function Home() {
             </tbody>
           </table>
         </div>
+      </section>
+
+      <section className="border-t border-[color:var(--border)] py-16">
+        <SectionLabel n="06" label="Governance" />
+        <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
+          Built in, not retrofitted.
+        </h2>
+        <p className="mt-5 max-w-[660px] text-[15px] leading-7 text-[var(--text-secondary)]">
+          Default-on recording is coming to work, and most tools plan to bolt
+          the controls on afterward. Minutes takes the other path: governance
+          lives in the record itself, because the record&apos;s primary reader
+          is now an agent.
+        </p>
+        <div className="mt-8 grid gap-4 md:grid-cols-3">
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5 shadow-[var(--shadow-panel)]">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              Shipped
+            </p>
+            <p className="mt-3 text-[14px] leading-6 text-[var(--text-secondary)]">
+              Every recording stamps its consent basis into the file&apos;s
+              frontmatter. An optional disclosure reminder shows before each
+              meeting, and Require mode blocks CLI recording until consent is
+              confirmed.
+            </p>
+          </div>
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5 shadow-[var(--shadow-panel)]">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              Next
+            </p>
+            <p className="mt-3 text-[14px] leading-6 text-[var(--text-secondary)]">
+              Sensitive meetings that never touch the recorder but still produce
+              structured notes, and retention rules the corpus enforces on its
+              own audio.
+            </p>
+          </div>
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5 shadow-[var(--shadow-panel)]">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              The point
+            </p>
+            <p className="mt-3 text-[14px] leading-6 text-[var(--text-secondary)]">
+              Sensitivity metadata your agents are required to respect: a
+              restricted meeting never appears in search, graph queries, or
+              anything an agent assembles.
+            </p>
+          </div>
+        </div>
+        <p className="mt-6 text-[13px] leading-6 text-[var(--text-secondary)]">
+          A disclosure aid, not legal advice; make sure everyone present has
+          agreed where required. The design is public:{" "}
+          <a
+            href="/writing/governance-built-in-not-retrofitted"
+            className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+          >
+            why we built it this way
+          </a>
+          {" and the "}
+          <a
+            href="https://github.com/silverstein/minutes/blob/main/docs/plans/consent-layer-phase2-2026-06-10.md"
+            className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+          >
+            phase 2 plan
+          </a>
+          .
+        </p>
       </section>
 
       <footer className="border-t border-[color:var(--border)] py-14 text-center text-[13px] text-[var(--text-secondary)]">

--- a/site/app/writing/governance-built-in-not-retrofitted/page.tsx
+++ b/site/app/writing/governance-built-in-not-retrofitted/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Governance built in, not retrofitted — minutes",
+  description:
+    "Default-on recording at work is coming. The controls cannot be bolted on afterward, because the record's primary reader is now an agent.",
+  alternates: {
+    canonical: "/writing/governance-built-in-not-retrofitted",
+  },
+};
+
+export default function Post() {
+  return (
+    <div className="mx-auto max-w-[680px] px-6 pb-16 sm:px-8">
+      <nav className="flex items-center justify-between border-b border-[color:var(--border)] py-4">
+        <a
+          href="/"
+          className="font-mono text-[15px] font-medium text-[var(--text)]"
+        >
+          minutes
+        </a>
+        <div className="flex gap-x-6 text-sm text-[var(--text-secondary)]">
+          <a href="/writing" className="hover:text-[var(--accent)]">
+            Writing
+          </a>
+          <a
+            href="https://github.com/silverstein/minutes"
+            className="hover:text-[var(--accent)]"
+          >
+            GitHub
+          </a>
+        </div>
+      </nav>
+
+      <article className="pt-14">
+        <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+          2026-06-10 · Mat Silverstein
+        </p>
+        <h1 className="font-serif text-[36px] leading-[1.05] tracking-[-0.04em] text-[var(--text)] sm:text-[42px]">
+          Governance built in, not retrofitted
+        </h1>
+
+        <div className="mt-8 space-y-5 text-[16px] leading-[1.75] text-[var(--text-secondary)]">
+          <p>
+            Every meeting I&apos;ve taken since March sits in plain markdown on
+            my laptop.
+          </p>
+          <p>
+            I built a small open source tool called Minutes to do it: local
+            transcription, speaker labels, action items, nothing leaves the
+            machine. Three months of dogfooding taught me something I
+            didn&apos;t expect. I almost never reread a transcript. The value
+            shows up later, when an agent answers &quot;what did we decide
+            about pricing in April&quot; from files it can actually read.
+          </p>
+          <p>
+            That experience is why one line in a16z&apos;s piece{" "}
+            <a
+              href="https://www.a16z.news/p/everything-is-recorded-now"
+              className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+            >
+              &quot;Everything Is Recorded Now&quot;
+            </a>{" "}
+            stuck with me. David Haber argues default-on recording is
+            inevitable and that a new system of record will form around voice.
+            He&apos;s right, and the piece is worth reading. But he also
+            concedes the governance controls will get &quot;retrofitted on
+            top&quot; after adoption wins.
+          </p>
+          <p>
+            Retrofitting worked when the reader of a record was a person. It
+            breaks when the reader is an agent, because an agent will happily
+            surface the one conversation you never should have captured, in a
+            context you never imagined, years later. Whoever holds the corpus
+            sets the rules, and if the corpus lives on someone else&apos;s
+            servers, the rules were never yours to set.
+          </p>
+          <p>
+            So we&apos;re building the controls into the record itself. Every
+            Minutes recording now carries its consent basis in the file&apos;s
+            frontmatter. Next: meetings you designate sensitive produce
+            structured notes with no audio captured at all, plus a sensitivity
+            field the agent layer is required to respect. A restricted meeting
+            simply never appears in search results, graph queries, or anything
+            an agent assembles.
+          </p>
+          <p>
+            Recording everything is coming either way. I&apos;d rather own my
+            record, and have my agents respect boundaries I set, before the
+            default flips.
+          </p>
+          <p>
+            Minutes is MIT licensed. If you&apos;re building in this space, the{" "}
+            <a
+              href="https://github.com/silverstein/minutes/blob/main/docs/plans/consent-layer-spec-2026-06-04.md"
+              className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+            >
+              consent spec
+            </a>{" "}
+            and the{" "}
+            <a
+              href="https://github.com/silverstein/minutes/blob/main/docs/plans/consent-layer-phase2-2026-06-10.md"
+              className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+            >
+              phase 2 plan
+            </a>{" "}
+            are in the repo. Point Claude or Codex at it and spin up your own
+            version.
+          </p>
+        </div>
+
+        <p className="mt-10 border-t border-[color:var(--border)] pt-6 text-[13px] leading-6 text-[var(--text-secondary)]">
+          The consent layer is a disclosure aid, not legal advice; make sure
+          everyone present has agreed where required.
+        </p>
+      </article>
+    </div>
+  );
+}

--- a/site/app/writing/page.tsx
+++ b/site/app/writing/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Writing — minutes",
+  description:
+    "Essays from building Minutes: local-first conversation memory, agent-readable records, and governance that lives in the data.",
+  alternates: {
+    canonical: "/writing",
+  },
+};
+
+const posts = [
+  {
+    slug: "governance-built-in-not-retrofitted",
+    date: "2026-06-10",
+    title: "Governance built in, not retrofitted",
+    summary:
+      "a16z says everything at work will be recorded and the controls will get bolted on afterward. The retrofit assumption breaks the moment the record's reader is an agent.",
+  },
+] as const;
+
+export default function WritingIndex() {
+  return (
+    <div className="mx-auto max-w-[720px] px-6 pb-16 sm:px-8">
+      <nav className="flex items-center justify-between border-b border-[color:var(--border)] py-4">
+        <a
+          href="/"
+          className="font-mono text-[15px] font-medium text-[var(--text)]"
+        >
+          minutes
+        </a>
+        <div className="flex gap-x-6 text-sm text-[var(--text-secondary)]">
+          <a
+            href="https://github.com/silverstein/minutes"
+            className="hover:text-[var(--accent)]"
+          >
+            GitHub
+          </a>
+          <a href="/" className="hover:text-[var(--accent)]">
+            Home
+          </a>
+        </div>
+      </nav>
+
+      <header className="pb-10 pt-14">
+        <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Writing
+        </p>
+        <h1 className="font-serif text-[36px] leading-tight tracking-[-0.04em] text-[var(--text)]">
+          Notes from building Minutes
+        </h1>
+        <p className="mt-4 max-w-[560px] text-[15px] leading-7 text-[var(--text-secondary)]">
+          Essays on local-first conversation memory, agent-readable records,
+          and where the recorded workplace is heading.
+        </p>
+      </header>
+
+      <div className="space-y-6 border-t border-[color:var(--border)] pt-10">
+        {posts.map((post) => (
+          <a
+            key={post.slug}
+            href={`/writing/${post.slug}`}
+            className="block rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)] transition hover:border-[color:var(--border-mid)] hover:bg-[var(--bg-hover)]"
+          >
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+              {post.date}
+            </p>
+            <h2 className="mt-2 font-serif text-[24px] leading-7 text-[var(--text)]">
+              {post.title}
+            </h2>
+            <p className="mt-3 text-[14px] leading-6 text-[var(--text-secondary)]">
+              {post.summary}
+            </p>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -1,0 +1,9 @@
+// Social-proof constants. Hand-refreshed at release time (see docs/RELEASE.md
+// step 12) from the GitHub and npm APIs. Coarse on purpose: better slightly
+// stale and honest than a flaky build-time fetch.
+// Last refreshed: 2026-06-10.
+
+export const GITHUB_STARS = "1,265";
+export const GITHUB_FORKS = "132";
+export const GITHUB_CONTRIBUTORS = "19";
+export const NPM_MONTHLY_DOWNLOADS = "2,271";

--- a/site/public/compare.md
+++ b/site/public/compare.md
@@ -7,6 +7,7 @@ These are buying guides, not teardown posts. The point is simple: some people sh
 - [Minutes vs Granola AI](/compare/granola-vs-minutes)
 - [Minutes vs Otter AI](/compare/otter-vs-minutes)
 - [Minutes vs Fireflies.ai](/compare/fireflies-vs-minutes)
+- [Minutes vs Hyprnote](/compare/hyprnote-vs-minutes)
 
 ## Notes
 

--- a/site/public/compare/hyprnote-vs-minutes.md
+++ b/site/public/compare/hyprnote-vs-minutes.md
@@ -1,0 +1,31 @@
+# Minutes vs Hyprnote (Anarlog)
+
+Last reviewed: 2026-06-10
+
+## Quick verdict
+
+- Choose **Hyprnote** if you want a polished local notepad for taking and enhancing your own meeting notes, and the app itself is where you want to live.
+- Choose **Minutes** if you want a durable, agent-readable corpus: files on your disk, MCP tools, a CLI, and consent and provenance metadata your tools can rely on.
+
+## Where Hyprnote wins
+
+- The in-meeting note-taking experience is the product: you write, it listens and enhances
+- Larger community today with a tight focus on the notepad job
+- Simpler if you only need meeting notes (no voice memos, dictation, or agent surface)
+
+## Where Minutes wins
+
+- Built for what happens after the meeting: structured markdown with YAML frontmatter that agents query across months of conversations
+- Broader agent surface: MCP server, CLI, SDK, live transcript reads, Claude Code plugin
+- Governance lives in the data: consent basis stamped into every recording, with sensitive no-capture meetings and agent-enforced sensitivity on the roadmap
+
+## When Minutes is not the right fit
+
+- When you mainly want to write notes during meetings and have AI clean them up
+- When MCP, CLIs, and agent memory are not part of your workflow
+
+## Notes
+
+Both projects are open source (MIT) and process audio locally, so the privacy floor is similar. The fork in the road is the output contract: Hyprnote's durable artifact is your enhanced notes; Minutes' durable artifact is a diarized transcript plus extracted decisions, action items, and people, written as plain files that outlive any one app. Running both is coherent.
+
+Full comparison: https://useminutes.app/compare/hyprnote-vs-minutes


### PR DESCRIPTION
Implements all four phases of the June 2026 site review (scored ~6.6/10; this addresses every gap found):

**Phase 1 (accuracy + proof):** comparison table fact-fixes (Granola/Otter cloud chat, freemium), Meetily swapped for Hyprnote, new consent-provenance row, proof band with verified numbers (1,265 stars / 132 forks / 19 contributors / 2,271 npm installs-mo).

**Phase 2 (positioning):** new hero H1 claiming the agent-readable lane, Governance section (built in, not retrofitted), changelog strip replaces the hero release blurb.

**Phase 3 (conversion):** orphaned Remotion DemoPlayer mounted on homepage, mobile star-the-repo path, releases atom feed link.

**Phase 4 (compounding):** /writing section seeded with the governance essay (David Haber attribution verified against the byline), /compare/hyprnote-vs-minutes + md mirror, RELEASE.md freshness ritual.

Build green locally (20/20 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)