### PR TITLE
fix(settings): persist global hotkey + completion notifications to config.toml

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -41,6 +41,60 @@ pub struct Config {
     pub hooks: HooksConfig,
     pub knowledge: KnowledgeConfig,
     pub palette: PaletteConfig,
+    pub global_hotkey: GlobalHotkeyConfig,
+    pub notifications: NotificationsConfig,
+}
+
+/// Quick-Thought global hotkey configuration.
+///
+/// Mirrors the shortcut-bearing sections (`palette`, `live_transcript`):
+/// a `shortcut_enabled` bool plus a `shortcut` chord string. This is the
+/// config-file home for the Quick-Thought hotkey that `cmd_set_global_hotkey`
+/// and the `quick_thought` slot of `cmd_set_shortcut` write to. The AppState
+/// fields `global_hotkey_enabled` / `global_hotkey_shortcut` are seeded from
+/// here at startup (see `main.rs`).
+///
+/// Defaults match the historical startup defaults: disabled, with the first
+/// entry of `HOTKEY_CHOICES` (`CmdOrCtrl+Shift+M`) as the chord. `#[serde(default)]`
+/// keeps `Config::load()` working on older `config.toml` files that predate
+/// this section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GlobalHotkeyConfig {
+    /// Whether the Quick-Thought global hotkey is enabled.
+    pub shortcut_enabled: bool,
+    /// The hotkey chord string (e.g., "CmdOrCtrl+Shift+M").
+    pub shortcut: String,
+}
+
+impl Default for GlobalHotkeyConfig {
+    fn default() -> Self {
+        Self {
+            shortcut_enabled: false,
+            shortcut: "CmdOrCtrl+Shift+M".into(),
+        }
+    }
+}
+
+/// Notification preferences.
+///
+/// `completion_enabled` controls the system notification fired when a
+/// recording finishes processing. Defaults to `true` to preserve the
+/// historical behavior (AppState previously seeded `AtomicBool::new(true)`).
+/// `#[serde(default)]` keeps old `config.toml` files loading.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NotificationsConfig {
+    /// Whether the "processing complete" notification is shown.
+    pub completion_enabled: bool,
+}
+
+impl Default for NotificationsConfig {
+    fn default() -> Self {
+        Self {
+            completion_enabled: true,
+        }
+    }
 }
 
 /// Command palette configuration.
@@ -879,6 +933,8 @@ impl Default for Config {
             hooks: HooksConfig::default(),
             knowledge: KnowledgeConfig::default(),
             palette: PaletteConfig::default(),
+            global_hotkey: GlobalHotkeyConfig::default(),
+            notifications: NotificationsConfig::default(),
         }
     }
 }
@@ -1816,6 +1872,44 @@ enabled = true
         let config = Config::default();
         assert!(config.palette.shortcut_enabled);
         assert_eq!(config.palette.shortcut, "CmdOrCtrl+Shift+K");
+    }
+
+    #[test]
+    fn global_hotkey_and_notifications_defaults_match_legacy_startup() {
+        let config = Config::default();
+        // Quick-Thought hotkey: disabled, CmdOrCtrl+Shift+M (HOTKEY_CHOICES[0]).
+        assert!(!config.global_hotkey.shortcut_enabled);
+        assert_eq!(config.global_hotkey.shortcut, "CmdOrCtrl+Shift+M");
+        // Completion notifications default-on, preserving prior behavior.
+        assert!(config.notifications.completion_enabled);
+    }
+
+    #[test]
+    fn old_config_without_new_sections_still_loads() {
+        // An old config.toml that predates [global_hotkey] / [notifications]
+        // must still deserialize (backward compatibility), falling back to the
+        // section defaults via `#[serde(default)]`.
+        let parsed: Config = toml::from_str(
+            "[transcription]\nengine = \"whisper\"\n\n[palette]\nshortcut_enabled = false\nshortcut = \"CmdOrCtrl+Shift+K\"\n",
+        )
+        .expect("old config without new sections must load");
+        assert!(!parsed.global_hotkey.shortcut_enabled);
+        assert_eq!(parsed.global_hotkey.shortcut, "CmdOrCtrl+Shift+M");
+        assert!(parsed.notifications.completion_enabled);
+    }
+
+    #[test]
+    fn new_sections_round_trip_through_toml() {
+        let mut config = Config::default();
+        config.global_hotkey.shortcut_enabled = true;
+        config.global_hotkey.shortcut = "CmdOrCtrl+Shift+J".into();
+        config.notifications.completion_enabled = false;
+
+        let out = toml::to_string(&config).unwrap();
+        let parsed: Config = toml::from_str(&out).unwrap();
+        assert!(parsed.global_hotkey.shortcut_enabled);
+        assert_eq!(parsed.global_hotkey.shortcut, "CmdOrCtrl+Shift+J");
+        assert!(!parsed.notifications.completion_enabled);
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1199;
+export const MINUTES_TEST_COUNT = 1202;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -6975,11 +6975,46 @@ pub fn cmd_clear_latest_output(state: tauri::State<AppState>) {
     set_latest_output(&state.latest_output, None);
 }
 
+/// Persist the completion-notification preference to `config.toml`.
+///
+/// Extracted so the round-trip test can exercise the real save path without
+/// constructing a `tauri::State` (which has no public test constructor). The
+/// setter command below seeds AppState and then delegates here.
+fn persist_completion_notifications(enabled: bool) -> Result<(), String> {
+    let mut config = Config::load();
+    config.notifications.completion_enabled = enabled;
+    config
+        .save()
+        .map_err(|e| format!("Failed to save config: {}", e))
+}
+
+/// Persist the Quick-Thought global hotkey to `config.toml`.
+///
+/// Extracted (like `persist_completion_notifications`) so the round-trip test
+/// can verify the on-disk write without a `tauri::AppHandle` / global-shortcut
+/// manager. `cmd_set_global_hotkey` and the `quick_thought` slot of
+/// `cmd_set_shortcut` both target the same `[global_hotkey]` fields.
+fn persist_global_hotkey(enabled: bool, shortcut: &str) -> Result<(), String> {
+    let mut config = Config::load();
+    config.global_hotkey.shortcut_enabled = enabled;
+    config.global_hotkey.shortcut = shortcut.to_string();
+    config
+        .save()
+        .map_err(|e| format!("Failed to save config: {}", e))
+}
+
 #[tauri::command]
-pub fn cmd_set_completion_notifications(state: tauri::State<AppState>, enabled: bool) {
+pub fn cmd_set_completion_notifications(
+    state: tauri::State<AppState>,
+    enabled: bool,
+) -> Result<(), String> {
     state
         .completion_notifications_enabled
         .store(enabled, Ordering::Relaxed);
+
+    persist_completion_notifications(enabled)?;
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -7027,8 +7062,10 @@ pub fn cmd_set_global_hotkey(
         .global_hotkey_enabled
         .store(enabled, Ordering::Relaxed);
     if let Ok(mut current) = state.global_hotkey_shortcut.lock() {
-        *current = next_shortcut;
+        *current = next_shortcut.clone();
     }
+
+    persist_global_hotkey(enabled, &next_shortcut)?;
 
     Ok(current_hotkey_settings(&state))
 }
@@ -8511,6 +8548,13 @@ pub fn cmd_get_settings() -> serde_json::Value {
             "shortcut_enabled": config.palette.shortcut_enabled,
             "shortcut": config.palette.shortcut,
         },
+        "global_hotkey": {
+            "shortcut_enabled": config.global_hotkey.shortcut_enabled,
+            "shortcut": config.global_hotkey.shortcut,
+        },
+        "notifications": {
+            "completion_enabled": config.notifications.completion_enabled,
+        },
         "identity": {
             "name": config.identity.name,
             "email": config.identity.email,
@@ -9355,10 +9399,12 @@ mod tests {
         ("dictation", "auto_paste"),
         ("dictation", "cleanup_engine"),
         ("dictation", "destination"),
-        // dictation.shortcut_enabled is written directly by cmd_set_shortcut
-        // via `config.dictation.shortcut_enabled = ...` — the cmd_set_setting
-        // arm is vestigial. Keep for symmetry with other shortcut slots.
-        ("dictation", "shortcut_enabled"),
+        // NOTE: ("dictation", "shortcut_enabled") used to live here as a
+        // vestigial arm (cmd_set_shortcut writes the field directly). It now
+        // has a real caller via the central path — the round-trip persistence
+        // test `dictation_shortcut_round_trips_to_config` exercises it — so it
+        // dropped off the allowlist. The arm⇒caller guard's stale-orphan check
+        // enforces this: leaving it here would fail the guard.
         // screen_context.keep_after_summary controls post-summary screenshot
         // retention. Low-traffic; TOML-only is fine.
         ("screen_context", "keep_after_summary"),
@@ -9462,6 +9508,396 @@ mod tests {
              Remove these from the allowlist so the guard catches future \
              regressions on them.",
             stale.join("\n  ")
+        );
+    }
+
+    /// Extract every *statically literal* `(section, key)` pair targeted by a
+    /// `cmd_set_setting` call — both the HTML
+    /// `invoke('cmd_set_setting', { section: 'X', key: 'Y', ... })` shape
+    /// (single- or multi-line) and the Rust
+    /// `cmd_set_setting("X".into(), "Y".into(), ...)` shape.
+    ///
+    /// Calls whose `key` (or `section`) is a non-literal expression — e.g. the
+    /// `desktop_context` wrappers that pass a `key` *variable* — are skipped:
+    /// they can't be resolved statically and are already covered by the
+    /// arm⇒caller wrapper allowlist in `arm_has_caller`.
+    /// Remove top-level `#[cfg(test)] mod ... { ... }` blocks from Rust source.
+    /// Test modules in these files are top-level (their closing `}` sits at
+    /// column 0), so a simple state machine that drops everything from the
+    /// `#[cfg(test)]` attribute through the next column-0 `}` is sufficient.
+    /// Used by the caller⇒arm guard so test scaffolding and the guard's own
+    /// literal anchors aren't mistaken for shipping call sites.
+    fn strip_cfg_test_modules(src: &str) -> String {
+        let mut out = String::with_capacity(src.len());
+        let mut in_test = false;
+        let mut pending_cfg = false;
+        for line in src.lines() {
+            if in_test {
+                if line == "}" {
+                    in_test = false;
+                }
+                out.push('\n');
+                continue;
+            }
+            let trimmed = line.trim();
+            if trimmed == "#[cfg(test)]" {
+                pending_cfg = true;
+                out.push('\n');
+                continue;
+            }
+            if pending_cfg {
+                pending_cfg = false;
+                if trimmed.starts_with("mod ") && trimmed.ends_with('{') {
+                    in_test = true;
+                    out.push('\n');
+                    continue;
+                }
+                // `#[cfg(test)]` on a non-module item (e.g. a single test fn or
+                // use); keep this line, it won't contain a real call site.
+            }
+            out.push_str(line);
+            out.push('\n');
+        }
+        out
+    }
+
+    fn extract_set_setting_callers(haystack: &str) -> Vec<(String, String)> {
+        let mut callers = Vec::new();
+        // Build every anchor at runtime (split literals) so this scanner's own
+        // source — the `anchors` array below — is not parsed as a real call
+        // site when the guard scans this file.
+        let rust_anchor = ["cmd_set_setting", "("].concat();
+        // HTML/JS `invoke(...)` anchors, both quoting styles. The single-quoted
+        // form is the legacy in-tree style; the double-quoted form catches a
+        // future `invoke("cmd_set_setting", { section: "x", key: "y" })`, which
+        // is otherwise invisible to caller⇒arm and would compile, ship, and
+        // silently drop. The object-value parser already handles either quote.
+        let html_anchor_single = ["'", "cmd_set_setting", "'"].concat();
+        let html_anchor_double = ["\"", "cmd_set_setting", "\""].concat();
+        let anchors = [
+            rust_anchor.as_str(),
+            html_anchor_single.as_str(),
+            html_anchor_double.as_str(),
+        ];
+        for anchor in &anchors {
+            let mut cursor = 0;
+            while let Some(offset) = haystack[cursor..].find(anchor) {
+                let abs = cursor + offset;
+                // Skip anchors that sit *inside* a string literal (the char
+                // right before the anchor is a quote), e.g. the `"cmd_set_setting("`
+                // array element in this very function. Those aren't call sites.
+                let preceded_by_quote = abs
+                    .checked_sub(1)
+                    .map(|i| matches!(haystack.as_bytes()[i], b'"' | b'\''))
+                    .unwrap_or(false);
+                if *anchor == rust_anchor.as_str() && preceded_by_quote {
+                    cursor = abs + anchor.len();
+                    continue;
+                }
+                let window_end = (abs + 320).min(haystack.len());
+                let window = &haystack[abs..window_end];
+
+                let pair = if *anchor == rust_anchor.as_str() {
+                    // Rust: cmd_set_setting("section".into(), "key".into(), ..)
+                    // First two quoted string literals after the paren.
+                    let after = &window[anchor.len()..];
+                    extract_first_two_double_quoted(after)
+                } else {
+                    // HTML: invoke('cmd_set_setting', { section: 'X', key: 'Y' })
+                    let section = extract_object_literal_value(window, "section:");
+                    let key = extract_object_literal_value(window, "key:");
+                    match (section, key) {
+                        (Some(s), Some(k)) => Some((s, k)),
+                        _ => None,
+                    }
+                };
+
+                if let Some(pair) = pair {
+                    callers.push(pair);
+                }
+                cursor = abs + anchor.len();
+            }
+        }
+        callers
+    }
+
+    /// Pull the first two `"..."`-quoted string literals out of a Rust slice.
+    fn extract_first_two_double_quoted(s: &str) -> Option<(String, String)> {
+        let (first, rest) = next_double_quoted(s)?;
+        let (second, _) = next_double_quoted(rest)?;
+        Some((first, second))
+    }
+
+    fn next_double_quoted(s: &str) -> Option<(String, &str)> {
+        let start = s.find('"')?;
+        let after = &s[start + 1..];
+        let end = after.find('"')?;
+        Some((after[..end].to_string(), &after[end + 1..]))
+    }
+
+    /// Resolve a `field: 'literal'` (or `field: "literal"`) value in a JS object
+    /// literal window. Returns `None` if the value is a non-literal expression
+    /// (variable / template / call), so dynamic callers are skipped rather than
+    /// mis-parsed.
+    fn extract_object_literal_value(window: &str, field: &str) -> Option<String> {
+        let idx = window.find(field)?;
+        let after = window[idx + field.len()..].trim_start();
+        let mut chars = after.char_indices();
+        let (_, quote) = chars.next()?;
+        if quote != '\'' && quote != '"' {
+            // Non-literal value (e.g. `key,` shorthand or an expression).
+            return None;
+        }
+        let body = &after[quote.len_utf8()..];
+        let end = body.find(quote)?;
+        Some(body[..end].to_string())
+    }
+
+    /// Both `invoke('cmd_set_setting', …)` (single-quoted, legacy in-tree
+    /// style) and `invoke("cmd_set_setting", …)` (double-quoted) call sites are
+    /// visible to `extract_set_setting_callers`. The double-quoted form was a
+    /// blind spot: `every_cmd_set_setting_caller_has_an_arm` would have missed
+    /// a future double-quoted caller to a (section, key) with no arm, letting it
+    /// compile, ship, and silently drop. The fixture anchors are assembled from
+    /// split literals so this test's own source isn't parsed as a call site.
+    #[test]
+    fn extract_set_setting_callers_handles_both_quote_styles() {
+        let invoke = "invoke(";
+        let cmd = "cmd_set_setting";
+        let single = format!(
+            "{}'{}', {{ section: 'bogus_single', key: 'k1' }})",
+            invoke, cmd
+        );
+        let double = format!(
+            "{}\"{}\", {{ section: \"bogus_double\", key: \"k2\" }})",
+            invoke, cmd
+        );
+        let haystack = format!("{}\n{}\n", single, double);
+
+        let callers = extract_set_setting_callers(&haystack);
+        assert!(
+            callers.contains(&("bogus_single".to_string(), "k1".to_string())),
+            "single-quoted caller not detected: {:?}",
+            callers
+        );
+        assert!(
+            callers.contains(&("bogus_double".to_string(), "k2".to_string())),
+            "double-quoted caller not detected (blind spot the anchor fix closes): {:?}",
+            callers
+        );
+    }
+
+    /// CI guard (inverse direction): every `cmd_set_setting` *call site* — HTML
+    /// `invoke` or Rust-internal — must target a `(section, key)` that actually
+    /// has a match arm. This catches the recurring palette-style regression
+    /// where a frontend call uses a section/key with no arm: it compiles,
+    /// ships, and silently drops. `every_cmd_set_setting_arm_has_a_caller`
+    /// proves arm⇒caller; this proves caller⇒arm.
+    #[test]
+    fn every_cmd_set_setting_caller_has_an_arm() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let commands_path = format!("{}/src/commands.rs", manifest);
+        let commands = std::fs::read_to_string(&commands_path).expect("failed to read commands.rs");
+        let arms = extract_set_setting_arms(&commands);
+        assert!(!arms.is_empty(), "found no cmd_set_setting arms");
+        let arm_set: std::collections::HashSet<(String, String)> = arms.into_iter().collect();
+
+        let mut missing: Vec<String> = Vec::new();
+
+        // Rust callers: scan every src/*.rs EXCEPT the test module's own
+        // synthetic literals would otherwise self-match. We strip the match
+        // block from commands.rs (the arms themselves are `("X", "Y") =>`, not
+        // `cmd_set_setting("X", ...)` calls, so they're already ignored by the
+        // anchor — but stripping keeps the window clean) and scan the rest.
+        let rust_root = format!("{}/src", manifest);
+        for path in walk_with_extensions(&rust_root, &["rs"]) {
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            // Strip test modules first: `#[cfg(test)]` code is scaffolding, not
+            // a shipping call site, and the guard's own parser/assertion-string
+            // literals would otherwise self-match. Then strip the match block in
+            // commands.rs (arm definitions aren't callers).
+            let no_tests = strip_cfg_test_modules(&contents);
+            let filtered = if path.file_name().and_then(|n| n.to_str()) == Some("commands.rs") {
+                strip_set_setting_match_block(&no_tests)
+            } else {
+                no_tests
+            };
+            for (s, k) in extract_set_setting_callers(&filtered) {
+                if !arm_set.contains(&(s.clone(), k.clone())) {
+                    missing.push(format!("Rust {}: (\"{}\", \"{}\")", path.display(), s, k));
+                }
+            }
+        }
+
+        // HTML/JS callers.
+        let html_root = format!("{}/../src", manifest);
+        for path in walk_with_extensions(&html_root, &["html", "js"]) {
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            for (s, k) in extract_set_setting_callers(&contents) {
+                if !arm_set.contains(&(s.clone(), k.clone())) {
+                    missing.push(format!("HTML {}: (\"{}\", \"{}\")", path.display(), s, k));
+                }
+            }
+        }
+
+        missing.sort();
+        missing.dedup();
+        assert!(
+            missing.is_empty(),
+            "cmd_set_setting call sites target a (section, key) with NO match arm \
+             (would compile, ship, and silently drop):\n  {}\n\n\
+             Add the arm in cmd_set_setting (and the config field), or fix the \
+             caller's section/key.",
+            missing.join("\n  ")
+        );
+    }
+
+    /// Round-trip: `cmd_set_completion_notifications`' persistence step writes
+    /// `notifications.completion_enabled` to config.toml and survives a fresh
+    /// `Config::load()`. Would have caught confirmed drop #2.
+    #[test]
+    fn completion_notifications_round_trips_to_config() {
+        with_temp_home(|_| {
+            // Default is true; flip to false and confirm it lands on disk.
+            persist_completion_notifications(false).unwrap();
+            assert!(
+                !Config::load().notifications.completion_enabled,
+                "completion_enabled=false did not persist"
+            );
+
+            persist_completion_notifications(true).unwrap();
+            assert!(
+                Config::load().notifications.completion_enabled,
+                "completion_enabled=true did not persist"
+            );
+        });
+    }
+
+    /// Round-trip: the Quick-Thought global hotkey persistence step (shared by
+    /// `cmd_set_global_hotkey` and the `quick_thought` slot of
+    /// `cmd_set_shortcut`) writes `global_hotkey.{shortcut_enabled,shortcut}`
+    /// to config.toml. Would have caught confirmed drops #1 and #3.
+    #[test]
+    fn global_hotkey_round_trips_to_config() {
+        with_temp_home(|_| {
+            // Default is disabled with CmdOrCtrl+Shift+M.
+            persist_global_hotkey(true, "CmdOrCtrl+Shift+J").unwrap();
+            let loaded = Config::load();
+            assert!(
+                loaded.global_hotkey.shortcut_enabled,
+                "global_hotkey.shortcut_enabled=true did not persist"
+            );
+            assert_eq!(
+                loaded.global_hotkey.shortcut, "CmdOrCtrl+Shift+J",
+                "global_hotkey.shortcut did not persist"
+            );
+
+            persist_global_hotkey(false, "CmdOrCtrl+Shift+T").unwrap();
+            let loaded = Config::load();
+            assert!(
+                !loaded.global_hotkey.shortcut_enabled,
+                "global_hotkey.shortcut_enabled=false did not persist"
+            );
+            assert_eq!(loaded.global_hotkey.shortcut, "CmdOrCtrl+Shift+T");
+        });
+    }
+
+    /// Round-trip regression coverage: the dictation shortcut written through
+    /// the `cmd_set_setting` central path persists. (`cmd_set_dictation_shortcut`
+    /// and the Dictation slot of `cmd_set_shortcut` write the same fields via
+    /// `Config::load()`→mutate→`save()`; this exercises the on-disk write of
+    /// those fields without a `tauri::AppHandle`.)
+    #[test]
+    fn dictation_shortcut_round_trips_to_config() {
+        with_temp_home(|_| {
+            cmd_set_setting("dictation".into(), "shortcut_enabled".into(), "true".into()).unwrap();
+            cmd_set_setting(
+                "dictation".into(),
+                "shortcut".into(),
+                "CmdOrCtrl+Alt+Space".into(),
+            )
+            .unwrap();
+            let loaded = Config::load();
+            assert!(loaded.dictation.shortcut_enabled);
+            assert_eq!(loaded.dictation.shortcut, "CmdOrCtrl+Alt+Space");
+        });
+    }
+
+    /// Ban the `.ok()`/`let _ =` swallow on `cmd_set_setting`. A discarded
+    /// Result hides an "Unknown setting" error and silently drops the write —
+    /// the exact failure mode behind the palette/live regressions. Require `?`
+    /// or an explicit `if let Err(e) = ... { log }` instead.
+    #[test]
+    fn cmd_set_setting_result_is_never_swallowed() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let rust_root = format!("{}/src", manifest);
+        // Build the banned anchors at runtime (split literals) so this very
+        // test's source — which must mention them to scan for them — does not
+        // self-match. A bare contiguous `cmd_set_setting(` never appears in
+        // this function's body.
+        let call_anchor = ["cmd_set_setting", "("].concat();
+        let discard_let = ["let _ = cmd_set", "_setting"].concat();
+        let ok_tail = [".ok", "()"].concat();
+        let mut offenders: Vec<String> = Vec::new();
+        for path in walk_with_extensions(&rust_root, &["rs"]) {
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let lines: Vec<&str> = contents.lines().collect();
+            for (lineno, line) in lines.iter().enumerate() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with("//") {
+                    continue;
+                }
+
+                // Shape A: `let _ = cmd_set_setting(...)`.
+                if line.contains(&discard_let) {
+                    offenders.push(format!("{}:{} {}", path.display(), lineno + 1, trimmed));
+                    continue;
+                }
+
+                // Shape B (inline): `cmd_set_setting(...).ok()` on one line.
+                if line.contains(&call_anchor) && line.contains(&ok_tail) {
+                    offenders.push(format!("{}:{} {}", path.display(), lineno + 1, trimmed));
+                    continue;
+                }
+
+                // Shape C (multi-line tail): a standalone `.ok()` line whose
+                // statement opened with a `cmd_set_setting(` call. Look back a
+                // few lines for the opener, stopping at a statement boundary
+                // (`;` or `{`/`}`) so array literals like
+                // `[cmd_set_setting(...), ...];` (terminated by `;`) don't match.
+                if trimmed.starts_with(&ok_tail) {
+                    for back in 1..=8usize {
+                        let Some(prev_idx) = lineno.checked_sub(back) else {
+                            break;
+                        };
+                        let prev = lines[prev_idx].trim();
+                        if prev.contains(&call_anchor) {
+                            offenders.push(format!(
+                                "{}:{} {}",
+                                path.display(),
+                                prev_idx + 1,
+                                lines[prev_idx].trim_start()
+                            ));
+                            break;
+                        }
+                        // Stop at a statement boundary that isn't the call we want.
+                        if prev.ends_with(';') || prev.ends_with('{') || prev.ends_with('}') {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "cmd_set_setting Result is swallowed (use `?` or `if let Err(e) = ..`):\n  {}",
+            offenders.join("\n  ")
         );
     }
 
@@ -12605,9 +13041,8 @@ pub fn cmd_set_live_shortcut(
         "live_transcript".into(),
         "shortcut_enabled".into(),
         enabled.to_string(),
-    )
-    .ok();
-    cmd_set_setting("live_transcript".into(), "shortcut".into(), next_shortcut).ok();
+    )?;
+    cmd_set_setting("live_transcript".into(), "shortcut".into(), next_shortcut)?;
 
     Ok(cmd_live_shortcut_settings(state))
 }
@@ -12727,7 +13162,18 @@ pub fn cmd_set_palette_shortcut(
                 state
                     .palette_shortcut_enabled
                     .store(false, Ordering::Relaxed);
-                cmd_set_setting("palette".into(), "shortcut_enabled".into(), "false".into()).ok();
+                // We're already returning an error to the user; if persisting
+                // the force-disabled state ALSO fails, log it rather than
+                // swallow (the original registration error is what the user
+                // needs to see, so don't override the return value here).
+                if let Err(persist_err) =
+                    cmd_set_setting("palette".into(), "shortcut_enabled".into(), "false".into())
+                {
+                    eprintln!(
+                        "[palette-shortcut] failed to persist force-disabled state: {}",
+                        persist_err
+                    );
+                }
                 return Err(format!(
                     "Could not register {} and could not restore the previous shortcut. \
                      Palette shortcut is now disabled — set a different binding from \
@@ -12755,9 +13201,8 @@ pub fn cmd_set_palette_shortcut(
         "palette".into(),
         "shortcut_enabled".into(),
         enabled.to_string(),
-    )
-    .ok();
-    cmd_set_setting("palette".into(), "shortcut".into(), next_shortcut).ok();
+    )?;
+    cmd_set_setting("palette".into(), "shortcut".into(), next_shortcut)?;
 
     Ok(cmd_palette_settings(state))
 }
@@ -13491,7 +13936,10 @@ pub fn cmd_set_shortcut(
                     config.dictation.hotkey_enabled = false;
                 }
             }
-            ShortcutSlot::QuickThought => {}
+            ShortcutSlot::QuickThought => {
+                config.global_hotkey.shortcut_enabled = true;
+                config.global_hotkey.shortcut = status.shortcut.clone();
+            }
         }
         config
             .save()
@@ -13522,7 +13970,12 @@ pub fn cmd_set_shortcut(
                     }
                 }
             }
-            ShortcutSlot::QuickThought => {}
+            ShortcutSlot::QuickThought => {
+                config.global_hotkey.shortcut_enabled = false;
+                if !shortcut.is_empty() {
+                    config.global_hotkey.shortcut = shortcut;
+                }
+            }
         }
         config
             .save()

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1294,10 +1294,15 @@ fn main() {
     let processing_stage = Arc::new(Mutex::new(None));
     let latest_output = Arc::new(Mutex::new(None));
     let activation_progress = commands::load_activation_progress(&startup_config_snapshot);
-    let completion_notifications_enabled = Arc::new(AtomicBool::new(true));
-    let global_hotkey_enabled = Arc::new(AtomicBool::new(false));
-    let global_hotkey_shortcut =
-        Arc::new(Mutex::new(commands::default_hotkey_shortcut().to_string()));
+    let completion_notifications_enabled = Arc::new(AtomicBool::new(
+        startup_config_snapshot.notifications.completion_enabled,
+    ));
+    let global_hotkey_enabled = Arc::new(AtomicBool::new(
+        startup_config_snapshot.global_hotkey.shortcut_enabled,
+    ));
+    let global_hotkey_shortcut = Arc::new(Mutex::new(
+        startup_config_snapshot.global_hotkey.shortcut.clone(),
+    ));
     let dictation_shortcut_enabled = Arc::new(AtomicBool::new(false));
     let dictation_shortcut = Arc::new(Mutex::new(
         startup_config_snapshot.dictation.shortcut.clone(),

--- a/tauri/src-tauri/src/shortcut_manager.rs
+++ b/tauri/src-tauri/src/shortcut_manager.rs
@@ -567,16 +567,26 @@ impl ShortcutManager {
                     message,
                 }
             }
-            None => ShortcutStatus {
-                slot: slot.as_str().into(),
-                enabled: false,
-                pending: false,
-                shortcut: default_shortcut_for_slot(slot).into(),
-                keycode: default_keycode_for_slot(slot),
-                backend: "standard".into(),
-                needs_permission: false,
-                message: "Off.".into(),
-            },
+            None => {
+                // Inactive slot: surface the PERSISTED config shortcut rather
+                // than the compile-time default. Otherwise a disabled slot with
+                // a custom chord reports the default, and toggling it back on
+                // (which echoes the reported shortcut) would clobber the user's
+                // saved chord. `Config::load()` here is cheap and only happens
+                // for inactive slots — not on any per-keystroke hot path.
+                let (shortcut, keycode, backend) =
+                    persisted_shortcut_for_slot(&minutes_core::Config::load(), slot);
+                ShortcutStatus {
+                    slot: slot.as_str().into(),
+                    enabled: false,
+                    pending: false,
+                    shortcut,
+                    keycode,
+                    backend: backend.into(),
+                    needs_permission: false,
+                    message: "Off.".into(),
+                }
+            }
         }
     }
 
@@ -597,10 +607,41 @@ pub fn default_shortcut_for_slot(slot: ShortcutSlot) -> &'static str {
     }
 }
 
-pub fn default_keycode_for_slot(slot: ShortcutSlot) -> i64 {
+/// Resolve the persisted shortcut for a slot from config, for use when the slot
+/// is currently inactive (not registered in the ShortcutManager).
+///
+/// Returns `(shortcut_string, keycode, backend_label)`. This mirrors the
+/// canonical startup-restore mapping in `main.rs`: for dictation the native
+/// keycode variant (CapsLock=57 / fn=63) takes precedence when
+/// `dictation.hotkey_enabled` is set, otherwise the standard chord
+/// (`dictation.shortcut`, keycode -1) is used. Quick Thought reads
+/// `global_hotkey.shortcut` (keycode -1, always standard backend).
+///
+/// Falls back to the compile-time defaults only when a config field is empty,
+/// so a user's saved-but-disabled custom chord is never replaced by the default.
+pub fn persisted_shortcut_for_slot(
+    config: &minutes_core::Config,
+    slot: ShortcutSlot,
+) -> (String, i64, &'static str) {
     match slot {
-        ShortcutSlot::QuickThought => -1,
-        ShortcutSlot::Dictation => -1,
+        ShortcutSlot::Dictation => {
+            if config.dictation.hotkey_enabled {
+                let kc = config.dictation.hotkey_keycode;
+                let label = if kc == 63 { "fn" } else { "CapsLock" };
+                (label.to_string(), kc, "native")
+            } else if !config.dictation.shortcut.is_empty() {
+                (config.dictation.shortcut.clone(), -1, "standard")
+            } else {
+                (default_shortcut_for_slot(slot).to_string(), -1, "standard")
+            }
+        }
+        ShortcutSlot::QuickThought => {
+            if !config.global_hotkey.shortcut.is_empty() {
+                (config.global_hotkey.shortcut.clone(), -1, "standard")
+            } else {
+                (default_shortcut_for_slot(slot).to_string(), -1, "standard")
+            }
+        }
     }
 }
 
@@ -993,6 +1034,78 @@ mod tests {
         // Second press while key is down = ignored
         let action = sm.handle_press();
         assert!(matches!(action, StateMachineAction::None));
+    }
+
+    #[test]
+    fn persisted_shortcut_disabled_slot_reports_custom_not_default() {
+        // A disabled slot with a custom persisted chord must report the custom
+        // chord, not the compile-time default. This is the core round-trip fix:
+        // build_status' inactive branch reads these values.
+        let mut config = minutes_core::Config::default();
+
+        // Quick Thought: custom chord, disabled.
+        config.global_hotkey.shortcut_enabled = false;
+        config.global_hotkey.shortcut = "CmdOrCtrl+Shift+J".into();
+        let (shortcut, keycode, backend) =
+            persisted_shortcut_for_slot(&config, ShortcutSlot::QuickThought);
+        assert_eq!(shortcut, "CmdOrCtrl+Shift+J");
+        assert_ne!(
+            shortcut,
+            default_shortcut_for_slot(ShortcutSlot::QuickThought)
+        );
+        assert_eq!(keycode, -1);
+        assert_eq!(backend, "standard");
+
+        // Dictation, standard chord variant: custom chord, disabled.
+        config.dictation.hotkey_enabled = false;
+        config.dictation.shortcut_enabled = false;
+        config.dictation.shortcut = "CmdOrCtrl+Shift+P".into();
+        let (shortcut, keycode, backend) =
+            persisted_shortcut_for_slot(&config, ShortcutSlot::Dictation);
+        assert_eq!(shortcut, "CmdOrCtrl+Shift+P");
+        assert_ne!(shortcut, default_shortcut_for_slot(ShortcutSlot::Dictation));
+        assert_eq!(keycode, -1);
+        assert_eq!(backend, "standard");
+    }
+
+    #[test]
+    fn persisted_shortcut_dictation_native_keycode_preserved() {
+        // Dictation's native keycode special-casing (CapsLock=57, fn=63) must be
+        // preserved when hotkey_enabled is set, even though the slot is inactive.
+        let mut config = minutes_core::Config::default();
+
+        config.dictation.hotkey_enabled = true;
+        config.dictation.hotkey_keycode = 57; // Caps Lock
+        let (shortcut, keycode, backend) =
+            persisted_shortcut_for_slot(&config, ShortcutSlot::Dictation);
+        assert_eq!(shortcut, "CapsLock");
+        assert_eq!(keycode, 57);
+        assert_eq!(backend, "native");
+
+        config.dictation.hotkey_keycode = 63; // fn
+        let (shortcut, keycode, backend) =
+            persisted_shortcut_for_slot(&config, ShortcutSlot::Dictation);
+        assert_eq!(shortcut, "fn");
+        assert_eq!(keycode, 63);
+        assert_eq!(backend, "native");
+    }
+
+    #[test]
+    fn persisted_shortcut_falls_back_to_default_when_config_empty() {
+        // An empty config field falls back to the compile-time default so we
+        // never report an empty chord.
+        let mut config = minutes_core::Config::default();
+        config.global_hotkey.shortcut = String::new();
+        let (shortcut, _, _) = persisted_shortcut_for_slot(&config, ShortcutSlot::QuickThought);
+        assert_eq!(
+            shortcut,
+            default_shortcut_for_slot(ShortcutSlot::QuickThought)
+        );
+
+        config.dictation.hotkey_enabled = false;
+        config.dictation.shortcut = String::new();
+        let (shortcut, _, _) = persisted_shortcut_for_slot(&config, ShortcutSlot::Dictation);
+        assert_eq!(shortcut, default_shortcut_for_slot(ShortcutSlot::Dictation));
     }
 
     #[test]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -6925,12 +6925,15 @@
       // Skip entirely if the unified shortcut system is active
       if (typeof unifiedShortcutsActive !== 'undefined' && unifiedShortcutsActive) return;
       try {
+        // config.toml is the source of truth: cmd_global_hotkey_settings
+        // returns AppState, which is seeded from config.global_hotkey at
+        // startup. localStorage is no longer authoritative (the old shadow
+        // store masked the config drop fixed in the settings round-trip
+        // audit); we keep writing it for backward-compat but never read it
+        // as the deciding value.
         const settings = await invoke('cmd_global_hotkey_settings');
-        hotkeyShortcut =
-          localStorage.getItem('minutes.globalHotkeyShortcut') || settings.shortcut || hotkeyShortcut;
-        const storedEnabled = localStorage.getItem('minutes.globalHotkeyEnabled');
-        const desiredEnabled = storedEnabled === null ? !!settings.enabled : storedEnabled === 'true';
-        await syncHotkey(desiredEnabled, hotkeyShortcut);
+        hotkeyShortcut = settings.shortcut || hotkeyShortcut;
+        await syncHotkey(!!settings.enabled, hotkeyShortcut);
       } catch (e) {
         console.error('Load hotkey settings:', e);
         setHotkeyStatus('Global shortcut is unavailable right now.', true);
@@ -8773,8 +8776,13 @@
           document.getElementById('settings-identity-emails').value = (s.identity.emails || []).join(', ');
           document.getElementById('settings-identity-aliases').value = (s.identity.aliases || []).join(', ');
         }
-        // General: sync with existing app state
-        setSettingsToggle('settings-notifications', notifyOnCompletion);
+        // General: notifications come from config (single source of truth);
+        // paint both the settings toggle and the footer toggle / in-memory var
+        // from notifications.completion_enabled, not the cached JS value.
+        const notifyEnabled = s?.notifications?.completion_enabled !== false;
+        setNotificationToggle(notifyEnabled);
+        setSettingsToggle('settings-notifications', notifyEnabled);
+        // Cues are localStorage-only (no config section).
         setSettingsToggle('settings-cues', playCaptureCues);
         // Autostart
         try { const autoOn = await invoke('cmd_get_autostart'); setSettingsToggle('settings-autostart', autoOn); } catch (e) { console.error('autostart check:', e); }
@@ -9950,7 +9958,9 @@
     function updateSlotUI(slot, status) {
       unifiedSlotState[slot] = status;
 
-      // Sync QuickThought state to localStorage for persistence and legacy compat
+      // Mirror QuickThought state to localStorage for legacy compat only.
+      // config.toml (via cmd_set_shortcut → config.global_hotkey) is the
+      // source of truth now; nothing reads this value as authoritative.
       if (slot === 'quick_thought') {
         localStorage.setItem('minutes.globalHotkeyEnabled', status.enabled ? 'true' : 'false');
         if (status.shortcut) localStorage.setItem('minutes.globalHotkeyShortcut', status.shortcut);
@@ -10240,9 +10250,89 @@
     // Flag: set synchronously so loadHotkeySettings() knows to skip
     let unifiedShortcutsActive = true;
 
+    // ── One-time legacy localStorage → config.toml migration ──────────────
+    // Before this change, two settings lived ONLY in localStorage (and the
+    // in-memory AppState seeded from it), never in config.toml:
+    //   • minutes.notifyOnCompletion   → notifications.completion_enabled
+    //   • minutes.globalHotkeyEnabled  → global_hotkey.shortcut_enabled
+    //   • minutes.globalHotkeyShortcut → global_hotkey.shortcut
+    // config.toml is now the single source of truth for both. On the first
+    // launch after this update we copy any pre-existing localStorage value
+    // INTO config, then DELETE the localStorage key so the migration runs
+    // exactly once and the old drift source is gone. Key-removal is the
+    // one-time guard: once removed, getItem() returns null and the block is
+    // a no-op, so a machine that already migrated can never have a stale JS
+    // value clobber config. A separate `minutes.localStorageConfigMigrated`
+    // sentinel is also set as a belt-and-suspenders marker.
+    //
+    // The promise is awaited by the unified-shortcut restore below (and the
+    // notifications init reads config after it resolves) so the migrated
+    // values are on disk BEFORE anything reads cmd_get_settings.
+    const legacyConfigMigrationReady = (async () => {
+      // One-time guard. updateSlotUI('quick_thought', …) re-writes the legacy
+      // hotkey mirror keys on every status update (they're kept as legacy
+      // compat), so key-removal alone is not durable — the sentinel is. Once
+      // set, this whole block short-circuits and config stays authoritative.
+      if (localStorage.getItem('minutes.localStorageConfigMigrated') === '1') return;
+      try {
+        // Notifications: only migrate an explicit stored value. The historical
+        // default was On, so a *missing* key means "user never changed it" →
+        // leave config's own default (completion_enabled = true) authoritative.
+        const storedNotify = localStorage.getItem('minutes.notifyOnCompletion');
+        if (storedNotify !== null) {
+          try {
+            await invoke('cmd_set_completion_notifications', { enabled: storedNotify !== 'false' });
+          } catch (e) {
+            console.error('Migrate notifyOnCompletion → config:', e);
+          }
+          localStorage.removeItem('minutes.notifyOnCompletion');
+        }
+
+        // Quick-Thought global hotkey: migrate the legacy enable+shortcut shadow
+        // into config via the unified ShortcutManager path (cmd_set_shortcut,
+        // slot quick_thought). We deliberately do NOT use cmd_set_global_hotkey
+        // here: that registers the OS chord through the plugin, and the unified
+        // restore below would then register the SAME chord again through the
+        // ShortcutManager → duplicate-registration error. Routing the migration
+        // through cmd_set_shortcut registers exactly once and persists the same
+        // config.global_hotkey.{shortcut_enabled,shortcut} fields, after which
+        // the restore loop's `current.enabled` guard skips the slot.
+        const storedHkEnabled = localStorage.getItem('minutes.globalHotkeyEnabled');
+        const storedHkShortcut = localStorage.getItem('minutes.globalHotkeyShortcut');
+        if (storedHkEnabled !== null || storedHkShortcut !== null) {
+          const enabled = storedHkEnabled === 'true';
+          const shortcut = storedHkShortcut || hotkeyShortcut || 'CmdOrCtrl+Shift+M';
+          // Migrate regardless of enabled state so a custom (but disabled)
+          // chord is preserved in config — the Rust disable arm keeps a
+          // non-empty shortcut. Skip only the pure no-op (disabled with no
+          // custom chord), where config's defaults already match.
+          if (enabled || storedHkShortcut !== null) {
+            try {
+              const status = await invoke('cmd_set_shortcut', {
+                slot: 'quick_thought', enabled, shortcut, keycode: -1,
+              });
+              updateSlotUI('quick_thought', status);
+            } catch (e) {
+              console.error('Migrate globalHotkey → config:', e);
+            }
+          }
+          // Remove BOTH legacy keys so the migration is one-shot. (updateSlotUI
+          // for quick_thought re-writes these as legacy-compat mirrors, so
+          // remove them AFTER the cmd_set_shortcut call above.)
+          localStorage.removeItem('minutes.globalHotkeyEnabled');
+          localStorage.removeItem('minutes.globalHotkeyShortcut');
+        }
+      } finally {
+        localStorage.setItem('minutes.localStorageConfigMigrated', '1');
+      }
+    })();
+
     // Load initial state for all slots
     // Also restore from saved config
     (async () => {
+      // Wait for the one-time migration so config reflects any legacy
+      // localStorage hotkey value before we read it as the source of truth.
+      await legacyConfigMigrationReady;
       const settings = await invoke('cmd_get_settings').catch(() => null);
       for (const slot of UNIFIED_SLOTS) {
         await loadSlotStatus(slot);
@@ -10270,11 +10360,13 @@
           }
 
           if (slot === 'quick_thought') {
-            const storedEnabled = localStorage.getItem('minutes.globalHotkeyEnabled');
-            const storedShortcut = localStorage.getItem('minutes.globalHotkeyShortcut');
-            if (storedEnabled === 'true') {
+            // config.toml is the source of truth (settings.global_hotkey),
+            // mirroring the dictation slot above. The old localStorage shadow
+            // store is no longer read here — it masked the config drop fixed
+            // in the settings round-trip audit.
+            if (settings.global_hotkey?.shortcut_enabled) {
               shouldRestore = true;
-              shortcut = storedShortcut || shortcut;
+              shortcut = settings.global_hotkey.shortcut || shortcut;
               keycode = -1;
             }
           }
@@ -12847,21 +12939,28 @@
     });
 
     // ── Init ──
-    const storedNotify = localStorage.getItem('minutes.notifyOnCompletion');
-    if (storedNotify === 'false') {
-      setNotificationToggle(false);
-    } else {
-      setNotificationToggle(true);
-    }
+    // Notifications: config.toml is the source of truth. Wait for the one-time
+    // localStorage→config migration, then paint the toggle from
+    // notifications.completion_enabled (cmd_get_settings). We no longer read
+    // minutes.notifyOnCompletion here, and we no longer push the JS value into
+    // config on launch — that push was what stomped a config `false` back to
+    // `true` whenever localStorage was absent/stale.
+    (async () => {
+      try {
+        await legacyConfigMigrationReady;
+        const s = await invoke('cmd_get_settings');
+        setNotificationToggle(s?.notifications?.completion_enabled !== false);
+      } catch (e) {
+        console.error('Init notifications from config:', e);
+      }
+    })();
+    // Capture cues are localStorage-only (no config section); unchanged.
     const storedCues = localStorage.getItem('minutes.playCaptureCues');
     if (storedCues === 'false') {
       setCueToggle(false);
     } else {
       setCueToggle(true);
     }
-    invoke('cmd_set_completion_notifications', { enabled: notifyOnCompletion }).catch((e) => {
-      console.error('Init notifications:', e);
-    });
     loadDesktopCapabilities();
     loadHotkeySettings();
     checkSetup();


### PR DESCRIPTION
## What

Fixes a recurring class of "I toggled it in the app but `config.toml` didn't change / it reverted on restart" bugs, and hardens the guard test so it can't recur. Driven by a full audit of the settings round-trip surface.

### The three confirmed drops (settings that never persisted)
- `cmd_set_global_hotkey` (Quick-Thought hotkey: enabled + shortcut): AppState-only, leaned on browser `localStorage`
- `cmd_set_completion_notifications`: AppState-only, reverted to `true` on restart
- the `ShortcutSlot::QuickThought` arms of `cmd_set_shortcut`: empty `=> {}`

### The fix
- New `[global_hotkey]` and `[notifications]` config sections (`#[serde(default)]`, backward-compatible, so old `config.toml` still loads)
- Setters now `Config::load() -> mutate -> save()`; AppState seeded from config at startup; both surfaced in `cmd_get_settings`
- Frontend reads config as authoritative, with a one-time `localStorage` to config migration so existing users keep their settings (a custom-but-disabled chord is migrated too)
- Disabled-slot status fix: `build_status`' inactive branch now reports the persisted custom chord instead of the compile-time default, so re-enabling a slot no longer overwrites a user's custom shortcut (affected `quick_thought` and `dictation`; `palette` and `live` already seed from config)

### Guard hardening (so this class can't recur)
- `caller -> arm` assertion (both quote styles) alongside the existing `arm -> caller` test. A frontend or internal call to a non-existent arm now fails the build.
- Round-trip persistence tests (set, reload `Config` from a temp HOME, assert on disk) for each side-channel setter
- Ban `cmd_set_setting(...).ok()`; the fragile `.ok()` callers (`cmd_set_live_shortcut`, `cmd_set_palette_shortcut`) converted to `?`

## Testing
- `cargo check -p minutes-core -p minutes-app --tests`: clean
- `minutes-app` bin suite 224/224, `minutes-core` config 57/57
- New tests: round-trip persistence, `caller->arm` both quote styles, disabled-slot reports the persisted chord, backward-compat config load

## Review
Reviewed across 4 Codex passes (final: GATE PASS). Each pass's findings were fixed and re-verified: notifications config-authority, the one-time migration for existing users, the `cmd_set_shortcut` vs `cmd_set_global_hotkey` double-registration choice, and the disabled-slot restore.

Generated with [Claude Code](https://claude.com/claude-code)
