### PR TITLE
feat(app): sensitive-meeting detail card, Run debrief handoff, in-window Cmd+K

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1296,6 +1296,13 @@ pub struct MeetingDetail {
     pub adjacent_artifacts: Vec<RecentArtifactView>,
     pub sections: Vec<MeetingSection>,
     pub speaker_map: Vec<SpeakerAttributionView>,
+    /// Capture policy from frontmatter ("none" for sensitive no-capture
+    /// meetings); absent for normal captured meetings.
+    pub capture: Option<String>,
+    /// Sensitivity designation from frontmatter ("restricted"), if any.
+    pub sensitivity: Option<String>,
+    /// Debrief status from frontmatter ("pending"), if any.
+    pub debrief: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -6068,6 +6075,35 @@ pub fn cmd_sensitive_stop(
 /// Toggle (or force-set) the Minutes-local mic mute for the active
 /// dual-source recording. Returns the new muted state. System audio
 /// keeps capturing; only the mic stream is silenced.
+/// Hand an existing meeting to the assistant with a debrief prompt.
+///
+/// Used by the detail view's "Run debrief" action on no-capture sensitive
+/// meetings whose frontmatter says `debrief: pending` (bead minutes-3yub.5);
+/// mirrors the handoff `cmd_sensitive_stop` performs at stop time.
+#[tauri::command]
+pub fn cmd_run_meeting_debrief(
+    app: tauri::AppHandle,
+    state: tauri::State<AppState>,
+    path: String,
+) -> Result<(), String> {
+    let config = Config::load();
+    let meeting_path = std::path::PathBuf::from(&path);
+    minutes_core::notes::validate_meeting_path(&meeting_path, &config.output_dir)?;
+    spawn_terminal(&app, &state.pty_manager, "meeting", Some(&path), None)?;
+    if let Ok(mut manager) = state.pty_manager.lock() {
+        if let Some(command) = manager.session_command(crate::pty::ASSISTANT_SESSION_ID) {
+            let debrief_prompt = "Run /minutes-debrief for CURRENT_MEETING.md.";
+            let input = if is_shell_command(&command) {
+                format!("cat <<'__MINUTES__'\n{debrief_prompt}\n__MINUTES__\n")
+            } else {
+                format!("{debrief_prompt}\n")
+            };
+            let _ = manager.write_input(crate::pty::ASSISTANT_SESSION_ID, input.as_bytes());
+        }
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn cmd_toggle_mic_mute(force_state: Option<bool>) -> bool {
     match force_state {
@@ -7387,6 +7423,10 @@ pub fn cmd_get_meeting_detail(path: String) -> Result<MeetingDetail, String> {
 
     let related = build_related_context(&config, &meeting_path, &frontmatter);
 
+    let capture_is_none = matches!(
+        frontmatter.capture,
+        Some(minutes_core::markdown::CapturePolicy::None)
+    );
     Ok(MeetingDetail {
         path,
         title: frontmatter.title,
@@ -7403,9 +7443,34 @@ pub fn cmd_get_meeting_detail(path: String) -> Result<MeetingDetail, String> {
         related_topics: related.related_topics,
         related_meetings: related.related_meetings,
         related_commitments: related.related_commitments,
-        adjacent_artifacts: related.adjacent_artifacts,
+        // Adjacent prep/brief artifacts are navigation noise on a no-capture
+        // sensitive meeting; the card is about its own markers and debrief.
+        adjacent_artifacts: if capture_is_none {
+            Vec::new()
+        } else {
+            related.adjacent_artifacts
+        },
         sections: parse_sections(body),
         speaker_map,
+        capture: frontmatter.capture.map(|c| {
+            match c {
+                minutes_core::markdown::CapturePolicy::None => "none",
+            }
+            .to_string()
+        }),
+        sensitivity: frontmatter.sensitivity.map(|s| {
+            match s {
+                minutes_core::markdown::Sensitivity::Normal => "normal",
+                minutes_core::markdown::Sensitivity::Restricted => "restricted",
+            }
+            .to_string()
+        }),
+        debrief: frontmatter.debrief.map(|d| {
+            match d {
+                minutes_core::markdown::DebriefStatus::Pending => "pending",
+            }
+            .to_string()
+        }),
     })
 }
 
@@ -13937,6 +14002,15 @@ pub fn handle_palette_shortcut_event(
 /// still live and a reopen race could attach to a window that is
 /// about to disappear. `destroy()` skips the close-request event and
 /// removes the window immediately.
+/// In-window accelerator: plain Cmd+K opens the palette when the main
+/// Minutes window already has focus (bead minutes-s5fb). The GLOBAL
+/// binding stays Cmd+Shift+K; a global plain Cmd+K would shadow the
+/// palette key of half the apps on the machine.
+#[tauri::command]
+pub fn cmd_toggle_palette(app: tauri::AppHandle) {
+    toggle_palette_window(&app);
+}
+
 pub fn toggle_palette_window(app: &tauri::AppHandle) {
     let state = app.state::<AppState>();
 

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -2358,6 +2358,8 @@ fn main() {
             commands::cmd_add_note,
             commands::cmd_sensitive_start,
             commands::cmd_sensitive_stop,
+            commands::cmd_run_meeting_debrief,
+            commands::cmd_toggle_palette,
             commands::cmd_start_recording,
             commands::cmd_stop_recording,
             commands::cmd_cancel_call_end_countdown,

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -8195,13 +8195,67 @@
         detailScroll.appendChild(artifactsCard);
       }
 
-      if (!detail.sections || detail.sections.length === 0) {
-        const empty = document.createElement('div');
-        empty.className = 'detail-empty';
-        empty.textContent = 'No transcript content available for this recording.';
-        detailScroll.appendChild(empty);
+      if (detail.capture === 'none') {
+        // No-capture sensitive meeting: replace the raw "Audio was not
+        // captured" transcript line with a purposeful status card, including
+        // the debrief affordance the frontmatter promises (minutes-3yub.5).
+        const sensitiveCard = document.createElement('div');
+        sensitiveCard.className = 'detail-context';
+        const sensitiveLabel = document.createElement('div');
+        sensitiveLabel.className = 'detail-context-label';
+        sensitiveLabel.textContent = 'Sensitive Meeting';
+        const sensitiveBody = document.createElement('div');
+        sensitiveBody.className = 'detail-action-list';
+        const statusRow = document.createElement('div');
+        statusRow.className = 'detail-action-item';
+        const statusText = document.createElement('span');
+        statusText.className = 'detail-action-text';
+        statusText.textContent = 'No audio was captured, by design. Markers and the debrief are the record.';
+        statusRow.appendChild(statusText);
+        sensitiveBody.appendChild(statusRow);
+        if (detail.debrief === 'pending') {
+          const debriefRow = document.createElement('div');
+          debriefRow.className = 'detail-action-item';
+          const debriefText = document.createElement('span');
+          debriefText.className = 'detail-action-text';
+          debriefText.textContent = 'Debrief pending: capture decisions and action items while they are fresh.';
+          debriefRow.appendChild(debriefText);
+          const debriefBtn = document.createElement('button');
+          debriefBtn.className = 'btn btn-primary btn-sm';
+          debriefBtn.textContent = 'Run debrief';
+          debriefBtn.addEventListener('click', async () => {
+            try {
+              await invoke('cmd_run_meeting_debrief', { path: detail.path });
+            } catch (e) {
+              showDetailFeedback(`Could not start debrief: ${e}`, 'error');
+            }
+          });
+          debriefRow.appendChild(debriefBtn);
+          sensitiveBody.appendChild(debriefRow);
+        }
+        sensitiveCard.appendChild(sensitiveLabel);
+        sensitiveCard.appendChild(sensitiveBody);
+        detailScroll.appendChild(sensitiveCard);
+      }
+
+      const renderableSections = (detail.sections || []).filter((section) => {
+        // The transcript section of a no-capture meeting is a fixed
+        // placeholder line; the sensitive card above carries that message.
+        if (detail.capture === 'none' && /^transcript$/i.test(section.heading || '')) {
+          return false;
+        }
+        return true;
+      });
+
+      if (!renderableSections || renderableSections.length === 0) {
+        if (detail.capture !== 'none') {
+          const empty = document.createElement('div');
+          empty.className = 'detail-empty';
+          empty.textContent = 'No transcript content available for this recording.';
+          detailScroll.appendChild(empty);
+        }
       } else {
-        for (const section of detail.sections) {
+        for (const section of renderableSections) {
           const sectionEl = document.createElement('section');
           sectionEl.className = 'detail-section';
 
@@ -8684,6 +8738,18 @@
 
     // ⌘, keyboard shortcut
     document.addEventListener('keydown', (e) => { if (e.metaKey && e.key === ',') { e.preventDefault(); openSettings(); } });
+    // Plain Cmd+K opens the palette when the Minutes window has focus
+    // (minutes-s5fb). Skip while typing in inputs; the global Cmd+Shift+K
+    // binding is unchanged.
+    document.addEventListener('keydown', (e) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === 'k') {
+        const target = e.target;
+        const tag = target && target.tagName ? target.tagName.toLowerCase() : '';
+        if (tag === 'input' || tag === 'textarea' || (target && target.isContentEditable)) return;
+        e.preventDefault();
+        invoke('cmd_toggle_palette').catch(() => {});
+      }
+    });
 
     async function loadSettings() {
       try {

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -8226,6 +8226,10 @@
           debriefBtn.addEventListener('click', async () => {
             try {
               await invoke('cmd_run_meeting_debrief', { path: detail.path });
+              // The debrief prompt lands in the assistant session BEHIND
+              // this overlay; close it so the handoff is visible instead of
+              // appearing to do nothing (Mat's first-use catch).
+              closeDetailView();
             } catch (e) {
               showDetailFeedback(`Could not start debrief: ${e}`, 'error');
             }


### PR DESCRIPTION
Fast-follow to #306 (beads minutes-3yub.5 + minutes-s5fb).

**Sensitive detail card:** a capture:none meeting now renders a purposeful Sensitive Meeting card (no-audio-by-design message, debrief status, one-click Run debrief that hands the meeting to the assistant with the /minutes-debrief prompt). The placeholder transcript section folds into the card; adjacent prep artifacts are suppressed (navigation noise on a no-capture record). The overlay closes on handoff so the action is visible (caught by Mat on first real use).

**In-window Cmd+K:** plain Cmd+K opens the palette when the main window has focus, skipping text inputs. Global binding stays Cmd+Shift+K.

Render-checked in the dev app against a real `debrief: pending` artifact. 776 core + 205 app tests, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)