### PR TITLE
fix(ui): replace hardcoded ⌘/Option symbols with platform-aware labels

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -4429,7 +4429,7 @@
         </div>
       </div>
       <div class="header-actions">
-        <button class="btn btn-icon" id="btn-settings" title="Settings (⌘,)">⚙</button>
+        <button class="btn btn-icon" id="btn-settings">⚙</button>
         <button class="header-chip readiness" id="btn-readiness">Readiness</button>
         <button class="header-chip" id="btn-jobs">Jobs <span id="jobs-count">0</span></button>
         <button class="header-chip" id="btn-recovery">Recovery <span id="recovery-count">0</span></button>
@@ -5745,6 +5745,22 @@
 
   <script>
     const { invoke } = window.__TAURI__.core;
+
+    // Platform detection — mirrors the data-platform attribute set in the inline
+    // <script> at the top of <head>. Used to swap macOS-specific symbols (⌘, ⌥)
+    // for their Windows/Linux equivalents without touching macOS behaviour.
+    const isMac = document.documentElement.dataset.platform === 'macos';
+
+    // Rewrite shortcut-select option labels to use platform-appropriate key names.
+    // On macOS: "Cmd+Shift+L" / "Cmd+Option+L" (unchanged).
+    // On Windows/Linux: "Ctrl+Shift+L" / "Ctrl+Alt+L".
+    if (!isMac) {
+      document.querySelectorAll('.shortcut-select option').forEach((opt) => {
+        opt.textContent = opt.textContent
+          .replace(/Cmd/g, 'Ctrl')
+          .replace(/Option/g, 'Alt');
+      });
+    }
 
     const statusPill = document.getElementById('status-pill');
     const recordingBar = document.getElementById('recording-bar');
@@ -8774,8 +8790,16 @@
     document.getElementById('btn-settings-close').addEventListener('click', closeSettings);
     settingsOverlay.addEventListener('click', (e) => { if (e.target === settingsOverlay) closeSettings(); });
 
-    // ⌘, keyboard shortcut
-    document.addEventListener('keydown', (e) => { if (e.metaKey && e.key === ',') { e.preventDefault(); openSettings(); } });
+    // Set platform-appropriate tooltip for the settings button.
+    document.getElementById('btn-settings').title = isMac ? 'Settings (⌘,)' : 'Settings (Ctrl+,)';
+
+    // ⌘, / Ctrl+, keyboard shortcut to open settings
+    document.addEventListener('keydown', (e) => {
+      if (isMac ? (e.metaKey && e.key === ',') : (e.ctrlKey && e.key === ',')) {
+        e.preventDefault();
+        openSettings();
+      }
+    });
     // Plain Cmd+K opens the palette when the Minutes window has focus
     // (minutes-s5fb). Skip while typing in inputs; the global Cmd+Shift+K
     // binding is unchanged.
@@ -9973,14 +9997,19 @@
     function shortcutDisplayLabel(shortcut, keycode) {
       if (keycode === 57) return 'Caps Lock';
       if (keycode === 63) return 'fn';
-      // Format "CmdOrCtrl+Shift+Space" as "⌘ Shift Space"
+      if (isMac) {
+        // Format "CmdOrCtrl+Shift+Space" as "⌘ Shift Space"
+        return shortcut
+          .replace(/CmdOrCtrl/g, '\u2318')
+          .replace(/Shift/g, 'Shift')
+          .replace(/Alt/g, 'Option')
+          .replace(/\+/g, ' ');
+      }
+      // Format "CmdOrCtrl+Shift+Space" as "Ctrl+Shift+Space" on Windows/Linux
       return shortcut
-        .replace(/CmdOrCtrl/g, '\u2318')
-        .replace(/Shift/g, 'Shift')
-        .replace(/Alt/g, 'Option')
-        .replace(/\+/g, ' ');
+        .replace(/CmdOrCtrl/g, 'Ctrl')
+        .replace(/\+/g, '+');
     }
-
     function updateSlotUI(slot, status) {
       unifiedSlotState[slot] = status;
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded macOS keyboard symbols (⌘, Option, "Cmd") with platform-aware
  equivalents so Windows and Linux users see Ctrl/Alt instead.
- macOS behaviour and appearance are **completely unchanged** — all fixes are
  behind an `isMac` guard derived from the existing `data-platform` attribute.

Fixes #353.

## Changes

- Added `const isMac` reusing the `data-platform` attribute already set in `<head>` — no new platform detection logic.
- **Settings button tooltip**: removed static `title` attr from HTML; set via JS as `Settings (⌘,)` on macOS or `Settings (Ctrl+,)` elsewhere.
- **Settings keyboard shortcut** (functional bug): was `e.metaKey` only (broken on Windows); now `isMac ? e.metaKey : e.ctrlKey` so `Ctrl+,` actually opens Settings.
- **Shortcut-select dropdown labels**: on non-macOS, rewrites `.shortcut-select option` text replacing `Cmd→Ctrl` and `Option→Alt`. `value` attributes are untouched (the Tauri backend already uses `CmdOrCtrl` there).
- **`shortcutDisplayLabel()`**: added `if (isMac)` branch; non-Mac path formats as `Ctrl+Shift+Space` (with `+` separator) instead of `⌘ Shift Space`.

## Notes

External contributor on Windows 11. Tested Windows behaviour locally. The `isMac`
constant mirrors the same `navigator.platform` check already at lines 9-10 of the
inline `<head>` script, so no new platform detection logic is introduced.
