### PR TITLE
chore(settings): remove dead domain config; refresh orphan ledger (drift sweep)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -317,8 +317,11 @@ pub struct DesktopContextConfig {
     pub capture_browser_context: bool,
     pub allowed_apps: Vec<String>,
     pub denied_apps: Vec<String>,
-    pub allowed_domains: Vec<String>,
-    pub denied_domains: Vec<String>,
+    // Domain allow/deny lists were removed in the #295-era drift sweep: the
+    // fields were parsed and settable but enforced nowhere (browser capture
+    // is window-title-only in v1; URLs and domains are never collected).
+    // Reintroduce together with actual enforcement if browser-context
+    // capture ever graduates.
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -439,8 +442,6 @@ impl Default for DesktopContextConfig {
             capture_browser_context: false,
             allowed_apps: vec![],
             denied_apps: vec![],
-            allowed_domains: vec![],
-            denied_domains: vec![],
         }
     }
 }

--- a/crates/core/src/desktop_context.rs
+++ b/crates/core/src/desktop_context.rs
@@ -921,8 +921,6 @@ mod tests {
             capture_browser_context: false,
             allowed_apps: vec!["arc".into()],
             denied_apps: vec!["1password".into()],
-            allowed_domains: vec![],
-            denied_domains: vec![],
         };
 
         assert!(app_allowed(

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -308,8 +308,6 @@ This section is intentionally narrow:
 | `capture_browser_context` | `false` | Opt in to browser-page title context (URL/domain enrichment remains deferred) |
 | `allowed_apps` | `[]` | Optional allowlist of app or bundle-id fragments |
 | `denied_apps` | `[]` | Optional denylist of app or bundle-id fragments |
-| `allowed_domains` | `[]` | Reserved for future browser URL/domain enrichment policy |
-| `denied_domains` | `[]` | Reserved for future browser URL/domain enrichment policy |
 
 This section is the policy layer for meeting-adjacent desktop context:
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -8478,12 +8478,6 @@ pub fn cmd_set_setting(section: String, key: String, value: String) -> Result<St
         ("desktop_context", "denied_apps") => {
             config.desktop_context.denied_apps = parse_comma_separated_setting(&value);
         }
-        ("desktop_context", "allowed_domains") => {
-            config.desktop_context.allowed_domains = parse_comma_separated_setting(&value);
-        }
-        ("desktop_context", "denied_domains") => {
-            config.desktop_context.denied_domains = parse_comma_separated_setting(&value);
-        }
 
         // Assistant
         ("assistant", "agent") => config.assistant.agent = value.clone(),
@@ -9112,12 +9106,9 @@ mod tests {
         // screen_context.keep_after_summary controls post-summary screenshot
         // retention. Low-traffic; TOML-only is fine.
         ("screen_context", "keep_after_summary"),
-        // Desktop-context domain policy is intentionally deferred until the
-        // browser capture path graduates beyond window-title-only context.
-        ("desktop_context", "allowed_domains"),
-        ("desktop_context", "denied_domains"),
-        // Parakeet sidecar is beta / opt-in. No UI until the sidecar path is
-        // out of beta.
+        // Parakeet sidecar auto-resolves from engine + binary presence since
+        // #295; the arm accepts auto/on/off for power users but the resolved
+        // state (not a toggle) is what Settings displays.
         ("transcription", "parakeet_sidecar_enabled"),
     ];
 


### PR DESCRIPTION
Companion to #295's drift-class audit.

- `desktop_context.allowed_domains` / `denied_domains` removed entirely: parsed, settable, documented, **enforced nowhere** (browser capture is window-title-only in v1; URLs/domains never collected). Per the INTENTIONAL_ORPHANS policy, an arm whose field has no executor is removed, not deferred.
- `parakeet_sidecar_enabled` orphan comment refreshed for #295 auto semantics.
- Audit resolution: dictation trio + `keep_after_summary` confirmed as documented intentional orphans (managed drift, no change); setup capability claims honest post-#295.

Guard test passes the removals. 768 core + 204 app tests green, fmt+clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)