### PR TITLE
fix(tauri): stop Windows recall panel from resizing window and leaving a phantom column

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -4271,6 +4271,15 @@
       gap: 12px;
     }
 
+    /* On non-macOS (Windows/Linux) the OS window stays wide when the panel is
+       collapsed, so the `padding: 16px` above — combined with `width: 0` and
+       `box-sizing: border-box` — leaves a ~32px phantom column on the right.
+       On macOS the window shrinks to 520px on collapse (below any threshold),
+       so this was never visible there. Zero the padding only when collapsed. */
+    html:not([data-platform="macos"]) .recall-panel:not(.expanded) {
+      padding: 0;
+    }
+
     .recall-header {
       border-radius: 12px;
     }
@@ -10568,6 +10577,14 @@
     const COLLAPSED_WIDTH = 520;
     const EXPANDED_WIDTH = 960;
     const DEFAULT_RECALL_RATIO = 0.5;
+    // On Windows the OS window resize (expand→960, collapse→520) is jarring:
+    // closing the panel snaps the window to 520px regardless of the user's size.
+    // The CSS flex layout (recall-panel width:0 / expanded, app-left flex:1) handles
+    // the visual reflow on its own — the OS resize is purely a macOS UX choice.
+    // Skip it on Windows so the window stays at whatever size the user set.
+    const IS_WINDOWS = typeof navigator !== 'undefined' &&
+      navigator.platform &&
+      navigator.platform.toLowerCase().startsWith('win');
     const MIN_RECALL_RATIO = 0.25;
     const MAX_RECALL_RATIO = 0.667;
     const SESSION_ID = 'assistant';
@@ -10756,6 +10773,10 @@
 
     // ── Expand / collapse with window resize ──
     function applyRecallWindowLayout(width, options = {}) {
+      // Windows: skip OS resize — the flex layout reflows correctly without it,
+      // and forcing a width on collapse (520px) is jarring when the user had a
+      // different window size. macOS/Linux behavior is unchanged.
+      if (IS_WINDOWS) return Promise.resolve();
       return invoke('cmd_apply_recall_window_layout', {
         width,
         height: 640,


### PR DESCRIPTION
## Problem

On Windows, the embedded AI-assistant (Recall) panel caused two layout issues on the home view that don't occur on macOS (I am a win user):

1. **Window resizes when toggling the panel.** Opening/closing the panel drives an OS-level window resize (expand → 960px, collapse → 520px) through `cmd_apply_recall_window_layout`. On macOS this "grow to fit, snap back" is intentional, but on Windows it snaps the window to a fixed 520px on close regardless of the size the user chose, and the timing leaves transient whitespace.

2. **Phantom empty column when the panel is collapsed.** The top-level `.recall-panel { padding: 16px }` rule, combined with `width: 0` and the global `box-sizing: border-box`, forces the collapsed panel to render ~32px wide — a permanent empty column on the right edge of the home view. macOS never shows it because the window shrinks below the panel's footprint on collapse.

## Fix

Both changes are **platform-gated; macOS behavior is byte-for-byte unchanged.**

1. Skip the OS window resize on Windows (`IS_WINDOWS` guard, early-return in `applyRecallWindowLayout`). The CSS flex layout (`.recall-panel` `width: 0` ↔ `expanded`, `.app-left { flex: 1 }`) reflows on its own, so the window stays at whatever size the user set.

2. Zero the padding on the **collapsed** panel for non-macOS only:
   ```css
   html:not([data-platform="macos"]) .recall-panel:not(.expanded) { padding: 0; }
   ```
   The expanded panel keeps its 16px padding (the terminal needs it).

Linux also benefits from fix #2 (it had the same phantom column); the rule is gated away from macOS, not toward a single platform, and removes a gap that shouldn't exist anywhere.

## Scope

- 1 file changed: `tauri/src/index.html` (+21 lines)
- No Rust changes
- No macOS/Linux regressions — all changes guarded by platform detection

## Testing

Verified visually on Windows 11 with `cargo tauri dev`:
- Toggling the AI assistant panel no longer resizes/snaps the window
- Collapsed panel no longer leaves an empty column on the right
- Expanded panel still renders with correct internal padding
