### PR TITLE
docs(import): clarify how to populate the Granola export dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ minutes import granola              # Import all meetings to ~/meetings/
 
 Reads from `~/.granola-archivist/output/`. Meetings are converted to Minutes' markdown format with YAML frontmatter. Duplicates are skipped automatically. All your data stays local — no cloud, no $18/mo.
 
+> **Populating the export directory:** `~/.granola-archivist/output/` has to be filled by a separate Granola export tool first. Recent Granola versions encrypt their local cache, which can break exporters that scrape it. If `minutes import granola` finds nothing, use the API-based [granola-to-minutes](https://github.com/calvindotsg/granola-to-minutes) route below instead (it reads Granola's API and writes straight to `~/meetings/`).
+
 ### Want transcripts and AI summaries?
 
 [granola-to-minutes](https://github.com/calvindotsg/granola-to-minutes) exports richer data using [granola-cli](https://github.com/magarcia/granola-cli), a community-built CLI tool (not affiliated with Granola Labs) that accesses Granola's internal API:

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8004,7 +8004,8 @@ fn import_granola(dir: Option<&Path>, dry_run: bool, config: &Config) -> Result<
     if !source_dir.exists() {
         anyhow::bail!(
             "Granola export directory not found: {}\n\
-             Export your Granola meetings first, or specify a directory with --dir",
+             Export your Granola meetings into it first (see \"Switching from Granola?\" in \
+             the README for the granola-cli route), or pass an existing export dir with --dir",
             source_dir.display()
         );
     }


### PR DESCRIPTION
## What

Clarifies the **Switching from Granola?** import flow. Docs and error message only, no behavior change to the importer.

- **README**: adds a note that `~/.granola-archivist/output/` must be populated by a separate Granola export tool first, and that recent Granola versions encrypt their local cache (`cache-v6.json.enc`), which breaks cache-scraping exporters. Points users to the API-based [`granola-to-minutes`](https://github.com/calvindotsg/granola-to-minutes) route already documented just below.
- **Error message**: the "directory not found" error from `minutes import granola` now names the working granola-cli route instead of a vague "export first".

## Why

`import_granola` is fine. It parses exported markdown, not Granola's cache, so it is unaffected by the encryption change. But the README never explained how to produce the export directory, and the common cache-scraping approach silently stopped working when Granola encrypted its cache. Users who hit `Granola export directory not found` had no actionable next step.

## Follow-up

A native Granola-API import path (so import does not depend on a fragile pre-export step) is filed separately: #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
