### PR TITLE
fix(core): resolve ffmpeg outside the GUI PATH

### DIFF
--- a/crates/core/src/autoresearch.rs
+++ b/crates/core/src/autoresearch.rs
@@ -1115,7 +1115,13 @@ fn materialize_eval_audio_path(
         .prefix("minutes-decode-hint-eval-")
         .tempdir()?;
     let output = dir.path().join("clip.wav");
-    let ffmpeg = Command::new("ffmpeg")
+    let ffmpeg_path = crate::ffmpeg::resolve_ffmpeg().map_err(|error| {
+        MinutesError::Io(std::io::Error::other(format!(
+            "{} could not resolve ffmpeg for eval clip: {}",
+            case.id, error
+        )))
+    })?;
+    let ffmpeg = Command::new(&ffmpeg_path)
         .arg("-hide_banner")
         .arg("-loglevel")
         .arg("error")
@@ -1142,7 +1148,12 @@ fn materialize_eval_audio_path(
         )))),
         Err(error) => Err(MinutesError::Io(std::io::Error::new(
             error.kind(),
-            format!("{} could not run ffmpeg for eval clip: {}", case.id, error),
+            format!(
+                "{} could not run ffmpeg for eval clip via {}: {}",
+                case.id,
+                ffmpeg_path.display(),
+                error
+            ),
         ))),
     }
 }

--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -289,8 +289,15 @@ pub fn models_installed(config: &Config) -> bool {
 /// are often 44.1kHz F32, which the symphonia fallback can struggle with.
 fn preprocess_audio(audio_path: &Path) -> (std::path::PathBuf, Option<std::path::PathBuf>) {
     let temp_path = std::env::temp_dir().join("minutes-diarize-preprocessed.wav");
+    let ffmpeg = match crate::ffmpeg::resolve_ffmpeg() {
+        Ok(path) => path,
+        Err(error) => {
+            tracing::debug!(error = %error, "ffmpeg not available for preprocessing, using original audio");
+            return (audio_path.to_path_buf(), None);
+        }
+    };
 
-    match std::process::Command::new("ffmpeg")
+    match std::process::Command::new(&ffmpeg)
         .args([
             "-y",
             "-i",
@@ -308,7 +315,7 @@ fn preprocess_audio(audio_path: &Path) -> (std::path::PathBuf, Option<std::path:
         .status()
     {
         Ok(status) if status.success() => {
-            tracing::info!("audio preprocessed to 16kHz mono via ffmpeg");
+            tracing::info!(ffmpeg = %ffmpeg.display(), "audio preprocessed to 16kHz mono via ffmpeg");
             (temp_path.clone(), Some(temp_path))
         }
         _ => {

--- a/crates/core/src/ffmpeg.rs
+++ b/crates/core/src/ffmpeg.rs
@@ -1,0 +1,188 @@
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+const FFMPEG_ENV_VAR: &str = "MINUTES_FFMPEG";
+
+/// Error returned when Minutes cannot resolve an executable `ffmpeg` binary.
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct ResolveFfmpegError {
+    message: String,
+}
+
+impl ResolveFfmpegError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Resolve the `ffmpeg` executable used by decoding, stem mixing, diarization,
+/// health checks, and evaluation clip extraction.
+///
+/// Dock/Finder-launched macOS apps inherit a minimal launchd `PATH`, so a bare
+/// `Command::new("ffmpeg")` misses Homebrew installs under `/opt/homebrew/bin`.
+/// Resolution order is:
+///
+/// 1. `MINUTES_FFMPEG` explicit override
+/// 2. `PATH` lookup via the `which` crate
+/// 3. common macOS/Linux install locations
+pub fn resolve_ffmpeg() -> Result<PathBuf, ResolveFfmpegError> {
+    resolve_ffmpeg_with_candidates(default_known_ffmpeg_candidates())
+}
+
+fn resolve_ffmpeg_with_candidates(
+    known_candidates: impl IntoIterator<Item = PathBuf>,
+) -> Result<PathBuf, ResolveFfmpegError> {
+    let mut candidates_tried = Vec::new();
+
+    if let Some(configured) = std::env::var_os(FFMPEG_ENV_VAR) {
+        let configured = PathBuf::from(configured);
+        candidates_tried.push(format!("{}={}", FFMPEG_ENV_VAR, configured.display()));
+        if verify_ffmpeg_binary(&configured).is_ok() {
+            return Ok(configured);
+        }
+        return Err(ResolveFfmpegError::new(format!(
+            "{} points to '{}' but it is not an executable file.",
+            FFMPEG_ENV_VAR,
+            configured.display()
+        )));
+    }
+
+    if let Ok(path_binary) = which::which("ffmpeg") {
+        candidates_tried.push(format!("PATH:{}", path_binary.display()));
+        if verify_ffmpeg_binary(&path_binary).is_ok() {
+            return Ok(path_binary);
+        }
+    } else {
+        candidates_tried.push("PATH:ffmpeg".to_string());
+    }
+
+    for candidate in dedupe_paths(known_candidates) {
+        candidates_tried.push(candidate.display().to_string());
+        if verify_ffmpeg_binary(&candidate).is_ok() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(ResolveFfmpegError::new(format!(
+        "No executable ffmpeg binary was found. Tried: {}. Install ffmpeg (macOS: brew install ffmpeg) or set {} to an absolute ffmpeg path.",
+        candidates_tried.join(", "),
+        FFMPEG_ENV_VAR
+    )))
+}
+
+fn default_known_ffmpeg_candidates() -> Vec<PathBuf> {
+    vec![
+        PathBuf::from("/opt/homebrew/bin/ffmpeg"),
+        PathBuf::from("/usr/local/bin/ffmpeg"),
+        PathBuf::from("/usr/bin/ffmpeg"),
+    ]
+}
+
+fn dedupe_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut deduped = Vec::new();
+    for path in paths {
+        if !deduped.iter().any(|existing: &PathBuf| existing == &path) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
+fn verify_ffmpeg_binary(path: &Path) -> Result<(), ()> {
+    if !path.is_file() {
+        return Err(());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path)
+            .map_err(|_| ())?
+            .permissions()
+            .mode();
+        if mode & 0o111 == 0 {
+            return Err(());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{ffi::OsStr, fs};
+
+    fn set_env_var(key: &str, value: impl AsRef<OsStr>) -> Option<std::ffi::OsString> {
+        let old = std::env::var_os(key);
+        std::env::set_var(key, value);
+        old
+    }
+
+    fn restore_env_var(key: &str, previous: Option<std::ffi::OsString>) {
+        if let Some(previous) = previous {
+            std::env::set_var(key, previous);
+        } else {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_fake_ffmpeg(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, "#!/bin/sh\nprintf 'ffmpeg fake\\n'\n").unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(windows)]
+    fn write_fake_ffmpeg(path: &Path) {
+        fs::write(path, "@echo off\r\necho ffmpeg fake\r\n").unwrap();
+    }
+
+    #[test]
+    fn env_override_wins_over_path_and_known_locations() {
+        let _env_lock = crate::test_home_env_lock();
+        let env_dir = tempfile::TempDir::new().unwrap();
+        let path_dir = tempfile::TempDir::new().unwrap();
+        let known_dir = tempfile::TempDir::new().unwrap();
+        let env_binary = env_dir.path().join("ffmpeg-env");
+        let path_binary = path_dir.path().join("ffmpeg");
+        let known_binary = known_dir.path().join("ffmpeg");
+        write_fake_ffmpeg(&env_binary);
+        write_fake_ffmpeg(&path_binary);
+        write_fake_ffmpeg(&known_binary);
+
+        let old_override = set_env_var(FFMPEG_ENV_VAR, env_binary.as_os_str());
+        let old_path = set_env_var("PATH", path_dir.path().as_os_str());
+
+        let resolved = resolve_ffmpeg_with_candidates([known_binary]).unwrap();
+        assert_eq!(resolved, env_binary);
+
+        restore_env_var("PATH", old_path);
+        restore_env_var(FFMPEG_ENV_VAR, old_override);
+    }
+
+    #[test]
+    fn errors_clearly_when_no_candidate_resolves() {
+        let _env_lock = crate::test_home_env_lock();
+        let empty_path = tempfile::TempDir::new().unwrap();
+        let missing_dir = tempfile::TempDir::new().unwrap();
+        let old_override = std::env::var_os(FFMPEG_ENV_VAR);
+        std::env::remove_var(FFMPEG_ENV_VAR);
+        let old_path = set_env_var("PATH", empty_path.path().as_os_str());
+
+        let error = resolve_ffmpeg_with_candidates([missing_dir.path().join("ffmpeg")])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("No executable ffmpeg binary was found"));
+        assert!(error.contains("MINUTES_FFMPEG"));
+
+        restore_env_var("PATH", old_path);
+        restore_env_var(FFMPEG_ENV_VAR, old_override);
+    }
+}

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -238,22 +238,21 @@ pub fn vad_model_status(config: &Config) -> HealthItem {
 
 /// Check if ffmpeg is available for audio decoding.
 pub fn ffmpeg_status() -> HealthItem {
-    let available = std::process::Command::new("ffmpeg")
-        .arg("-version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok();
+    let resolved = crate::ffmpeg::resolve_ffmpeg();
+    let available = resolved.is_ok();
 
     HealthItem {
         label: "ffmpeg".into(),
         state: if available { "ready" } else { "attention" }.into(),
-        detail: if available {
-            "Installed. Used for high-quality audio decoding of m4a/mp3/ogg files.".into()
-        } else {
-            "Not found. Non-English audio in m4a/mp3/ogg format may produce poor transcriptions. \
-             Install: brew install ffmpeg (macOS) / apt install ffmpeg (Linux)"
-                .into()
+        detail: match resolved {
+            Ok(path) => format!(
+                "Installed at {}. Used for high-quality audio decoding of m4a/mp3/ogg files.",
+                path.display()
+            ),
+            Err(error) => format!(
+                "{} Non-English audio in m4a/mp3/ogg format may produce poor transcriptions.",
+                error
+            ),
         },
         optional: true,
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod diarize;
 pub mod dictation_memory;
 pub mod error;
 pub mod events;
+pub mod ffmpeg;
 pub mod graph;
 pub mod health;
 pub mod jobs;

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -751,7 +751,18 @@ fn prepare_transcription_input(
         }
     })?;
 
-    let output = std::process::Command::new("ffmpeg")
+    let ffmpeg = crate::ffmpeg::resolve_ffmpeg().map_err(|error| {
+        let _ = std::fs::remove_file(&tmp);
+        crate::error::TranscribeError::NativeCaptureStemMixUnavailable {
+            reason: format!(
+                "ffmpeg could not be resolved for stem mix of {}: {}",
+                canonical.display(),
+                error
+            ),
+        }
+    })?;
+
+    let output = std::process::Command::new(&ffmpeg)
         .args([
             "-y",
             "-i",
@@ -776,8 +787,9 @@ fn prepare_transcription_input(
             let _ = std::fs::remove_file(&tmp);
             crate::error::TranscribeError::NativeCaptureStemMixUnavailable {
                 reason: format!(
-                    "ffmpeg could not be invoked for stem mix of {}: {}. Install ffmpeg (brew install ffmpeg).",
+                    "ffmpeg could not be invoked for stem mix of {} via {}: {}. Install ffmpeg (brew install ffmpeg) or set MINUTES_FFMPEG.",
                     canonical.display(),
+                    ffmpeg.display(),
                     e
                 ),
             }
@@ -6547,7 +6559,10 @@ mod prepare_transcription_input_tests {
     }
 
     fn ffmpeg_available() -> bool {
-        std::process::Command::new("ffmpeg")
+        let Ok(ffmpeg) = crate::ffmpeg::resolve_ffmpeg() else {
+            return false;
+        };
+        std::process::Command::new(ffmpeg)
             .arg("-version")
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -1041,8 +1041,6 @@ fn load_wav(path: &Path) -> Result<Vec<f32>, TranscribeError> {
 /// Returns an error if ffmpeg is not installed or the conversion fails,
 /// allowing the caller to fall back to symphonia.
 fn decode_with_ffmpeg(path: &Path) -> Result<Vec<f32>, TranscribeError> {
-    use std::process::Command;
-
     let tmp_dir = std::env::temp_dir();
     let tmp_wav = tmp_dir.join(format!("minutes-ffmpeg-{}.wav", std::process::id()));
 
@@ -1057,7 +1055,9 @@ fn decode_with_ffmpeg(path: &Path) -> Result<Vec<f32>, TranscribeError> {
         }
     }
 
-    let output = Command::new("ffmpeg")
+    let ffmpeg = crate::ffmpeg::resolve_ffmpeg()
+        .map_err(|e| TranscribeError::TranscriptionFailed(format!("ffmpeg not available: {e}")))?;
+    let output = std::process::Command::new(&ffmpeg)
         .args([
             "-i",
             path.to_str().unwrap_or(""),
@@ -1075,7 +1075,11 @@ fn decode_with_ffmpeg(path: &Path) -> Result<Vec<f32>, TranscribeError> {
         .stderr(std::process::Stdio::piped())
         .output()
         .map_err(|e| {
-            TranscribeError::TranscriptionFailed(format!("ffmpeg not available: {}", e))
+            TranscribeError::TranscriptionFailed(format!(
+                "ffmpeg not available at {}: {}",
+                ffmpeg.display(),
+                e
+            ))
         })?;
 
     if !output.status.success() {

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1178;
+export const MINUTES_TEST_COUNT = 1180;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Closes #314. Dock/Finder-launched apps inherit a minimal launchd PATH without /opt/homebrew/bin, so all five bare `Command::new("ffmpeg")` call sites (pipeline stem mix, diarization, health, autoresearch, and a decode path in transcribe) silently failed in the desktop app. New shared resolver mirroring the parakeet-binary pattern: `MINUTES_FFMPEG` override first (hard error if set but invalid), then PATH lookup, then /opt/homebrew/bin, /usr/local/bin, /usr/bin. The health check now reports which path resolved. Resolver unit tests cover override precedence and the missing-binary error. 778 core tests green, clippy clean.

Thanks @ridjex for the precise diagnosis.