### PR TITLE
Fix meeting prompt dismissal crash

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1016,6 +1016,14 @@ pub fn cmd_get_meeting_prompt(
     }
 }
 
+#[tauri::command]
+pub fn cmd_close_meeting_prompt(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(win) = app.get_webview_window("meeting-prompt") {
+        win.destroy().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 /// Surface a deferred update notification if one is pending and no session is active.
 /// Call this after recording/live/dictation stops.
 pub fn surface_deferred_update(app: &tauri::AppHandle) {

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -932,7 +932,7 @@ fn show_meeting_prompt(app: &tauri::AppHandle, event: &minutes_core::calendar::C
 
     // Close any existing prompt window
     if let Some(win) = app.get_webview_window("meeting-prompt") {
-        win.close().ok();
+        win.destroy().ok();
     }
 
     // Stage the payload keyed by a monotonic token. The overlay reads its
@@ -2436,6 +2436,7 @@ fn main() {
             commands::cmd_vault_unlink,
             commands::cmd_open_meeting_url,
             commands::cmd_get_meeting_prompt,
+            commands::cmd_close_meeting_prompt,
             commands::cmd_start_dictation,
             commands::cmd_stop_dictation,
             commands::cmd_dismiss_dictation_overlay,
@@ -2511,15 +2512,46 @@ mod tray_activity_tests {
 
     #[test]
     fn main_window_uses_opaque_webview_for_hidden_tray_lifecycle() {
-        assert!(
-            !MAIN_WINDOW_TRANSPARENT,
-            "the long-lived main WebView is hidden/shown from the tray; keep it opaque"
-        );
+        const {
+            assert!(
+                !MAIN_WINDOW_TRANSPARENT,
+                "the long-lived main WebView is hidden/shown from the tray; keep it opaque"
+            );
+        }
 
         #[cfg(target_os = "macos")]
+        const {
+            assert!(
+                !super::MAIN_WINDOW_APPLY_VIBRANCY,
+                "macOS vibrancy on the hidden main WebView can crash WebKit during frame updates"
+            );
+        }
+    }
+
+    #[test]
+    fn meeting_prompt_dismiss_uses_native_destroy_path() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let main_rs = std::fs::read_to_string(format!("{}/src/main.rs", manifest))
+            .expect("failed to read main.rs");
+        let prompt_html =
+            std::fs::read_to_string(format!("{}/../src/meeting-prompt.html", manifest))
+                .expect("failed to read meeting-prompt.html");
+
         assert!(
-            !super::MAIN_WINDOW_APPLY_VIBRANCY,
-            "macOS vibrancy on the hidden main WebView can crash WebKit during frame updates"
+            main_rs.contains("commands::cmd_close_meeting_prompt"),
+            "meeting prompt close command must be registered with Tauri"
+        );
+        assert!(
+            main_rs.contains("win.destroy().ok()"),
+            "replacing an existing meeting prompt should destroy, not close, the old WebView"
+        );
+        assert!(
+            prompt_html.contains("cmd_close_meeting_prompt"),
+            "meeting prompt dismiss must route through native destroy"
+        );
+        assert!(
+            !prompt_html.contains("getCurrentWebviewWindow().close()"),
+            "direct JS WebView close can crash WebKit during prompt frame updates"
         );
     }
 

--- a/tauri/src/meeting-prompt.html
+++ b/tauri/src/meeting-prompt.html
@@ -314,9 +314,6 @@
 
   <script>
     const invoke = window.__TAURI__?.core?.invoke || (async () => null);
-    const getCurrentWebviewWindow =
-      window.__TAURI__?.webviewWindow?.getCurrentWebviewWindow ||
-      (() => ({ close: () => window.close() }));
 
     // Element refs
     const titleEl = document.getElementById('title');
@@ -331,6 +328,7 @@
     let minutesUntil = 0;
     let meetingUrl = '';
     let hasUrl = false;
+    let closeScheduled = false;
 
     function renderFromState() {
       titleEl.textContent = title || 'Meeting';
@@ -351,8 +349,21 @@
         : 'Minutes can start a local recording now so the transcript, decisions, and action items are captured from the beginning.';
     }
 
+    async function closeWindowNative() {
+      try {
+        await invoke('cmd_close_meeting_prompt');
+      } catch (e) {
+        console.warn('cmd_close_meeting_prompt failed:', e);
+        window.close();
+      }
+    }
+
     function closeWindow() {
-      try { getCurrentWebviewWindow().close(); } catch { window.close(); }
+      if (closeScheduled) return;
+      closeScheduled = true;
+      setTimeout(() => {
+        closeWindowNative();
+      }, 0);
     }
 
     (async () => {
@@ -415,7 +426,7 @@
         toast.classList.add('show');
         setTimeout(() => {
           toast.classList.remove('show');
-          setTimeout(() => getCurrentWebviewWindow().close(), 200);
+          setTimeout(closeWindow, 200);
         }, 600);
       } catch (e) {
         primaryBtn.disabled = false;
@@ -426,7 +437,7 @@
     }
 
     function dismiss() {
-      getCurrentWebviewWindow().close();
+      closeWindow();
     }
 
     primaryBtn.addEventListener('click', startRecording);
@@ -442,7 +453,7 @@
     setTimeout(() => {
       document.body.style.transition = 'opacity 300ms ease-out';
       document.body.style.opacity = '0';
-      setTimeout(() => getCurrentWebviewWindow().close(), 300);
+      setTimeout(closeWindow, 300);
     }, 60000);
   </script>
 </body>


### PR DESCRIPTION
## Summary

- Close the `meeting-prompt` window through a native `cmd_close_meeting_prompt` command that destroys the webview window.
- Make prompt dismissal idempotent so Dismiss, X, Escape, success auto-close, and auto-dismiss all share the same close path.
- Add a regression test covering that the meeting prompt dismissal flow uses the native destroy path.

Fixes #333.

## Scope

This branch is intentionally limited to the meeting-prompt crash fix and excludes the call-detection changes from #331.

## Tests

- `cargo fmt --check`
- `cargo clippy -p minutes-app --all-targets -- -D warnings`
- `cargo test -p minutes-app` (`207 passed`)
- `./scripts/install-dev-app.sh --no-open`
- Manual: built/installed `Minutes Dev.app`, exercised meeting-prompt dismissal paths, and confirmed dismissing no longer crashes the app.

## Manual test caveat

I could not fully exercise the `Join & Record` calendar URL path on this managed Mac. The bundled `calendar-events` helper continued to report write-only Calendar access even though System Settings showed Full Access, so direct helper reads failed with `access not granted`.
