### PR TITLE
fix: avoid dev app WebKit frame crash

### DIFF
--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -1772,23 +1772,28 @@ mod tests {
     #[test]
     fn rename_meeting_resolves_slug_collision() {
         let dir = TempDir::new().unwrap();
+        let frontmatter =
+            "title: \"Call\"\ntype: meeting\ndate: 2026-04-07T10:00:00-07:00\nduration: 0\n";
         let path = write_meeting(
             &dir,
             "2026-04-07-call.md",
-            "title: \"Call\"\ntype: meeting\ndate: 2026-04-07T10:00:00-07:00\nduration: 0\n",
+            frontmatter,
             "## Transcript\n\nHi\n",
         );
         // Pre-create a sibling that the new slug would collide with.
+        let parsed: Frontmatter = serde_yaml::from_str(frontmatter).unwrap();
+        let collision_slug = generate_slug("Pricing Review", parsed.date, None);
         std::fs::write(
-            dir.path().join("2026-04-07-pricing-review.md"),
+            dir.path().join(&collision_slug),
             "---\ntitle: existing\ntype: meeting\ndate: 2026-04-07T10:00:00-07:00\nduration: 0\n---\n",
         )
         .unwrap();
 
         let new_path = rename_meeting(&path, "Pricing Review").unwrap();
         let name = new_path.file_name().unwrap().to_str().unwrap();
+        let collision_stem = collision_slug.trim_end_matches(".md");
         assert!(
-            name.starts_with("2026-04-07-pricing-review-") && name.ends_with(".md"),
+            name.starts_with(&format!("{collision_stem}-")) && name.ends_with(".md"),
             "expected collision-resolved slug, got {}",
             name
         );

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -32,6 +32,9 @@ mod text_insertion;
 const MINUTES_WEBSITE_URL: &str = "https://useminutes.app";
 const MINUTES_CHANGELOG_URL: &str = "https://github.com/silverstein/minutes/releases";
 const MINUTES_DISCUSSIONS_URL: &str = "https://github.com/silverstein/minutes/discussions";
+const MAIN_WINDOW_TRANSPARENT: bool = false;
+#[cfg(target_os = "macos")]
+const MAIN_WINDOW_APPLY_VIBRANCY: bool = false;
 
 static CLEAN_EXIT_STARTED: AtomicBool = AtomicBool::new(false);
 
@@ -255,7 +258,13 @@ fn show_main_window(app: &tauri::AppHandle) {
         .title("")
         .inner_size(560.0, 700.0)
         .min_inner_size(460.0, 520.0)
-        .transparent(true)
+        // The main window is hidden, shown, and resized while the app lives in
+        // the tray. On macOS 26, keeping that long-lived WebView transparent
+        // and backed by vibrancy can trip a WebKit frame-update PAC trap when
+        // the hidden window is re-framed. The UI already paints solid app
+        // surfaces, so keep this WebView opaque and reserve transparency for
+        // short-lived overlays that need it.
+        .transparent(MAIN_WINDOW_TRANSPARENT)
         .content_protected(Config::load().privacy.hide_from_screen_share)
         .focused(true);
 
@@ -271,7 +280,7 @@ fn show_main_window(app: &tauri::AppHandle) {
 
     if let Ok(win) = builder.build() {
         #[cfg(target_os = "macos")]
-        {
+        if MAIN_WINDOW_APPLY_VIBRANCY {
             use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
             apply_vibrancy(&win, NSVisualEffectMaterial::Sidebar, None, None).ok();
         }
@@ -2487,7 +2496,10 @@ fn main() {
 
 #[cfg(test)]
 mod tray_activity_tests {
-    use super::{derive_tray_activity, TrayActivity, TrayAppearance, TrayStateSnapshot};
+    use super::{
+        derive_tray_activity, TrayActivity, TrayAppearance, TrayStateSnapshot,
+        MAIN_WINDOW_TRANSPARENT,
+    };
 
     fn snap(recording: bool, live: bool, dictation: bool) -> TrayStateSnapshot {
         TrayStateSnapshot {
@@ -2495,6 +2507,20 @@ mod tray_activity_tests {
             live,
             dictation,
         }
+    }
+
+    #[test]
+    fn main_window_uses_opaque_webview_for_hidden_tray_lifecycle() {
+        assert!(
+            !MAIN_WINDOW_TRANSPARENT,
+            "the long-lived main WebView is hidden/shown from the tray; keep it opaque"
+        );
+
+        #[cfg(target_os = "macos")]
+        assert!(
+            !super::MAIN_WINDOW_APPLY_VIBRANCY,
+            "macOS vibrancy on the hidden main WebView can crash WebKit during frame updates"
+        );
     }
 
     #[test]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -11409,12 +11409,10 @@
     }
 
     // Idempotent DOM writes — skip when the value is unchanged. The status poll
-    // (checkStatus) reasserts identical idle text every 2s forever; on the main
-    // window (transparent + NSVisualEffectMaterial::Sidebar vibrancy) every text
-    // mutation forces WindowServer to re-blend the whole window, so unguarded
-    // no-op writes peg WindowServer while the app sits idle. These let an
-    // unchanged idle tick produce zero DOM churn. clearChildren() above is
-    // already idempotent (no-ops when the node is empty).
+    // (checkStatus) reasserts identical idle text every 2s forever; repeated
+    // no-op writes still make WebKit re-layout the main app surface while idle.
+    // These let an unchanged idle tick produce zero DOM churn. clearChildren()
+    // above is already idempotent (no-ops when the node is empty).
     function setText(el, value) {
       if (el && el.textContent !== value) el.textContent = value;
     }


### PR DESCRIPTION
## Summary
- Keep the long-lived main Tauri WebView opaque and skip macOS vibrancy to reduce WebKit frame-update crashes when the app is hidden/shown from the tray.
- Stop upcoming-meeting calendar polls from mutating hidden main-window UI, and gate Recall auto-expand on the main window being visible and focused before it resizes the WebView.
- Add regression guards for both the main-window opacity/vibrancy settings and the upcoming-meeting auto-expand visibility/focus contract.
- Make the markdown rename collision test timezone-safe after it failed under Asia/Singapore local time.

## Testing
- cargo fmt --all -- --check
- cargo clippy --all --no-default-features -- -D warnings
- cargo test -p minutes-core --no-default-features --lib
- cargo test -p minutes-app --no-default-features
- ./scripts/install-dev-app.sh
- Relaunched ~/Applications/Minutes Dev.app, hid the main window, waited 75s for the upcoming-meeting poll interval, and confirmed PID stayed alive with no new minutes-app .ips after the 2026-06-15 14:27:23 pre-fix crash report.