### PR TITLE
feat(capture): pre-flight microphone permission gate (silent-capture L0)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8587,6 +8587,14 @@ fn cmd_dictate(stdout: bool, note_only: bool, config: &Config) -> Result<()> {
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
+    let permission_preflight = minutes_core::capture::preflight_microphone_only();
+    if let Some(reason) = &permission_preflight.blocking_reason {
+        anyhow::bail!("{}", reason);
+    }
+    for warning in &permission_preflight.warnings {
+        eprintln!("[minutes] {}", warning);
+    }
+
     eprintln!("[minutes] Starting dictation (Ctrl-C to stop)...");
     if config.dictation.accumulate {
         eprintln!(
@@ -9158,6 +9166,14 @@ fn cmd_confirm(
 fn cmd_live(config: &Config) -> Result<()> {
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
+
+    let permission_preflight = minutes_core::capture::preflight_microphone_only();
+    if let Some(reason) = &permission_preflight.blocking_reason {
+        anyhow::bail!("{}", reason);
+    }
+    for warning in &permission_preflight.warnings {
+        eprintln!("[minutes] {}", warning);
+    }
 
     eprintln!("Starting live transcript session...");
     if config.transcription.engine == "apple-speech" {

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::error::CaptureError;
+use crate::macos_permissions::{microphone_status, screen_recording_status, MacPermissionStatus};
 use crate::pid::CaptureMode;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -377,6 +378,13 @@ pub enum RecordingIntent {
     Call,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapturePreflightBlockKind {
+    CallRoute,
+    Permission,
+}
+
 #[derive(Debug, Clone)]
 pub struct RecordingStartedContext {
     pub session_id: Option<String>,
@@ -401,7 +409,20 @@ pub struct CapturePreflight {
     pub input_device: String,
     pub system_audio_ready: bool,
     pub allow_degraded: bool,
+    #[serde(default)]
+    pub microphone_permission: MacPermissionStatus,
+    #[serde(default)]
+    pub screen_recording_permission: MacPermissionStatus,
     pub blocking_reason: Option<String>,
+    #[serde(default)]
+    pub blocking_kind: Option<CapturePreflightBlockKind>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionPreflight {
+    pub blocking_reason: Option<String>,
+    pub blocking_kind: Option<CapturePreflightBlockKind>,
     pub warnings: Vec<String>,
 }
 
@@ -667,6 +688,103 @@ fn should_bypass_loopback_preflight_for_native_call_capture(
     }
 
     matches!(error, CaptureError::Io(io_error) if io_error.to_string() == MISSING_DUAL_SOURCE_LOOPBACK_MESSAGE)
+}
+
+const MIC_PERMISSION_BLOCKING_MESSAGE: &str = "Minutes does not have microphone permission, so this recording would capture silence. Grant Microphone access in System Settings > Privacy & Security > Microphone, then start the recording again.";
+const MIC_PERMISSION_DEGRADED_CALL_WARNING: &str = "Minutes does not have microphone permission, so this call recording will miss your side. The other side is still captured.";
+const MIC_PERMISSION_UNCONFIRMED_WARNING: &str = "macOS has not yet confirmed microphone access for Minutes (this happens after an app update or re-sign). If the first few seconds capture silence, approve the macOS prompt or grant Microphone access in System Settings > Privacy & Security > Microphone.";
+const SCREEN_PERMISSION_DENIED_WARNING: &str = "Heads up: Minutes does not have Screen Recording permission, so native call capture may not include system audio. Grant Screen Recording access in System Settings > Privacy & Security > Screen Recording, then start the recording again.";
+const SCREEN_PERMISSION_UNCONFIRMED_WARNING: &str = "macOS has not yet confirmed Screen Recording access for Minutes. Native call capture may need Screen Recording permission; if system audio is missing, approve the macOS prompt or grant Screen Recording access in System Settings > Privacy & Security > Screen Recording.";
+
+pub(crate) fn evaluate_microphone_only_permission_preflight(
+    mic: MacPermissionStatus,
+) -> PermissionPreflight {
+    let mut warnings = Vec::new();
+    let mut blocking_reason = None;
+    let mut blocking_kind = None;
+
+    match mic {
+        MacPermissionStatus::Denied => {
+            blocking_reason = Some(MIC_PERMISSION_BLOCKING_MESSAGE.into());
+            blocking_kind = Some(CapturePreflightBlockKind::Permission);
+        }
+        MacPermissionStatus::NotDetermined | MacPermissionStatus::StaleOrRestartNeeded => {
+            warnings.push(MIC_PERMISSION_UNCONFIRMED_WARNING.into());
+        }
+        MacPermissionStatus::Granted
+        | MacPermissionStatus::NotNeeded
+        | MacPermissionStatus::Unsupported
+        | MacPermissionStatus::Unknown => {}
+    }
+
+    PermissionPreflight {
+        blocking_reason,
+        blocking_kind,
+        warnings,
+    }
+}
+
+pub fn preflight_microphone_only() -> PermissionPreflight {
+    evaluate_microphone_only_permission_preflight(microphone_status())
+}
+
+pub(crate) fn evaluate_permission_preflight(
+    intent: RecordingIntent,
+    mic: MacPermissionStatus,
+    screen: MacPermissionStatus,
+    system_audio_ready: bool,
+) -> PermissionPreflight {
+    let mut warnings = Vec::new();
+    let mut blocking_reason = None;
+    let mut blocking_kind = None;
+    let call_has_recoverable_remote_audio = intent == RecordingIntent::Call && system_audio_ready;
+
+    match mic {
+        MacPermissionStatus::Denied if call_has_recoverable_remote_audio => {
+            warnings.push(MIC_PERMISSION_DEGRADED_CALL_WARNING.into());
+        }
+        MacPermissionStatus::Denied => {
+            blocking_reason = Some(MIC_PERMISSION_BLOCKING_MESSAGE.into());
+            blocking_kind = Some(CapturePreflightBlockKind::Permission);
+        }
+        MacPermissionStatus::NotDetermined | MacPermissionStatus::StaleOrRestartNeeded => {
+            warnings.push(MIC_PERMISSION_UNCONFIRMED_WARNING.into());
+        }
+        MacPermissionStatus::Granted
+        | MacPermissionStatus::NotNeeded
+        | MacPermissionStatus::Unsupported
+        | MacPermissionStatus::Unknown => {}
+    }
+
+    if intent == RecordingIntent::Call && system_audio_ready {
+        match screen {
+            MacPermissionStatus::Denied => {
+                warnings.push(SCREEN_PERMISSION_DENIED_WARNING.into());
+            }
+            MacPermissionStatus::NotDetermined | MacPermissionStatus::StaleOrRestartNeeded => {
+                warnings.push(SCREEN_PERMISSION_UNCONFIRMED_WARNING.into());
+            }
+            MacPermissionStatus::Granted
+            | MacPermissionStatus::NotNeeded
+            | MacPermissionStatus::Unsupported
+            | MacPermissionStatus::Unknown => {}
+        }
+    }
+
+    PermissionPreflight {
+        blocking_reason,
+        blocking_kind,
+        warnings,
+    }
+}
+
+pub fn should_bypass_preflight_block_for_native_call_capture(
+    preflight: &CapturePreflight,
+    native_call_capture_available: bool,
+) -> bool {
+    preflight.intent == RecordingIntent::Call
+        && native_call_capture_available
+        && preflight.blocking_kind == Some(CapturePreflightBlockKind::CallRoute)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -2224,6 +2342,7 @@ fn evaluate_capture_preflight(
     let allow_degraded = allow_degraded || config.recording.allow_degraded_call_capture;
     let mut warnings = Vec::new();
     let mut blocking_reason = None;
+    let mut blocking_kind = None;
 
     if intent == RecordingIntent::Call {
         if let Some(app_name) = detected_call_app.as_deref() {
@@ -2244,6 +2363,7 @@ fn evaluate_capture_preflight(
                 "Minutes inferred a call capture, but '{}' looks like a microphone input, not a call-audio route. To record both sides, use the desktop app's native call capture path or choose a system-audio device like BlackHole. If you intentionally want mic-only capture, explicitly allow degraded call capture.",
                 input_device
             ));
+            blocking_kind = Some(CapturePreflightBlockKind::CallRoute);
         }
     }
 
@@ -2253,7 +2373,10 @@ fn evaluate_capture_preflight(
         input_device,
         system_audio_ready,
         allow_degraded,
+        microphone_permission: MacPermissionStatus::Unknown,
+        screen_recording_permission: MacPermissionStatus::Unknown,
         blocking_reason,
+        blocking_kind,
         warnings,
     })
 }
@@ -2312,6 +2435,7 @@ pub fn preflight_recording_with_native_call_capture(
     if preflight.intent == RecordingIntent::Call {
         if preflight.system_audio_ready {
             preflight.blocking_reason = None;
+            preflight.blocking_kind = None;
             if preflight.warnings.is_empty() {
                 preflight.warnings.push(format!(
                     "Using '{}' as the capture route for call recording.",
@@ -2323,8 +2447,29 @@ pub fn preflight_recording_with_native_call_capture(
                 "Minutes inferred a call capture, but '{}' does not include a recognized system-audio route. To record both sides, choose a loopback/system-audio device like BlackHole for the call source or use the desktop app's native call capture path. If you intentionally want mic-only capture, explicitly allow degraded call capture.",
                 preflight.input_device
             ));
+            preflight.blocking_kind = Some(CapturePreflightBlockKind::CallRoute);
         }
     }
+
+    let microphone_permission = microphone_status();
+    let screen_recording_permission = screen_recording_status();
+    let permission_system_audio_ready = preflight.system_audio_ready
+        || (preflight.intent == RecordingIntent::Call
+            && native_call_capture_available
+            && screen_recording_permission.is_granted());
+    let permission_preflight = evaluate_permission_preflight(
+        preflight.intent,
+        microphone_permission,
+        screen_recording_permission,
+        permission_system_audio_ready,
+    );
+    preflight.microphone_permission = microphone_permission;
+    preflight.screen_recording_permission = screen_recording_permission;
+    if permission_preflight.blocking_reason.is_some() {
+        preflight.blocking_reason = permission_preflight.blocking_reason;
+        preflight.blocking_kind = permission_preflight.blocking_kind;
+    }
+    preflight.warnings.extend(permission_preflight.warnings);
 
     Ok(preflight)
 }
@@ -2894,6 +3039,10 @@ mod tests {
         assert_eq!(preflight.intent, RecordingIntent::Call);
         assert!(!preflight.system_audio_ready);
         assert!(preflight.blocking_reason.is_some());
+        assert_eq!(
+            preflight.blocking_kind,
+            Some(CapturePreflightBlockKind::CallRoute)
+        );
     }
 
     #[test]
@@ -2911,6 +3060,7 @@ mod tests {
 
         assert!(preflight.system_audio_ready);
         assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
         assert!(!preflight.warnings.is_empty());
     }
 
@@ -2928,8 +3078,219 @@ mod tests {
         .unwrap();
 
         assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
         assert!(preflight.allow_degraded);
         assert!(!preflight.warnings.is_empty());
+    }
+
+    #[test]
+    fn permission_preflight_granted_meeting_has_no_warning_or_block() {
+        let preflight = evaluate_permission_preflight(
+            RecordingIntent::Room,
+            MacPermissionStatus::Granted,
+            MacPermissionStatus::Granted,
+            false,
+        );
+
+        assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
+        assert!(preflight.warnings.is_empty());
+    }
+
+    #[test]
+    fn permission_preflight_denied_meeting_blocks_with_mic_fix() {
+        let preflight = evaluate_permission_preflight(
+            RecordingIntent::Room,
+            MacPermissionStatus::Denied,
+            MacPermissionStatus::Granted,
+            false,
+        );
+
+        assert_eq!(
+            preflight.blocking_kind,
+            Some(CapturePreflightBlockKind::Permission)
+        );
+        let blocking_reason = preflight
+            .blocking_reason
+            .expect("denied mic should block meeting capture");
+        assert!(blocking_reason.contains("microphone permission"));
+        assert!(blocking_reason.contains("System Settings > Privacy & Security > Microphone"));
+        assert!(preflight.warnings.is_empty());
+    }
+
+    #[test]
+    fn permission_preflight_denied_system_only_call_warns_without_blocking() {
+        let preflight = evaluate_permission_preflight(
+            RecordingIntent::Call,
+            MacPermissionStatus::Denied,
+            MacPermissionStatus::Granted,
+            true,
+        );
+
+        assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
+        assert_eq!(preflight.warnings.len(), 1);
+        assert_eq!(preflight.warnings[0], MIC_PERMISSION_DEGRADED_CALL_WARNING);
+        assert!(!preflight.warnings[0].contains("would capture silence"));
+    }
+
+    #[test]
+    fn permission_preflight_denied_call_without_system_audio_blocks() {
+        let preflight = evaluate_permission_preflight(
+            RecordingIntent::Call,
+            MacPermissionStatus::Denied,
+            MacPermissionStatus::Granted,
+            false,
+        );
+
+        assert!(preflight.blocking_reason.is_some());
+        assert_eq!(
+            preflight.blocking_kind,
+            Some(CapturePreflightBlockKind::Permission)
+        );
+        assert!(preflight.warnings.is_empty());
+    }
+
+    #[test]
+    fn permission_preflight_not_determined_meeting_warns_without_blocking() {
+        let preflight = evaluate_permission_preflight(
+            RecordingIntent::Room,
+            MacPermissionStatus::NotDetermined,
+            MacPermissionStatus::Granted,
+            false,
+        );
+
+        assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
+        assert_eq!(preflight.warnings.len(), 1);
+        assert!(preflight.warnings[0].contains("not yet confirmed microphone access"));
+    }
+
+    #[test]
+    fn permission_preflight_stale_meeting_warns_without_blocking() {
+        let preflight = evaluate_permission_preflight(
+            RecordingIntent::Room,
+            MacPermissionStatus::StaleOrRestartNeeded,
+            MacPermissionStatus::Granted,
+            false,
+        );
+
+        assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
+        assert_eq!(preflight.warnings.len(), 1);
+        assert!(preflight.warnings[0].contains("not yet confirmed microphone access"));
+    }
+
+    #[test]
+    fn permission_preflight_screen_recording_denied_call_warns_only() {
+        let preflight = evaluate_permission_preflight(
+            RecordingIntent::Call,
+            MacPermissionStatus::Granted,
+            MacPermissionStatus::Denied,
+            true,
+        );
+
+        assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
+        assert_eq!(preflight.warnings.len(), 1);
+        assert!(preflight.warnings[0].contains("Screen Recording permission"));
+    }
+
+    #[test]
+    fn permission_preflight_preserves_call_mode_block_when_mic_is_granted() {
+        let config = Config::default();
+        let mut preflight = evaluate_capture_preflight(
+            CaptureMode::Meeting,
+            Some(RecordingIntent::Call),
+            Some("Teams".into()),
+            "Built-in Microphone".into(),
+            false,
+            &config,
+        )
+        .unwrap();
+        let original_blocking_reason = preflight.blocking_reason.clone();
+        let permission_preflight = evaluate_permission_preflight(
+            preflight.intent,
+            MacPermissionStatus::Granted,
+            MacPermissionStatus::Granted,
+            preflight.system_audio_ready,
+        );
+
+        if permission_preflight.blocking_reason.is_some() {
+            preflight.blocking_reason = permission_preflight.blocking_reason;
+        }
+        preflight.warnings.extend(permission_preflight.warnings);
+
+        assert_eq!(preflight.blocking_reason, original_blocking_reason);
+        assert!(preflight.blocking_reason.is_some());
+        assert_eq!(
+            preflight.blocking_kind,
+            Some(CapturePreflightBlockKind::CallRoute)
+        );
+    }
+
+    #[test]
+    fn native_call_capture_bypass_only_skips_call_route_blocks() {
+        let config = Config::default();
+        let mut preflight = evaluate_capture_preflight(
+            CaptureMode::Meeting,
+            Some(RecordingIntent::Call),
+            Some("Teams".into()),
+            "Built-in Microphone".into(),
+            false,
+            &config,
+        )
+        .unwrap();
+
+        assert!(should_bypass_preflight_block_for_native_call_capture(
+            &preflight, true
+        ));
+
+        preflight.blocking_kind = Some(CapturePreflightBlockKind::Permission);
+        preflight.blocking_reason = Some(MIC_PERMISSION_BLOCKING_MESSAGE.into());
+        assert!(!should_bypass_preflight_block_for_native_call_capture(
+            &preflight, true
+        ));
+
+        preflight.blocking_kind = None;
+        assert!(!should_bypass_preflight_block_for_native_call_capture(
+            &preflight, true
+        ));
+    }
+
+    #[test]
+    fn microphone_only_preflight_granted_has_no_warning_or_block() {
+        let preflight = evaluate_microphone_only_permission_preflight(MacPermissionStatus::Granted);
+
+        assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
+        assert!(preflight.warnings.is_empty());
+    }
+
+    #[test]
+    fn microphone_only_preflight_denied_blocks_with_permission_kind() {
+        let preflight = evaluate_microphone_only_permission_preflight(MacPermissionStatus::Denied);
+
+        assert_eq!(
+            preflight.blocking_kind,
+            Some(CapturePreflightBlockKind::Permission)
+        );
+        assert_eq!(
+            preflight.blocking_reason.as_deref(),
+            Some(MIC_PERMISSION_BLOCKING_MESSAGE)
+        );
+        assert!(preflight.warnings.is_empty());
+    }
+
+    #[test]
+    fn microphone_only_preflight_not_determined_warns_without_blocking() {
+        let preflight =
+            evaluate_microphone_only_permission_preflight(MacPermissionStatus::NotDetermined);
+
+        assert!(preflight.blocking_reason.is_none());
+        assert_eq!(preflight.blocking_kind, None);
+        assert_eq!(preflight.warnings.len(), 1);
+        assert!(preflight.warnings[0].contains("not yet confirmed microphone access"));
     }
 
     #[test]

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -318,6 +318,14 @@ where
     #[cfg(feature = "whisper")]
     {
         let device_override = config.recording.device.as_deref();
+        let permission_preflight = crate::capture::preflight_microphone_only();
+        if let Some(reason) = permission_preflight.blocking_reason {
+            return Err(DictationError::PermissionBlocked(reason).into());
+        }
+        for warning in permission_preflight.warnings {
+            tracing::warn!(warning = %warning, "dictation microphone permission preflight warning");
+        }
+
         let audio_start = Instant::now();
         startup_debug(
             "audio_stream_start",

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -220,6 +220,9 @@ pub enum DictationError {
     #[error("accessibility permission required for auto-paste")]
     AccessibilityDenied,
 
+    #[error("{0}")]
+    PermissionBlocked(String),
+
     #[error("dictation not active")]
     NotActive,
 
@@ -237,6 +240,9 @@ pub enum LiveTranscriptError {
 
     #[error("live transcript already active (PID: {0})")]
     AlreadyActive(u32),
+
+    #[error("{0}")]
+    PermissionBlocked(String),
 
     #[error("no live transcript session active")]
     NoActiveSession,

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -668,6 +668,14 @@ fn run_inner(
 
     // Start audio stream FIRST — validate mic access before truncating any files
     let device_override = config.recording.device.as_deref();
+    let permission_preflight = crate::capture::preflight_microphone_only();
+    if let Some(reason) = permission_preflight.blocking_reason {
+        return Err(LiveTranscriptError::PermissionBlocked(reason).into());
+    }
+    for warning in permission_preflight.warnings {
+        tracing::warn!(warning = %warning, "live transcript microphone permission preflight warning");
+    }
+
     let mut stream = AudioStream::start(device_override)?;
     tracing::info!(device = %stream.device_name, "live transcript audio stream started");
 

--- a/crates/core/src/macos_permissions.rs
+++ b/crates/core/src/macos_permissions.rs
@@ -15,7 +15,7 @@ pub enum MacPermissionKind {
     Automation,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MacPermissionStatus {
     Granted,
@@ -24,6 +24,7 @@ pub enum MacPermissionStatus {
     NotNeeded,
     Unsupported,
     StaleOrRestartNeeded,
+    #[default]
     Unknown,
 }
 
@@ -103,8 +104,16 @@ pub fn permission_rows() -> Vec<MacPermissionRow> {
     ]
 }
 
+pub fn microphone_status() -> MacPermissionStatus {
+    platform::microphone_status()
+}
+
+pub fn screen_recording_status() -> MacPermissionStatus {
+    platform::screen_recording_status()
+}
+
 pub fn microphone_row() -> MacPermissionRow {
-    let status = platform::microphone_status();
+    let status = microphone_status();
     MacPermissionRow::new(MacPermissionRowSpec {
         kind: MacPermissionKind::Microphone,
         label: "Microphone",
@@ -138,7 +147,7 @@ pub fn microphone_row() -> MacPermissionRow {
 }
 
 pub fn screen_recording_row() -> MacPermissionRow {
-    let status = platform::screen_recording_status();
+    let status = screen_recording_status();
     MacPermissionRow::new(MacPermissionRowSpec {
         kind: MacPermissionKind::ScreenRecording,
         label: "Screen Recording",

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-11",
-  "visibleCount": 56,
+  "generatedAt": "2026-06-15",
+  "visibleCount": 58,
   "hiddenCount": 16,
   "groups": [
     {
@@ -493,7 +493,7 @@
     },
     {
       "enumName": "DictationError",
-      "count": 6,
+      "count": 7,
       "entries": [
         {
           "id": "dictationerror-recordingactive",
@@ -551,6 +551,17 @@
           "docsUrl": "https://useminutes.app/docs/errors#error-dictationerror-accessibilitydenied"
         },
         {
+          "id": "dictationerror-permissionblocked",
+          "enumName": "DictationError",
+          "variant": "PermissionBlocked",
+          "cfg": null,
+          "message": "{0}",
+          "sourceFile": "crates/core/src/error.rs",
+          "hidden": false,
+          "anchorId": "error-dictationerror-permissionblocked",
+          "docsUrl": "https://useminutes.app/docs/errors#error-dictationerror-permissionblocked"
+        },
+        {
           "id": "dictationerror-notactive",
           "enumName": "DictationError",
           "variant": "NotActive",
@@ -565,7 +576,7 @@
     },
     {
       "enumName": "LiveTranscriptError",
-      "count": 4,
+      "count": 5,
       "entries": [
         {
           "id": "livetranscripterror-recordingactive",
@@ -599,6 +610,17 @@
           "hidden": false,
           "anchorId": "error-livetranscripterror-alreadyactive",
           "docsUrl": "https://useminutes.app/docs/errors#error-livetranscripterror-alreadyactive"
+        },
+        {
+          "id": "livetranscripterror-permissionblocked",
+          "enumName": "LiveTranscriptError",
+          "variant": "PermissionBlocked",
+          "cfg": null,
+          "message": "{0}",
+          "sourceFile": "crates/core/src/error.rs",
+          "hidden": false,
+          "anchorId": "error-livetranscripterror-permissionblocked",
+          "docsUrl": "https://useminutes.app/docs/errors#error-livetranscripterror-permissionblocked"
         },
         {
           "id": "livetranscripterror-noactivesession",

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1182;
+export const MINUTES_TEST_COUNT = 1194;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -2,11 +2,11 @@
 
 > Generated file. Do not edit by hand.
 > Source: crates/core thiserror definitions
-> Last generated: 2026-06-11
+> Last generated: 2026-06-15
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 
-- Visible actionable errors: 56
+- Visible actionable errors: 58
 - Hidden low-signal wrappers: 16
 
 # CaptureError
@@ -579,6 +579,18 @@ Source: `crates/core/src/error.rs`
 
 Reference URL: https://useminutes.app/docs/errors#error-dictationerror-accessibilitydenied
 
+<a id="error-dictationerror-permissionblocked"></a>
+
+## `DictationError::PermissionBlocked`
+
+Exact message:
+
+> {0}
+
+Source: `crates/core/src/error.rs`
+
+Reference URL: https://useminutes.app/docs/errors#error-dictationerror-permissionblocked
+
 <a id="error-dictationerror-notactive"></a>
 
 ## `DictationError::NotActive`
@@ -628,6 +640,18 @@ Exact message:
 Source: `crates/core/src/error.rs`
 
 Reference URL: https://useminutes.app/docs/errors#error-livetranscripterror-alreadyactive
+
+<a id="error-livetranscripterror-permissionblocked"></a>
+
+## `LiveTranscriptError::PermissionBlocked`
+
+Exact message:
+
+> {0}
+
+Source: `crates/core/src/error.rs`
+
+Reference URL: https://useminutes.app/docs/errors#error-livetranscripterror-permissionblocked
 
 <a id="error-livetranscripterror-noactivesession"></a>
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2,7 +2,9 @@ use crate::call_capture;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use futures_util::StreamExt;
 use minisign_verify::{PublicKey, Signature};
-use minutes_core::capture::RecordingIntent;
+use minutes_core::capture::{
+    should_bypass_preflight_block_for_native_call_capture, RecordingIntent,
+};
 use minutes_core::config::{ConsentMode, VALID_LIVE_TRANSCRIPT_BACKENDS, VALID_PARAKEET_MODELS};
 use minutes_core::markdown::ConsentBasis;
 use minutes_core::{CaptureMode, Config, ContentType};
@@ -5165,7 +5167,10 @@ pub fn start_recording(
             call_capture::CallCaptureAvailability::Available { .. }
         );
     if let Some(reason) = &preflight.blocking_reason {
-        if !(preflight.intent == RecordingIntent::Call && native_call_capture_available) {
+        if !should_bypass_preflight_block_for_native_call_capture(
+            &preflight,
+            native_call_capture_available,
+        ) {
             eprintln!("Recording preflight blocked: {}", reason);
             set_recording_start_error(&latest_output, reason.clone());
             show_user_notification(&app_handle, "Recording blocked", reason);
@@ -12442,6 +12447,16 @@ pub fn cmd_start_live_transcript(
 ) -> Result<(), String> {
     try_acquire_live(&state)?;
 
+    let permission_preflight = minutes_core::capture::preflight_microphone_only();
+    if let Some(reason) = permission_preflight.blocking_reason {
+        state.live_transcript_active.store(false, Ordering::SeqCst);
+        return Err(reason);
+    }
+    for warning in permission_preflight.warnings {
+        eprintln!("[live-transcript] {}", warning);
+        app.emit("live-transcript:warning", warning.as_str()).ok();
+    }
+
     let active = state.live_transcript_active.clone();
     let stop_flag = state.live_transcript_stop_flag.clone();
     stop_flag.store(false, Ordering::Relaxed);
@@ -13208,6 +13223,15 @@ fn start_dictation_session(
         active: Arc::clone(&state.dictation_active),
         app: app.clone(),
     };
+
+    let permission_preflight = minutes_core::capture::preflight_microphone_only();
+    if let Some(reason) = permission_preflight.blocking_reason {
+        return Err(reason);
+    }
+    for warning in permission_preflight.warnings {
+        eprintln!("[dictation] {}", warning);
+        app.emit("dictation:warning", warning.as_str()).ok();
+    }
 
     let dictation_target_context = take_pending_dictation_target(&state)
         .or_else(crate::text_insertion::capture_active_target_context);

--- a/tauri/src-tauri/src/palette_dispatch.rs
+++ b/tauri/src-tauri/src/palette_dispatch.rs
@@ -448,7 +448,10 @@ fn dispatch_action(
                         crate::call_capture::availability(),
                         crate::call_capture::CallCaptureAvailability::Available { .. }
                     );
-                if !native_call_capture_available {
+                if !minutes_core::capture::should_bypass_preflight_block_for_native_call_capture(
+                    &preflight,
+                    native_call_capture_available,
+                ) {
                     return Err(format!("recording blocked: {}", reason));
                 }
             }


### PR DESCRIPTION
Closes the core of bead minutes-9bc8 (silent-capture warning). Catches a denied or unconfirmed microphone permission at record-start, instead of discovering it after a meeting is already lost. Motivated by the real incident where a re-signed dev app dropped its mic TCC grant and an 8-minute Zoom call recorded near-silence with no warning.

This is L0 of a layered capture-integrity model (the deterministic permission check). L1 callback-liveness and L2 statistical dead-stem detection are separate follow-ups.

## What it does
- Reads the microphone authorization status (which already existed but was never gated at record-start) and surfaces a block or warning through the pre-flight that both the CLI and desktop start paths already consume.
- Typed block kind `CapturePreflightBlockKind { CallRoute, Permission }`. The native-call and palette bypass (which intentionally skips the no-system-audio-route block when native capture is available) now skips ONLY CallRoute blocks, via a shared core helper, so a Permission block can never be swallowed on the native-call path. That was the path the incident came from.
- Recoverable-call degradation: a call with recoverable system audio plus a denied mic WARNS (and still captures the remote side) rather than blocking. Mic-only meeting, memo, dictation, and live transcript with a denied mic BLOCK.
- NotDetermined and StaleOrRestartNeeded warn but never block (blocking would prevent the OS permission prompt that grants access).
- The mic-only pre-flight is also wired into dictation and live transcript starts, so the gate is not meeting-only.
- Pure, OS-free decision functions (unit-tested without a mic). Capability check, never an interactive prompt or TTY gate, no hangs for non-interactive callers.
- Cross-platform safe: non-macOS reports NotNeeded and the gate is a no-op.

## Deferred follow-ups (not in this PR)
- A strict-complete-capture override config (block instead of warn on a degraded call).
- A visible recording-state label for the degraded-call case (belongs with L1 indicator integrity).

## Tests
792 core tests green (5 new), clippy clean on both feature sets, app and cli build. New tests cover recoverable-call warn vs mic-only block, block-kind tagging, the mic-only helper, and a regression test that a Permission block survives the native-call bypass.