### PR TITLE
fix(release): bundle the real CLI sidecar, never the placeholder (#324)

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -102,6 +102,12 @@ jobs:
           chmod 600 "$key_path"
           echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
+      # The bundle ships the CLI as a sidecar (in-app "Set up CLI" symlinks to
+      # it). build.rs stages it from target/release/minutes, so the CLI must be
+      # built first or the bundle ships a placeholder stub (#324).
+      - name: Build release CLI for bundling
+        run: cargo build --release -p minutes-cli --features parakeet,metal
+
       - name: Build signed + notarized bundle (with updater artifacts)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,7 +118,20 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          MINUTES_REQUIRE_REAL_CLI_SIDECAR: "1"
         run: cargo tauri build --features parakeet,metal --bundles app
+
+      - name: Verify bundled CLI sidecar is real
+        run: |
+          sidecar="target/release/bundle/macos/Minutes.app/Contents/MacOS/minutes"
+          test -f "$sidecar" || { echo "ERROR: bundled CLI sidecar missing" >&2; exit 1; }
+          size=$(stat -f%z "$sidecar")
+          echo "bundled CLI sidecar size: $size bytes"
+          if [ "$size" -lt 10000000 ]; then
+            echo "ERROR: bundled CLI sidecar is too small to be the real binary (placeholder? #324)" >&2
+            exit 1
+          fi
+          file "$sidecar" | grep -q "Mach-O" || { echo "ERROR: bundled CLI sidecar is not a Mach-O binary" >&2; exit 1; }
 
       - name: Refresh release helper scripts for manual reruns
         if: github.event_name == 'workflow_dispatch'

--- a/tauri/src-tauri/build.rs
+++ b/tauri/src-tauri/build.rs
@@ -10,15 +10,24 @@ fn main() {
     tauri_build::build()
 }
 
+/// Below this size the staged sidecar cannot be a real CLI binary (the real
+/// one is tens of MB; the placeholder is ~52 bytes).
+const MIN_REAL_CLI_SIDECAR_BYTES: u64 = 1_000_000;
+
 /// Ensure `bin/minutes-<target>` exists so Tauri's `externalBin` resolution
 /// succeeds during plain `cargo check` / `cargo clippy` runs that don't go
 /// through `scripts/build.sh`.
 ///
 /// If the release CLI has been built (`target/release/minutes`), copy it. If
 /// not, write a non-empty placeholder. The placeholder is enough to satisfy
-/// Tauri's existence check at compile time; the real bundling step
-/// (`cargo tauri build --bundles app`) is preceded by `scripts/build.sh`'s
-/// CLI build + copy, which overwrites this with the actual binary.
+/// Tauri's existence check at compile time for check/clippy runs.
+///
+/// Distributable bundles must never contain the placeholder. Release builds
+/// set `MINUTES_REQUIRE_REAL_CLI_SIDECAR=1`, which makes this step hard-fail
+/// instead of writing a placeholder, and re-stage over a stale placeholder
+/// left by an earlier check/clippy run (issue #324: the release workflow
+/// called `cargo tauri build` without building the CLI first, and every
+/// CI-built macOS bundle since v0.16.2 shipped the stub).
 fn stage_minutes_cli_sidecar() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if target_os != "macos" {
@@ -33,9 +42,20 @@ fn stage_minutes_cli_sidecar() {
     let staged = bin_dir.join(format!("minutes-{}", target));
 
     println!("cargo:rerun-if-changed={}", staged.display());
+    println!("cargo:rerun-if-env-changed=MINUTES_REQUIRE_REAL_CLI_SIDECAR");
+
+    let require_real = std::env::var("MINUTES_REQUIRE_REAL_CLI_SIDECAR")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
 
     if staged.exists() {
-        return;
+        let staged_len = fs::metadata(&staged).map(|m| m.len()).unwrap_or(0);
+        if !require_real || staged_len >= MIN_REAL_CLI_SIDECAR_BYTES {
+            return;
+        }
+        // Required mode found a stale placeholder from an earlier
+        // check/clippy run: drop it and stage the real binary below.
+        fs::remove_file(&staged).expect("failed to remove stale placeholder sidecar");
     }
 
     fs::create_dir_all(&bin_dir).expect("failed to create sidecar bin dir");
@@ -57,7 +77,17 @@ fn stage_minutes_cli_sidecar() {
         }
     }
 
-    // Placeholder — `cargo tauri build` will overwrite this from `scripts/build.sh`.
+    if require_real {
+        panic!(
+            "MINUTES_REQUIRE_REAL_CLI_SIDECAR is set but no release CLI binary was found \
+             (looked at {:?}). Run `cargo build --release -p minutes-cli` before \
+             `cargo tauri build` so the bundle ships a working CLI instead of a placeholder.",
+            candidate_paths
+        );
+    }
+
+    // Placeholder for check/clippy only. Distributable builds set
+    // MINUTES_REQUIRE_REAL_CLI_SIDECAR and hard-fail above instead.
     println!(
         "cargo:warning=No minutes CLI release binary found; writing placeholder sidecar at {}. Run `cargo build --release -p minutes-cli` (or `scripts/build.sh`) before `cargo tauri build`.",
         staged.display()


### PR DESCRIPTION
Closes #324. Three layers:

1. **release-macos.yml builds the CLI before `cargo tauri build`** (`--features parakeet,metal`, matching build.sh), so build.rs has a real binary to stage. This is the actual fix.
2. **build.rs hard-fails instead of writing a placeholder when `MINUTES_REQUIRE_REAL_CLI_SIDECAR=1`** (set in the release workflow). It also re-stages over a stale sub-1MB placeholder left by an earlier check/clippy run, so the early-return can't smuggle one through. Plain check/clippy without the env keeps the placeholder behavior and stays green.
3. **A post-build workflow assert** that the bundled `Contents/MacOS/minutes` exists, is over 10MB, and is Mach-O.

All four build.rs paths verified locally: require+no-CLI fails with an actionable message, normal+no-CLI writes the placeholder and check passes, require+stale-placeholder+real-CLI re-stages 52B to 33MB, normal+real-staged is untouched. fmt and clippy clean.