### PR TITLE
fix(mcp): parseVersion captures semver prerelease + build metadata

### DIFF
--- a/crates/mcp/src/version.test.ts
+++ b/crates/mcp/src/version.test.ts
@@ -77,3 +77,45 @@ describe("isCliCompatible", () => {
     expect(result.severity).toBe("info");
   });
 });
+
+describe("parseVersion semver suffixes (#185)", () => {
+  it("captures prerelease", () => {
+    expect(parseVersion("0.14.0-rc1")).toEqual({
+      major: 0, minor: 14, patch: 0, prerelease: "rc1",
+    });
+    expect(parseVersion("0.14.0-rc.2")).toEqual({
+      major: 0, minor: 14, patch: 0, prerelease: "rc.2",
+    });
+  });
+
+  it("captures build metadata", () => {
+    expect(parseVersion("0.14.0+git.abc123")).toEqual({
+      major: 0, minor: 14, patch: 0, build: "git.abc123",
+    });
+  });
+
+  it("captures both prerelease and build", () => {
+    expect(parseVersion("0.14.0-rc1+build.3")).toEqual({
+      major: 0, minor: 14, patch: 0, prerelease: "rc1", build: "build.3",
+    });
+  });
+
+  it("still parses prefixed forms", () => {
+    expect(parseVersion("minutes 0.14.0")).toEqual({ major: 0, minor: 14, patch: 0 });
+    expect(parseVersion("v0.14.0")).toEqual({ major: 0, minor: 14, patch: 0 });
+  });
+});
+
+describe("isCliCompatible prerelease honesty (#185)", () => {
+  it("prerelease vs GA on the same triple is info, not 'up to date'", () => {
+    const result = isCliCompatible("0.14.0-rc1", "0.14.0");
+    expect(result.ok).toBe(true);
+    expect(result.severity).toBe("info");
+    expect(result.message).toContain("prerelease");
+  });
+
+  it("GA vs GA on the same triple stays ok", () => {
+    const result = isCliCompatible("0.14.0", "0.14.0");
+    expect(result.severity).toBe("ok");
+  });
+});

--- a/crates/mcp/src/version.ts
+++ b/crates/mcp/src/version.ts
@@ -13,6 +13,11 @@ export type VersionParts = {
   major: number;
   minor: number;
   patch: number;
+  /** Semver prerelease component ("rc1", "beta.2"), if present (#185). */
+  prerelease?: string;
+  /** Semver build metadata ("git.abc123"), if present. Never affects
+   *  compatibility per semver, surfaced for honest logging only (#185). */
+  build?: string;
 };
 
 export type CompatibilitySeverity = "ok" | "info" | "error";
@@ -24,14 +29,24 @@ export type CompatibilityResult = {
 };
 
 export function parseVersion(raw: string): VersionParts | null {
-  const match = raw.trim().match(/(\d+)\.(\d+)\.(\d+)/);
+  // Core triple plus optional semver prerelease (-rc1, -beta.2) and build
+  // metadata (+git.abc123). Pre-#185 this matched only the triple, so
+  // "0.14.0-rc1" silently passed as GA 0.14.0.
+  const match = raw
+    .trim()
+    .match(
+      /(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?/
+    );
   if (!match) return null;
-  const [, major, minor, patch] = match;
-  return {
+  const [, major, minor, patch, prerelease, build] = match;
+  const parts: VersionParts = {
     major: Number.parseInt(major, 10),
     minor: Number.parseInt(minor, 10),
     patch: Number.parseInt(patch, 10),
   };
+  if (prerelease) parts.prerelease = prerelease;
+  if (build) parts.build = build;
+  return parts;
 }
 
 const UPGRADE_ADVICE =
@@ -78,6 +93,17 @@ export function isCliCompatible(
     cli.minor === server.minor &&
     cli.patch === server.patch
   ) {
+    // A prerelease is NOT the GA release (#185): still compatible within
+    // the major, but say what it actually is instead of "up to date".
+    if (cli.prerelease || server.prerelease) {
+      return {
+        ok: true,
+        severity: "info",
+        message:
+          `CLI v${cliVersion} and MCP server v${serverVersion} share ` +
+          `${cli.major}.${cli.minor}.${cli.patch} but differ in prerelease; proceeding`,
+      };
+    }
     return {
       ok: true,
       severity: "ok",

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 52;
-export const MINUTES_TEST_COUNT = 1164;
+export const MINUTES_TEST_COUNT = 1170;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Closes #185. Prerelease/build suffixes no longer collapse into GA; same-triple prerelease mismatches log honestly as info instead of 'up to date'. 17 vitest green (6 new), MCP build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)