### PR TITLE
fix(tauri): stop banners collapsing text to one word per line at narrow width

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -3541,8 +3541,8 @@
     /* ── Call ended countdown banner ── */
     .call-ended {
       display: none;
-      align-items: flex-start;
-      gap: 10px;
+      flex-direction: column;
+      gap: 8px;
       padding: 12px 16px;
       background: var(--red-bg);
       border-bottom: 1px solid var(--red-border-strong);
@@ -3552,20 +3552,26 @@
       display: flex;
     }
 
+    .call-ended-info {
+      min-width: 0;
+    }
+
+    .call-ended-head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
     .call-ended-icon {
       font-size: 16px;
       flex-shrink: 0;
-    }
-
-    .call-ended-info {
-      flex: 1;
-      min-width: 0;
     }
 
     .call-ended-title {
       font-size: 13px;
       font-weight: 600;
       color: var(--text);
+      min-width: 0;
     }
 
     .call-ended-subtitle {
@@ -3585,7 +3591,10 @@
     .call-ended-actions {
       display: flex;
       gap: 6px;
-      align-items: flex-start;
+    }
+
+    .call-ended-actions .btn {
+      flex: 1;
     }
 
     /* ── Update available banner ── */
@@ -3617,6 +3626,7 @@
       display: flex;
       align-items: center;
       gap: 12px;
+      flex-wrap: wrap;
     }
 
     .update-banner-phase {
@@ -3624,6 +3634,7 @@
       align-items: center;
       gap: 8px;
       min-width: 0;
+      flex: 1 1 auto;
     }
 
     .update-banner-spinner {
@@ -3645,6 +3656,9 @@
       font-size: 12px;
       font-weight: 600;
       color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .update-banner-sub {
@@ -3852,6 +3866,7 @@
       display: flex;
       gap: 6px;
       flex-shrink: 0;
+      flex-wrap: wrap;
     }
 
     .update-banner-actions .btn {
@@ -4518,9 +4533,11 @@
 
     <!-- Call ended countdown banner -->
     <div class="call-ended" id="call-ended-banner" role="alert" aria-live="polite">
-      <div class="call-ended-icon">⏲</div>
       <div class="call-ended-info">
-        <div class="call-ended-title" id="call-ended-title">Call ended</div>
+        <div class="call-ended-head">
+          <div class="call-ended-icon">⏲</div>
+          <div class="call-ended-title" id="call-ended-title">Call ended</div>
+        </div>
         <div class="call-ended-subtitle" id="call-ended-subtitle">Stopping in 30s</div>
         <div class="call-ended-detail" id="call-ended-detail">Keep recording if you're wrapping up notes or takeaways. Otherwise Minutes will stop and process this session.</div>
       </div>


### PR DESCRIPTION
## Problem

When the recall/assistant panel is open, the main column is squeezed to its 320px floor (`.recall-panel` is `min-width: 320px` at 50% of a 660px window). Two banners laid out as `[text][buttons]` in a horizontal row where the buttons did not shrink, so the text column collapsed to a tall one-word-per-line stack:

- `.call-ended`: the call-ended countdown banner (Google Meet ended / Stopping in Ns / Stop now / Keep recording)
- `.update-banner`: same structure, would break the next time it showed with the panel open

## Fix

- **call-ended**: stack vertically. Icon and title in a `.call-ended-head` row, detail text full width, the two buttons split evenly below (`.call-ended-actions .btn { flex: 1 }`).
- **update-banner**: `flex-wrap` the row so actions drop below when tight, give the phase `flex: 1 1 auto`, and add `nowrap` plus `text-overflow: ellipsis` on the title so it never collapses.

Audited every other banner, card, notice, and action row: the rest already stack, wrap, or ellipsize, and modals are fixed-width (`min(Npx, 100%)`) so they are never squeezed. These were the only two instances of the bug class.

## Verification

Rendered both banners at 320px (squeezed) and 620px (normal). The one-word-per-line collapse is gone in both. Built and installed the dev app to confirm it compiles into the bundle (hotkey/TCC diagnostic green).