### PR TITLE
fix: centralize main window reveal

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -5545,10 +5545,7 @@ pub fn launch_recording(
             // the in-window button instead of erroring or bypassing
             // (spec Part A; review F1/F2). The frontend listener stashes the
             // pending args and re-invokes with consent confirmed.
-            if let Some(window) = app.get_webview_window("main") {
-                window.show().ok();
-                window.set_focus().ok();
-            }
+            crate::show_main_window(&app);
             let _ = app.emit(
                 "minutes://recording-consent-required",
                 serde_json::json!({ "disclosure": disclosure }),
@@ -8228,9 +8225,8 @@ pub fn spawn_terminal(
     // Emit recall:expand event to the main window instead of opening a
     // separate terminal window. The JS in index.html handles the panel
     // expand animation and xterm.js initialisation.
-    if let Some(win) = app.get_webview_window("main") {
-        win.show().ok();
-        win.set_focus().ok();
+    if app.get_webview_window("main").is_some() {
+        crate::show_main_window(app);
         app.emit_to(
             "main",
             "recall:expand",

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -246,10 +246,17 @@ fn maybe_run_process_queue_worker() -> Option<i32> {
     }
 }
 
-fn show_main_window(app: &tauri::AppHandle) {
+pub(crate) fn show_main_window(app: &tauri::AppHandle) {
     if let Some(win) = app.get_webview_window("main") {
-        win.show().ok();
-        win.set_focus().ok();
+        if !win.is_visible().ok().unwrap_or(false) {
+            win.show().ok();
+        }
+        if win.is_minimized().ok().unwrap_or(false) {
+            win.unminimize().ok();
+        }
+        if !win.is_focused().ok().unwrap_or(false) {
+            win.set_focus().ok();
+        }
         return;
     }
     let mut builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::App("index.html".into()))
@@ -298,6 +305,11 @@ fn show_main_window(app: &tauri::AppHandle) {
             }
         }
     }
+}
+
+#[tauri::command]
+fn cmd_show_main_window(app: tauri::AppHandle) {
+    show_main_window(&app);
 }
 
 fn show_note_window(app: &tauri::AppHandle) {
@@ -2414,6 +2426,7 @@ fn main() {
             commands::cmd_needs_setup,
             commands::cmd_download_model,
             commands::cmd_mark_activation_nudge_shown,
+            cmd_show_main_window,
             commands::cmd_upcoming_meetings,
             commands::cmd_spawn_terminal,
             commands::cmd_pty_input,
@@ -2526,6 +2539,24 @@ mod tray_activity_tests {
                 "macOS vibrancy on the hidden main WebView can crash WebKit during frame updates"
             );
         }
+    }
+
+    #[test]
+    fn show_main_window_restores_minimized_window_before_focus() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let main_rs =
+            std::fs::read_to_string(format!("{}/src/main.rs", manifest)).expect("read main.rs");
+        let restore_idx = main_rs
+            .find("win.unminimize().ok()")
+            .expect("main-window reveal should restore minimized windows");
+        let focus_idx = main_rs
+            .find("win.set_focus().ok()")
+            .expect("main-window reveal should focus the window");
+
+        assert!(
+            restore_idx < focus_idx,
+            "main-window reveal should unminimize before requesting focus"
+        );
     }
 
     #[test]

--- a/tauri/src-tauri/src/palette_dispatch.rs
+++ b/tauri/src-tauri/src/palette_dispatch.rs
@@ -43,7 +43,6 @@ use std::path::Path;
 use std::sync::atomic::Ordering;
 
 use serde::Deserialize;
-use tauri::Manager;
 use tauri::{AppHandle, Emitter, State};
 
 use minutes_core::palette::recents::RecentsStore;
@@ -465,10 +464,7 @@ fn dispatch_action(
                     // blocking modal as the in-window button instead of
                     // silently reporting success with no recording
                     // (spec Part A; review F1).
-                    if let Some(window) = app.get_webview_window("main") {
-                        window.show().ok();
-                        window.set_focus().ok();
-                    }
+                    crate::show_main_window(&app);
                     let _ = app.emit(
                         "minutes://recording-consent-required",
                         serde_json::json!({ "disclosure": disclosure }),

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -10826,8 +10826,7 @@
 
       // Only steal focus on first detection, not periodic reminders
       if (!is_reminder) {
-        currentWindow.show();
-        currentWindow.setFocus();
+        invoke('cmd_show_main_window').catch(() => {});
       }
     });
 


### PR DESCRIPTION
## Summary
- make `show_main_window` idempotent for existing main windows
- expose a native `cmd_show_main_window` for frontend-triggered reveals
- route call detection, Recall expansion, and consent prompt reveals through the same guarded path

## Why
The latest Minutes Dev crash still points at WebKit frame updates on the main thread. The prior opacity/vibrancy fix is already present in the crashed binary, so this removes remaining duplicate show/focus triggers that bypassed the native main-window helper.

## Tests
- `cargo fmt --check`
- `cargo check -p minutes-app`
- `cargo test -p minutes-app tray_activity_tests -- --nocapture`
- `cargo test -p minutes-app`

## Dogfood
Rebuilt and installed `/Applications/Minutes Dev.app` on 0.18.12. Bundle seal verifies; local install is ad-hoc signed because no Developer ID identity is available on this machine.