### PR TITLE
fix(windows): clipboard read/write and tray copy via arboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1035,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1610,6 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1704,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -2266,6 +2313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2682,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -3256,6 +3315,7 @@ dependencies = [
 name = "minutes-app"
 version = "0.1.0"
 dependencies = [
+ "arboard",
  "base64 0.22.1",
  "chrono",
  "dirs 6.0.0",
@@ -3685,6 +3745,7 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -4550,6 +4611,12 @@ dependencies = [
  "ndarray",
  "ort",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -6665,6 +6732,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7591,6 +7672,12 @@ dependencies = [
  "windows",
  "windows-core",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -8540,6 +8627,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -45,6 +45,9 @@ tracing = "0.1"
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3.7"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+arboard = "3"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2213,7 +2213,7 @@ pub fn supports_call_detection() -> bool {
 }
 
 pub fn supports_tray_artifact_copy() -> bool {
-    cfg!(target_os = "macos")
+    cfg!(any(target_os = "macos", target_os = "windows"))
 }
 
 pub fn supports_dictation_hotkey() -> bool {

--- a/tauri/src-tauri/src/text_insertion.rs
+++ b/tauri/src-tauri/src/text_insertion.rs
@@ -842,4 +842,13 @@ mod tests {
         };
         assert_eq!(result.overlay_state(), "error");
     }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_clipboard_round_trip() {
+        let text = "minutes-clipboard-test-windows";
+        write_clipboard(text).expect("write_clipboard should succeed on Windows");
+        let got = read_clipboard().expect("read_clipboard should succeed on Windows");
+        assert_eq!(got, text);
+    }
 }

--- a/tauri/src-tauri/src/text_insertion.rs
+++ b/tauri/src-tauri/src/text_insertion.rs
@@ -103,7 +103,15 @@ pub fn read_clipboard() -> Result<String, String> {
         linux_read_clipboard()
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(target_os = "windows")]
+    {
+        arboard::Clipboard::new()
+            .map_err(|error| format!("Could not open clipboard: {error}"))?
+            .get_text()
+            .map_err(|error| format!("Could not read clipboard: {error}"))
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         Err("Clipboard snapshot is not implemented on this platform.".into())
     }
@@ -353,7 +361,15 @@ fn write_clipboard(text: &str) -> Result<(), String> {
         linux_write_clipboard(text)
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(target_os = "windows")]
+    {
+        arboard::Clipboard::new()
+            .map_err(|error| format!("Could not open clipboard: {error}"))?
+            .set_text(text)
+            .map_err(|error| format!("Could not write to clipboard: {error}"))
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         let _ = text;
         Err("Clipboard insertion is not implemented on this platform.".into())


### PR DESCRIPTION
## Summary

On Windows, `write_clipboard()` always returned an error (the platform had no implementation), and `supports_tray_artifact_copy()` was hard-coded to `false`. This meant the tray artifact "Copy" button was hidden on Windows and any clipboard operation silently failed.

Closes #352

## Changes

- **`tauri/src-tauri/Cargo.toml`** — adds `arboard = "3"` under `[target.'cfg(target_os = "windows")'.dependencies]` (Windows-only dep, does not touch macOS or Linux dependency trees)
- **`tauri/src-tauri/src/text_insertion.rs`** — implements `read_clipboard()` and `write_clipboard()` for Windows via `arboard::Clipboard`, gated with `#[cfg(target_os = "windows")]`. The existing `pbcopy`-based macOS path and `xclip`/`wl-copy`-based Linux path are byte-identical to before. The `not(any(macos, linux))` fallback now excludes Windows too.
- **`tauri/src-tauri/src/commands.rs`** — `supports_tray_artifact_copy()` updated from `cfg!(target_os = "macos")` to `cfg!(any(target_os = "macos", target_os = "windows"))`, enabling the Copy button in the tray artifact panel on Windows.

## Out of scope

Paste-into-app keyboard automation (the `osascript` / `xdotool` path) is not implemented for Windows. On Windows, the flow falls through to `copy_after_block` — clipboard is written with the content, but no keystroke injection is attempted. This matches the explicit scope discussed in #352.

## Testing

**Manual (Windows):**
1. Build the Tauri app: `cargo tauri build --bundles app`
2. Start a recording and stop it.
3. Open the tray artifact panel — the "Copy" button should now be visible.
4. Click "Copy" — content should land in the clipboard (verify with Ctrl+V into any editor).

**Automated:**
```
cargo test -p minutes-app -- windows_clipboard_round_trip
```
The new test (`#[cfg(target_os = "windows")]`) writes a string to the clipboard and reads it back, asserting round-trip correctness.

**macOS / Linux (regression):**
No code paths changed on these platforms. The arboard crate is not compiled in. The `pbcopy` / `xclip` paths run as before.