### PR TITLE
feat(minutes-prep): add Microsoft 365 / Outlook calendar source

### DIFF
--- a/.agents/skills/minutes/minutes-prep/SKILL.md
+++ b/.agents/skills/minutes/minutes-prep/SKILL.md
@@ -45,7 +45,33 @@ gog calendar list --today --json -a <account> 2>/dev/null
 osascript -e 'tell application "Calendar" to get {summary, start date} of (every event of every calendar whose start date >= (current date) and start date < ((current date) + 1 * days))'
 ```
 
-**4. None available** — skip to Phase 1 and ask manually.
+**4. Microsoft 365 / Outlook (`m365` CLI)** (if installed):
+
+First check if m365 is installed and whether it's logged in:
+```bash
+command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
+```
+
+- **If not installed**: skip silently to the next source.
+- **If installed but not logged in** (`status` returns `"Logged out"`): ask the user via AskUserQuestion:
+  > "I found the Microsoft 365 CLI (`m365`) but you're not logged in. Want me to start the login flow so I can pull your Outlook calendar?"
+  - If **yes**: run `m365 login --authType browser` and wait. Once done, proceed to fetch events below.
+  - If **no**: skip to the next source silently.
+- **If installed and logged in**: fetch today's remaining events:
+```bash
+m365 outlook event list \
+  --userId "@meId" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --output json 2>/dev/null
+```
+Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:
+- **Title**: `event.subject`
+- **Start time**: `event.start.dateTime` (UTC — convert to local time for display)
+- **Attendees**: `event.attendees[].emailAddress.name` (extract first names)
+- **Skip if**: `event.isAllDay === true`, `event.isCancelled === true`, or `event.attendees` is empty
+
+**5. None available** — skip to Phase 1 and ask manually.
 
 **If upcoming meetings are found:**
 Present via AskUserQuestion: "I see you have these meetings coming up today:
@@ -195,6 +221,8 @@ node "$MINUTES_SKILLS_ROOT/_runtime/hooks/lib/minutes-learn-cli.mjs" set-alias "
 ```
 
 - **Calendar auto-detect is best-effort** — If no calendar source is available, silently fall back to asking manually. Never error or nag the user about calendar setup. The Google Calendar MCP (`gcal.mcp.claude.com/mcp`) is the recommended source for Claude users.
+- **m365 login is non-blocking** — Only prompt for `m365 login` if m365 is installed but the user is not yet authenticated. It's a one-time browser flow. If the user declines, fall through silently.
+- **m365 event times are UTC** — `start.dateTime` and `end.dateTime` are in UTC. Convert to local time before displaying to the user. Use `date -d` (Linux) or `date -jf` (macOS) for conversion, or show the raw UTC time with a `(UTC)` suffix if conversion is unavailable.
 - **Calendar attendee names may differ from meeting transcript names** — Calendar says "Alex Chen (sarah@company.com)" but transcripts say "Alex" or "SPEAKER_0". Match on first name.
 - **Skip all-day events and solo events** — Only show events with 2+ attendees as prep candidates. All-day events and events where the user is the only attendee aren't meetings.
 - **Push back on vague answers** — This is the most important pattern. Vague prep = useless prep. "Everyone" → "Name one person." "Catch up" → "What would you regret not discussing?"

--- a/.agents/skills/minutes/minutes-prep/SKILL.md
+++ b/.agents/skills/minutes/minutes-prep/SKILL.md
@@ -61,8 +61,8 @@ command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
 ```bash
 m365 outlook event list \
   --userId "@meId" \
-  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
-  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59Z" \
   --output json 2>/dev/null
 ```
 Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:

--- a/.claude/plugins/minutes/skills/minutes-prep/SKILL.md
+++ b/.claude/plugins/minutes/skills/minutes-prep/SKILL.md
@@ -53,8 +53,8 @@ command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
 ```bash
 m365 outlook event list \
   --userId "@meId" \
-  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
-  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59Z" \
   --output json 2>/dev/null
 ```
 Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:

--- a/.claude/plugins/minutes/skills/minutes-prep/SKILL.md
+++ b/.claude/plugins/minutes/skills/minutes-prep/SKILL.md
@@ -37,7 +37,33 @@ gog calendar list --today --json -a <account> 2>/dev/null
 osascript -e 'tell application "Calendar" to get {summary, start date} of (every event of every calendar whose start date >= (current date) and start date < ((current date) + 1 * days))'
 ```
 
-**4. None available** — skip to Phase 1 and ask manually.
+**4. Microsoft 365 / Outlook (`m365` CLI)** (if installed):
+
+First check if m365 is installed and whether it's logged in:
+```bash
+command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
+```
+
+- **If not installed**: skip silently to the next source.
+- **If installed but not logged in** (`status` returns `"Logged out"`): ask the user via AskUserQuestion:
+  > "I found the Microsoft 365 CLI (`m365`) but you're not logged in. Want me to start the login flow so I can pull your Outlook calendar?"
+  - If **yes**: run `m365 login --authType browser` and wait. Once done, proceed to fetch events below.
+  - If **no**: skip to the next source silently.
+- **If installed and logged in**: fetch today's remaining events:
+```bash
+m365 outlook event list \
+  --userId "@meId" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --output json 2>/dev/null
+```
+Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:
+- **Title**: `event.subject`
+- **Start time**: `event.start.dateTime` (UTC — convert to local time for display)
+- **Attendees**: `event.attendees[].emailAddress.name` (extract first names)
+- **Skip if**: `event.isAllDay === true`, `event.isCancelled === true`, or `event.attendees` is empty
+
+**5. None available** — skip to Phase 1 and ask manually.
 
 **If upcoming meetings are found:**
 Present via AskUserQuestion: "I see you have these meetings coming up today:
@@ -187,6 +213,8 @@ node "${CLAUDE_PLUGIN_ROOT}/hooks/lib/minutes-learn-cli.mjs" set-alias "Case Win
 ```
 
 - **Calendar auto-detect is best-effort** — If no calendar source is available, silently fall back to asking manually. Never error or nag the user about calendar setup. The Google Calendar MCP (`gcal.mcp.claude.com/mcp`) is the recommended source for Claude users.
+- **m365 login is non-blocking** — Only prompt for `m365 login` if m365 is installed but the user is not yet authenticated. It's a one-time browser flow. If the user declines, fall through silently.
+- **m365 event times are UTC** — `start.dateTime` and `end.dateTime` are in UTC. Convert to local time before displaying to the user. Use `date -d` (Linux) or `date -jf` (macOS) for conversion, or show the raw UTC time with a `(UTC)` suffix if conversion is unavailable.
 - **Calendar attendee names may differ from meeting transcript names** — Calendar says "Alex Chen (sarah@company.com)" but transcripts say "Alex" or "SPEAKER_0". Match on first name.
 - **Skip all-day events and solo events** — Only show events with 2+ attendees as prep candidates. All-day events and events where the user is the only attendee aren't meetings.
 - **Push back on vague answers** — This is the most important pattern. Vague prep = useless prep. "Everyone" → "Name one person." "Catch up" → "What would you regret not discussing?"

--- a/.opencode/skills/minutes-prep/SKILL.md
+++ b/.opencode/skills/minutes-prep/SKILL.md
@@ -62,8 +62,8 @@ command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
 ```bash
 m365 outlook event list \
   --userId "@meId" \
-  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
-  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59Z" \
   --output json 2>/dev/null
 ```
 Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:

--- a/.opencode/skills/minutes-prep/SKILL.md
+++ b/.opencode/skills/minutes-prep/SKILL.md
@@ -46,7 +46,33 @@ gog calendar list --today --json -a <account> 2>/dev/null
 osascript -e 'tell application "Calendar" to get {summary, start date} of (every event of every calendar whose start date >= (current date) and start date < ((current date) + 1 * days))'
 ```
 
-**4. None available** — skip to Phase 1 and ask manually.
+**4. Microsoft 365 / Outlook (`m365` CLI)** (if installed):
+
+First check if m365 is installed and whether it's logged in:
+```bash
+command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
+```
+
+- **If not installed**: skip silently to the next source.
+- **If installed but not logged in** (`status` returns `"Logged out"`): ask the user via AskUserQuestion:
+  > "I found the Microsoft 365 CLI (`m365`) but you're not logged in. Want me to start the login flow so I can pull your Outlook calendar?"
+  - If **yes**: run `m365 login --authType browser` and wait. Once done, proceed to fetch events below.
+  - If **no**: skip to the next source silently.
+- **If installed and logged in**: fetch today's remaining events:
+```bash
+m365 outlook event list \
+  --userId "@meId" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --output json 2>/dev/null
+```
+Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:
+- **Title**: `event.subject`
+- **Start time**: `event.start.dateTime` (UTC — convert to local time for display)
+- **Attendees**: `event.attendees[].emailAddress.name` (extract first names)
+- **Skip if**: `event.isAllDay === true`, `event.isCancelled === true`, or `event.attendees` is empty
+
+**5. None available** — skip to Phase 1 and ask manually.
 
 **If upcoming meetings are found:**
 Present via AskUserQuestion: "I see you have these meetings coming up today:
@@ -196,6 +222,8 @@ node "$MINUTES_SKILLS_ROOT/_runtime/hooks/lib/minutes-learn-cli.mjs" set-alias "
 ```
 
 - **Calendar auto-detect is best-effort** — If no calendar source is available, silently fall back to asking manually. Never error or nag the user about calendar setup. The Google Calendar MCP (`gcal.mcp.claude.com/mcp`) is the recommended source for Claude users.
+- **m365 login is non-blocking** — Only prompt for `m365 login` if m365 is installed but the user is not yet authenticated. It's a one-time browser flow. If the user declines, fall through silently.
+- **m365 event times are UTC** — `start.dateTime` and `end.dateTime` are in UTC. Convert to local time before displaying to the user. Use `date -d` (Linux) or `date -jf` (macOS) for conversion, or show the raw UTC time with a `(UTC)` suffix if conversion is unavailable.
 - **Calendar attendee names may differ from meeting transcript names** — Calendar says "Alex Chen (sarah@company.com)" but transcripts say "Alex" or "SPEAKER_0". Match on first name.
 - **Skip all-day events and solo events** — Only show events with 2+ attendees as prep candidates. All-day events and events where the user is the only attendee aren't meetings.
 - **Push back on vague answers** — This is the most important pattern. Vague prep = useless prep. "Everyone" → "Name one person." "Catch up" → "What would you regret not discussing?"

--- a/tooling/skills/sources/minutes-prep/skill.md
+++ b/tooling/skills/sources/minutes-prep/skill.md
@@ -80,8 +80,8 @@ command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
 ```bash
 m365 outlook event list \
   --userId "@meId" \
-  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
-  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59Z" \
   --output json 2>/dev/null
 ```
 Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:

--- a/tooling/skills/sources/minutes-prep/skill.md
+++ b/tooling/skills/sources/minutes-prep/skill.md
@@ -64,7 +64,33 @@ gog calendar list --today --json -a <account> 2>/dev/null
 osascript -e 'tell application "Calendar" to get {summary, start date} of (every event of every calendar whose start date >= (current date) and start date < ((current date) + 1 * days))'
 ```
 
-**4. None available** — skip to Phase 1 and ask manually.
+**4. Microsoft 365 / Outlook (`m365` CLI)** (if installed):
+
+First check if m365 is installed and whether it's logged in:
+```bash
+command -v m365 2>/dev/null && m365 status --output json 2>/dev/null
+```
+
+- **If not installed**: skip silently to the next source.
+- **If installed but not logged in** (`status` returns `"Logged out"`): ask the user via AskUserQuestion:
+  > "I found the Microsoft 365 CLI (`m365`) but you're not logged in. Want me to start the login flow so I can pull your Outlook calendar?"
+  - If **yes**: run `m365 login --authType browser` and wait. Once done, proceed to fetch events below.
+  - If **no**: skip to the next source silently.
+- **If installed and logged in**: fetch today's remaining events:
+```bash
+m365 outlook event list \
+  --userId "@meId" \
+  --startDateTime "$(date -u +%Y-%m-%dT%H:%M:%S)" \
+  --endDateTime "$(date -u +%Y-%m-%d)T23:59:59" \
+  --output json 2>/dev/null
+```
+Only use the result if the command exits with code 0 and returns a non-empty JSON array. Parse the response:
+- **Title**: `event.subject`
+- **Start time**: `event.start.dateTime` (UTC — convert to local time for display)
+- **Attendees**: `event.attendees[].emailAddress.name` (extract first names)
+- **Skip if**: `event.isAllDay === true`, `event.isCancelled === true`, or `event.attendees` is empty
+
+**5. None available** — skip to Phase 1 and ask manually.
 
 **If upcoming meetings are found:**
 Present via AskUserQuestion: "I see you have these meetings coming up today:
@@ -214,6 +240,8 @@ node "${CLAUDE_PLUGIN_ROOT}/hooks/lib/minutes-learn-cli.mjs" set-alias "Case Win
 ```
 
 - **Calendar auto-detect is best-effort** — If no calendar source is available, silently fall back to asking manually. Never error or nag the user about calendar setup. The Google Calendar MCP (`gcal.mcp.claude.com/mcp`) is the recommended source for Claude users.
+- **m365 login is non-blocking** — Only prompt for `m365 login` if m365 is installed but the user is not yet authenticated. It's a one-time browser flow. If the user declines, fall through silently.
+- **m365 event times are UTC** — `start.dateTime` and `end.dateTime` are in UTC. Convert to local time before displaying to the user. Use `date -d` (Linux) or `date -jf` (macOS) for conversion, or show the raw UTC time with a `(UTC)` suffix if conversion is unavailable.
 - **Calendar attendee names may differ from meeting transcript names** — Calendar says "Alex Chen (sarah@company.com)" but transcripts say "Alex" or "SPEAKER_0". Match on first name.
 - **Skip all-day events and solo events** — Only show events with 2+ attendees as prep candidates. All-day events and events where the user is the only attendee aren't meetings.
 - **Push back on vague answers** — This is the most important pattern. Vague prep = useless prep. "Everyone" → "Name one person." "Catch up" → "What would you regret not discussing?"


### PR DESCRIPTION
## What

Add `m365` CLI as a 4th calendar source in the `minutes-prep` skill, alongside the existing `gog`, `icalbuddy`, and `osascript` sources.

## Why

Users on Microsoft 365 / Outlook have no way to pull today's calendar events into the meeting prep flow. The `m365` CLI (CLI for Microsoft 365) is a widely-used cross-platform tool that can fetch Outlook events.

## How

- Detects if `m365` is installed (`command -v m365`)
- Checks login status via `m365 status`
- If not logged in, prompts user via `AskUserQuestion` to optionally start browser-based login (`m365 login --authType browser`)
- If logged in, fetches today's remaining events via `m365 outlook event list`
- Filters out all-day events, cancelled events, and solo events (no attendees)
- Converts UTC `start.dateTime` / `end.dateTime` to local time for display
- Falls through silently if m365 not installed or user declines login

## Files changed

- `tooling/skills/sources/minutes-prep/skill.md` — canonical source
- `.agents/skills/minutes/minutes-prep/SKILL.md` — agents mirror
- `.claude/plugins/minutes/skills/minutes-prep/SKILL.md` — Claude plugin mirror
- `.opencode/skills/minutes-prep/SKILL.md` — OpenCode mirror
