### PR TITLE
fix: avoid upcoming meeting hidden WebView crash

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -9308,6 +9308,34 @@ mod tests {
     }
 
     #[test]
+    fn upcoming_meeting_auto_expand_requires_visible_focused_main_window() {
+        let manifest = env!("CARGO_MANIFEST_DIR"); // .../tauri/src-tauri
+        let index_path = format!("{}/../src/index.html", manifest);
+        let html = std::fs::read_to_string(&index_path).expect("failed to read index.html");
+
+        assert!(
+            html.contains("async function mainWindowAllowsAutoExpand()"),
+            "frontend must centralize the visible/focused gate before auto-expanding Recall"
+        );
+        assert!(
+            html.contains("currentWindow.isVisible()"),
+            "auto-expand must check main window visibility before resizing the WebView"
+        );
+        assert!(
+            html.contains("currentWindow.isFocused()"),
+            "upcoming meeting prep should not resize a backgrounded WebView"
+        );
+        assert!(
+            html.contains("if (!(await mainWindowAllowsAutoExpand())) return;"),
+            "autoExpandRecall must bail before openRecall/expandRecallPanel on hidden background windows"
+        );
+        assert!(
+            html.contains("autoExpandRecall('prep', title).catch"),
+            "upcoming meeting auto-expand should handle async gate failures explicitly"
+        );
+    }
+
+    #[test]
     fn update_assistant_live_context_updates_both_instruction_files() {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path();

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -8692,6 +8692,7 @@
     // ── Upcoming meetings ──
     async function checkUpcoming() {
       const upcoming = document.getElementById('upcoming');
+      if (!(await mainWindowAllowsUiRefresh())) return;
       if (!desktopCapabilities.supportsCalendarIntegration) {
         upcoming.classList.remove('active');
         return;
@@ -10397,6 +10398,33 @@
     const { getCurrentWindow } = window.__TAURI__.window;
     const currentWindow = getCurrentWindow();
 
+    async function mainWindowAllowsUiRefresh() {
+      try {
+        if (typeof currentWindow.isVisible === 'function') {
+          const visible = await currentWindow.isVisible();
+          if (!visible) return false;
+        }
+      } catch (e) {
+        console.error('Main window visibility check:', e);
+        return false;
+      }
+      return true;
+    }
+
+    async function mainWindowAllowsAutoExpand() {
+      if (!(await mainWindowAllowsUiRefresh())) return false;
+      try {
+        if (typeof currentWindow.isFocused === 'function') {
+          const focused = await currentWindow.isFocused();
+          if (!focused) return false;
+        }
+      } catch (e) {
+        console.error('Main window focus check:', e);
+        return false;
+      }
+      return true;
+    }
+
     window.__TAURI__.app.getVersion?.().then((version) => {
       if (aboutVersion) aboutVersion.textContent = `Desktop app v${version}`;
     }).catch(() => { });
@@ -10791,12 +10819,13 @@
     }
 
     // ── Auto-expand triggers ──
-    function autoExpandRecall(mode, context) {
+    async function autoExpandRecall(mode, context) {
       if (userExplicitlyCollapsed) {
         recallNudge.classList.add('active');
         return;
       }
-      openRecall(mode === 'debrief' ? 'assistant' : mode);
+      if (!(await mainWindowAllowsAutoExpand())) return;
+      await openRecall(mode === 'debrief' ? 'assistant' : mode);
       if (mode === 'prep') setRecallPhase('prep', context);
       else if (mode === 'debrief') setRecallPhase('debrief', context);
     }
@@ -12103,7 +12132,7 @@
 
       if (!isRecording && prevRecording) {
         if (!recallExpanded) {
-          autoExpandRecall('debrief', null);
+          autoExpandRecall('debrief', null).catch((e) => console.error('Auto-expand debrief:', e));
         }
       }
 
@@ -12118,7 +12147,7 @@
       const upcomingEl = document.getElementById('upcoming');
       if (upcomingEl && upcomingEl.classList.contains('active') && !recallExpanded && !isRecording) {
         const title = document.getElementById('upcoming-title').textContent;
-        autoExpandRecall('prep', title);
+        autoExpandRecall('prep', title).catch((e) => console.error('Auto-expand prep:', e));
       }
     };
 
@@ -12868,6 +12897,14 @@
     checkSetup();
     checkStatus();
     setInterval(() => { if (!pollInterval) checkStatus(); }, 2000);
+    if (typeof currentWindow.onFocusChanged === 'function') {
+      currentWindow.onFocusChanged((event) => {
+        const focused = typeof event?.payload === 'boolean' ? event.payload : true;
+        if (focused) {
+          checkUpcoming().catch((e) => console.error('Upcoming after focus:', e));
+        }
+      }).catch((e) => console.error('Focus listener:', e));
+    }
     // Defer heavy checks (osascript calendar queries) so the UI is interactive immediately
     setTimeout(() => {
       loadReadinessItems();


### PR DESCRIPTION
## Summary
- Skip upcoming-meeting UI refreshes while the main window is hidden, so the calendar poll does not mutate a tray-hidden WebView.
- Gate Recall auto-expand on the main window being both visible and focused before it resizes/repositions the WebView.
- Add a frontend contract test for the upcoming-meeting prep auto-expand guard.

## Testing
- cargo fmt --all -- --check
- cargo clippy --all --no-default-features -- -D warnings
- cargo test -p minutes-app --no-default-features
- ./scripts/install-dev-app.sh
- Relaunched ~/Applications/Minutes Dev.app, hid the main window, waited 75s for the upcoming-meeting poll interval, and confirmed PID stayed alive with no new minutes-app .ips after the 2026-06-15 14:27:23 pre-fix crash report.