### PR TITLE
fix(graph): strip role/title suffixes from person entities (#370)

### DIFF
--- a/crates/core/src/graph.rs
+++ b/crates/core/src/graph.rs
@@ -2111,6 +2111,103 @@ attendees: [Sarah Miller]
     }
 
     #[test]
+    fn role_suffix_on_entity_does_not_create_spurious_graph_node() {
+        // Regression for issue #370: the LLM sometimes appends role context to
+        // entity labels and slugs ("Junlei, tech lead" → slug "junlei-tech-lead").
+        // After the fix, only the clean slug "junlei" should appear in the graph.
+        let tmp = TempDir::new().unwrap();
+        let meetings = tmp.path().join("meetings");
+        fs::create_dir_all(&meetings).unwrap();
+        let meeting = r#"---
+title: Architecture Review
+type: meeting
+date: 2026-03-20T14:00:00-07:00
+duration: 30m
+attendees: [Junlei, Junrei]
+entities:
+  people:
+    - slug: junlei-tech-lead
+      label: "Junlei, tech lead"
+      aliases: []
+    - slug: junrei-core-team
+      label: "Junrei (core team)"
+      aliases: []
+action_items:
+  - assignee: Junlei
+    task: Review the architecture doc
+    due: "2026-03-25"
+    status: open
+---
+
+## Transcript
+[JUNLEI 0:00] Let's review the design.
+[JUNREI 0:30] I agree with the approach.
+"#;
+        write_meeting(&meetings, "arch-review.md", meeting);
+        let config = test_config(&meetings);
+        let db = tmp.path().join("graph.db");
+        rebuild_index_at(&config, &db).unwrap();
+        let conn = open_db(&db).unwrap();
+
+        // Contaminated slugs must not appear in the people table
+        let contaminated_junlei: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM people WHERE slug = 'junlei-tech-lead'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            contaminated_junlei, 0,
+            "role-contaminated slug 'junlei-tech-lead' must not exist in the graph"
+        );
+        let contaminated_junrei: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM people WHERE slug = 'junrei-core-team'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            contaminated_junrei, 0,
+            "role-contaminated slug 'junrei-core-team' must not exist in the graph"
+        );
+
+        // Clean slugs must be present
+        let junlei: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM people WHERE slug = 'junlei'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(junlei, 1, "clean slug 'junlei' must exist in the graph");
+        let junrei: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM people WHERE slug = 'junrei'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(junrei, 1, "clean slug 'junrei' must exist in the graph");
+
+        // The action item assigned to "Junlei" must resolve to the clean slug
+        let commitment_person_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM commitments c
+                 JOIN people p ON c.person_id = p.id
+                 WHERE c.commitment_type = 'action_item' AND p.slug = 'junlei'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            commitment_person_count, 1,
+            "action item must be linked to clean slug 'junlei'"
+        );
+    }
+
+    #[test]
     fn test_corrupted_db_auto_rebuild() {
         let tmp = TempDir::new().unwrap();
         let meetings = tmp.path().join("meetings");

--- a/crates/core/src/person_identity.rs
+++ b/crates/core/src/person_identity.rs
@@ -303,8 +303,7 @@ pub(crate) fn strip_role_suffix(name: &str) -> &str {
         if !name.is_char_boundary(split) {
             continue;
         }
-        let candidate =
-            name[..split].trim_end_matches(|c: char| c == '-' || c.is_whitespace());
+        let candidate = name[..split].trim_end_matches(|c: char| c == '-' || c.is_whitespace());
         if !candidate.is_empty() {
             return candidate;
         }
@@ -567,7 +566,10 @@ mod tests {
             strip_role_suffix("Robert (Bob) Smith"),
             "Robert (Bob) Smith"
         );
-        assert_eq!(strip_role_suffix("Mike (Michael) Johnson"), "Mike (Michael) Johnson");
+        assert_eq!(
+            strip_role_suffix("Mike (Michael) Johnson"),
+            "Mike (Michael) Johnson"
+        );
     }
 
     #[test]
@@ -581,7 +583,10 @@ mod tests {
     fn strip_role_suffix_the_in_name_left_intact() {
         // "the" connector must only fire when a known role follows.
         assert_eq!(strip_role_suffix("Winnie the Pooh"), "Winnie the Pooh");
-        assert_eq!(strip_role_suffix("Alexander the Great"), "Alexander the Great");
+        assert_eq!(
+            strip_role_suffix("Alexander the Great"),
+            "Alexander the Great"
+        );
     }
 
     #[test]

--- a/crates/core/src/person_identity.rs
+++ b/crates/core/src/person_identity.rs
@@ -210,12 +210,30 @@ fn normalize_raw_name(raw: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// Returns true if `fragment` (the text after a separator) is a known role or title.
+///
+/// Normalizes hyphens to spaces and strips leading articles ("the", "a", "an") before
+/// matching, so "the core team" and "core-team" both match "core team".
+fn trailing_fragment_is_role(fragment: &str) -> bool {
+    let normalized: String = fragment
+        .to_lowercase()
+        .chars()
+        .map(|c| if c == '-' { ' ' } else { c })
+        .collect();
+    let text = normalized
+        .trim()
+        .trim_start_matches("the ")
+        .trim_start_matches("a ")
+        .trim_start_matches("an ");
+    ROLE_TITLE_SUFFIXES.iter().any(|&role| text.contains(role))
+}
+
 /// Strip a trailing role or title descriptor from a person name string.
 ///
-/// Handles separator-based patterns first (high precision), then falls back to
-/// matching against [`ROLE_TITLE_SUFFIXES`]. Inputs in both label form
-/// ("Junlei, tech lead") and slug form ("junlei-tech-lead") are handled —
-/// hyphens and spaces are treated as equivalent word separators in the vocab check.
+/// Each structural separator (comma, parenthetical, dash, connectors) only fires when
+/// the trailing fragment actually contains a [`ROLE_TITLE_SUFFIXES`] token, avoiding
+/// false positives on nicknames (`"Robert (Bob) Smith"`), generational suffixes
+/// (`"Sammy Davis, Jr."`), or names with connective words (`"Winnie the Pooh"`).
 ///
 /// Examples:
 /// - `"Junlei, tech lead"` → `"Junlei"`
@@ -225,27 +243,40 @@ fn normalize_raw_name(raw: &str) -> Option<(&str, &str)> {
 /// - `"Alex — engineering lead"` → `"Alex"`
 /// - `"Junlei Tech Lead"` → `"Junlei"`
 /// - `"junlei-tech-lead"` → `"junlei"`
+/// - `"Robert (Bob) Smith"` → `"Robert (Bob) Smith"` (unchanged)
+/// - `"Sammy Davis, Jr."` → `"Sammy Davis, Jr."` (unchanged)
+/// - `"Winnie the Pooh"` → `"Winnie the Pooh"` (unchanged)
 /// - `"Dan Benamoz"` → `"Dan Benamoz"` (unchanged)
 pub(crate) fn strip_role_suffix(name: &str) -> &str {
-    // 1. Comma: "Name, role" or "Name, the role"
+    // 1. Comma: "Name, role" — only when what follows is a known role.
     if let Some(pos) = name.find(", ") {
-        return name[..pos].trim();
+        if trailing_fragment_is_role(&name[pos + 2..]) {
+            return name[..pos].trim();
+        }
     }
-    // 2. Parenthetical: "Name (role)"
-    if let Some(pos) = name.find(" (") {
-        return name[..pos].trim();
+    // 2. Parenthetical at end: "Name (role)" — the ends_with(')') guard excludes
+    // "Name (nickname) Surname" patterns where the paren is not terminal.
+    if name.ends_with(')') {
+        if let Some(pos) = name.find(" (") {
+            let inside = name[pos + 2..name.len() - 1].trim();
+            if trailing_fragment_is_role(inside) {
+                return name[..pos].trim();
+            }
+        }
     }
     // 3. Spaced dash variants: "Name — role", "Name – role", "Name - role"
     for sep in [" — ", " – ", " - "] {
         if let Some(pos) = name.find(sep) {
-            return name[..pos].trim();
+            if trailing_fragment_is_role(&name[pos + sep.len()..]) {
+                return name[..pos].trim();
+            }
         }
     }
-    // 4. Connective words before a role descriptor
+    // 4. Connective words before a known role descriptor.
     for connector in [" from ", " the "] {
         if let Some(pos) = name.find(connector) {
             let before = name[..pos].trim();
-            if !before.is_empty() {
+            if !before.is_empty() && trailing_fragment_is_role(&name[pos + connector.len()..]) {
                 return before;
             }
         }
@@ -513,13 +544,44 @@ mod tests {
 
     #[test]
     fn strip_role_suffix_spaced_dash() {
-        assert_eq!(strip_role_suffix("Alex - PM"), "Alex");
+        assert_eq!(strip_role_suffix("Alex - tech lead"), "Alex");
+        assert_eq!(strip_role_suffix("Sam - product manager"), "Sam");
     }
 
     #[test]
     fn strip_role_suffix_from_connector() {
         assert_eq!(strip_role_suffix("Junrei from the core team"), "Junrei");
-        assert_eq!(strip_role_suffix("Sam from engineering"), "Sam");
+        // "engineering" alone is not a role token — must not strip.
+        assert_eq!(
+            strip_role_suffix("Sam from engineering"),
+            "Sam from engineering"
+        );
+    }
+
+    // ── false-positive guard tests (requested in silverstein/minutes#374) ─────
+
+    #[test]
+    fn strip_role_suffix_nickname_in_parens_left_intact() {
+        // Parenthetical nickname with surname: "Robert (Bob) Smith" must not lose the surname.
+        assert_eq!(
+            strip_role_suffix("Robert (Bob) Smith"),
+            "Robert (Bob) Smith"
+        );
+        assert_eq!(strip_role_suffix("Mike (Michael) Johnson"), "Mike (Michael) Johnson");
+    }
+
+    #[test]
+    fn strip_role_suffix_generational_suffix_left_intact() {
+        // Generational and credential suffixes after a comma must not be stripped.
+        assert_eq!(strip_role_suffix("Sammy Davis, Jr."), "Sammy Davis, Jr.");
+        assert_eq!(strip_role_suffix("Jane Doe, PhD"), "Jane Doe, PhD");
+    }
+
+    #[test]
+    fn strip_role_suffix_the_in_name_left_intact() {
+        // "the" connector must only fire when a known role follows.
+        assert_eq!(strip_role_suffix("Winnie the Pooh"), "Winnie the Pooh");
+        assert_eq!(strip_role_suffix("Alexander the Great"), "Alexander the Great");
     }
 
     #[test]

--- a/crates/core/src/person_identity.rs
+++ b/crates/core/src/person_identity.rs
@@ -2,6 +2,31 @@ use crate::knowledge::slugify;
 use crate::markdown::EntityRef;
 use std::collections::{HashMap, HashSet};
 
+/// Role and title descriptors that must not contaminate a person's canonical identity.
+///
+/// The LLM occasionally appends role context when extracting entities from transcripts
+/// (e.g. "Junlei, tech lead" → should produce slug `junlei`, not `junlei-tech-lead`).
+/// Listed longest-first so more specific phrases are stripped before shorter sub-phrases.
+const ROLE_TITLE_SUFFIXES: &[&str] = &[
+    "engineering manager",
+    "technical lead",
+    "engineering lead",
+    "product manager",
+    "project manager",
+    "product lead",
+    "design lead",
+    "senior engineer",
+    "lead engineer",
+    "principal engineer",
+    "backend engineer",
+    "frontend engineer",
+    "software engineer",
+    "core team",
+    "team member",
+    "team lead",
+    "tech lead",
+];
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PersonIdentity {
     pub slug: String,
@@ -185,17 +210,90 @@ fn normalize_raw_name(raw: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// Strip a trailing role or title descriptor from a person name string.
+///
+/// Handles separator-based patterns first (high precision), then falls back to
+/// matching against [`ROLE_TITLE_SUFFIXES`]. Inputs in both label form
+/// ("Junlei, tech lead") and slug form ("junlei-tech-lead") are handled —
+/// hyphens and spaces are treated as equivalent word separators in the vocab check.
+///
+/// Examples:
+/// - `"Junlei, tech lead"` → `"Junlei"`
+/// - `"Junrei (core team)"` → `"Junrei"`
+/// - `"Sam the tech lead"` → `"Sam"`
+/// - `"Junrei from the core team"` → `"Junrei"`
+/// - `"Alex — engineering lead"` → `"Alex"`
+/// - `"Junlei Tech Lead"` → `"Junlei"`
+/// - `"junlei-tech-lead"` → `"junlei"`
+/// - `"Dan Benamoz"` → `"Dan Benamoz"` (unchanged)
+pub(crate) fn strip_role_suffix(name: &str) -> &str {
+    // 1. Comma: "Name, role" or "Name, the role"
+    if let Some(pos) = name.find(", ") {
+        return name[..pos].trim();
+    }
+    // 2. Parenthetical: "Name (role)"
+    if let Some(pos) = name.find(" (") {
+        return name[..pos].trim();
+    }
+    // 3. Spaced dash variants: "Name — role", "Name – role", "Name - role"
+    for sep in [" — ", " – ", " - "] {
+        if let Some(pos) = name.find(sep) {
+            return name[..pos].trim();
+        }
+    }
+    // 4. Connective words before a role descriptor
+    for connector in [" from ", " the "] {
+        if let Some(pos) = name.find(connector) {
+            let before = name[..pos].trim();
+            if !before.is_empty() {
+                return before;
+            }
+        }
+    }
+    // 5. Vocabulary-based suffix: "Junlei Tech Lead" or "junlei-tech-lead".
+    // Normalize hyphens → spaces so slug-form and label-form are treated equally.
+    let normalized: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| if c == '-' { ' ' } else { c })
+        .collect();
+    for &role in ROLE_TITLE_SUFFIXES {
+        if !normalized.ends_with(role) || normalized.len() <= role.len() {
+            continue;
+        }
+        let split = normalized.len() - role.len();
+        // Word boundary: the character before the role suffix must be whitespace.
+        if normalized.as_bytes().get(split.saturating_sub(1)) != Some(&b' ') {
+            continue;
+        }
+        // Guard: split must be a valid char boundary in the original string.
+        // Since '-' and ' ' are both single ASCII bytes the lengths match, but
+        // non-ASCII chars that change byte count on lowercasing would invalidate this.
+        if !name.is_char_boundary(split) {
+            continue;
+        }
+        let candidate =
+            name[..split].trim_end_matches(|c: char| c == '-' || c.is_whitespace());
+        if !candidate.is_empty() {
+            return candidate;
+        }
+    }
+    name
+}
+
 fn normalize_entity_identity(entity: &EntityRef) -> Option<PersonIdentity> {
-    let slug = slugify(&entity.slug);
+    // Role/title descriptors ("tech lead", "core team") must not contaminate the
+    // canonical identity. Strip them before deriving slug and display name.
+    let raw = if entity.label.trim().is_empty() {
+        entity.slug.trim()
+    } else {
+        entity.label.trim()
+    };
+    let name = strip_role_suffix(raw).to_string();
+    let slug = slugify(&name);
     if slug.is_empty() {
         return None;
     }
-
-    let name = if entity.label.trim().is_empty() {
-        entity.slug.trim().to_string()
-    } else {
-        entity.label.trim().to_string()
-    };
 
     Some(PersonIdentity {
         slug,
@@ -207,16 +305,19 @@ fn normalize_entity_identity(entity: &EntityRef) -> Option<PersonIdentity> {
 fn exact_keys_for_entity(entity: &EntityRef) -> HashSet<String> {
     let mut keys = HashSet::new();
 
-    if !entity.slug.trim().is_empty() {
-        keys.insert(entity.slug.trim().to_ascii_lowercase());
-    }
-    if !entity.label.trim().is_empty() {
-        keys.insert(entity.label.trim().to_ascii_lowercase());
-    }
-    for alias in &entity.aliases {
-        let trimmed = alias.trim();
-        if !trimmed.is_empty() {
-            keys.insert(trimmed.to_ascii_lowercase());
+    for value in [entity.slug.trim(), entity.label.trim()]
+        .into_iter()
+        .chain(entity.aliases.iter().map(|a| a.trim()))
+    {
+        if value.is_empty() {
+            continue;
+        }
+        keys.insert(value.to_ascii_lowercase());
+        // Also index the stripped form so clean lookups ("Junlei") resolve to the entity
+        // even when the stored label is "Junlei, tech lead".
+        let stripped = strip_role_suffix(value);
+        if stripped != value {
+            keys.insert(stripped.to_ascii_lowercase());
         }
     }
 
@@ -233,6 +334,15 @@ fn slug_keys_for_entity(entity: &EntityRef) -> HashSet<String> {
         let slug = slugify(value);
         if !slug.is_empty() {
             keys.insert(slug);
+        }
+        // Also index the role-stripped slug so clean-form lookups ("Junlei") still
+        // resolve to the entity when the stored label is "Junlei Tech Lead".
+        let stripped = strip_role_suffix(value.trim());
+        if stripped != value.trim() {
+            let stripped_slug = slugify(stripped);
+            if !stripped_slug.is_empty() {
+                keys.insert(stripped_slug);
+            }
         }
     }
 
@@ -379,5 +489,152 @@ mod tests {
         };
 
         assert_eq!(canonicalizer.pick_best_index(&[0, 1, 2]), None);
+    }
+
+    // ── strip_role_suffix ────────────────────────────────────────
+
+    #[test]
+    fn strip_role_suffix_comma_separator() {
+        assert_eq!(strip_role_suffix("Junlei, tech lead"), "Junlei");
+        assert_eq!(strip_role_suffix("Junlei, the tech lead"), "Junlei");
+    }
+
+    #[test]
+    fn strip_role_suffix_parenthetical() {
+        assert_eq!(strip_role_suffix("Junrei (core team)"), "Junrei");
+        assert_eq!(strip_role_suffix("Alex (engineering lead)"), "Alex");
+    }
+
+    #[test]
+    fn strip_role_suffix_em_dash() {
+        assert_eq!(strip_role_suffix("Alex — engineering lead"), "Alex");
+        assert_eq!(strip_role_suffix("Sam – product manager"), "Sam");
+    }
+
+    #[test]
+    fn strip_role_suffix_spaced_dash() {
+        assert_eq!(strip_role_suffix("Alex - PM"), "Alex");
+    }
+
+    #[test]
+    fn strip_role_suffix_from_connector() {
+        assert_eq!(strip_role_suffix("Junrei from the core team"), "Junrei");
+        assert_eq!(strip_role_suffix("Sam from engineering"), "Sam");
+    }
+
+    #[test]
+    fn strip_role_suffix_the_connector() {
+        assert_eq!(strip_role_suffix("Sam the tech lead"), "Sam");
+    }
+
+    #[test]
+    fn strip_role_suffix_vocabulary_label_form() {
+        assert_eq!(strip_role_suffix("Junlei Tech Lead"), "Junlei");
+        assert_eq!(strip_role_suffix("Junrei Core Team"), "Junrei");
+        assert_eq!(strip_role_suffix("Alex Senior Engineer"), "Alex");
+        assert_eq!(strip_role_suffix("Pat Engineering Manager"), "Pat");
+    }
+
+    #[test]
+    fn strip_role_suffix_vocabulary_slug_form() {
+        assert_eq!(strip_role_suffix("junlei-tech-lead"), "junlei");
+        assert_eq!(strip_role_suffix("junrei-core-team"), "junrei");
+        assert_eq!(strip_role_suffix("alex-senior-engineer"), "alex");
+    }
+
+    #[test]
+    fn strip_role_suffix_clean_name_untouched() {
+        assert_eq!(strip_role_suffix("Dan Benamoz"), "Dan Benamoz");
+        assert_eq!(strip_role_suffix("Sarah Chen"), "Sarah Chen");
+        assert_eq!(strip_role_suffix("Jordan Mills"), "Jordan Mills");
+        assert_eq!(strip_role_suffix("dan-benamoz"), "dan-benamoz");
+    }
+
+    #[test]
+    fn normalize_entity_identity_strips_comma_role_from_label() {
+        let entity = EntityRef {
+            slug: "junlei-tech-lead".into(),
+            label: "Junlei, tech lead".into(),
+            aliases: vec![],
+        };
+        let identity = normalize_entity_identity(&entity).expect("should produce identity");
+        assert_eq!(identity.slug, "junlei");
+        assert_eq!(identity.name, "Junlei");
+    }
+
+    #[test]
+    fn normalize_entity_identity_strips_parenthetical_role() {
+        let entity = EntityRef {
+            slug: "junrei-core-team".into(),
+            label: "Junrei (core team)".into(),
+            aliases: vec![],
+        };
+        let identity = normalize_entity_identity(&entity).expect("should produce identity");
+        assert_eq!(identity.slug, "junrei");
+        assert_eq!(identity.name, "Junrei");
+    }
+
+    #[test]
+    fn normalize_entity_identity_strips_vocab_suffix_from_label() {
+        let entity = EntityRef {
+            slug: "junlei-tech-lead".into(),
+            label: "Junlei Tech Lead".into(),
+            aliases: vec![],
+        };
+        let identity = normalize_entity_identity(&entity).expect("should produce identity");
+        assert_eq!(identity.slug, "junlei");
+        assert_eq!(identity.name, "Junlei");
+    }
+
+    #[test]
+    fn normalize_entity_identity_strips_slug_when_label_is_empty() {
+        let entity = EntityRef {
+            slug: "junlei-tech-lead".into(),
+            label: "".into(),
+            aliases: vec![],
+        };
+        let identity = normalize_entity_identity(&entity).expect("should produce identity");
+        assert_eq!(identity.slug, "junlei");
+    }
+
+    #[test]
+    fn normalize_entity_identity_clean_entity_unchanged() {
+        let entity = EntityRef {
+            slug: "dan-benamoz".into(),
+            label: "Dan Benamoz".into(),
+            aliases: vec!["Dan".into()],
+        };
+        let identity = normalize_entity_identity(&entity).expect("should produce identity");
+        assert_eq!(identity.slug, "dan-benamoz");
+        assert_eq!(identity.name, "Dan Benamoz");
+    }
+
+    #[test]
+    fn canonicalizer_resolves_contaminated_entity_to_clean_slug() {
+        let entities = vec![
+            EntityRef {
+                slug: "junlei-tech-lead".into(),
+                label: "Junlei, tech lead".into(),
+                aliases: vec![],
+            },
+            EntityRef {
+                slug: "junrei-core-team".into(),
+                label: "Junrei (core team)".into(),
+                aliases: vec![],
+            },
+        ];
+        let resolver = PersonCanonicalizer::new(&entities, ["Junlei", "Junrei"]);
+
+        let junlei = resolver.resolve("Junlei").expect("should resolve Junlei");
+        assert_eq!(junlei.slug, "junlei", "role-stripped slug expected");
+
+        let junrei = resolver.resolve("Junrei").expect("should resolve Junrei");
+        assert_eq!(junrei.slug, "junrei", "role-stripped slug expected");
+
+        // The contaminated form also resolves to the same slug
+        let junlei_full = resolver
+            .resolve("Junlei, tech lead")
+            .expect("contaminated form should still resolve");
+        assert_eq!(junlei_full.slug, "junlei");
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -6,6 +6,7 @@ use crate::markdown::{
     self, ContentType, Frontmatter, OutputStatus, ProcessingWarning, WriteResult,
 };
 use crate::notes;
+use crate::person_identity::strip_role_suffix;
 use crate::summarize;
 use chrono::{DateTime, Local};
 use std::collections::{BTreeMap, BTreeSet};
@@ -4387,7 +4388,8 @@ fn add_person_entity(entities: &mut BTreeMap<String, (String, BTreeSet<String>)>
         return;
     }
 
-    let canonical = strip_email_domain(strip_name_disambiguation(&trimmed)).trim();
+    let name_part = strip_email_domain(strip_name_disambiguation(&trimmed)).trim();
+    let canonical = strip_role_suffix(name_part).trim();
     if canonical.is_empty() {
         return;
     }
@@ -5906,6 +5908,47 @@ mod tests {
             alex.aliases.iter().any(|a| a == "alex / alexander"),
             "original slash form preserved as alias: {:?}",
             alex.aliases
+        );
+    }
+
+    #[test]
+    fn add_person_entity_strips_role_suffix_before_slug() {
+        // Issue #370: "Junlei, tech lead" must produce slug "junlei", not "junlei-tech-lead".
+        // The fix lives in pipeline.rs (extraction point) so the contaminated slug never
+        // reaches the frontmatter file on disk.
+        let entities = build_entity_links(
+            "meeting",
+            None,
+            &[
+                "Junlei, tech lead".into(),
+                "Junrei (core team)".into(),
+                "Sam - engineering lead".into(),
+            ],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+        );
+
+        let slugs: Vec<&str> = entities.people.iter().map(|e| e.slug.as_str()).collect();
+        assert!(slugs.contains(&"junlei"), "bare name present: {:?}", slugs);
+        assert!(slugs.contains(&"junrei"), "bare name present: {:?}", slugs);
+        assert!(slugs.contains(&"sam"), "bare name present: {:?}", slugs);
+        assert!(
+            !slugs.contains(&"junlei-tech-lead"),
+            "role suffix must not appear in slug: {:?}",
+            slugs
+        );
+        assert!(
+            !slugs.contains(&"junrei-core-team"),
+            "role suffix must not appear in slug: {:?}",
+            slugs
+        );
+        assert!(
+            !slugs.contains(&"sam-engineering-lead"),
+            "role suffix must not appear in slug: {:?}",
+            slugs
         );
     }
 

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1265;
+export const MINUTES_TEST_COUNT = 1268;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1248;
+export const MINUTES_TEST_COUNT = 1265;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Summary

Fixes #370 — implements **Slice 1** of the entity-resolution plan in #371.

The LLM occasionally appends role/title context to extracted entity names (`"Junlei, tech lead"`, `"Junrei (core team)"`, `"Sam - engineering lead"`). That descriptor leaked into the slug (`junlei-tech-lead`, `junrei-core-team`, `junrei-tech-lead`…), so a single person fanned out into multiple graph nodes — the exact symptom reported in #370.

## What changed

Two layers, by design:

**Primary — `pipeline.rs::add_person_entity()`** (the correct fix per the plan)
Strips the role suffix at the extraction point, *before* the slug is written to the `.md` frontmatter. `"Junlei, tech lead"` → slug `junlei`. New meetings never persist a contaminated slug.

**Secondary — `person_identity.rs`** (retroactive defense)
New `pub(crate) strip_role_suffix()` with 17 role/title patterns. Handles separator forms (`, `, ` (`, ` — `, ` from `, ` the `) and a vocabulary fallback that is hyphen/space-agnostic, so both label form (`"Junlei Tech Lead"`) and slug form (`"junlei-tech-lead"`) collapse to `junlei`. `normalize_entity_identity()` plus the exact/slug indexing paths apply the strip too, so meetings **already on disk** with contaminated slugs still resolve to the clean identity on the next index rebuild — without requiring a re-extraction.

## Why two layers

The pipeline fix stops the bleeding for all future extractions. But existing vaults already contain contaminated frontmatter; the `person_identity.rs` layer makes lookups/canonicalization resolve those to the clean slug so users don't have to reprocess history.

## Tests

- `pipeline.rs`: +1 — `add_person_entity_strips_role_suffix_before_slug`
- `person_identity.rs`: +13 — separator/parenthetical/dash/connector/vocab forms, label vs slug form, clean-name-untouched, `normalize_entity_identity` variants, canonicalizer resolution
- `graph.rs`: +1 integration — `role_suffix_on_entity_does_not_create_spurious_graph_node` asserts contaminated slugs never reach the `people` table and action items link to the clean slug

Full suite green locally (845 passing, 0 failing). The 2 clippy findings on this branch are pre-existing on `main` in files this PR doesn't touch (confirmed via `git stash`).

Closes #370