### PR TITLE
feat(names): post-pass name correction, off by default (minutes-25x3.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3357,7 @@ dependencies = [
  "objc2-av-foundation",
  "ort",
  "pyannote-rs",
+ "rphonetic",
  "rusqlite",
  "schemars 1.2.1",
  "serde",
@@ -4981,6 +5002,21 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rphonetic"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c97095b4c3d5de9fae5abc43299a9d0035a9ffa8fb513371da7e641f7f3e2"
+dependencies = [
+ "document-features",
+ "either",
+ "enum-iterator",
+ "lazy_static",
+ "nom 8.0.0",
+ "regex",
+ "serde",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -64,6 +64,7 @@ nnnoiseless = { workspace = true, optional = true }
 base64 = "0.22"
 rusqlite = { workspace = true }
 tempfile = "3"
+rphonetic = "3.0.6"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -421,6 +421,19 @@ pub enum ConsentMode {
 }
 
 /// Post-pass name correction behavior.
+///
+/// `Conservative` corrects transcript name-tokens toward the expected-name pool
+/// (attendees, identity, vocabulary) only on high-confidence, unique matches,
+/// and records the raw token in frontmatter provenance (never a silent rewrite).
+/// Off by default.
+///
+/// Known residual: when a name spoken in the meeting is NOT in the pool but is
+/// within ~2 edits of a pool name and sits in a name slot (e.g. a guest "Brett"
+/// near a pool "Geert"), it can be corrected to the pool name. This is inherent
+/// to fuzzy correction; it is mitigated by being off by default, requiring a
+/// unique match, and preserving the raw token in provenance for review. Default-on
+/// promotion should wait on a stronger signal (speaker attribution / phonetic
+/// agreement).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum NameCorrectionMode {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -275,6 +275,9 @@ pub struct TranscriptionConfig {
     /// Default 30s matches the design note in `streaming_whisper.rs`. Raise
     /// for long-form dictation; lower if you still see CPU pressure.
     pub partial_max_secs: u32,
+    /// Post-pass person-name correction mode. Off by default.
+    #[serde(default)]
+    pub name_correction: NameCorrectionMode,
 }
 
 pub const VALID_PARAKEET_MODELS: &[&str] = &["tdt-ctc-110m", "tdt-600m"];
@@ -415,6 +418,15 @@ pub enum ConsentMode {
     #[default]
     Remind,
     Require,
+}
+
+/// Post-pass name correction behavior.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NameCorrectionMode {
+    #[default]
+    Off,
+    Conservative,
 }
 
 /// Retention policy for raw audio artifacts.
@@ -974,6 +986,7 @@ impl Default for TranscriptionConfig {
             parakeet_fp16_blacklist_reset: false,
             parakeet_vocab: "tdt-600m.tokenizer.vocab".into(),
             partial_max_secs: 30,
+            name_correction: NameCorrectionMode::Off,
         }
     }
 }

--- a/crates/core/src/daily_notes.rs
+++ b/crates/core/src/daily_notes.rs
@@ -304,6 +304,7 @@ mod tests {
             consent_notice: None,
             visibility: None,
             speaker_map: vec![],
+            name_corrections: Vec::new(),
             recording_health: None,
             processing_warnings: Vec::new(),
             template: None,

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -1138,6 +1138,7 @@ fn write_dictation_file(text: &str, duration_secs: f64, config: &Config) -> Opti
         consent_notice: None,
         visibility: None,
         speaker_map: vec![],
+        name_corrections: Vec::new(),
         recording_health: None,
         template: None,
         filter_diagnosis: None,

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -1806,6 +1806,7 @@ mod tests {
                 consent_notice: None,
                 visibility: None,
                 speaker_map: vec![],
+                name_corrections: Vec::new(),
                 recording_health: None,
                 processing_warnings: Vec::new(),
                 template: None,

--- a/crates/core/src/knowledge_extract.rs
+++ b/crates/core/src/knowledge_extract.rs
@@ -238,6 +238,7 @@ mod tests {
             consent_notice: None,
             visibility: None,
             speaker_map: vec![],
+            name_corrections: Vec::new(),
             recording_health: None,
             processing_warnings: Vec::new(),
             template: None,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,9 @@ pub mod knowledge_extract;
 pub mod logging;
 pub mod macos_permissions;
 pub mod markdown;
+/// Post-pass name correction (config-gated, off by default): the big lever of
+/// the name-accuracy epic (bead minutes-25x3.4).
+pub mod name_correction;
 /// Name-accuracy evaluation harness (text-level). Test-only; the measurement
 /// contract for the post-pass name-correction lever (bead minutes-25x3.4).
 #[cfg(test)]

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -284,6 +284,8 @@ pub struct Frontmatter {
     pub visibility: Option<Visibility>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub speaker_map: Vec<crate::diarize::SpeakerAttribution>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub name_corrections: Vec<crate::name_correction::NameCorrection>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recording_health: Option<RecordingHealth>,
     /// Slug of the template applied to this recording, if any.
@@ -1100,6 +1102,7 @@ mod tests {
             consent_notice: None,
             visibility: None,
             speaker_map: vec![],
+            name_corrections: Vec::new(),
             recording_health: None,
             processing_warnings: Vec::new(),
             template: None,

--- a/crates/core/src/name_correction.rs
+++ b/crates/core/src/name_correction.rs
@@ -27,6 +27,7 @@
 //!   is never touched, in or out of name-position.
 
 use rphonetic::{DoubleMetaphone, Encoder};
+use serde::{Deserialize, Serialize};
 
 /// Minimum token length eligible for a non-accent (misspelling) correction.
 /// Short tokens (`tan`, `mark`) collide with common words and real names too
@@ -35,12 +36,44 @@ const MIN_MISSPELL_LEN: usize = 4;
 
 /// A single applied correction, surfaced for frontmatter provenance so the
 /// rewrite is auditable and reversible. The raw token is always preserved.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct NameCorrection {
     /// The token as transcribed.
     pub raw: String,
     /// The pool spelling it was rewritten to.
     pub corrected: String,
+}
+
+pub fn build_name_pool(
+    attendees: &[String],
+    identity: Option<&crate::config::IdentityConfig>,
+    vocabulary: Option<&crate::vocabulary::VocabularyStore>,
+) -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Some(identity) = identity {
+        if let Some(name) = identity.name.as_ref() {
+            candidates.push(name.clone());
+        }
+        candidates.extend(identity.aliases.iter().cloned());
+    }
+    candidates.extend(attendees.iter().cloned());
+    if let Some(vocabulary) = vocabulary {
+        candidates.extend(vocabulary.decode_phrases(8));
+    }
+
+    let mut names = Vec::new();
+    for token in candidates
+        .iter()
+        .flat_map(|candidate| candidate.split_whitespace())
+        .map(str::trim)
+        .filter(|token| token.chars().all(|c| c.is_alphabetic()))
+        .filter(|token| token.chars().count() >= 2)
+    {
+        if !names.iter().any(|name| name == token) {
+            names.push(token.to_string());
+        }
+    }
+    names
 }
 
 struct PoolEntry {
@@ -341,6 +374,29 @@ mod tests {
 
     fn pool(names: &[&str]) -> Vec<String> {
         names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn build_name_pool_collects_unique_single_name_tokens() {
+        let identity = crate::config::IdentityConfig {
+            name: Some("Mathieu Silverstein".into()),
+            aliases: vec!["Mat".into(), "M S".into(), "J9".into()],
+            ..Default::default()
+        };
+        let attendees = vec![
+            "Sarah Chen".into(),
+            "Mat".into(),
+            "A".into(),
+            "D4n".into(),
+            "Mónica".into(),
+        ];
+
+        let pool = build_name_pool(&attendees, Some(&identity), None);
+
+        assert_eq!(
+            pool,
+            vec!["Mathieu", "Silverstein", "Mat", "Sarah", "Chen", "Mónica"]
+        );
     }
 
     #[test]

--- a/crates/core/src/name_correction.rs
+++ b/crates/core/src/name_correction.rs
@@ -68,6 +68,10 @@ pub fn build_name_pool(
         .map(str::trim)
         .filter(|token| token.chars().all(|c| c.is_alphabetic()))
         .filter(|token| token.chars().count() >= 2)
+        // A pool entry that is itself a common word (e.g. "The"/"Team" from a
+        // "The Team" attendee, or a stopword-like vocabulary term) would turn
+        // ordinary words into correction targets, so keep them out of the pool.
+        .filter(|token| !is_stopword(&normalize(token)))
     {
         if !names.iter().any(|name| name == token) {
             names.push(token.to_string());
@@ -144,6 +148,18 @@ fn distance_budget(len: usize) -> usize {
     }
 }
 
+/// Double Metaphone primary code, guarded to ASCII input. `rphonetic`'s
+/// encoder panics on some non-ASCII strings (e.g. "José"), and Double Metaphone
+/// is an ASCII/English algorithm anyway, so non-ASCII names get an empty code
+/// (they match via the accent/normalized path, never via phonetics).
+fn dm_encode(dm: &DoubleMetaphone, s: &str) -> String {
+    if s.is_ascii() {
+        dm.encode(s)
+    } else {
+        String::new()
+    }
+}
+
 fn build_pool(pool: &[String]) -> Vec<PoolEntry> {
     let dm = DoubleMetaphone::default();
     pool.iter()
@@ -160,7 +176,7 @@ fn build_pool(pool: &[String]) -> Vec<PoolEntry> {
             }
             Some(PoolEntry {
                 surface: surface.to_string(),
-                dm: dm.encode(surface),
+                dm: dm_encode(&dm, surface),
                 norm,
             })
         })
@@ -171,9 +187,35 @@ fn build_pool(pool: &[String]) -> Vec<PoolEntry> {
 /// or referenced (vocative / dative slots). Multilingual to match the
 /// multilingual name target (merci/gracias/etc.).
 const ADDRESS_CUES: &[&str] = &[
-    "thanks", "thank", "hi", "hey", "hello", "to", "from", "with", "cc", "ping", "dear", "for",
-    "merci", "gracias", "hola", "bonjour", "ciao", "over",
+    // Strong vocatives only. High-frequency prepositions (to/for/with/from/over/cc)
+    // are deliberately excluded: they dominate ordinary prepositional phrases, so
+    // they would turn "to go over" into a name slot. Names after a preposition are
+    // still corrected via the normal same-first-letter / accent path.
+    "thanks", "thank", "hi", "hey", "hello", "dear", "ping", "merci", "gracias", "hola", "bonjour",
+    "ciao",
 ];
+
+/// Common function words / pronouns / auxiliaries that must never be rewritten
+/// to a name and must never enter the pool, even in a name-position. They are
+/// the dominant collision risk for short pool names (e.g. `we`->`Wei`,
+/// `all`->`Al`, `them`->`Team`, `go`->`Jo`, `well`->`Will`).
+const STOPWORDS: &[&str] = &[
+    "a", "an", "the", "and", "or", "but", "so", "as", "at", "by", "for", "from", "in", "into",
+    "of", "off", "on", "onto", "to", "too", "up", "down", "out", "over", "under", "with", "via",
+    "per", "vs", "we", "you", "your", "yours", "i", "me", "my", "mine", "he", "him", "his", "she",
+    "her", "hers", "it", "its", "they", "them", "their", "theirs", "this", "that", "these",
+    "those", "here", "there", "then", "than", "is", "am", "are", "was", "were", "be", "been",
+    "being", "do", "did", "does", "done", "has", "had", "have", "will", "would", "can", "could",
+    "should", "may", "might", "must", "shall", "go", "got", "get", "well", "yes", "no", "not",
+    "now", "new", "one", "two", "who", "why", "how", "what", "when", "where", "ok", "okay", "just",
+    "like", "also", "more", "most", "some", "any", "all", "each", "even", "only", "very", "much",
+    "many", "few", "our", "ours", "us", "if", "else", "about", "after", "before", "again",
+];
+
+/// True when the normalized token is a common word that must never be corrected.
+fn is_stopword(norm: &str) -> bool {
+    STOPWORDS.contains(&norm)
+}
 
 /// Words that, immediately after a token, mark it as a person-subject.
 const NAME_VERB_CUES: &[&str] = &[
@@ -227,61 +269,57 @@ fn match_token(
         return None;
     }
     let tok_norm = normalize(token);
-    let tok_dm = dm.encode(token);
+    // Never rewrite a common function word / pronoun, in or out of name-position.
+    if is_stopword(&tok_norm) {
+        return None;
+    }
+    let tok_dm = dm_encode(dm, token);
 
-    let mut accent_hit: Option<&PoolEntry> = None;
-    let mut accent_count = 0usize;
-    let mut fuzzy_hit: Option<&PoolEntry> = None;
-    let mut fuzzy_count = 0usize;
+    // Collect DISTINCT candidate pool entries (accent restoration OR fuzzy). A
+    // correction fires only when exactly one pool name is a candidate, so an
+    // accent match is suppressed when another name is also fuzzy-close (and
+    // vice versa) -- ambiguity always means leave it alone.
+    let mut candidate: Option<&PoolEntry> = None;
+    let mut candidate_count = 0usize;
 
     for entry in pool {
         // Already the exact surface form, or a pure-casing variant: leave alone.
         if token == entry.surface || differs_only_by_case(token, &entry.surface) {
             return None;
         }
-        if tok_norm == entry.norm {
+        let is_candidate = if tok_norm == entry.norm {
             // Same letters, differ by accent only -> accent restoration.
-            accent_hit = Some(entry);
-            accent_count += 1;
-            continue;
-        }
-        let dist = levenshtein(&tok_norm, &entry.norm);
-        if dist == 0 {
-            continue;
-        }
-        if name_position {
-            // Context confirms a name: a unique pool name within 2 edits wins,
-            // even across a different first letter or short length.
-            if dist <= 2 {
-                fuzzy_hit = Some(entry);
-                fuzzy_count += 1;
+            true
+        } else {
+            let dist = levenshtein(&tok_norm, &entry.norm);
+            if dist == 0 {
+                false
+            } else if name_position {
+                // Context confirms a name: a pool name within 2 edits qualifies,
+                // even across a different first letter or short length. ASCII-only
+                // so a non-Latin token is never coerced into a Latin name.
+                tok_norm.is_ascii() && entry.norm.is_ascii() && dist <= 2
+            } else {
+                // No context: require a corroborating signal (same first letter
+                // OR matching Double Metaphone) and a minimum length.
+                let within = tok_norm.len() >= MIN_MISSPELL_LEN
+                    && dist <= distance_budget(tok_norm.len().max(entry.norm.len()));
+                let same_first = tok_norm.as_bytes().first() == entry.norm.as_bytes().first();
+                let dm_match = !tok_dm.is_empty() && tok_dm == entry.dm;
+                tok_norm.is_ascii() && entry.norm.is_ascii() && within && (same_first || dm_match)
             }
-            continue;
-        }
-        // No context: require a corroborating signal (same first normalized
-        // letter OR matching Double Metaphone) and a minimum length.
-        if tok_norm.len() < MIN_MISSPELL_LEN
-            || dist > distance_budget(tok_norm.len().max(entry.norm.len()))
-        {
-            continue;
-        }
-        let same_first = tok_norm.as_bytes().first() == entry.norm.as_bytes().first();
-        let dm_match = !tok_dm.is_empty() && tok_dm == entry.dm;
-        if same_first || dm_match {
-            fuzzy_hit = Some(entry);
-            fuzzy_count += 1;
+        };
+        if is_candidate {
+            candidate = Some(entry);
+            candidate_count += 1;
         }
     }
 
-    // Accent restoration is the highest-confidence path and wins when unique.
-    if accent_count == 1 {
-        return accent_hit.map(|e| e.surface.clone());
+    if candidate_count == 1 {
+        candidate.map(|e| e.surface.clone())
+    } else {
+        None
     }
-    // Otherwise require a unique fuzzy winner; ambiguity means leave it alone.
-    if accent_count == 0 && fuzzy_count == 1 {
-        return fuzzy_hit.map(|e| e.surface.clone());
-    }
-    None
 }
 
 /// Correct person-name tokens in `text` against `pool`. Returns the corrected
@@ -339,12 +377,35 @@ pub fn correct_names(text: &str, pool: &[String]) -> (String, Vec<NameCorrection
         })
     };
 
+    // Mark word segments that sit inside a `[...]` span (the `[SPEAKER_N m:ss]`
+    // prefix). Those tokens are never correction candidates -- correcting
+    // `SPEAKER` to a pool name would corrupt the speaker label.
+    let mut bracketed = vec![false; segs.len()];
+    let mut depth: i32 = 0;
+    for (i, s) in segs.iter().enumerate() {
+        match s {
+            Seg::Other(text) => {
+                for c in text.chars() {
+                    match c {
+                        '[' => depth += 1,
+                        ']' => depth = (depth - 1).max(0),
+                        _ => {}
+                    }
+                }
+            }
+            Seg::Word(_) => bracketed[i] = depth > 0,
+        }
+    }
+
     let mut corrections = Vec::new();
     let mut replacements: Vec<(usize, String)> = Vec::new();
     for (k, &i) in word_positions.iter().enumerate() {
         let Seg::Word(token) = &segs[i] else {
             continue;
         };
+        if bracketed[i] {
+            continue;
+        }
         let prev = word_at(k.checked_sub(1).and_then(|kp| word_positions.get(kp)));
         let next = word_at(word_positions.get(k + 1));
         if let Some(surface) = match_token(token, in_name_position(prev, next), &dm, &entries) {
@@ -474,6 +535,63 @@ mod tests {
     fn empty_pool_is_a_noop() {
         let (out, corr) = correct_names("merci jacque", &pool(&[]));
         assert_eq!(out, "merci jacque");
+        assert!(corr.is_empty());
+    }
+
+    // ---- regression guards for adversarial-review findings ----
+
+    #[test]
+    fn stopword_in_name_position_is_never_corrected() {
+        // "we"/"all" are common words a dist <= 2 from short pool names but must
+        // never be rewritten, even though the surrounding syntax is a name slot.
+        let (out, corr) = correct_names("we will demo today", &pool(&["Wei", "Aki"]));
+        assert_eq!(out, "we will demo today");
+        assert!(corr.is_empty());
+        let (out2, _) = correct_names("thanks all for joining", &pool(&["Al"]));
+        assert_eq!(out2, "thanks all for joining");
+    }
+
+    #[test]
+    fn speaker_prefix_is_never_corrupted() {
+        // SPEAKER sits inside the [..] prefix; "will" follows it, but the bracket
+        // guard keeps the label intact.
+        let (out, corr) = correct_names("[SPEAKER_1 0:05] will present", &pool(&["Spencer"]));
+        assert_eq!(out, "[SPEAKER_1 0:05] will present");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn pool_excludes_common_words_from_attendees() {
+        // "The Team" must contribute "Team" but not "The"; "them" then stays put.
+        let names = build_name_pool(&["The Team".to_string()], None, None);
+        assert!(names.iter().any(|n| n == "Team"));
+        assert!(!names.iter().any(|n| n.eq_ignore_ascii_case("the")));
+        let (out, _) = correct_names("we did this for them today", &names);
+        assert_eq!(out, "we did this for them today");
+    }
+
+    #[test]
+    fn non_latin_token_is_not_fuzzy_matched_to_latin_name() {
+        let (out, corr) = correct_names("thanks 王 now", &pool(&["Al"]));
+        assert_eq!(out, "thanks 王 now");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn accent_match_suppressed_when_another_name_is_also_close() {
+        // "Jose" accent-matches "José" but is also 1 edit from "Jase": ambiguous,
+        // so leave it alone rather than guess.
+        let (out, corr) = correct_names("thanks Jose now", &pool(&["José", "Jase"]));
+        assert_eq!(out, "thanks Jose now");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn dropped_preposition_cue_does_not_open_a_name_slot() {
+        // "to" is no longer an address cue, so a different-first-letter token
+        // after it is not relaxed-corrected.
+        let (out, corr) = correct_names("send this to bob", &pool(&["Rob"]));
+        assert_eq!(out, "send this to bob");
         assert!(corr.is_empty());
     }
 }

--- a/crates/core/src/name_correction.rs
+++ b/crates/core/src/name_correction.rs
@@ -200,16 +200,174 @@ const ADDRESS_CUES: &[&str] = &[
 /// the dominant collision risk for short pool names (e.g. `we`->`Wei`,
 /// `all`->`Al`, `them`->`Team`, `go`->`Jo`, `well`->`Will`).
 const STOPWORDS: &[&str] = &[
-    "a", "an", "the", "and", "or", "but", "so", "as", "at", "by", "for", "from", "in", "into",
-    "of", "off", "on", "onto", "to", "too", "up", "down", "out", "over", "under", "with", "via",
-    "per", "vs", "we", "you", "your", "yours", "i", "me", "my", "mine", "he", "him", "his", "she",
-    "her", "hers", "it", "its", "they", "them", "their", "theirs", "this", "that", "these",
-    "those", "here", "there", "then", "than", "is", "am", "are", "was", "were", "be", "been",
-    "being", "do", "did", "does", "done", "has", "had", "have", "will", "would", "can", "could",
-    "should", "may", "might", "must", "shall", "go", "got", "get", "well", "yes", "no", "not",
-    "now", "new", "one", "two", "who", "why", "how", "what", "when", "where", "ok", "okay", "just",
-    "like", "also", "more", "most", "some", "any", "all", "each", "even", "only", "very", "much",
-    "many", "few", "our", "ours", "us", "if", "else", "about", "after", "before", "again",
+    "a",
+    "an",
+    "the",
+    "and",
+    "or",
+    "but",
+    "so",
+    "as",
+    "at",
+    "by",
+    "for",
+    "from",
+    "in",
+    "into",
+    "of",
+    "off",
+    "on",
+    "onto",
+    "to",
+    "too",
+    "up",
+    "down",
+    "out",
+    "over",
+    "under",
+    "with",
+    "via",
+    "per",
+    "vs",
+    "we",
+    "you",
+    "your",
+    "yours",
+    "i",
+    "me",
+    "my",
+    "mine",
+    "he",
+    "him",
+    "his",
+    "she",
+    "her",
+    "hers",
+    "it",
+    "its",
+    "they",
+    "them",
+    "their",
+    "theirs",
+    "this",
+    "that",
+    "these",
+    "those",
+    "here",
+    "there",
+    "then",
+    "than",
+    "is",
+    "am",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "do",
+    "did",
+    "does",
+    "done",
+    "has",
+    "had",
+    "have",
+    "will",
+    "would",
+    "can",
+    "could",
+    "should",
+    "may",
+    "might",
+    "must",
+    "shall",
+    "go",
+    "got",
+    "get",
+    "well",
+    "yes",
+    "no",
+    "not",
+    "now",
+    "new",
+    "one",
+    "two",
+    "who",
+    "why",
+    "how",
+    "what",
+    "when",
+    "where",
+    "ok",
+    "okay",
+    "just",
+    "like",
+    "also",
+    "more",
+    "most",
+    "some",
+    "any",
+    "all",
+    "each",
+    "even",
+    "only",
+    "very",
+    "much",
+    "many",
+    "few",
+    "our",
+    "ours",
+    "us",
+    "if",
+    "else",
+    "about",
+    "after",
+    "before",
+    "again",
+    // Collective / role nouns that arrive via multi-word attendee fields ("The
+    // Team", "Product Group") and would otherwise become correction targets.
+    "team",
+    "group",
+    "staff",
+    "board",
+    "crew",
+    "panel",
+    "folks",
+    "everyone",
+    "everybody",
+    "guys",
+    // Days and months: high-frequency words a short edit from many names.
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+    "january",
+    "february",
+    "march",
+    "april",
+    "june",
+    "july",
+    "august",
+    "september",
+    "october",
+    "november",
+    "december",
+    // Common English words that double as names; too collision-prone to correct
+    // without stronger context (Bill<->Will, June<->Jane, Mark<->Marc, etc.).
+    "mark",
+    "bill",
+    "art",
+    "grace",
+    "hope",
+    "min",
+    "rose",
+    "dawn",
+    "sunny",
+    "drew",
+    "sun",
 ];
 
 /// True when the normalized token is a common word that must never be corrected.
@@ -296,9 +454,10 @@ fn match_token(
                 false
             } else if name_position {
                 // Context confirms a name: a pool name within 2 edits qualifies,
-                // even across a different first letter or short length. ASCII-only
-                // so a non-Latin token is never coerced into a Latin name.
-                tok_norm.is_ascii() && entry.norm.is_ascii() && dist <= 2
+                // even across a different first letter. ASCII-only so a non-Latin
+                // token is never coerced into a Latin name, and a >=3 floor keeps
+                // 2-char tokens (e.g. "Bo"->"Jo") out of the relaxed tier.
+                tok_norm.is_ascii() && entry.norm.is_ascii() && tok_norm.len() >= 3 && dist <= 2
             } else {
                 // No context: require a corroborating signal (same first letter
                 // OR matching Double Metaphone) and a minimum length.
@@ -561,11 +720,18 @@ mod tests {
     }
 
     #[test]
-    fn pool_excludes_common_words_from_attendees() {
-        // "The Team" must contribute "Team" but not "The"; "them" then stays put.
-        let names = build_name_pool(&["The Team".to_string()], None, None);
-        assert!(names.iter().any(|n| n == "Team"));
+    fn pool_keeps_real_names_drops_stopwords() {
+        // Real per-token names survive; stopwords ("The") and collective nouns
+        // ("Team") are dropped from the pool.
+        let names = build_name_pool(
+            &["Sarah Chen".to_string(), "The Team".to_string()],
+            None,
+            None,
+        );
+        assert!(names.iter().any(|n| n == "Sarah"));
+        assert!(names.iter().any(|n| n == "Chen"));
         assert!(!names.iter().any(|n| n.eq_ignore_ascii_case("the")));
+        assert!(!names.iter().any(|n| n.eq_ignore_ascii_case("team")));
         let (out, _) = correct_names("we did this for them today", &names);
         assert_eq!(out, "we did this for them today");
     }
@@ -592,6 +758,33 @@ mod tests {
         // after it is not relaxed-corrected.
         let (out, corr) = correct_names("send this to bob", &pool(&["Rob"]));
         assert_eq!(out, "send this to bob");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn collective_noun_attendee_does_not_pollute_pool() {
+        // "The Team" must contribute no pool names, so "term will change" stays.
+        let names = build_name_pool(&["The Team".to_string()], None, None);
+        assert!(!names.iter().any(|n| n.eq_ignore_ascii_case("team")));
+        let (out, corr) = correct_names("the term will change", &names);
+        assert_eq!(out, "the term will change");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn common_word_names_are_left_alone_in_name_position() {
+        // Words that double as names must not be rewritten across the gap.
+        let (out, _) = correct_names("Bill noted the issue", &pool(&["Will"]));
+        assert_eq!(out, "Bill noted the issue");
+        let (out2, _) = correct_names("June said yes", &pool(&["Jane"]));
+        assert_eq!(out2, "June said yes");
+    }
+
+    #[test]
+    fn two_char_token_not_corrected_in_name_position() {
+        // Below the relaxed-tier length floor; "Bo" stays even after a cue.
+        let (out, corr) = correct_names("thanks Bo now", &pool(&["Jo"]));
+        assert_eq!(out, "thanks Bo now");
         assert!(corr.is_empty());
     }
 }

--- a/crates/core/src/name_correction.rs
+++ b/crates/core/src/name_correction.rs
@@ -1,0 +1,423 @@
+//! Post-pass name correction (config-gated, off by default).
+//!
+//! The "big lever" of the name-accuracy epic (bead minutes-25x3.4): after
+//! transcription, fuzzy/phonetic-match person-name tokens against the
+//! expected-name pool (calendar attendees, identity, vocabulary) and rewrite
+//! clear mis-transcriptions to the correct spelling. Measured against the
+//! text-level harness in `name_eval` (`docs/plans/every-name-right-2026-06-11.md`).
+//!
+//! Design philosophy: **wrong corrections are worse than wrong
+//! transcriptions.** Every gate below favors leaving a token untouched over a
+//! risky rewrite, and corrections are returned with the raw token preserved so
+//! the pipeline can record provenance (never a silent rewrite). The pass is
+//! config-gated and off by default.
+//!
+//! Two tiers of confidence:
+//! - **Out of name-position** (no syntactic name cue around the token): only
+//!   accent restoration and bounded edit-distance with a corroborating signal
+//!   (same first letter OR matching Double Metaphone) and a minimum length.
+//!   This is the conservative tier that protects common words like `mark`.
+//! - **In name-position** (preceded by an address cue like `thanks`/`to`/`merci`
+//!   or followed by a name-verb like `will`/`owns`): the surrounding syntax
+//!   confirms the token is a person name, so the first-letter / DM / min-length
+//!   gates are relaxed and a unique pool name within 2 edits wins. This is what
+//!   safely recovers the harder different-first-letter (`Geert`<-`bert`) and
+//!   short-token (`Thanh`<-`tan`) cases. The edit-distance budget and
+//!   unique-winner requirement always hold, so a token far from any pool name
+//!   is never touched, in or out of name-position.
+
+use rphonetic::{DoubleMetaphone, Encoder};
+
+/// Minimum token length eligible for a non-accent (misspelling) correction.
+/// Short tokens (`tan`, `mark`) collide with common words and real names too
+/// easily without speaker-turn context, so v1 does not touch them.
+const MIN_MISSPELL_LEN: usize = 4;
+
+/// A single applied correction, surfaced for frontmatter provenance so the
+/// rewrite is auditable and reversible. The raw token is always preserved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NameCorrection {
+    /// The token as transcribed.
+    pub raw: String,
+    /// The pool spelling it was rewritten to.
+    pub corrected: String,
+}
+
+struct PoolEntry {
+    /// Canonical surface form (properly cased/accented), what we rewrite to.
+    surface: String,
+    /// Lowercased, accent-folded form for distance + accent comparison.
+    norm: String,
+    /// Double Metaphone primary code of the surface form.
+    dm: String,
+}
+
+/// Fold common Latin accented characters to ASCII (Mónica -> monica). Covers
+/// the Latin-1 / Latin-Extended vowels plus ñ/ç that appear in European names;
+/// non-Latin romanizations (e.g. Xiulan) have no accents to fold.
+fn fold_char(c: char) -> char {
+    match c {
+        'á' | 'à' | 'â' | 'ä' | 'ã' | 'å' => 'a',
+        'é' | 'è' | 'ê' | 'ë' => 'e',
+        'í' | 'ì' | 'î' | 'ï' => 'i',
+        'ó' | 'ò' | 'ô' | 'ö' | 'õ' => 'o',
+        'ú' | 'ù' | 'û' | 'ü' => 'u',
+        'ñ' => 'n',
+        'ç' => 'c',
+        'ý' | 'ÿ' => 'y',
+        other => other,
+    }
+}
+
+/// Lowercase + accent-fold for comparison.
+fn normalize(s: &str) -> String {
+    s.chars()
+        .flat_map(char::to_lowercase)
+        .map(fold_char)
+        .collect()
+}
+
+/// True when `token` equals `surface` ignoring case but NOT ignoring accents.
+/// This is the pure-casing guard: `mark` vs `Mark` is case-only (skip, it is a
+/// common word or already fine), whereas `monica` vs `Mónica` differs by accent
+/// (a real restoration target).
+fn differs_only_by_case(token: &str, surface: &str) -> bool {
+    token != surface && token.to_lowercase() == surface.to_lowercase()
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+/// Distance budget for a normalized token of the given length. Strict: 1 edit
+/// for short names, 2 for longer ones.
+fn distance_budget(len: usize) -> usize {
+    if len >= 6 {
+        2
+    } else {
+        1
+    }
+}
+
+fn build_pool(pool: &[String]) -> Vec<PoolEntry> {
+    let dm = DoubleMetaphone::default();
+    pool.iter()
+        .filter_map(|name| {
+            let surface = name.trim();
+            // Single-word names only in v1: multi-word handling (and matching a
+            // surname token against a full name) is its own design.
+            if surface.is_empty() || surface.split_whitespace().count() != 1 {
+                return None;
+            }
+            let norm = normalize(surface);
+            if norm.is_empty() {
+                return None;
+            }
+            Some(PoolEntry {
+                surface: surface.to_string(),
+                dm: dm.encode(surface),
+                norm,
+            })
+        })
+        .collect()
+}
+
+/// Words that, immediately before a token, mark it as a person being addressed
+/// or referenced (vocative / dative slots). Multilingual to match the
+/// multilingual name target (merci/gracias/etc.).
+const ADDRESS_CUES: &[&str] = &[
+    "thanks", "thank", "hi", "hey", "hello", "to", "from", "with", "cc", "ping", "dear", "for",
+    "merci", "gracias", "hola", "bonjour", "ciao", "over",
+];
+
+/// Words that, immediately after a token, mark it as a person-subject.
+const NAME_VERB_CUES: &[&str] = &[
+    "will",
+    "owns",
+    "said",
+    "says",
+    "asked",
+    "mentioned",
+    "presented",
+    "joined",
+    "leads",
+    "wants",
+    "needs",
+    "added",
+    "noted",
+    "agreed",
+    "owns",
+    "owned",
+    "presents",
+];
+
+/// True when the token sits in a grammatical slot strongly associated with a
+/// person name: preceded by an address cue, or followed by a name-verb. This is
+/// the lightweight "context" signal (the plan's speaker-turn-context goal,
+/// realized syntactically with no NLP dependency) that lets us safely correct
+/// the harder different-first-letter / short-token cases.
+fn in_name_position(prev_word: Option<&str>, next_word: Option<&str>) -> bool {
+    let prev_hit = prev_word
+        .map(normalize)
+        .is_some_and(|w| ADDRESS_CUES.contains(&w.as_str()));
+    let next_hit = next_word
+        .map(normalize)
+        .is_some_and(|w| NAME_VERB_CUES.contains(&w.as_str()));
+    prev_hit || next_hit
+}
+
+/// Decide the correction for a single word token, or `None` to leave it alone.
+/// `name_position` relaxes the misspelling gate (drops the first-letter / DM /
+/// min-length requirements) because the surrounding syntax already confirms the
+/// token is a person name; the edit-distance budget and unique-winner
+/// requirement still apply, so a token far from any pool name is never touched.
+fn match_token(
+    token: &str,
+    name_position: bool,
+    dm: &DoubleMetaphone,
+    pool: &[PoolEntry],
+) -> Option<String> {
+    // Only consider alphabetic tokens (skip numbers, IDs, mixed tokens).
+    if token.is_empty() || !token.chars().all(|c| c.is_alphabetic()) {
+        return None;
+    }
+    let tok_norm = normalize(token);
+    let tok_dm = dm.encode(token);
+
+    let mut accent_hit: Option<&PoolEntry> = None;
+    let mut accent_count = 0usize;
+    let mut fuzzy_hit: Option<&PoolEntry> = None;
+    let mut fuzzy_count = 0usize;
+
+    for entry in pool {
+        // Already the exact surface form, or a pure-casing variant: leave alone.
+        if token == entry.surface || differs_only_by_case(token, &entry.surface) {
+            return None;
+        }
+        if tok_norm == entry.norm {
+            // Same letters, differ by accent only -> accent restoration.
+            accent_hit = Some(entry);
+            accent_count += 1;
+            continue;
+        }
+        let dist = levenshtein(&tok_norm, &entry.norm);
+        if dist == 0 {
+            continue;
+        }
+        if name_position {
+            // Context confirms a name: a unique pool name within 2 edits wins,
+            // even across a different first letter or short length.
+            if dist <= 2 {
+                fuzzy_hit = Some(entry);
+                fuzzy_count += 1;
+            }
+            continue;
+        }
+        // No context: require a corroborating signal (same first normalized
+        // letter OR matching Double Metaphone) and a minimum length.
+        if tok_norm.len() < MIN_MISSPELL_LEN
+            || dist > distance_budget(tok_norm.len().max(entry.norm.len()))
+        {
+            continue;
+        }
+        let same_first = tok_norm.as_bytes().first() == entry.norm.as_bytes().first();
+        let dm_match = !tok_dm.is_empty() && tok_dm == entry.dm;
+        if same_first || dm_match {
+            fuzzy_hit = Some(entry);
+            fuzzy_count += 1;
+        }
+    }
+
+    // Accent restoration is the highest-confidence path and wins when unique.
+    if accent_count == 1 {
+        return accent_hit.map(|e| e.surface.clone());
+    }
+    // Otherwise require a unique fuzzy winner; ambiguity means leave it alone.
+    if accent_count == 0 && fuzzy_count == 1 {
+        return fuzzy_hit.map(|e| e.surface.clone());
+    }
+    None
+}
+
+/// Correct person-name tokens in `text` against `pool`. Returns the corrected
+/// text and the list of applied corrections (raw preserved). Non-word
+/// characters (whitespace, punctuation, the `[SPEAKER m:ss]` prefix) are passed
+/// through verbatim; only whole alphabetic word spans are ever rewritten.
+pub fn correct_names(text: &str, pool: &[String]) -> (String, Vec<NameCorrection>) {
+    let entries = build_pool(pool);
+    if entries.is_empty() {
+        return (text.to_string(), Vec::new());
+    }
+    let dm = DoubleMetaphone::default();
+
+    // Tokenize into alternating word / non-word segments, preserving everything
+    // (whitespace, punctuation, the `[SPEAKER m:ss]` prefix) so only whole
+    // alphabetic word spans are ever rewritten and structure is byte-preserved.
+    enum Seg {
+        Word(String),
+        Other(String),
+    }
+    let mut segs: Vec<Seg> = Vec::new();
+    let mut cur = String::new();
+    let mut cur_is_word = false;
+    for c in text.chars() {
+        let is_word = c.is_alphabetic();
+        if !cur.is_empty() && is_word != cur_is_word {
+            let taken = std::mem::take(&mut cur);
+            segs.push(if cur_is_word {
+                Seg::Word(taken)
+            } else {
+                Seg::Other(taken)
+            });
+        }
+        cur.push(c);
+        cur_is_word = is_word;
+    }
+    if !cur.is_empty() {
+        segs.push(if cur_is_word {
+            Seg::Word(cur)
+        } else {
+            Seg::Other(cur)
+        });
+    }
+
+    // Word segment positions, for prev/next-word lookup.
+    let word_positions: Vec<usize> = segs
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| matches!(s, Seg::Word(_)).then_some(i))
+        .collect();
+    let word_at = |idx: Option<&usize>| -> Option<&str> {
+        idx.and_then(|&i| match &segs[i] {
+            Seg::Word(w) => Some(w.as_str()),
+            Seg::Other(_) => None,
+        })
+    };
+
+    let mut corrections = Vec::new();
+    let mut replacements: Vec<(usize, String)> = Vec::new();
+    for (k, &i) in word_positions.iter().enumerate() {
+        let Seg::Word(token) = &segs[i] else {
+            continue;
+        };
+        let prev = word_at(k.checked_sub(1).and_then(|kp| word_positions.get(kp)));
+        let next = word_at(word_positions.get(k + 1));
+        if let Some(surface) = match_token(token, in_name_position(prev, next), &dm, &entries) {
+            corrections.push(NameCorrection {
+                raw: token.clone(),
+                corrected: surface.clone(),
+            });
+            replacements.push((i, surface));
+        }
+    }
+    for (i, surface) in replacements {
+        segs[i] = Seg::Word(surface);
+    }
+
+    let out: String = segs
+        .iter()
+        .map(|s| match s {
+            Seg::Word(w) | Seg::Other(w) => w.as_str(),
+        })
+        .collect();
+    (out, corrections)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn restores_accent_and_records_provenance() {
+        let (out, corr) = correct_names("gracias monica for the update", &pool(&["Mónica"]));
+        assert_eq!(out, "gracias Mónica for the update");
+        assert_eq!(corr.len(), 1);
+        assert_eq!(corr[0].raw, "monica");
+        assert_eq!(corr[0].corrected, "Mónica");
+    }
+
+    #[test]
+    fn corrects_same_first_letter_misspelling() {
+        let (out, _) = correct_names("merci jacque for joining", &pool(&["Jacques"]));
+        assert_eq!(out, "merci Jacques for joining");
+    }
+
+    #[test]
+    fn leaves_pure_case_common_word_alone() {
+        // "mark" the word must not become the name "Mark" (case-only differs).
+        let (out, corr) = correct_names("that was a good mark on the exam", &pool(&["Mark"]));
+        assert_eq!(out, "that was a good mark on the exam");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn leaves_already_correct_name_alone() {
+        let (out, corr) = correct_names("hi Sarah how are you", &pool(&["Sarah"]));
+        assert_eq!(out, "hi Sarah how are you");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn does_not_touch_short_tokens_outside_name_position() {
+        // "tan" with no address cue or name-verb around it stays the word "tan".
+        let (out, corr) = correct_names("we got a nice tan today", &pool(&["Thanh"]));
+        assert_eq!(out, "we got a nice tan today");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn corrects_hard_cases_in_name_position() {
+        // Different first letter (bert->Geert) and short (tan->Thanh) only
+        // become correctable when the surrounding syntax confirms a name.
+        let (out, _) = correct_names("thanks bert for the notes", &pool(&["Geert", "Sanne"]));
+        assert_eq!(out, "thanks Geert for the notes");
+        let (out2, _) = correct_names("tan owns the rollout", &pool(&["Thanh", "Linh"]));
+        assert_eq!(out2, "Thanh owns the rollout");
+    }
+
+    #[test]
+    fn name_position_is_still_distance_gated() {
+        // A token in a name slot but far from every pool name is left alone:
+        // context relaxes the corroboration gates, not the edit-distance budget.
+        let (out, corr) = correct_names("thanks everyone for joining", &pool(&["Geert"]));
+        assert_eq!(out, "thanks everyone for joining");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn ambiguous_match_is_left_alone() {
+        // Two equally-close pool names -> no unique winner -> no correction.
+        let (out, corr) = correct_names("ping karan", &pool(&["Karen", "Kiran"]));
+        assert_eq!(out, "ping karan");
+        assert!(corr.is_empty());
+    }
+
+    #[test]
+    fn preserves_punctuation_and_structure() {
+        let (out, _) = correct_names("[SPEAKER_1 0:05] merci, jacque!", &pool(&["Jacques"]));
+        assert_eq!(out, "[SPEAKER_1 0:05] merci, Jacques!");
+    }
+
+    #[test]
+    fn empty_pool_is_a_noop() {
+        let (out, corr) = correct_names("merci jacque", &pool(&[]));
+        assert_eq!(out, "merci jacque");
+        assert!(corr.is_empty());
+    }
+}

--- a/crates/core/src/name_eval.rs
+++ b/crates/core/src/name_eval.rs
@@ -216,6 +216,31 @@ mod tests {
         }
     }
 
+    /// The real post-pass correction (minutes-25x3.4) measured against the
+    /// corpus. The gating invariant is zero false corrections; `recovered` is
+    /// reported and asserted at the level v1 actually achieves.
+    #[test]
+    fn post_pass_correction_recovers_without_false_corrections() {
+        let report = run_harness(|raw, pool| {
+            let pool_vec: Vec<String> = pool.iter().map(|s| (*s).to_string()).collect();
+            crate::name_correction::correct_names(raw, &pool_vec).0
+        });
+        eprintln!("NAME-CORRECTION HARNESS REPORT: {report:?}");
+        assert_eq!(
+            report.false_corrections, 0,
+            "false corrections must be zero: {report:?}"
+        );
+        assert_eq!(report.structural_mismatches, 0, "{report:?}");
+        // With name-position context, all 6 targets are recovered: the
+        // same-first-letter / accent cases plus the harder different-first-letter
+        // (Geert<-Bert, Xiulan<-shulan) and short-token (Thanh<-tan) cases, which
+        // the surrounding syntax (address cues / name-verbs) confirms as names.
+        assert_eq!(
+            report.recovered, 6,
+            "expected to recover all 6 corpus targets: {report:?}"
+        );
+    }
+
     /// A correction that blindly title-cases and swaps any pool name in would
     /// recover names but corrupt negatives. This asserts the scorer actually
     /// catches false corrections (guards the gating metric itself).

--- a/crates/core/src/name_eval.rs
+++ b/crates/core/src/name_eval.rs
@@ -115,6 +115,22 @@ pub(crate) const CORPUS: &[NameCase] = &[
         raw: "the feature is ready to demo",
         truth: "the feature is ready to demo",
     },
+    // A common word / pronoun in a name slot (after a cue, before a name-verb)
+    // that is a short edit from a short pool name. Must never be rewritten.
+    NameCase {
+        label: "neg-pronoun-in-name-position",
+        pool: &["Wei", "Aki"],
+        raw: "we will demo today",
+        truth: "we will demo today",
+    },
+    // The [SPEAKER_N m:ss] prefix: SPEAKER is a short edit from a pool name and
+    // is followed by a name-verb, but the bracket guard must keep it intact.
+    NameCase {
+        label: "neg-speaker-prefix",
+        pool: &["Spencer"],
+        raw: "[SPEAKER_1 0:05] will present",
+        truth: "[SPEAKER_1 0:05] will present",
+    },
 ];
 
 /// Score one candidate transcript against ground truth, position-aligned by
@@ -171,13 +187,13 @@ pub(crate) fn run_harness(correct: impl Fn(&str, &[&str]) -> String) -> HarnessR
 mod tests {
     use super::*;
 
-    /// The corpus has exactly 6 name targets (raw != truth) and 4 negatives.
+    /// The corpus has exactly 6 name targets (raw != truth) and 6 negatives.
     #[test]
-    fn corpus_shape_is_six_targets_four_negatives() {
+    fn corpus_shape_is_six_targets_six_negatives() {
         let targets = CORPUS.iter().filter(|c| c.raw != c.truth).count();
         let negatives = CORPUS.iter().filter(|c| c.raw == c.truth).count();
         assert_eq!(targets, 6, "expected 6 correction-target cases");
-        assert_eq!(negatives, 4, "expected 4 negative (no-change) cases");
+        assert_eq!(negatives, 6, "expected 6 negative (no-change) cases");
     }
 
     /// Baseline: the identity correction (no change) recovers nothing and, by

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, IdentityConfig};
+use crate::config::{Config, IdentityConfig, NameCorrectionMode};
 use crate::diarize;
 use crate::error::MinutesError;
 use crate::logging;
@@ -1608,6 +1608,7 @@ pub fn write_transcript_artifact(
         consent_notice: context.consent_notice.clone(),
         visibility: None,
         speaker_map: vec![],
+        name_corrections: Vec::new(),
         recording_health: context.recording_health.clone(),
         processing_warnings: Vec::new(),
         template: context.template.as_ref().map(|t| t.slug().to_string()),
@@ -1874,6 +1875,21 @@ where
     transcript = attribution.transcript;
     let speaker_map = attribution.speaker_map;
     let attendees = normalize_attendees_with_speaker_map(&attendees, &speaker_map);
+    let name_corrections = if config.transcription.name_correction != NameCorrectionMode::Off
+        && artifact.frontmatter.r#type == ContentType::Meeting
+    {
+        let name_pool = crate::name_correction::build_name_pool(
+            &attendees,
+            Some(&config.identity),
+            load_vocabulary_for_decode_hints().as_ref(),
+        );
+        let (corrected_transcript, corrections) =
+            crate::name_correction::correct_names(&transcript, &name_pool);
+        transcript = corrected_transcript;
+        corrections
+    } else {
+        Vec::new()
+    };
     let structured_actions =
         normalize_action_items_with_speaker_map(structured_actions, &speaker_map);
     let structured_intents = normalize_intents_with_speaker_map(structured_intents, &speaker_map);
@@ -1954,6 +1970,7 @@ where
     frontmatter.decisions = structured_decisions;
     frontmatter.intents = structured_intents;
     frontmatter.speaker_map = speaker_map;
+    frontmatter.name_corrections = name_corrections;
     frontmatter.recording_health =
         merge_recording_health(recording_health, frontmatter.recording_health);
 
@@ -2438,9 +2455,24 @@ where
         transcript,
     );
     let attribution_ms = attribution_start.elapsed().as_millis() as u64;
-    let transcript = attribution.transcript;
+    let mut transcript = attribution.transcript;
     let speaker_map = attribution.speaker_map;
     let attendees = normalize_attendees_with_speaker_map(&attendees, &speaker_map);
+    let name_corrections = if config.transcription.name_correction != NameCorrectionMode::Off
+        && content_type == ContentType::Meeting
+    {
+        let name_pool = crate::name_correction::build_name_pool(
+            &attendees,
+            Some(&config.identity),
+            load_vocabulary_for_decode_hints().as_ref(),
+        );
+        let (corrected_transcript, corrections) =
+            crate::name_correction::correct_names(&transcript, &name_pool);
+        transcript = corrected_transcript;
+        corrections
+    } else {
+        Vec::new()
+    };
     let structured_actions =
         normalize_action_items_with_speaker_map(structured_actions, &speaker_map);
     let structured_intents = normalize_intents_with_speaker_map(structured_intents, &speaker_map);
@@ -2580,6 +2612,7 @@ where
         consent_notice: None,
         visibility: None,
         speaker_map,
+        name_corrections,
         recording_health,
         template: template.map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
@@ -4890,6 +4923,7 @@ mod tests {
             consent_notice: None,
             visibility: None,
             speaker_map: vec![],
+            name_corrections: Vec::new(),
             recording_health: None,
             processing_warnings: Vec::new(),
             template: None,
@@ -6358,6 +6392,7 @@ mod tests {
                 confidence: diarize::Confidence::Medium,
                 source: diarize::AttributionSource::Llm,
             }],
+            name_corrections: Vec::new(),
             recording_health: None,
             processing_warnings: Vec::new(),
             template: None,

--- a/crates/core/src/sensitive.rs
+++ b/crates/core/src/sensitive.rs
@@ -378,6 +378,7 @@ fn write_artifact(
         consent_notice: None,
         visibility: None,
         speaker_map: vec![],
+        name_corrections: Vec::new(),
         recording_health: None,
         template: None,
         filter_diagnosis: None,

--- a/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
+++ b/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
@@ -114,6 +114,12 @@ expression: schema
         "$ref": "#/$defs/Intent"
       }
     },
+    "name_corrections": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/NameCorrection"
+      }
+    },
     "people": {
       "type": "array",
       "items": {
@@ -502,6 +508,24 @@ expression: schema
         "decision",
         "open-question",
         "commitment"
+      ]
+    },
+    "NameCorrection": {
+      "description": "A single applied correction, surfaced for frontmatter provenance so the\nrewrite is auditable and reversible. The raw token is always preserved.",
+      "type": "object",
+      "properties": {
+        "corrected": {
+          "description": "The pool spelling it was rewritten to.",
+          "type": "string"
+        },
+        "raw": {
+          "description": "The token as transcribed.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "raw",
+        "corrected"
       ]
     },
     "OutputStatus": {

--- a/crates/sdk/src/reader.ts
+++ b/crates/sdk/src/reader.ts
@@ -122,6 +122,8 @@ export interface Frontmatter {
   decisions: Decision[];
   intents: Intent[];
   speaker_map?: SpeakerAttribution[];
+  /** Applied post-pass name corrections (raw token preserved), if any. */
+  name_corrections?: { raw: string; corrected: string }[];
   recording_health?: RecordingHealth;
 }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,6 +32,7 @@ So `minutes record --device "MacBook Pro Microphone"` always wins over `[recordi
 | `parakeet_sidecar_enabled` | auto | Warm sidecar: auto-enables when parakeet is the engine and `example-server` resolves. `true`/`"on"` forces on, `"off"` forces off. A legacy bool `false` is treated as auto (pre-0.18.8 saves wrote it into every config) (#295) |
 | `parakeet_fp16` | `true` | GPU fp16 inference for lower memory use |
 | `parakeet_boost_limit` / `parakeet_boost_score` | `0` / `2.0` | Knowledge-graph phrase boosting; 0 = off |
+| `name_correction` | `"off"` | Post-pass name correction against attendees and vocabulary. Values: `"off"` or `"conservative"`; off by default. |
 
 ### `[diarization]` — speaker attribution
 

--- a/docs/frontmatter-schema.md
+++ b/docs/frontmatter-schema.md
@@ -69,6 +69,7 @@ schema version bump. Additive fields do not.
 | `attendees_raw` | string | Legacy free-text attendee string (e.g. Granola imports). Optional; prefer `attendees`. |
 | `entities` | object | Structured entity links. See [Entities](#entities) below. |
 | `speaker_map` | list&lt;SpeakerAttribution&gt; | Diarizer speaker label → real person mapping. See [Speaker attribution](#speaker-attribution) below. |
+| `name_corrections` | list&lt;NameCorrection&gt; | Applied post-pass name corrections as `{raw, corrected}` records. Omitted when no corrections were made. |
 
 ### Structured extraction
 

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1225;
+export const MINUTES_TEST_COUNT = 1237;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1237;
+export const MINUTES_TEST_COUNT = 1243;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1243;
+export const MINUTES_TEST_COUNT = 1246;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary

Post-pass name correction (`minutes-25x3.4`), the "big lever" of the name-accuracy epic. After transcription, it rewrites mis-transcribed person-name tokens to the correct spelling from the expected-name pool (attendees, identity, vocabulary). **Config-gated, off by default**; corrections are annotated with the raw token preserved in frontmatter provenance (never a silent rewrite).

Measured against the text-level harness from #363: **recovered 6/6, false_corrections 0** across Dutch/French/Spanish/Indian/Chinese/Vietnamese name families.

## Algorithm (two tiers of confidence)

- **Out of name-position:** accent restoration + bounded edit-distance with a corroborating signal (same first letter OR Double Metaphone) and a minimum length. The conservative tier; protects common words like `mark`.
- **In name-position** (preceded by a vocative like `thanks`/`merci`, or followed by a name-verb like `will`/`owns`): the syntax confirms a person name, so the first-letter/length gates relax and a *unique* pool name within 2 edits wins. This safely recovers the hard `Geert`<-`bert` (different first letter) and `Thanh`<-`tan` (short) cases.

The edit-distance budget and unique-winner requirement always hold, so a token far from any pool name is never touched.

## How it was hardened (two adversarial passes)

This is the lexical-rewrite the `minutes-h1zm` review flagged as risky, so it went through two Codex adversarial passes. They earned their keep:

- **Pass 1** found 6 false-correction holes, all fixed + regression-tested: pronoun/function-word rewrites (`we`->`Wei`), `[SPEAKER …]` prefix corruption, pool-sourced common words (`The Team`), generic-preposition cues opening name slots, non-Latin tokens fuzzy-matching Latin names, and accent-vs-fuzzy ambiguity.
- **A regression test surfaced a latent crash:** `rphonetic`'s Double Metaphone panics on accented input (e.g. "José"), which would have crashed the pipeline for any user with an accented attendee name. Fixed with an ASCII-guarded encoder.
- **Pass 2** confirmed all 6 closed + the pipeline hook clean, and flagged residuals now fixed: collective nouns / days / months / common-word-names denylisted, and a min-length floor on the relaxed tier.

Guards: a stopword/denylist (token never corrected, never pooled), a `[...]` bracket guard for speaker prefixes, ASCII-gated fuzzy matching, combined-uniqueness, and the ASCII-guarded Double Metaphone.

## Known residual (documented, not a blocker for off-by-default)

A name spoken in the meeting that is NOT in the pool but within ~2 edits of a pool name in a name slot (a guest "Brett" near a pool "Geert") can be corrected. This is inherent to fuzzy correction, mitigated by off-by-default + unique-match + raw provenance. Documented on `NameCorrectionMode`; default-on promotion should wait on a stronger signal (speaker attribution / phonetic agreement). Speaker-turn context is the natural next lever.

## Surfaces

- `[transcription] name_correction = "off" | "conservative"` (default off).
- `correct_names` + `build_name_pool` in `name_correction.rs`; pipeline hook in both finalize paths (gated, meeting-only, after attribution).
- `Frontmatter.name_corrections` provenance (+ SDK reader type, JsonSchema, docs).

## Verification

- Harness 6/6 recovered, 0 false corrections (6 negatives incl. SPEAKER-prefix, pronoun-in-name-position).
- 20 matcher unit tests + the harness; full core suite **831** passing.
- `cargo clippy --all --no-default-features -- -D warnings` clean; `cargo fmt` clean; cli builds; SDK `tsc` clean.
- `rphonetic` (Apache-2.0) added to `minutes-core`.
