### PR TITLE
feat: add MLX Audio batch transcription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Streams local transcription to a JSONL file in real time — any AI agent can re
 minutes dictate                                  # Speak → text appears as you talk
 minutes dictate --stdout                         # Output to stdout instead of clipboard
 ```
-Text streams progressively as you speak (partial results every 2 seconds). By default it accumulates across pauses and writes the combined text to clipboard + daily note when dictation ends. Set `[dictation] accumulate = false` to keep the older per-pause behavior. The default backend is local Whisper; on supported macOS builds, `[dictation] backend = "apple-speech"` tries Apple DictationTranscriber for final utterances, and `[dictation] backend = "parakeet"` tries the installed Parakeet backend for final utterances. Both opt-in paths keep Whisper partials and fallback. Linux clipboard output works through `wl-clipboard` on Wayland or `xclip` / `xsel` on X11; desktop auto-paste only attempts X11 paste automation when `xdotool` is available. Local engines, no cloud.
+Text streams progressively as you speak (partial results every 2 seconds). By default it accumulates across pauses and writes the combined text to clipboard + daily note when dictation ends. Set `[dictation] accumulate = false` to keep the older per-pause behavior. The default backend is local Whisper; on supported macOS builds, `[dictation] backend = "apple-speech"` tries Apple DictationTranscriber for final utterances, and `[dictation] backend = "parakeet"` tries the installed Parakeet backend. Opt-in final backends keep Whisper partials and fallback. Linux clipboard output works through `wl-clipboard` on Wayland or `xclip` / `xsel` on X11; desktop auto-paste only attempts X11 paste automation when `xdotool` is available. Local engines, no cloud.
 
 ### Command palette (desktop app)
 Press `⌘⇧K` from anywhere on macOS to open a keyboard-first palette of every Minutes command. Start a recording, drop a note into the active session, jump to the latest meeting, search transcripts, or rename the meeting open in your assistant — all without leaving the keyboard. Backed by a single typed command registry in `minutes-core`, so visibility follows real backend state: stop-recording only appears while you're recording, mid-recording dictation rows are hidden, and the list re-fetches automatically when state changes.
@@ -922,6 +922,13 @@ minutes setup --parakeet                          # Multilingual v3 (tdt-600m, ~
 minutes setup --parakeet --parakeet-model tdt-ctc-110m  # English-only compact model (~220MB)
 # Also installs native Silero VAD weights for the parakeet.cpp --vad path
 
+# Alternative: use MLX Audio (opt-in, Apple Silicon local models)
+minutes setup --mlx-audio
+minutes setup --mlx-audio --mlx-audio-model mlx-community/Qwen3-ASR-1.7B-8bit
+# Desktop post-recording processing reads the same config. Use Settings >
+# Advanced > Open config to review MLX fields; the Settings dropdown may not
+# list MLX until a later UI PR.
+
 # Enroll your voice for automatic speaker identification
 minutes enroll              # Records 10s of your voice
 minutes voices              # View enrolled profiles
@@ -1075,7 +1082,7 @@ Optional — minutes works out of the box.
 # Or: $XDG_CONFIG_HOME/minutes/config.toml when XDG_CONFIG_HOME is set
 
 [transcription]
-engine = "whisper"        # "whisper" (default), "parakeet" (opt-in, lower WER), or "apple-speech" (experimental)
+engine = "whisper"        # "whisper" (default), "parakeet", "mlx-audio", or "apple-speech" (experimental)
 model = "small"           # whisper: tiny (75MB), base, small (466MB), medium, large-v3 (3.1GB)
 # language = "ur"          # Force transcription language (ISO 639-1 code, e.g. "en", "ur", "es", "zh")
                           # Default: auto-detect. Set this for similar-sounding languages (Urdu/Hindi, etc.)
@@ -1088,6 +1095,10 @@ model = "small"           # whisper: tiny (75MB), base, small (466MB), medium, l
 # parakeet_boost_score = 2.0                     # Experimental tuning for parakeet.cpp --boost-score
 # parakeet_fp16 = true                           # Default on macOS Apple Silicon: ~35% faster transcription with lower GPU memory (see docs/designs/parakeet-perf-2026-04-14.md)
 # parakeet_vocab = "tdt-600m.tokenizer.vocab"      # Safer when multiple Parakeet models are installed
+# mlx_audio_model = "mlx-community/Qwen3-ASR-1.7B-8bit"  # MLX Audio model id/path
+# mlx_audio_python = "/Users/you/.minutes/mlx-audio/bin/python"  # Python with mlx-audio installed
+# mlx_audio_warm = true                          # Keep the model loaded between requests
+# mlx_audio_chunk_secs = 30.0                    # Forwarded to timestamp-capable MLX models
 # vad_model = "silero-v6.2.0"     # Silero VAD model (auto-downloaded by setup). Empty = disable.
                                    # Prevents whisper hallucination loops on non-English/noisy audio.
 
@@ -1197,7 +1208,7 @@ const meetings = await listMeetings("~/meetings", 20);
 const results = await searchMeetings("~/meetings", "pricing");
 ```
 
-**Built with:** Rust, [whisper.cpp](https://github.com/ggerganov/whisper.cpp) (transcription), [pyannote-rs](https://github.com/pyannote/pyannote-rs) (speaker diarization), [Silero VAD](https://github.com/snakers4/silero-vad) (voice activity detection), [symphonia](https://github.com/pdeljanov/Symphonia) (audio decoding), [cpal](https://github.com/RustAudio/cpal) (audio capture), [Tauri v2](https://v2.tauri.app/) (desktop app), [ureq](https://github.com/algesten/ureq) (HTTP). Optional: [ffmpeg](https://ffmpeg.org/) (recommended for non-English audio decoding).
+**Built with:** Rust, [whisper.cpp](https://github.com/ggerganov/whisper.cpp) (transcription), [pyannote-rs](https://github.com/pyannote/pyannote-rs) (speaker diarization), [Silero VAD](https://github.com/snakers4/silero-vad) (voice activity detection), [symphonia](https://github.com/pdeljanov/Symphonia) (audio decoding), [cpal](https://github.com/RustAudio/cpal) (audio capture), [Tauri v2](https://v2.tauri.app/) (desktop app), [ureq](https://github.com/algesten/ureq) (HTTP). Optional: [MLX Audio](https://github.com/Blaizzy/mlx-audio) for local ASR and [ffmpeg](https://ffmpeg.org/) for non-English audio decoding.
 
 ## Star History
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,7 +9,7 @@ use minutes_core::autoresearch::{
     DecodeHintEvalComparisonRequest, DecodeHintEvalOptions, DecodeHintEvalRequest,
 };
 use minutes_core::capture::RecordingIntent;
-use minutes_core::config::{ConsentMode, VALID_PARAKEET_MODELS};
+use minutes_core::config::{ConsentMode, DEFAULT_MLX_AUDIO_MODEL, VALID_PARAKEET_MODELS};
 use minutes_core::markdown::ConsentBasis;
 use minutes_core::parakeet;
 use minutes_core::{CaptureMode, Config, ContentType};
@@ -765,6 +765,14 @@ enum Commands {
         /// Parakeet model to download: tdt-ctc-110m, tdt-600m
         #[arg(long, default_value = "tdt-600m")]
         parakeet_model: String,
+
+        /// Create/use a local Python environment for MLX Audio and select it as the transcription engine
+        #[arg(long)]
+        mlx_audio: bool,
+
+        /// MLX Audio model id/path to configure
+        #[arg(long, default_value = DEFAULT_MLX_AUDIO_MODEL)]
+        mlx_audio_model: String,
 
         /// Install the bundled 5-meeting fixture corpus for demoing search, graph, and MCP flows
         #[arg(long)]
@@ -1668,10 +1676,14 @@ fn main() -> Result<()> {
             diarization,
             parakeet,
             parakeet_model,
+            mlx_audio,
+            mlx_audio_model,
             demo,
         } => {
             if demo {
                 cmd_setup_demo()
+            } else if mlx_audio {
+                cmd_setup_mlx_audio(&mlx_audio_model)
             } else if parakeet {
                 cmd_setup_parakeet(&parakeet_model)
             } else {
@@ -5350,6 +5362,18 @@ fn cmd_setup_demo() -> Result<()> {
     Ok(())
 }
 
+const MLX_AUDIO_SETUP_VENV_ENV: &str = "MINUTES_MLX_AUDIO_SETUP_VENV";
+const MLX_AUDIO_SETUP_PYTHON_ENV: &str = "MINUTES_MLX_AUDIO_SETUP_PYTHON";
+
+const MLX_AUDIO_READY_CHECK: &str = r#"
+import sys
+from mlx_audio.stt.utils import load
+
+model_id = sys.argv[1]
+load(model_id)
+print(f"mlx-audio ready: {model_id}")
+"#;
+
 fn cmd_setup_diarization() -> Result<()> {
     use minutes_core::diarize;
 
@@ -5401,6 +5425,114 @@ fn cmd_setup_diarization() -> Result<()> {
     eprintln!("  # embedding_model = \"cam++-lm\"  # or \"cam++\" for the lighter original");
 
     Ok(())
+}
+
+/// Set up a local Python environment for MLX Audio and select it as the
+/// saved-audio transcription backend.
+fn cmd_setup_mlx_audio(model: &str) -> Result<()> {
+    let model = model.trim();
+    if model.is_empty() {
+        anyhow::bail!("mlx-audio model id/path cannot be empty");
+    }
+
+    let venv_dir = mlx_audio_setup_venv_dir();
+    let venv_python = mlx_audio_venv_python(&venv_dir);
+    let bootstrap_python =
+        std::env::var(MLX_AUDIO_SETUP_PYTHON_ENV).unwrap_or_else(|_| "python3".into());
+
+    if !venv_python.exists() {
+        eprintln!(
+            "Creating MLX Audio Python environment: {}",
+            venv_dir.display()
+        );
+        run_setup_command(
+            &bootstrap_python,
+            &["-m", "venv", venv_dir.to_string_lossy().as_ref()],
+            "create MLX Audio Python environment",
+        )?;
+    } else {
+        eprintln!(
+            "Using existing MLX Audio Python environment: {}",
+            venv_dir.display()
+        );
+    }
+
+    eprintln!("Installing/updating mlx-audio...");
+    run_setup_command(
+        &venv_python,
+        &["-m", "pip", "install", "-U", "pip"],
+        "upgrade pip in MLX Audio environment",
+    )?;
+    run_setup_command(
+        &venv_python,
+        &["-m", "pip", "install", "-U", "mlx-audio"],
+        "install mlx-audio",
+    )?;
+
+    eprintln!("Checking MLX Audio model readiness: {}", model);
+    run_setup_command(
+        &venv_python,
+        &["-c", MLX_AUDIO_READY_CHECK, model],
+        "load MLX Audio model",
+    )?;
+
+    let mut config = Config::load();
+    config.transcription.engine = "mlx-audio".into();
+    config.transcription.mlx_audio_model = model.into();
+    config.transcription.mlx_audio_python = venv_python.display().to_string();
+    config.transcription.mlx_audio_warm = true;
+    config
+        .save()
+        .map_err(|e| anyhow::anyhow!("failed to save config: {}", e))?;
+
+    eprintln!();
+    eprintln!("MLX Audio configured for saved-audio transcription.");
+    eprintln!("  Config: {}", Config::config_path().display());
+    eprintln!("  Python: {}", venv_python.display());
+    eprintln!("  Model:  {}", model);
+    eprintln!();
+    eprintln!("Desktop users can use Advanced > Open config to review these settings.");
+
+    Ok(())
+}
+
+fn mlx_audio_setup_venv_dir() -> PathBuf {
+    std::env::var_os(MLX_AUDIO_SETUP_VENV_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| Config::minutes_dir().join("mlx-audio"))
+}
+
+fn mlx_audio_venv_python(venv_dir: &Path) -> PathBuf {
+    if cfg!(windows) {
+        venv_dir.join("Scripts").join("python.exe")
+    } else {
+        venv_dir.join("bin").join("python")
+    }
+}
+
+fn run_setup_command<P>(program: P, args: &[&str], description: &str) -> Result<()>
+where
+    P: AsRef<std::ffi::OsStr>,
+{
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .map_err(|error| anyhow::anyhow!("failed to {description}: {error}"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() {
+        stdout
+    } else if stdout.is_empty() {
+        stderr
+    } else {
+        format!("{stderr}\n{stdout}")
+    };
+    anyhow::bail!("failed to {description}: {detail}");
 }
 
 /// Set up a parakeet.cpp model for alternative transcription.
@@ -6356,6 +6488,7 @@ mod tests {
         DecodeHintEvalReport, DecodeHintEvalTotals, DecodeHintEvalTranscriptMetrics,
     };
     use serde_json::json;
+    use std::ffi::{OsStr, OsString};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
@@ -6401,6 +6534,131 @@ mod tests {
         }
         std::fs::remove_dir_all(&dir).ok();
         result
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.original {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[test]
+    fn setup_clap_accepts_mlx_audio_flags() {
+        let parsed = Cli::try_parse_from([
+            "minutes",
+            "setup",
+            "--mlx-audio",
+            "--mlx-audio-model",
+            "local/qwen3-asr",
+        ])
+        .expect("setup --mlx-audio must parse");
+
+        match parsed.command {
+            Commands::Setup {
+                mlx_audio,
+                mlx_audio_model,
+                parakeet,
+                ..
+            } => {
+                assert!(mlx_audio);
+                assert!(!parakeet);
+                assert_eq!(mlx_audio_model, "local/qwen3-asr");
+            }
+            _ => panic!("expected setup command"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn setup_mlx_audio_saves_config_and_runs_fake_python() {
+        use std::os::unix::fs::PermissionsExt;
+
+        with_temp_home(|home| {
+            let fake_python = home.join("fake-python.py");
+            let fake_log = home.join("fake-python.log");
+            std::fs::write(
+                &fake_python,
+                r#"#!/usr/bin/env python3
+import os
+import pathlib
+import sys
+
+log_path = pathlib.Path(os.environ["MINUTES_FAKE_PYTHON_LOG"])
+with log_path.open("a", encoding="utf-8") as log:
+    log.write(repr(sys.argv[1:]) + "\n")
+
+if sys.argv[1:3] == ["-m", "venv"]:
+    venv = pathlib.Path(sys.argv[3])
+    child_python = venv / "bin" / "python"
+    child_python.parent.mkdir(parents=True, exist_ok=True)
+    child_python.write_text(pathlib.Path(__file__).read_text(), encoding="utf-8")
+    child_python.chmod(0o755)
+    sys.exit(0)
+
+if len(sys.argv) >= 3 and sys.argv[1:3] == ["-m", "pip"]:
+    sys.exit(0)
+
+if len(sys.argv) >= 4 and sys.argv[1] == "-c":
+    assert sys.argv[3] == "local/qwen3-asr"
+    print("mlx-audio ready")
+    sys.exit(0)
+
+print("unexpected fake-python argv", sys.argv, file=sys.stderr)
+sys.exit(2)
+"#,
+            )
+            .unwrap();
+            let mut permissions = std::fs::metadata(&fake_python).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&fake_python, permissions).unwrap();
+
+            let xdg_config = home.join("xdg-config");
+            let venv_dir = home.join("mlx-audio-env");
+            let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", &xdg_config);
+            let _venv = EnvVarGuard::set(MLX_AUDIO_SETUP_VENV_ENV, &venv_dir);
+            let _python = EnvVarGuard::set(MLX_AUDIO_SETUP_PYTHON_ENV, &fake_python);
+            let _fake_log = EnvVarGuard::set("MINUTES_FAKE_PYTHON_LOG", &fake_log);
+
+            cmd_setup_mlx_audio("local/qwen3-asr").unwrap();
+
+            let config = Config::load();
+            assert_eq!(config.transcription.engine, "mlx-audio");
+            assert_eq!(config.transcription.mlx_audio_model, "local/qwen3-asr");
+            assert_eq!(
+                config.transcription.mlx_audio_python,
+                venv_dir.join("bin").join("python").display().to_string()
+            );
+            assert!(config.transcription.mlx_audio_warm);
+
+            let log = std::fs::read_to_string(fake_log).unwrap();
+            assert!(log.contains(r#"['-m', 'venv',"#), "{log}");
+            assert!(
+                log.contains(r#"['-m', 'pip', 'install', '-U', 'pip']"#),
+                "{log}"
+            );
+            assert!(
+                log.contains(r#"['-m', 'pip', 'install', '-U', 'mlx-audio']"#),
+                "{log}"
+            );
+            assert!(log.contains("'local/qwen3-asr'"), "{log}");
+        });
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -104,7 +104,7 @@ impl Default for VoiceConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TranscriptionConfig {
-    /// Transcription engine: "whisper" (default), "parakeet", or
+    /// Transcription engine: "whisper" (default), "parakeet", "mlx-audio", or
     /// "apple-speech" (experimental live-transcript-only path on macOS 26+).
     pub engine: String,
     pub model: String,
@@ -217,9 +217,21 @@ pub struct TranscriptionConfig {
     /// Default 30s matches the design note in `streaming_whisper.rs`. Raise
     /// for long-form dictation; lower if you still see CPU pressure.
     pub partial_max_secs: u32,
+    /// Hugging Face repo id or local path for the MLX Audio STT model.
+    pub mlx_audio_model: String,
+    /// Python executable used to launch the local MLX Audio helper.
+    pub mlx_audio_python: String,
+    /// Keep a warm MLX Audio helper process resident between batch requests.
+    pub mlx_audio_warm: bool,
+    /// Timeout budget for MLX Audio batch transcription requests.
+    pub mlx_audio_timeout_secs: u64,
+    /// Chunk duration passed to MLX Audio models that expose chunk-level
+    /// timestamps, such as Qwen3-ASR.
+    pub mlx_audio_chunk_secs: f64,
 }
 
 pub const VALID_PARAKEET_MODELS: &[&str] = &["tdt-ctc-110m", "tdt-600m"];
+pub const DEFAULT_MLX_AUDIO_MODEL: &str = "mlx-community/Qwen3-ASR-1.7B-8bit";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -903,6 +915,11 @@ impl Default for TranscriptionConfig {
             parakeet_fp16_blacklist_reset: false,
             parakeet_vocab: "tdt-600m.tokenizer.vocab".into(),
             partial_max_secs: 30,
+            mlx_audio_model: DEFAULT_MLX_AUDIO_MODEL.into(),
+            mlx_audio_python: "python3".into(),
+            mlx_audio_warm: true,
+            mlx_audio_timeout_secs: 1800,
+            mlx_audio_chunk_secs: 30.0,
         }
     }
 }
@@ -1433,6 +1450,14 @@ mod tests {
             config.transcription.parakeet_vocab,
             "tdt-600m.tokenizer.vocab"
         );
+        assert_eq!(
+            config.transcription.mlx_audio_model,
+            "mlx-community/Qwen3-ASR-1.7B-8bit"
+        );
+        assert_eq!(config.transcription.mlx_audio_python, "python3");
+        assert!(config.transcription.mlx_audio_warm);
+        assert_eq!(config.transcription.mlx_audio_timeout_secs, 1800);
+        assert_eq!(config.transcription.mlx_audio_chunk_secs, 30.0);
         assert_eq!(config.diarization.engine, "auto");
         assert_eq!(config.summarization.engine, "none");
         assert_eq!(config.search.engine, "builtin");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod knowledge_extract;
 pub mod logging;
 pub mod macos_permissions;
 pub mod markdown;
+pub mod mlx_audio;
 pub mod notes;
 pub mod overlays;
 pub mod palette;

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -1876,7 +1876,10 @@ mod tests {
 
         let fm = Frontmatter {
             status: Some(OutputStatus::NoSpeech),
-            filter_diagnosis: Some("audio: 5.0s, whisper produced 3 segments, no_speech filter: -3 → 0, final: 0 words".into()),
+            filter_diagnosis: Some(
+                "audio: 5.0s, ASR produced 3 segments, no_speech filter: -3 → 0, final: 0 words"
+                    .into(),
+            ),
             ..test_frontmatter()
         };
 

--- a/crates/core/src/mlx_audio.rs
+++ b/crates/core/src/mlx_audio.rs
@@ -1,0 +1,1164 @@
+use crate::config::Config;
+use crate::error::TranscribeError;
+use crate::transcribe::{
+    load_audio_samples, transcript_from_timed_segments, FilterStats, TimedTranscriptSegment,
+    TranscribeResult,
+};
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::{Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const HELPER_CODE: &str = r#"
+import json
+import sys
+import time
+import traceback
+
+from mlx_audio.stt.utils import load
+
+models = {}
+
+def segment_dict(segment):
+    if hasattr(segment, "__dict__"):
+        segment = segment.__dict__
+    text = segment.get("text") or segment.get("Content") or segment.get("content") or ""
+    start = segment.get("start", segment.get("Start"))
+    end = segment.get("end", segment.get("End"))
+    if start is None or end is None:
+        return None
+    return {"start_secs": float(start), "end_secs": float(end), "text": str(text)}
+
+def collect_segments(result):
+    if getattr(result, "segments", None):
+        return [s for s in (segment_dict(segment) for segment in result.segments) if s]
+    if getattr(result, "sentences", None):
+        return [s for s in (segment_dict(sentence) for sentence in result.sentences) if s]
+    return []
+
+for line in sys.stdin:
+    request_id = None
+    started = time.time()
+    try:
+        req = json.loads(line)
+        request_id = req.get("request_id")
+        model_id = req["model"]
+        model_warm = model_id in models
+        cold_load_ms = 0
+        if not model_warm:
+            load_started = time.time()
+            models[model_id] = load(model_id)
+            cold_load_ms = int((time.time() - load_started) * 1000)
+        kwargs = {}
+        if req.get("language") is not None:
+            kwargs["language"] = req.get("language")
+        if req.get("context") is not None:
+            kwargs["context"] = req.get("context")
+        if req.get("chunk_duration_secs") is not None:
+            kwargs["chunk_duration"] = float(req.get("chunk_duration_secs"))
+        infer_started = time.time()
+        result = models[model_id].generate(req["audio_path"], **kwargs)
+        inference_ms = int((time.time() - infer_started) * 1000)
+        segments = collect_segments(result)
+        text = getattr(result, "text", "")
+        response = {
+            "request_id": request_id,
+            "ok": True,
+            "text": text,
+            "segments": segments,
+            "stats": {
+                "model_warm": model_warm,
+                "cold_load_ms": cold_load_ms,
+                "inference_ms": inference_ms,
+                "rtf": None,
+            },
+        }
+    except Exception as exc:
+        response = {
+            "request_id": request_id,
+            "ok": False,
+            "error": f"{type(exc).__name__}: {exc}",
+            "traceback": traceback.format_exc(),
+        }
+    sys.stdout.write(json.dumps(response, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+"#;
+
+#[derive(Debug, Serialize)]
+struct HelperRequest<'a> {
+    request_id: String,
+    audio_path: &'a str,
+    model: &'a str,
+    language: Option<&'a str>,
+    context: Option<&'a str>,
+    chunk_duration_secs: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HelperResponse {
+    request_id: Option<String>,
+    ok: Option<bool>,
+    error: Option<String>,
+    text: Option<String>,
+    segments: Option<Vec<HelperSegment>>,
+    stats: Option<HelperStats>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HelperSegment {
+    start_secs: f64,
+    end_secs: f64,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HelperStats {
+    model_warm: Option<bool>,
+    cold_load_ms: Option<u64>,
+    inference_ms: Option<u64>,
+    rtf: Option<f64>,
+}
+
+#[derive(Default)]
+struct MlxAudioHelperManager {
+    running: Option<RunningHelper>,
+    request_counter: u64,
+}
+
+struct RunningHelper {
+    child: Child,
+    stdin: ChildStdin,
+    stdout_rx: Receiver<Result<String, std::io::Error>>,
+    stdout_thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for RunningHelper {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        if let Some(stdout_thread) = self.stdout_thread.take() {
+            let _ = stdout_thread.join();
+        }
+    }
+}
+
+pub fn transcribe(audio_path: &Path, config: &Config) -> Result<TranscribeResult, TranscribeError> {
+    let samples = load_audio_samples(audio_path)?;
+    if samples.is_empty() {
+        return Err(TranscribeError::EmptyAudio);
+    }
+    let stats = FilterStats {
+        audio_duration_secs: samples.len() as f64 / 16_000.0,
+        samples_after_silence_strip: samples.len(),
+        ..FilterStats::default()
+    };
+    drop(samples);
+
+    let started = Instant::now();
+    let response = request_helper(audio_path, config)?;
+
+    let result = response_to_transcribe_result(response, stats, config)?;
+    tracing::info!(
+        engine = "mlx-audio",
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        words = result.stats.final_words,
+        diagnosis = result.stats.diagnosis(),
+        "mlx-audio transcription complete"
+    );
+    Ok(result)
+}
+
+fn request_helper(audio_path: &Path, config: &Config) -> Result<HelperResponse, TranscribeError> {
+    if config.transcription.mlx_audio_warm
+        && std::env::var_os("MINUTES_MLX_AUDIO_FORCE_ONESHOT").is_none()
+    {
+        global_manager()
+            .lock()
+            .map_err(|_| {
+                TranscribeError::TranscriptionFailed("mlx-audio helper lock poisoned".into())
+            })?
+            .request(audio_path, config)
+    } else {
+        request_one_shot(audio_path, config)
+    }
+}
+
+fn global_manager() -> &'static Mutex<MlxAudioHelperManager> {
+    static MANAGER: OnceLock<Mutex<MlxAudioHelperManager>> = OnceLock::new();
+    MANAGER.get_or_init(|| Mutex::new(MlxAudioHelperManager::default()))
+}
+
+impl MlxAudioHelperManager {
+    fn request(
+        &mut self,
+        audio_path: &Path,
+        config: &Config,
+    ) -> Result<HelperResponse, TranscribeError> {
+        let request_id = self.next_request_id();
+        match self.request_once(&request_id, audio_path, config) {
+            Ok(response) => Ok(response),
+            Err(first_error) => {
+                self.stop();
+                tracing::warn!(error = %first_error, "mlx-audio helper request failed; restarting once");
+                self.request_once(&request_id, audio_path, config)
+            }
+        }
+    }
+
+    fn request_once(
+        &mut self,
+        request_id: &str,
+        audio_path: &Path,
+        config: &Config,
+    ) -> Result<HelperResponse, TranscribeError> {
+        if self.running.is_none() {
+            self.running = Some(start_helper(config)?);
+        }
+        let running = self.running.as_mut().expect("helper just started");
+        request_running_helper(running, request_id, audio_path, config)
+    }
+
+    fn next_request_id(&mut self) -> String {
+        self.request_counter += 1;
+        format!("minutes-mlx-{}", self.request_counter)
+    }
+
+    fn stop(&mut self) {
+        self.running.take();
+    }
+}
+
+fn request_one_shot(audio_path: &Path, config: &Config) -> Result<HelperResponse, TranscribeError> {
+    let mut running = start_helper(config)?;
+    request_running_helper(&mut running, "minutes-mlx-oneshot", audio_path, config)
+}
+
+fn request_running_helper(
+    running: &mut RunningHelper,
+    request_id: &str,
+    audio_path: &Path,
+    config: &Config,
+) -> Result<HelperResponse, TranscribeError> {
+    let audio_path = audio_path.to_str().ok_or_else(|| {
+        TranscribeError::TranscriptionFailed("audio path is not valid UTF-8".into())
+    })?;
+    let request = HelperRequest {
+        request_id: request_id.to_string(),
+        audio_path,
+        model: &config.transcription.mlx_audio_model,
+        language: config.transcription.language.as_deref(),
+        context: None,
+        chunk_duration_secs: Some(config.transcription.mlx_audio_chunk_secs),
+    };
+
+    serde_json::to_writer(&mut running.stdin, &request)
+        .map_err(|error| TranscribeError::TranscriptionFailed(error.to_string()))?;
+    running.stdin.write_all(b"\n")?;
+    running.stdin.flush()?;
+
+    let line = read_helper_line(running, config)?;
+    let response: HelperResponse = serde_json::from_str(&line).map_err(|error| {
+        TranscribeError::TranscriptionFailed(format!(
+            "invalid mlx-audio helper JSON: {error}; line={line}"
+        ))
+    })?;
+    if response.request_id.as_deref() != Some(request_id) {
+        return Err(TranscribeError::TranscriptionFailed(format!(
+            "mlx-audio helper request_id mismatch: expected {request_id}, got {:?}",
+            response.request_id
+        )));
+    }
+    Ok(response)
+}
+
+fn read_helper_line(
+    running: &mut RunningHelper,
+    config: &Config,
+) -> Result<String, TranscribeError> {
+    if config.transcription.mlx_audio_timeout_secs == 0 {
+        return read_helper_line_result(running.stdout_rx.recv().map_err(|_| {
+            TranscribeError::TranscriptionFailed(
+                "mlx-audio helper closed stdout before responding".into(),
+            )
+        })?);
+    }
+
+    match running.stdout_rx.recv_timeout(Duration::from_secs(
+        config.transcription.mlx_audio_timeout_secs,
+    )) {
+        Ok(result) => read_helper_line_result(result),
+        Err(RecvTimeoutError::Timeout) => Err(TranscribeError::TranscriptionFailed(format!(
+            "mlx-audio helper timed out after {}s",
+            config.transcription.mlx_audio_timeout_secs
+        ))),
+        Err(RecvTimeoutError::Disconnected) => Err(TranscribeError::TranscriptionFailed(
+            "mlx-audio helper closed stdout before responding".into(),
+        )),
+    }
+}
+
+fn read_helper_line_result(
+    result: Result<String, std::io::Error>,
+) -> Result<String, TranscribeError> {
+    let line = result?;
+    if line.is_empty() {
+        return Err(TranscribeError::TranscriptionFailed(
+            "mlx-audio helper closed stdout before responding".into(),
+        ));
+    }
+    Ok(line)
+}
+
+fn start_helper(config: &Config) -> Result<RunningHelper, TranscribeError> {
+    let mut command = helper_command(config);
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|error| {
+            TranscribeError::TranscriptionFailed(format!(
+                "could not spawn mlx-audio helper: {error}"
+            ))
+        })?;
+    let stdin = child.stdin.take().ok_or_else(|| {
+        TranscribeError::TranscriptionFailed("could not open mlx-audio helper stdin".into())
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        TranscribeError::TranscriptionFailed("could not open mlx-audio helper stdout".into())
+    })?;
+    let (stdout_tx, stdout_rx) = mpsc::channel();
+    let stdout_thread = thread::spawn(move || read_stdout_lines(stdout, stdout_tx));
+    Ok(RunningHelper {
+        child,
+        stdin,
+        stdout_rx,
+        stdout_thread: Some(stdout_thread),
+    })
+}
+
+fn read_stdout_lines(stdout: ChildStdout, stdout_tx: mpsc::Sender<Result<String, std::io::Error>>) {
+    let mut reader = BufReader::new(stdout);
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                if stdout_tx.send(Ok(line)).is_err() {
+                    break;
+                }
+            }
+            Err(error) => {
+                let _ = stdout_tx.send(Err(error));
+                break;
+            }
+        }
+    }
+}
+
+fn helper_command(config: &Config) -> Command {
+    if let Ok(explicit) = std::env::var("MINUTES_MLX_AUDIO_HELPER") {
+        return Command::new(explicit);
+    }
+    let mut command = Command::new(&config.transcription.mlx_audio_python);
+    command.args(["-u", "-c", HELPER_CODE]);
+    command
+}
+
+fn response_to_transcribe_result(
+    response: HelperResponse,
+    mut stats: FilterStats,
+    config: &Config,
+) -> Result<TranscribeResult, TranscribeError> {
+    if response.ok == Some(false) {
+        return Err(TranscribeError::TranscriptionFailed(format!(
+            "mlx-audio helper failed: {}",
+            response.error.unwrap_or_else(|| "unknown error".into())
+        )));
+    }
+
+    let segments = response.segments.unwrap_or_default();
+    if segments.is_empty() {
+        let preview: String = response
+            .text
+            .unwrap_or_default()
+            .chars()
+            .take(200)
+            .collect();
+        return Err(TranscribeError::TranscriptionFailed(format!(
+            "mlx-audio output did not include timed segments; text-only output is unsupported. First 200 chars: {preview}"
+        )));
+    }
+
+    let timed_segments: Vec<TimedTranscriptSegment> = segments
+        .into_iter()
+        .map(|segment| TimedTranscriptSegment {
+            start_secs: segment.start_secs,
+            end_secs: segment.end_secs,
+            text: segment.text,
+        })
+        .collect();
+    let (text, cleanup_stats) = transcript_from_timed_segments(&timed_segments, config)?;
+
+    stats.raw_segments = cleanup_stats.raw_segments;
+    stats.after_no_speech_filter = cleanup_stats.raw_segments;
+    stats.after_dedup = cleanup_stats.after_dedup;
+    stats.after_interleaved = cleanup_stats.after_interleaved;
+    stats.after_script_filter = cleanup_stats.after_script_filter;
+    stats.after_noise_markers = cleanup_stats.after_noise_markers;
+    stats.after_trailing_trim = cleanup_stats.after_trailing_trim;
+    stats.final_words = text.split_whitespace().count();
+
+    if let Some(helper_stats) = response.stats {
+        tracing::debug!(
+            model_warm = helper_stats.model_warm.unwrap_or(false),
+            cold_load_ms = helper_stats.cold_load_ms.unwrap_or(0),
+            inference_ms = helper_stats.inference_ms.unwrap_or(0),
+            rtf = helper_stats.rtf.unwrap_or(-1.0),
+            "mlx-audio helper stats"
+        );
+    }
+
+    Ok(TranscribeResult { text, stats })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcribe::write_wav_16k_mono;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::MutexGuard;
+
+    fn test_lock() -> MutexGuard<'static, ()> {
+        static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("mlx-audio test lock")
+    }
+
+    fn config() -> Config {
+        let mut config = Config::default();
+        config.transcription.mlx_audio_timeout_secs = 5;
+        config
+    }
+
+    fn config_with_helper(helper: &Path, warm: bool) -> Config {
+        let mut config = config();
+        config.transcription.engine = "mlx-audio".into();
+        config.transcription.mlx_audio_python = helper.display().to_string();
+        config.transcription.mlx_audio_warm = warm;
+        config
+    }
+
+    fn write_audio(path: &Path) {
+        let samples: Vec<f32> = (0..1600)
+            .map(|i| 0.2 * (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16_000.0).sin())
+            .collect();
+        write_wav_16k_mono(path, &samples).expect("write test wav");
+    }
+
+    #[derive(Debug, Clone)]
+    struct VttCue {
+        start_secs: f64,
+        end_secs: f64,
+        text: String,
+    }
+
+    #[derive(Debug)]
+    struct ErrorRate {
+        edits: usize,
+        reference_len: usize,
+        rate: f64,
+    }
+
+    fn parse_vtt_cues(vtt: &str) -> Vec<VttCue> {
+        let lines: Vec<&str> = vtt.lines().collect();
+        let mut cues = Vec::new();
+        let mut index = 0;
+        while index < lines.len() {
+            let line = lines[index].trim();
+            if let Some((start, end)) = parse_vtt_timing(line) {
+                index += 1;
+                let mut cue_lines = Vec::new();
+                while index < lines.len() && !lines[index].trim().is_empty() {
+                    cue_lines.push(strip_vtt_speaker_label(lines[index].trim()));
+                    index += 1;
+                }
+                let text = cue_lines
+                    .into_iter()
+                    .filter(|line| !line.trim().is_empty())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                if !text.trim().is_empty() {
+                    cues.push(VttCue {
+                        start_secs: start,
+                        end_secs: end,
+                        text,
+                    });
+                }
+            } else {
+                index += 1;
+            }
+        }
+        cues
+    }
+
+    fn parse_vtt_timing(line: &str) -> Option<(f64, f64)> {
+        let (start, rest) = line.split_once("-->")?;
+        let end = rest.split_whitespace().next()?;
+        Some((
+            parse_vtt_timestamp(start.trim())?,
+            parse_vtt_timestamp(end)?,
+        ))
+    }
+
+    fn parse_vtt_timestamp(value: &str) -> Option<f64> {
+        let mut parts: Vec<&str> = value.split(':').collect();
+        if parts.len() == 2 {
+            parts.insert(0, "0");
+        }
+        if parts.len() != 3 {
+            return None;
+        }
+        let hours: f64 = parts[0].parse().ok()?;
+        let minutes: f64 = parts[1].parse().ok()?;
+        let seconds: f64 = parts[2].replace(',', ".").parse().ok()?;
+        Some(hours * 3600.0 + minutes * 60.0 + seconds)
+    }
+
+    fn strip_vtt_speaker_label(line: &str) -> String {
+        let without_tags = strip_vtt_tags(line);
+        if let Some((speaker, text)) = without_tags.split_once(':') {
+            let speaker = speaker.trim();
+            if !speaker.is_empty()
+                && speaker.len() <= 48
+                && speaker
+                    .chars()
+                    .all(|c| c.is_alphabetic() || c.is_whitespace() || c == '-' || c == '.')
+            {
+                return text.trim().to_string();
+            }
+        }
+        without_tags
+    }
+
+    fn strip_vtt_tags(line: &str) -> String {
+        let mut output = String::new();
+        let mut in_tag = false;
+        for ch in line.chars() {
+            match ch {
+                '<' => in_tag = true,
+                '>' => in_tag = false,
+                _ if !in_tag => output.push(ch),
+                _ => {}
+            }
+        }
+        output
+    }
+
+    fn reference_text_for_window(cues: &[VttCue], start_secs: f64, duration_secs: f64) -> String {
+        let end_secs = start_secs + duration_secs;
+        cues.iter()
+            .filter(|cue| cue.end_secs > start_secs && cue.start_secs < end_secs)
+            .map(|cue| cue.text.trim())
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn benchmark_audio_window(
+        audio_path: &Path,
+        start_secs: f64,
+        duration_secs: Option<f64>,
+    ) -> (tempfile::NamedTempFile, f64) {
+        let samples = load_audio_samples(audio_path).expect("load benchmark audio");
+        let start = ((start_secs.max(0.0) * 16_000.0).round() as usize).min(samples.len());
+        let requested_end = duration_secs
+            .map(|duration| start + (duration.max(0.0) * 16_000.0).round() as usize)
+            .unwrap_or(samples.len());
+        let end = requested_end.min(samples.len());
+        assert!(end > start, "benchmark audio window must not be empty");
+        let duration_secs = (end - start) as f64 / 16_000.0;
+        let tmp_wav = tempfile::Builder::new()
+            .prefix("minutes-mlx-audio-bench-")
+            .suffix(".wav")
+            .tempfile()
+            .expect("create benchmark wav");
+        write_wav_16k_mono(tmp_wav.path(), &samples[start..end]).expect("write benchmark wav");
+        (tmp_wav, duration_secs)
+    }
+
+    fn words_for_error_rate(text: &str) -> Vec<String> {
+        normalized_words(text)
+            .split_whitespace()
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    fn normalized_words(text: &str) -> String {
+        let text = strip_minutes_timestamp_markers(text);
+        let mut output = String::new();
+        let mut last_was_space = true;
+        for ch in text.chars() {
+            if ch.is_alphanumeric() || ch == '\'' {
+                for lower in ch.to_lowercase() {
+                    output.push(lower);
+                }
+                last_was_space = false;
+            } else if !last_was_space {
+                output.push(' ');
+                last_was_space = true;
+            }
+        }
+        output.trim().to_string()
+    }
+
+    fn strip_minutes_timestamp_markers(text: &str) -> String {
+        text.lines()
+            .map(|line| {
+                let trimmed = line.trim_start();
+                if let Some(rest) = strip_minutes_timestamp_prefix(trimmed) {
+                    rest.trim_start()
+                } else {
+                    line
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn strip_minutes_timestamp_prefix(line: &str) -> Option<&str> {
+        let rest = line.strip_prefix('[')?;
+        let (timestamp, rest) = rest.split_once(']')?;
+        if is_minutes_timestamp(timestamp) {
+            Some(rest)
+        } else {
+            None
+        }
+    }
+
+    fn is_minutes_timestamp(value: &str) -> bool {
+        let parts: Vec<&str> = value.split(':').collect();
+        (parts.len() == 2 || parts.len() == 3)
+            && parts
+                .iter()
+                .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+    }
+
+    fn chars_for_error_rate(text: &str) -> Vec<char> {
+        normalized_words(text)
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect()
+    }
+
+    fn error_rate<T: Eq>(reference: &[T], candidate: &[T]) -> ErrorRate {
+        let edits = levenshtein(reference, candidate);
+        ErrorRate {
+            edits,
+            reference_len: reference.len(),
+            rate: if reference.is_empty() {
+                0.0
+            } else {
+                edits as f64 / reference.len() as f64
+            },
+        }
+    }
+
+    fn levenshtein<T: Eq>(a: &[T], b: &[T]) -> usize {
+        if a.is_empty() {
+            return b.len();
+        }
+        if b.is_empty() {
+            return a.len();
+        }
+
+        let mut previous: Vec<usize> = (0..=b.len()).collect();
+        let mut current = vec![0; b.len() + 1];
+        for (i, a_item) in a.iter().enumerate() {
+            current[0] = i + 1;
+            for (j, b_item) in b.iter().enumerate() {
+                let substitution_cost = usize::from(a_item != b_item);
+                current[j + 1] = (previous[j + 1] + 1)
+                    .min(current[j] + 1)
+                    .min(previous[j] + substitution_cost);
+            }
+            std::mem::swap(&mut previous, &mut current);
+        }
+        previous[b.len()]
+    }
+
+    #[cfg(unix)]
+    fn write_fake_helper(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, body).expect("write fake helper");
+        let mut permissions = fs::metadata(&path)
+            .expect("fake helper metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("chmod fake helper");
+        path
+    }
+
+    fn stop_global_helper() {
+        if let Ok(mut manager) = global_manager().lock() {
+            manager.stop();
+        }
+    }
+
+    #[test]
+    fn response_with_timed_segments_formats_transcript() {
+        let response = HelperResponse {
+            request_id: Some("r1".into()),
+            ok: Some(true),
+            error: None,
+            text: Some("hello world next line".into()),
+            segments: Some(vec![
+                HelperSegment {
+                    start_secs: 0.0,
+                    end_secs: 1.0,
+                    text: "hello world".into(),
+                },
+                HelperSegment {
+                    start_secs: 61.2,
+                    end_secs: 63.0,
+                    text: "next line".into(),
+                },
+            ]),
+            stats: None,
+        };
+        let result =
+            response_to_transcribe_result(response, FilterStats::default(), &config()).unwrap();
+        assert_eq!(result.text, "[0:00] hello world\n[1:01] next line\n");
+        assert_eq!(result.stats.raw_segments, 2);
+    }
+
+    #[test]
+    fn response_with_text_only_is_hard_error() {
+        let response = HelperResponse {
+            request_id: Some("r1".into()),
+            ok: Some(true),
+            error: None,
+            text: Some("plain text without timestamps".into()),
+            segments: Some(Vec::new()),
+            stats: None,
+        };
+        let err = response_to_transcribe_result(response, FilterStats::default(), &config())
+            .expect_err("text-only output must be rejected");
+        assert!(err.to_string().contains("text-only output is unsupported"));
+    }
+
+    #[test]
+    fn response_with_invalid_timestamps_is_hard_error() {
+        let response = HelperResponse {
+            request_id: Some("r1".into()),
+            ok: Some(true),
+            error: None,
+            text: None,
+            segments: Some(vec![HelperSegment {
+                start_secs: 2.0,
+                end_secs: 1.0,
+                text: "backwards".into(),
+            }]),
+            stats: None,
+        };
+        let err = response_to_transcribe_result(response, FilterStats::default(), &config())
+            .expect_err("invalid timestamps must be rejected");
+        assert!(err.to_string().contains("invalid bounds"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn transcribe_with_fake_helper_uses_timed_segments() {
+        let _guard = test_lock();
+        stop_global_helper();
+        let dir = tempfile::tempdir().unwrap();
+        let audio_path = dir.path().join("audio.wav");
+        write_audio(&audio_path);
+        let helper = write_fake_helper(
+            dir.path(),
+            "helper_success.py",
+            r#"#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    req = json.loads(line)
+    if req.get("chunk_duration_secs") != 30.0:
+        sys.stdout.write(json.dumps({
+            "request_id": req["request_id"],
+            "ok": False,
+            "error": "missing chunk_duration_secs"
+        }) + "\n")
+        sys.stdout.flush()
+        continue
+    sys.stdout.write(json.dumps({
+        "request_id": req["request_id"],
+        "ok": True,
+        "text": "hello from mlx audio",
+        "segments": [
+            {"start_secs": 0.0, "end_secs": 0.7, "text": "hello from mlx"},
+            {"start_secs": 61.0, "end_secs": 62.0, "text": "audio"}
+        ],
+        "stats": {"model_warm": False, "cold_load_ms": 1, "inference_ms": 2, "rtf": 0.2}
+    }) + "\n")
+    sys.stdout.flush()
+"#,
+        );
+        let config = config_with_helper(&helper, false);
+
+        let result = transcribe(&audio_path, &config).unwrap();
+
+        assert_eq!(result.text, "[0:00] hello from mlx\n[1:01] audio\n");
+        assert_eq!(result.stats.raw_segments, 2);
+        assert_eq!(result.stats.after_trailing_trim, 2);
+        assert_eq!(result.stats.samples_after_silence_strip, 1600);
+        stop_global_helper();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn helper_failure_response_errors() {
+        let _guard = test_lock();
+        stop_global_helper();
+        let dir = tempfile::tempdir().unwrap();
+        let audio_path = dir.path().join("audio.wav");
+        write_audio(&audio_path);
+        let helper = write_fake_helper(
+            dir.path(),
+            "helper_failure.py",
+            r#"#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    req = json.loads(line)
+    sys.stdout.write(json.dumps({
+        "request_id": req["request_id"],
+        "ok": False,
+        "error": "model cache missing"
+    }) + "\n")
+    sys.stdout.flush()
+"#,
+        );
+        let config = config_with_helper(&helper, false);
+
+        let err = transcribe(&audio_path, &config).expect_err("helper failure must error");
+
+        assert!(err.to_string().contains("mlx-audio helper failed"));
+        assert!(err.to_string().contains("model cache missing"));
+        stop_global_helper();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn helper_request_id_mismatch_errors() {
+        let _guard = test_lock();
+        stop_global_helper();
+        let dir = tempfile::tempdir().unwrap();
+        let helper = write_fake_helper(
+            dir.path(),
+            "helper_mismatch.py",
+            r#"#!/usr/bin/env python3
+import json
+import sys
+
+for _line in sys.stdin:
+    sys.stdout.write(json.dumps({
+        "request_id": "wrong-request",
+        "ok": True,
+        "segments": [{"start_secs": 0.0, "end_secs": 0.5, "text": "hello"}]
+    }) + "\n")
+    sys.stdout.flush()
+"#,
+        );
+        let config = config_with_helper(&helper, false);
+
+        let err =
+            request_one_shot(&dir.path().join("audio.wav"), &config).expect_err("mismatch errors");
+
+        assert!(err.to_string().contains("request_id mismatch"));
+        stop_global_helper();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn warm_helper_restarts_once_after_closed_stdout() {
+        let _guard = test_lock();
+        stop_global_helper();
+        let dir = tempfile::tempdir().unwrap();
+        let audio_path = dir.path().join("audio.wav");
+        write_audio(&audio_path);
+        let state_path = dir.path().join("attempts.txt");
+        let helper_body = format!(
+            r#"#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+state_path = pathlib.Path({state_path:?})
+attempts = int(state_path.read_text()) if state_path.exists() else 0
+line = sys.stdin.readline()
+state_path.write_text(str(attempts + 1))
+if attempts == 0:
+    sys.exit(0)
+req = json.loads(line)
+sys.stdout.write(json.dumps({{
+    "request_id": req["request_id"],
+    "ok": True,
+    "segments": [{{"start_secs": 0.0, "end_secs": 0.5, "text": "after restart"}}]
+}}) + "\n")
+sys.stdout.flush()
+"#,
+            state_path = state_path.display().to_string()
+        );
+        let helper = write_fake_helper(dir.path(), "helper_restart.py", &helper_body);
+        let config = config_with_helper(&helper, true);
+
+        let result = transcribe(&audio_path, &config).unwrap();
+
+        assert_eq!(result.text, "[0:00] after restart\n");
+        assert_eq!(fs::read_to_string(&state_path).unwrap(), "2");
+        stop_global_helper();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn helper_request_times_out() {
+        let _guard = test_lock();
+        stop_global_helper();
+        let dir = tempfile::tempdir().unwrap();
+        let audio_path = dir.path().join("audio.wav");
+        write_audio(&audio_path);
+        let helper = write_fake_helper(
+            dir.path(),
+            "helper_timeout.py",
+            r#"#!/usr/bin/env python3
+import sys
+import time
+
+for _line in sys.stdin:
+    time.sleep(5)
+"#,
+        );
+        let mut config = config_with_helper(&helper, false);
+        config.transcription.mlx_audio_timeout_secs = 1;
+
+        let err = transcribe(&audio_path, &config).expect_err("slow helper must time out");
+
+        assert!(err.to_string().contains("timed out after 1s"));
+        stop_global_helper();
+    }
+
+    #[test]
+    fn vtt_reference_text_strips_cue_numbers_timestamps_and_speakers() {
+        let vtt = r#"WEBVTT
+
+1
+00:00:02.750 --> 00:00:08.729
+Speaker One: Okay, yeah, let me just repeat myself.
+
+2
+00:00:09.160 --> 00:00:27.820
+Speaker Two: Is there any metadata?
+
+3
+00:00:27.820 --> 00:00:31.459
+Outside Window: this should not be included
+"#;
+
+        let cues = parse_vtt_cues(vtt);
+        let text = reference_text_for_window(&cues, 0.0, 20.0);
+
+        assert_eq!(
+            text,
+            "Okay, yeah, let me just repeat myself. Is there any metadata?"
+        );
+    }
+
+    #[test]
+    fn error_rate_normalizes_words_and_counts_edits() {
+        let reference = words_for_error_rate("Hello, ASR world!");
+        let candidate = words_for_error_rate("hello world");
+
+        let wer = error_rate(&reference, &candidate);
+
+        assert_eq!(words_for_error_rate("[0:00] hello"), vec!["hello"]);
+        assert_eq!(reference, vec!["hello", "asr", "world"]);
+        assert_eq!(candidate, vec!["hello", "world"]);
+        assert_eq!(wer.edits, 1);
+        assert_eq!(wer.reference_len, 3);
+        assert!((wer.rate - (1.0 / 3.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mlx_audio_reference_benchmark_when_env_is_set() {
+        let Some(audio_path) = std::env::var_os("MINUTES_MLX_AUDIO_BENCH_AUDIO") else {
+            return;
+        };
+        let Some(reference_vtt_path) = std::env::var_os("MINUTES_MLX_AUDIO_BENCH_REFERENCE_VTT")
+        else {
+            return;
+        };
+        let _guard = test_lock();
+        stop_global_helper();
+        let mut config = Config::default();
+        config.transcription.engine = "mlx-audio".into();
+        config.transcription.mlx_audio_python = std::env::var("MINUTES_MLX_AUDIO_BENCH_PYTHON")
+            .or_else(|_| std::env::var("MINUTES_MLX_AUDIO_E2E_PYTHON"))
+            .unwrap_or_else(|_| config.transcription.mlx_audio_python.clone());
+        config.transcription.mlx_audio_model = std::env::var("MINUTES_MLX_AUDIO_BENCH_MODEL")
+            .or_else(|_| std::env::var("MINUTES_MLX_AUDIO_E2E_MODEL"))
+            .unwrap_or_else(|_| config.transcription.mlx_audio_model.clone());
+        config.transcription.mlx_audio_chunk_secs =
+            std::env::var("MINUTES_MLX_AUDIO_BENCH_CHUNK_SECS")
+                .or_else(|_| std::env::var("MINUTES_MLX_AUDIO_E2E_CHUNK_SECS"))
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(10.0);
+        config.transcription.mlx_audio_timeout_secs =
+            std::env::var("MINUTES_MLX_AUDIO_BENCH_TIMEOUT_SECS")
+                .or_else(|_| std::env::var("MINUTES_MLX_AUDIO_E2E_TIMEOUT_SECS"))
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(1800);
+
+        let start_secs = std::env::var("MINUTES_MLX_AUDIO_BENCH_START_SECS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0.0);
+        let requested_duration_secs = std::env::var("MINUTES_MLX_AUDIO_BENCH_DURATION_SECS")
+            .ok()
+            .and_then(|value| value.parse().ok());
+        let (bench_wav, duration_secs) =
+            benchmark_audio_window(Path::new(&audio_path), start_secs, requested_duration_secs);
+        let reference_vtt =
+            fs::read_to_string(reference_vtt_path).expect("read benchmark reference VTT");
+        let reference_text =
+            reference_text_for_window(&parse_vtt_cues(&reference_vtt), start_secs, duration_secs);
+        assert!(
+            !reference_text.trim().is_empty(),
+            "benchmark reference VTT window must include transcript text"
+        );
+
+        if let Some(warmup_secs) = std::env::var("MINUTES_MLX_AUDIO_BENCH_WARMUP_SECS")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+            .filter(|value| *value > 0.0)
+        {
+            let (warmup_wav, _) =
+                benchmark_audio_window(Path::new(&audio_path), start_secs, Some(warmup_secs));
+            let _ = transcribe(warmup_wav.path(), &config).expect("warm up mlx-audio model");
+        }
+
+        let started = Instant::now();
+        let result = transcribe(bench_wav.path(), &config).expect("benchmark transcription");
+        let elapsed_secs = started.elapsed().as_secs_f64();
+        let rtf = elapsed_secs / duration_secs;
+
+        let reference_words = words_for_error_rate(&reference_text);
+        let candidate_words = words_for_error_rate(&result.text);
+        let wer = error_rate(&reference_words, &candidate_words);
+        let reference_chars = chars_for_error_rate(&reference_text);
+        let candidate_chars = chars_for_error_rate(&result.text);
+        let cer = error_rate(&reference_chars, &candidate_chars);
+
+        eprintln!(
+            "mlx-audio reference benchmark: model={} duration_secs={:.2} elapsed_secs={:.2} rtf={:.3} wer={:.3} wer_edits={}/{} cer={:.3} cer_edits={}/{} candidate_words={} reference_words={}",
+            config.transcription.mlx_audio_model,
+            duration_secs,
+            elapsed_secs,
+            rtf,
+            wer.rate,
+            wer.edits,
+            wer.reference_len,
+            cer.rate,
+            cer.edits,
+            cer.reference_len,
+            candidate_words.len(),
+            reference_words.len()
+        );
+
+        assert!(
+            !candidate_words.is_empty(),
+            "benchmark candidate transcript must not be empty"
+        );
+        if let Some(max_wer) = std::env::var("MINUTES_MLX_AUDIO_BENCH_MAX_WER")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+        {
+            assert!(
+                wer.rate <= max_wer,
+                "WER {:.3} exceeded threshold {:.3}",
+                wer.rate,
+                max_wer
+            );
+        }
+        if let Some(max_cer) = std::env::var("MINUTES_MLX_AUDIO_BENCH_MAX_CER")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+        {
+            assert!(
+                cer.rate <= max_cer,
+                "CER {:.3} exceeded threshold {:.3}",
+                cer.rate,
+                max_cer
+            );
+        }
+        if let Some(max_rtf) = std::env::var("MINUTES_MLX_AUDIO_BENCH_MAX_RTF")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+        {
+            assert!(
+                rtf <= max_rtf,
+                "RTF {:.3} exceeded threshold {:.3}",
+                rtf,
+                max_rtf
+            );
+        }
+        stop_global_helper();
+    }
+
+    #[test]
+    fn mlx_audio_real_model_e2e_when_env_is_set() {
+        let Some(audio_path) = std::env::var_os("MINUTES_MLX_AUDIO_E2E_AUDIO") else {
+            return;
+        };
+        let _guard = test_lock();
+        stop_global_helper();
+        let mut config = Config::default();
+        config.transcription.engine = "mlx-audio".into();
+        config.transcription.mlx_audio_python = std::env::var("MINUTES_MLX_AUDIO_E2E_PYTHON")
+            .unwrap_or_else(|_| config.transcription.mlx_audio_python.clone());
+        config.transcription.mlx_audio_model = std::env::var("MINUTES_MLX_AUDIO_E2E_MODEL")
+            .unwrap_or_else(|_| config.transcription.mlx_audio_model.clone());
+        config.transcription.mlx_audio_chunk_secs =
+            std::env::var("MINUTES_MLX_AUDIO_E2E_CHUNK_SECS")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(10.0);
+        config.transcription.mlx_audio_timeout_secs =
+            std::env::var("MINUTES_MLX_AUDIO_E2E_TIMEOUT_SECS")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(1800);
+
+        let result = transcribe(Path::new(&audio_path), &config).unwrap();
+
+        assert!(result.text.contains("[0:00]"));
+        assert!(
+            result.stats.raw_segments > 0,
+            "real MLX model must return timed segments"
+        );
+
+        stop_global_helper();
+    }
+}

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -63,7 +63,7 @@ fn suppress_if_all_noise(
     }
 
     Some(format!(
-        "all-noise transcript on sparse stems (voice active {:.3}, system active {:.3}, threshold {:.2}); whisper produced only non-speech markers - body suppressed",
+        "all-noise transcript on sparse stems (voice active {:.3}, system active {:.3}, threshold {:.2}); ASR produced only non-speech markers - body suppressed",
         voice, system, SPARSE_STEM_ACTIVE_RATIO
     ))
 }
@@ -1500,7 +1500,12 @@ pub fn write_transcript_artifact(
         "transcribe",
         &audio_path.display().to_string(),
         transcribe_ms,
-        serde_json::json!({"words": word_count, "mode": "background", "diagnosis": filter_stats.diagnosis()}),
+        serde_json::json!({
+            "words": word_count,
+            "mode": "background",
+            "engine": config.transcription.engine,
+            "diagnosis": filter_stats.diagnosis()
+        }),
     );
 
     let status =
@@ -1598,8 +1603,8 @@ pub fn write_transcript_artifact(
         template: context.template.as_ref().map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
             // Prefer the all-noise-suppression diagnosis when it fired; it
-            // describes a different failure mode (whisper produced only
-            // non-speech markers on sparse stems) than the standard
+            // describes a different failure mode (ASR produced only non-speech
+            // markers on sparse stems) than the standard
             // min_words / no_speech filter path.
             Some(
                 forced_no_speech_diagnosis
@@ -2131,7 +2136,12 @@ where
         .as_ref()
         .map(|f| f.as_path())
         .unwrap_or(audio_path);
-    tracing::info!(step = "transcribe", file = %transcribe_input.display(), "transcribing audio");
+    tracing::info!(
+        step = "transcribe",
+        engine = %config.transcription.engine,
+        file = %transcribe_input.display(),
+        "transcribing audio"
+    );
     let step_start = std::time::Instant::now();
     let result = crate::transcription_coordinator::transcribe_path_for_content_with_hints(
         transcribe_input,
@@ -2155,6 +2165,7 @@ where
     let word_count = transcript.split_whitespace().count();
     tracing::info!(
         step = "transcribe",
+        engine = %config.transcription.engine,
         words = word_count,
         diagnosis = filter_stats.diagnosis(),
         "transcription complete"
@@ -2163,7 +2174,11 @@ where
         "transcribe",
         &audio_path.display().to_string(),
         transcribe_ms,
-        serde_json::json!({"words": word_count, "diagnosis": filter_stats.diagnosis()}),
+        serde_json::json!({
+            "words": word_count,
+            "engine": config.transcription.engine,
+            "diagnosis": filter_stats.diagnosis()
+        }),
     );
 
     // Check minimum word threshold
@@ -2566,8 +2581,8 @@ where
         template: template.map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
             // Prefer the all-noise-suppression diagnosis when it fired; it
-            // describes a different failure mode (whisper produced only
-            // non-speech markers on sparse stems) than the standard
+            // describes a different failure mode (ASR produced only non-speech
+            // markers on sparse stems) than the standard
             // min_words / no_speech filter path. Identical preference order
             // to `write_transcript_artifact` so both entry points produce
             // matching frontmatter.

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -34,7 +34,7 @@ pub struct FilterStats {
     pub audio_duration_secs: f64,
     /// Samples after silence stripping (0 = all silence)
     pub samples_after_silence_strip: usize,
-    /// Raw segments from whisper/parakeet before any filtering
+    /// Raw ASR segments before any filtering
     pub raw_segments: usize,
     /// Segments skipped by whisper's no_speech_prob > 0.8
     pub skipped_no_speech: usize,
@@ -65,7 +65,7 @@ impl FilterStats {
             parts.push("silence strip removed ALL audio".into());
             return parts.join(", ");
         }
-        parts.push(format!("whisper produced {} segments", self.raw_segments));
+        parts.push(format!("ASR produced {} segments", self.raw_segments));
         if self.raw_segments == 0 {
             return parts.join(", ");
         }
@@ -125,6 +125,75 @@ impl FilterStats {
 pub struct TranscribeResult {
     pub text: String,
     pub stats: FilterStats,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TimedTranscriptSegment {
+    pub start_secs: f64,
+    pub end_secs: f64,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TimestampedTranscriptStats {
+    pub raw_segments: usize,
+    pub after_dedup: usize,
+    pub after_interleaved: usize,
+    pub after_script_filter: usize,
+    pub after_noise_markers: usize,
+    pub after_trailing_trim: usize,
+}
+
+pub(crate) fn transcript_from_timed_segments(
+    segments: &[TimedTranscriptSegment],
+    config: &Config,
+) -> Result<(String, TimestampedTranscriptStats), TranscribeError> {
+    let mut lines = Vec::new();
+    for segment in segments {
+        let text = segment.text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        if !segment.start_secs.is_finite()
+            || !segment.end_secs.is_finite()
+            || segment.start_secs < 0.0
+            || segment.end_secs < segment.start_secs
+        {
+            return Err(TranscribeError::TranscriptionFailed(format!(
+                "timestamped transcript segment has invalid bounds: start={}, end={}",
+                segment.start_secs, segment.end_secs
+            )));
+        }
+        let mins = (segment.start_secs / 60.0) as u64;
+        let secs = (segment.start_secs % 60.0) as u64;
+        lines.push(format!("[{}:{:02}] {}", mins, secs, text));
+    }
+    let raw_segments = lines.len();
+
+    if lines.is_empty() {
+        return Err(TranscribeError::EmptyTranscript(
+            config.transcription.min_words,
+        ));
+    }
+
+    let cleanup = run_transcript_cleanup_pipeline(lines);
+    let stats = TimestampedTranscriptStats {
+        raw_segments,
+        after_dedup: cleanup.after(TranscriptCleanupStage::DedupSegments),
+        after_interleaved: cleanup.after(TranscriptCleanupStage::DedupInterleaved),
+        after_script_filter: cleanup.after(TranscriptCleanupStage::StripForeignScript),
+        after_noise_markers: cleanup.after(TranscriptCleanupStage::CollapseNoiseMarkers),
+        after_trailing_trim: cleanup.after(TranscriptCleanupStage::TrimTrailingNoise),
+    };
+
+    let transcript = cleanup.lines.join("\n");
+    if transcript.is_empty() {
+        return Err(TranscribeError::EmptyTranscript(
+            config.transcription.min_words,
+        ));
+    }
+
+    Ok((format!("{}\n", transcript), stats))
 }
 
 /// Meeting-local lexical hints that can safely inform batch decoding.
@@ -295,9 +364,11 @@ fn normalize_decode_hint_candidate(
 // Engines:
 //   - whisper (default): whisper.cpp via whisper-rs, Apple Accelerate on M-series
 //   - parakeet (opt-in): parakeet.cpp via subprocess, Metal on Apple Silicon
+//   - mlx-audio (opt-in): local Python helper, MLX on Apple Silicon
 //
-// Engine is selected via config.transcription.engine ("whisper" or "parakeet").
-// Model must be downloaded first via `minutes setup`.
+// Engine is selected via config.transcription.engine.
+// Whisper and Parakeet models can be downloaded via `minutes setup`; MLX Audio
+// uses the configured Python environment and model cache.
 // ──────────────────────────────────────────────────────────────
 
 /// Transcribe an audio file to text.
@@ -305,6 +376,7 @@ fn normalize_decode_hint_candidate(
 /// Dispatches to the engine configured in `config.transcription.engine`:
 /// - `"whisper"` (default): whisper.cpp via whisper-rs
 /// - `"parakeet"`: parakeet.cpp via subprocess
+/// - `"mlx-audio"`: MLX Audio via a warm local helper process
 /// - `"apple-speech"`: currently live-transcript-only; batch/default paths
 ///   fall back to whisper until the experiment graduates
 ///
@@ -330,6 +402,7 @@ fn transcribe_dispatch(
     match config.transcription.engine.as_str() {
         "whisper" => transcribe_whisper_dispatch(audio_path, config, hints),
         "parakeet" => transcribe_parakeet_dispatch(audio_path, config, hints),
+        "mlx-audio" => crate::mlx_audio::transcribe(audio_path, config),
         "apple-speech" => {
             tracing::warn!(
                 "apple-speech is experimental and live-transcript-only today — falling back to whisper for batch/default transcription"
@@ -912,6 +985,7 @@ fn transcribe_with_whisper(
     stats.final_words = word_count;
 
     tracing::info!(
+        engine = "whisper",
         segments = num_segments,
         words = word_count,
         diagnosis = stats.diagnosis(),
@@ -937,7 +1011,7 @@ fn transcribe_with_whisper(
 /// because symphonia's AAC decoder produces samples that cause whisper to
 /// hallucinate on non-English audio (issue #21). Falls back to symphonia
 /// when ffmpeg is not installed.
-fn load_audio_samples(path: &Path) -> Result<Vec<f32>, TranscribeError> {
+pub(crate) fn load_audio_samples(path: &Path) -> Result<Vec<f32>, TranscribeError> {
     let ext = path
         .extension()
         .and_then(|e| e.to_str())
@@ -2010,6 +2084,7 @@ fn transcribe_result_from_parakeet_parsed(
     let word_count = transcript.split_whitespace().count();
     stats.final_words = word_count;
     tracing::info!(
+        engine = "parakeet",
         words = word_count,
         segments = parsed.segments.len(),
         host_process_first_use,
@@ -2696,41 +2771,26 @@ fn parakeet_transcript_from_segments_with_stats(
     config: &Config,
 ) -> Result<(ParakeetCliTranscript, String, ParakeetFilterStats), TranscribeError> {
     let segments = crate::parakeet::group_word_segments(&segments);
-    let lines: Vec<String> = segments
+    let timed_segments: Vec<TimedTranscriptSegment> = segments
         .iter()
-        .map(|segment| {
-            let mins = (segment.start_secs / 60.0) as u64;
-            let secs = (segment.start_secs % 60.0) as u64;
-            format!("[{}:{:02}] {}", mins, secs, segment.text)
+        .map(|segment| TimedTranscriptSegment {
+            start_secs: segment.start_secs,
+            end_secs: segment.end_secs,
+            text: segment.text.clone(),
         })
         .collect();
-    let raw_segments = lines.len();
-
-    if lines.is_empty() {
-        return Err(TranscribeError::EmptyTranscript(
-            config.transcription.min_words,
-        ));
-    }
-
-    let cleanup = run_transcript_cleanup_pipeline(lines);
+    let (transcript_with_newline, cleanup_stats) =
+        transcript_from_timed_segments(&timed_segments, config)?;
 
     let pstats = ParakeetFilterStats {
-        raw_segments,
-        after_dedup: cleanup.after(TranscriptCleanupStage::DedupSegments),
-        after_interleaved: cleanup.after(TranscriptCleanupStage::DedupInterleaved),
-        after_script_filter: cleanup.after(TranscriptCleanupStage::StripForeignScript),
-        after_noise_markers: cleanup.after(TranscriptCleanupStage::CollapseNoiseMarkers),
-        after_trailing_trim: cleanup.after(TranscriptCleanupStage::TrimTrailingNoise),
+        raw_segments: cleanup_stats.raw_segments,
+        after_dedup: cleanup_stats.after_dedup,
+        after_interleaved: cleanup_stats.after_interleaved,
+        after_script_filter: cleanup_stats.after_script_filter,
+        after_noise_markers: cleanup_stats.after_noise_markers,
+        after_trailing_trim: cleanup_stats.after_trailing_trim,
     };
 
-    let transcript = cleanup.lines.join("\n");
-    if transcript.is_empty() {
-        return Err(TranscribeError::EmptyTranscript(
-            config.transcription.min_words,
-        ));
-    }
-
-    let transcript_with_newline = format!("{}\n", transcript);
     Ok((
         ParakeetCliTranscript {
             raw_output: raw_output.to_string(),
@@ -3799,6 +3859,27 @@ Hello there.
             parsed[1],
             Err(TranscribeError::EmptyTranscript(_))
         ));
+    }
+
+    #[test]
+    fn diagnosis_uses_engine_agnostic_segment_label() {
+        let stats = FilterStats {
+            audio_duration_secs: 30.0,
+            samples_after_silence_strip: 16_000 * 30,
+            raw_segments: 2,
+            after_no_speech_filter: 2,
+            after_dedup: 2,
+            after_interleaved: 2,
+            after_script_filter: 2,
+            after_noise_markers: 2,
+            after_trailing_trim: 2,
+            final_words: 12,
+            ..FilterStats::default()
+        };
+
+        let d = stats.diagnosis();
+        assert!(d.contains("ASR produced 2 segments"), "{d}");
+        assert!(!d.contains("whisper produced"), "{d}");
     }
 
     #[test]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -21,9 +21,9 @@ So `minutes record --device "MacBook Pro Microphone"` always wins over `[recordi
 
 | key | default | meaning |
 |---|---|---|
-| `engine` | `"whisper"` | `"whisper"` (default) or `"parakeet"` |
-| `model` | `"base"` | Whisper model: `tiny` / `base` / `small` / `medium` / `large-v3` |
-| `parakeet_model` | `"tdt-ctc-110m"` | Parakeet model: `tdt-ctc-110m` or `tdt-600m` |
+| `engine` | `"whisper"` | `"whisper"` (default), `"parakeet"`, `"mlx-audio"`, or experimental `"apple-speech"` for standalone live |
+| `model` | `"small"` | Whisper model: `tiny` / `base` / `small` / `medium` / `large-v3` |
+| `parakeet_model` | `"tdt-600m"` | Parakeet model: `tdt-ctc-110m` or `tdt-600m` |
 | `language` | auto-detect | BCP-47 tag (e.g. `"en"`, `"es"`) to force a specific language |
 | `noise_reduction` | `true` | RNNoise pre-filter (requires `denoise` feature) |
 | `vad_model` | `"silero-v6.2.0"` | Silero VAD model name; empty string disables |
@@ -32,12 +32,22 @@ So `minutes record --device "MacBook Pro Microphone"` always wins over `[recordi
 | `parakeet_sidecar_enabled` | auto | Warm sidecar: auto-enables when parakeet is the engine and `example-server` resolves. `true`/`"on"` forces on, `"off"` forces off. A legacy bool `false` is treated as auto (pre-0.18.8 saves wrote it into every config) (#295) |
 | `parakeet_fp16` | `true` | GPU fp16 inference for lower memory use |
 | `parakeet_boost_limit` / `parakeet_boost_score` | `0` / `2.0` | Knowledge-graph phrase boosting; 0 = off |
+| `mlx_audio_model` | `"mlx-community/Qwen3-ASR-1.7B-8bit"` | Hugging Face repo id or local MLX Audio model path |
+| `mlx_audio_python` | `"python3"` | Python executable used to launch the local MLX Audio helper |
+| `mlx_audio_warm` | `true` | Keep one helper process resident so large MLX models stay loaded between requests |
+| `mlx_audio_timeout_secs` | `1800` | Per-request timeout for MLX Audio transcription; `0` waits indefinitely |
+| `mlx_audio_chunk_secs` | `30.0` | Chunk duration forwarded to timestamp-capable MLX models such as Qwen3-ASR |
+
+For MLX Audio setup and model caveats, see [`docs/MLX_AUDIO.md`](MLX_AUDIO.md).
+
+Saved-audio MLX transcripts require timestamped segments. Live transcript and
+dictation do not use MLX in this phase.
 
 ### `[diarization]` — speaker attribution
 
 | key | default | meaning |
 |---|---|---|
-| `engine` | `"none"` | `"none"` or `"pyannote-rs"` |
+| `engine` | `"auto"` | `"auto"` (uses pyannote-rs if models are installed), `"pyannote-rs"`, `"pyannote"` (legacy Python), or `"none"` |
 | `threshold` | `0.4` | Cosine similarity cutoff; lower merges more aggressively |
 | `embedding_model` | `"cam++"` | `"cam++"` or `"cam++-lm"` (lower EER, lower similarities) |
 

--- a/docs/MLX_AUDIO.md
+++ b/docs/MLX_AUDIO.md
@@ -1,0 +1,136 @@
+# MLX Audio Engine Setup
+
+Minutes supports MLX Audio as an opt-in local transcription engine on Apple
+Silicon. It is designed for larger local ASR models that are expensive to load:
+Minutes starts a small Python helper, loads the configured model once, and sends
+JSONL requests for saved audio.
+
+## Scope
+
+`transcription.engine = "mlx-audio"` applies to saved-audio processing:
+`minutes process`, desktop post-recording processing, and meeting/memo
+processing.
+
+Live transcript and dictation are intentionally out of scope for this first
+backend. They can continue to use Whisper, Apple Speech, or Parakeet while
+saved-audio processing uses MLX.
+
+## Setup
+
+The recommended setup command creates/uses `~/.minutes/mlx-audio`, installs
+`mlx-audio`, checks that the selected model can load, and saves config:
+
+```bash
+minutes setup --mlx-audio
+minutes setup --mlx-audio --mlx-audio-model mlx-community/Qwen3-ASR-1.7B-8bit
+```
+
+Manual setup is also possible:
+
+```bash
+python3 -m venv ~/.minutes/mlx-audio
+~/.minutes/mlx-audio/bin/python -m pip install -U pip
+~/.minutes/mlx-audio/bin/python -m pip install -U mlx-audio
+```
+
+If the model you want requires unreleased MLX Audio support, install from a
+local clone or GitHub instead:
+
+```bash
+git clone https://github.com/Blaizzy/mlx-audio ~/src/mlx-audio
+~/.minutes/mlx-audio/bin/python -m pip install -e ~/src/mlx-audio
+```
+
+Then configure Minutes:
+
+```toml
+[transcription]
+engine = "mlx-audio"
+mlx_audio_python = "/Users/you/.minutes/mlx-audio/bin/python"
+mlx_audio_model = "mlx-community/Qwen3-ASR-1.7B-8bit"
+mlx_audio_warm = true
+mlx_audio_timeout_secs = 1800
+mlx_audio_chunk_secs = 30.0
+```
+
+For desktop launches on macOS, prefer an absolute `mlx_audio_python` path. Apps
+launched from Finder or Spotlight do not always inherit your shell `PATH`.
+Desktop post-recording/meeting processing uses the same core config and does
+not require a Settings UI change. Use **Settings → Advanced → Open config** to
+review or edit MLX fields. The Settings engine dropdown may not list MLX yet.
+
+## Timestamp Contract
+
+Saved-audio meeting/memo transcripts need timed transcript segments so
+downstream diarization can align speaker labels with transcript windows. The
+MLX batch path therefore accepts only model outputs with real segment or
+sentence timestamps.
+
+If a model returns text without timestamps, Minutes fails the transcription
+instead of inventing timing. Pick a timestamp-capable model or lower the chunk
+duration if the model exposes chunk-level timestamps.
+
+Live transcript and dictation do not use MLX in this phase.
+
+## Warm Helper Behavior
+
+`mlx_audio_warm = true` keeps one helper process resident in the current
+Minutes process. That avoids repeated model loads for large local ASR models
+during batch runs.
+
+Set `mlx_audio_warm = false` to spawn a fresh helper per request. For tests or
+debugging, `MINUTES_MLX_AUDIO_FORCE_ONESHOT=1` forces the one-shot path without
+editing config.
+
+## Real-Model Smoke Test
+
+The unit tests use fake helpers and do not download model weights. To exercise
+a real model:
+
+```bash
+MINUTES_MLX_AUDIO_E2E_AUDIO=/path/to/audio.wav \
+MINUTES_MLX_AUDIO_E2E_PYTHON=/Users/you/.minutes/mlx-audio/bin/python \
+MINUTES_MLX_AUDIO_E2E_MODEL=mlx-community/Qwen3-ASR-1.7B-8bit \
+MINUTES_MLX_AUDIO_E2E_CHUNK_SECS=10 \
+MINUTES_MLX_AUDIO_E2E_TIMEOUT_SECS=3600 \
+cargo test -p minutes-core mlx_audio_real_model_e2e_when_env_is_set -- --nocapture
+```
+
+For a private reference run, keep the audio and VTT outside the repo and point
+the env vars at local files, for example:
+
+```bash
+MINUTES_MLX_AUDIO_E2E_AUDIO=/path/to/reference-meeting.m4a \
+MINUTES_MLX_AUDIO_E2E_PYTHON=/Users/you/.minutes/mlx-audio/bin/python \
+MINUTES_MLX_AUDIO_E2E_MODEL=mlx-community/Qwen3-ASR-1.7B-8bit \
+cargo test -p minutes-core mlx_audio_real_model_e2e_when_env_is_set -- --nocapture
+```
+
+Use a matching `.vtt` transcript as local reference material for a private
+benchmark. The benchmark crops the audio in-process, compares the MLX
+transcript against the matching VTT window, and prints WER, CER, and realtime
+factor:
+
+```bash
+MINUTES_MLX_AUDIO_BENCH_AUDIO=/path/to/reference-meeting.m4a \
+MINUTES_MLX_AUDIO_BENCH_REFERENCE_VTT=/path/to/reference-meeting.vtt \
+MINUTES_MLX_AUDIO_BENCH_PYTHON=/Users/you/.minutes/mlx-audio/bin/python \
+MINUTES_MLX_AUDIO_BENCH_MODEL=mlx-community/Qwen3-ASR-1.7B-8bit \
+MINUTES_MLX_AUDIO_BENCH_START_SECS=2 \
+MINUTES_MLX_AUDIO_BENCH_DURATION_SECS=20 \
+MINUTES_MLX_AUDIO_BENCH_CHUNK_SECS=10 \
+MINUTES_MLX_AUDIO_BENCH_TIMEOUT_SECS=3600 \
+cargo test -p minutes-core mlx_audio_reference_benchmark_when_env_is_set -- --nocapture
+```
+
+Optional gates make the benchmark fail when a model regresses beyond an agreed
+threshold:
+
+```bash
+MINUTES_MLX_AUDIO_BENCH_MAX_WER=0.25 \
+MINUTES_MLX_AUDIO_BENCH_MAX_CER=0.15 \
+MINUTES_MLX_AUDIO_BENCH_MAX_RTF=1.0 \
+cargo test -p minutes-core mlx_audio_reference_benchmark_when_env_is_set -- --nocapture
+```
+
+Do not commit private meeting audio or transcripts to the upstream PR.


### PR DESCRIPTION
## Summary
- Add `transcription.engine = "mlx-audio"` as a config-driven saved-audio transcription backend for final meeting/memo transcripts.
- Add `minutes setup --mlx-audio --mlx-audio-model <id>` to create/use a local Python env, install `mlx-audio`, save config, and run a lightweight readiness check.
- Add a warm JSONL helper for MLX Audio, reuse the timestamped transcript formatter, and keep batch transcripts strict about timed segments.
- Make ASR diagnostics engine-neutral and include the selected transcription engine in pipeline logs.
- Document config-only desktop usage, the timestamp contract, and gated real-model/reference benchmark tests.

## Scope
- Saved-audio/batch processing only: `minutes process`, desktop post-recording processing, and meeting/memo processing.
- No live transcript or dictation backend changes in this PR.
- No desktop Settings dropdown changes; users configure MLX via `minutes setup` or Advanced -> Open config.
- No speakrs/diarization changes.

## Test plan
- `cargo check -p minutes-core`
- `cargo test -p minutes-core mlx_audio --lib`
- `cargo test -p minutes-core diagnosis_uses_engine_agnostic_segment_label --lib`
- `cargo test -p minutes-cli mlx_audio`
- `git diff --check`