### PR TITLE
chore(mcp): depend on minutes-sdk ^0.19.0

### DIFF
--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "minutes-sdk": "^0.18.0",
+    "minutes-sdk": "^0.19.0",
     "yaml": "^2.8.3",
     "zod": "^3.25 || ^4.0"
   },


### PR DESCRIPTION
Post-tag release mechanic for v0.19.0.

The 0.19.0 bump kept minutes-mcp pinned to minutes-sdk ^0.18.0 so CI's npm install would not fail before sdk 0.19.0 existed on the registry. Now that minutes-sdk@0.19.0 and minutes-mcp@0.19.0 are both published, this points the source at ^0.19.0 so the repo matches what is on npm.

This is what makes the sensitivity-enforcement reader (restricted meetings excluded from MCP/SDK surfaces) ship on the live MCP, closing the propagation gap.

Lockfile is intentionally untouched: the MCP CI job deletes and regenerates package-lock.json on the Linux runner (npm/cli#4828 workaround), so it resolves minutes-sdk straight from package.json.