### PR TITLE
feat(ui): Persistent UI font scaling with keyboard shortcuts

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -382,6 +382,35 @@ fn cmd_apply_recall_window_layout(
     Ok(())
 }
 
+#[tauri::command]
+fn cmd_scale_window(app: tauri::AppHandle, label: String, zoom: f64) -> Result<(), String> {
+    const BASE: f64 = 16.0;
+    let Some(win) = app.get_webview_window(&label) else {
+        return Ok(());
+    };
+    let scale = win
+        .current_monitor()
+        .ok()
+        .flatten()
+        .map(|m| m.scale_factor())
+        .unwrap_or(1.0);
+    let size = win.inner_size().map_err(|e| e.to_string())?;
+    let ratio = zoom / BASE;
+    let new_w = ((size.width as f64 / scale) * ratio).round();
+    let new_h = ((size.height as f64 / scale) * ratio).round();
+    let was_resizable = win.is_resizable().unwrap_or(false);
+    if !was_resizable {
+        win.set_resizable(true).ok();
+    }
+    let result = win
+        .set_size(LogicalSize::new(new_w, new_h))
+        .map_err(|e| e.to_string());
+    if !was_resizable {
+        win.set_resizable(false).ok();
+    }
+    result
+}
+
 fn show_note_window(app: &tauri::AppHandle) {
     if let Some(win) = app.get_webview_window("note") {
         win.show().ok();
@@ -2504,6 +2533,7 @@ fn main() {
             commands::cmd_mark_activation_nudge_shown,
             cmd_show_main_window,
             cmd_apply_recall_window_layout,
+            cmd_scale_window,
             commands::cmd_upcoming_meetings,
             commands::cmd_spawn_terminal,
             commands::cmd_pty_input,

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -410,19 +410,9 @@ fn cmd_scale_window(app: tauri::AppHandle, label: String, zoom: f64) -> Result<(
     let height = (base_h * ratio).round();
 
     // setFrame from Rust works on non-resizable windows; no resizable toggle is
-    // needed (toggling it makes macOS draw a square standard frame on the
-    // transparent rounded window).
+    // needed
     win.set_size(LogicalSize::new(width, height))
         .map_err(|e| e.to_string())?;
-
-    // Transparent + shadowed windows (palette) keep a stale square shadow around
-    // the full frame after a programmatic resize. Toggling the shadow forces
-    // AppKit to recompute it from the new rounded content mask. Decorated windows
-    // (note, meeting-prompt) and shadowless ones (dictation-overlay) don't need it.
-    if label == "palette" {
-        win.set_shadow(false).ok();
-        win.set_shadow(true).ok();
-    }
 
     // Clamp position so bottom-right anchored windows (e.g. dictation overlay)
     // don't extend off-screen after scaling up.

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -382,33 +382,77 @@ fn cmd_apply_recall_window_layout(
     Ok(())
 }
 
+/// Unscaled (zoom=16) logical size each secondary window is built at. Scaling
+/// always derives from this constant, never from the window's current size, so
+/// repeated opens can't compound the dimensions. Keep in sync with each
+/// window's `.inner_size(..)` in its builder.
+fn window_base_size(label: &str) -> Option<(f64, f64)> {
+    match label {
+        "palette" => Some((640.0, 420.0)),
+        "note" => Some((420.0, 260.0)),
+        "dictation-overlay" => Some((320.0, 88.0)),
+        "meeting-prompt" => Some((380.0, 240.0)),
+        _ => None,
+    }
+}
+
 #[tauri::command]
 fn cmd_scale_window(app: tauri::AppHandle, label: String, zoom: f64) -> Result<(), String> {
     const BASE: f64 = 16.0;
     let Some(win) = app.get_webview_window(&label) else {
         return Ok(());
     };
-    let scale = win
+    let Some((base_w, base_h)) = window_base_size(&label) else {
+        return Ok(());
+    };
+    let ratio = zoom / BASE;
+    let width = (base_w * ratio).round();
+    let height = (base_h * ratio).round();
+
+    // setFrame from Rust works on non-resizable windows; no resizable toggle is
+    // needed (toggling it makes macOS draw a square standard frame on the
+    // transparent rounded window).
+    win.set_size(LogicalSize::new(width, height))
+        .map_err(|e| e.to_string())?;
+
+    // Transparent + shadowed windows (palette) keep a stale square shadow around
+    // the full frame after a programmatic resize. Toggling the shadow forces
+    // AppKit to recompute it from the new rounded content mask. Decorated windows
+    // (note, meeting-prompt) and shadowless ones (dictation-overlay) don't need it.
+    if label == "palette" {
+        win.set_shadow(false).ok();
+        win.set_shadow(true).ok();
+    }
+
+    // Clamp position so bottom-right anchored windows (e.g. dictation overlay)
+    // don't extend off-screen after scaling up.
+    let monitor = win
         .current_monitor()
         .ok()
         .flatten()
-        .map(|m| m.scale_factor())
-        .unwrap_or(1.0);
-    let size = win.inner_size().map_err(|e| e.to_string())?;
-    let ratio = zoom / BASE;
-    let new_w = ((size.width as f64 / scale) * ratio).round();
-    let new_h = ((size.height as f64 / scale) * ratio).round();
-    let was_resizable = win.is_resizable().unwrap_or(false);
-    if !was_resizable {
-        win.set_resizable(true).ok();
+        .or_else(|| win.primary_monitor().ok().flatten())
+        .or_else(|| {
+            app.get_webview_window("main")
+                .and_then(|m| m.current_monitor().ok().flatten())
+        });
+    if let (Some(monitor), Ok(pos)) = (monitor, win.outer_position()) {
+        let scale = monitor.scale_factor();
+        let work_area = monitor.work_area();
+        let work_x = work_area.position.x as f64 / scale;
+        let work_y = work_area.position.y as f64 / scale;
+        let work_right = work_x + work_area.size.width as f64 / scale;
+        let work_bottom = work_y + work_area.size.height as f64 / scale;
+        let logical_x = pos.x as f64 / scale;
+        let logical_y = pos.y as f64 / scale;
+        let clamped_x = logical_x.min(work_right - width).max(work_x);
+        let clamped_y = logical_y.min(work_bottom - height).max(work_y);
+        if (clamped_x - logical_x).abs() > 0.5 || (clamped_y - logical_y).abs() > 0.5 {
+            win.set_position(LogicalPosition::new(clamped_x, clamped_y))
+                .ok();
+        }
     }
-    let result = win
-        .set_size(LogicalSize::new(new_w, new_h))
-        .map_err(|e| e.to_string());
-    if !was_resizable {
-        win.set_resizable(false).ok();
-    }
-    result
+
+    Ok(())
 }
 
 fn show_note_window(app: &tauri::AppHandle) {

--- a/tauri/src/dictation-overlay.html
+++ b/tauri/src/dictation-overlay.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dictation</title>
+  <script src="scripts/ui-zoom.js"></script>
+  <link rel="stylesheet" href="styles/ui-zoom-tokens.css">
   <style>
     @font-face {
       font-family: 'Geist';
@@ -203,7 +205,7 @@
 
     /* Label */
     .label {
-      font-size: 16px;
+      font-size: var(--text-base);
       font-weight: 600;
       letter-spacing: -0.02em;
       color: var(--text);
@@ -216,7 +218,7 @@
 
     /* Timer */
     .timer {
-      font-size: 14px;
+      font-size: var(--text-sm);
       font-weight: 600;
       color: var(--text-secondary);
       font-variant-numeric: tabular-nums;
@@ -265,7 +267,7 @@
     }
 
     .text-content {
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 400;
       color: var(--text-secondary);
       line-height: 1.35;
@@ -301,14 +303,14 @@
 
     /* Error icon */
     .error-icon {
-      font-size: 16px;
+      font-size: var(--text-base);
       color: var(--red);
       flex-shrink: 0;
     }
 
     /* Success icon */
     .success-icon {
-      font-size: 16px;
+      font-size: var(--text-base);
       color: var(--green);
       flex-shrink: 0;
     }

--- a/tauri/src/dictation-overlay.html
+++ b/tauri/src/dictation-overlay.html
@@ -106,10 +106,10 @@
       display: flex;
       flex-direction: column;
       width: 100%;
-      height: 48px;
+      height: 3rem;
       background: var(--bg-hover);
       border: 1px solid var(--border-mid);
-      border-radius: 20px;
+      border-radius: 1.25rem;
       box-shadow: var(--shadow);
       animation: appear 200ms ease-out;
       transition: height 200ms ease-out, border-color 220ms ease, box-shadow 220ms ease;
@@ -118,7 +118,7 @@
     }
 
     .pill.expanded {
-      height: 88px;
+      height: 5.5rem;
     }
 
     .pill.error {
@@ -148,16 +148,16 @@
     .status-row {
       display: flex;
       align-items: center;
-      gap: 12px;
-      padding: 12px 14px;
+      gap: 0.75rem;
+      padding: 0.75rem 0.875rem;
       flex-shrink: 0;
-      min-height: 46px;
+      min-height: 2.875rem;
     }
 
     /* Status dot */
     .dot {
-      width: 14px;
-      height: 14px;
+      width: 0.875rem;
+      height: 0.875rem;
       border-radius: 50%;
       flex-shrink: 0;
       background: var(--red);
@@ -190,8 +190,8 @@
 
     /* Spinner */
     .spinner {
-      width: 16px;
-      height: 16px;
+      width: 1rem;
+      height: 1rem;
       border: 2px solid var(--spinner-track);
       border-top-color: var(--accent);
       border-radius: 50%;
@@ -232,7 +232,7 @@
       display: flex;
       align-items: center;
       gap: 3px;
-      height: 16px;
+      height: 1rem;
       flex-shrink: 0;
       transition: opacity 180ms ease, transform 180ms ease;
     }

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -10617,6 +10617,11 @@
 
     const COLLAPSED_WIDTH = 520;
     const EXPANDED_WIDTH = 960;
+
+    function getZoomRatio() {
+      var z = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || 16;
+      return z / 16;
+    }
     const DEFAULT_RECALL_RATIO = 0.5;
     // On Windows the OS window resize (expand→960, collapse→520) is jarring:
     // closing the panel snaps the window to 520px regardless of the user's size.
@@ -10829,12 +10834,21 @@
       // and forcing a width on collapse (520px) is jarring when the user had a
       // different window size. macOS/Linux behavior is unchanged.
       if (IS_WINDOWS) return Promise.resolve();
+      const ratio = getZoomRatio();
       return invoke('cmd_apply_recall_window_layout', {
-        width,
-        height: 640,
+        width: Math.round(width * ratio),
+        height: Math.round(640 * ratio),
         avoidRightEdge: !!options.avoidRightEdge,
       });
     }
+
+    document.addEventListener('uizoomchange', async () => {
+      if (IS_WINDOWS) return;
+      const isFullscreen = await currentWindow.isFullscreen().catch(() => false);
+      if (isFullscreen) return;
+      const targetWidth = recallExpanded ? EXPANDED_WIDTH : COLLAPSED_WIDTH;
+      applyRecallWindowLayout(targetWidth).catch(() => {});
+    });
 
     async function expandRecallPanel() {
       if (recallExpanded || expandAnimating) return;

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -8824,34 +8824,6 @@
       }
     });
 
-    // UI font scale: Cmd/Ctrl +/-/0
-    document.addEventListener('keydown', (e) => {
-      const textBase = 16;
-      const textMax = 26;
-      
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
-        if (e.key === '=' || e.key === '+') {
-          e.preventDefault();
-          const cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || textBase;
-          const next = Math.min(textMax, cur + 2);
-          document.documentElement.style.setProperty('--text-scale-basis', next);
-          localStorage.setItem('minutes.uiZoom', next);
-          if (recallTerminal) { recallTerminal.options.fontSize = getTerminalFontSize(); if (recallFitAddon) recallFitAddon.fit(); }
-        } else if (e.key === '-') {
-          e.preventDefault();
-          const cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || textBase;
-          const next = Math.max(textBase, cur - 2);
-          document.documentElement.style.setProperty('--text-scale-basis', next);
-          localStorage.setItem('minutes.uiZoom', next);
-          if (recallTerminal) { recallTerminal.options.fontSize = getTerminalFontSize(); if (recallFitAddon) recallFitAddon.fit(); }
-        } else if (e.key === '0') {
-          e.preventDefault();
-          document.documentElement.style.setProperty('--text-scale-basis', textBase);
-          localStorage.removeItem('minutes.uiZoom');
-          if (recallTerminal) { recallTerminal.options.fontSize = getTerminalFontSize(); if (recallFitAddon) recallFitAddon.fit(); }
-        }
-      }
-    });
 
     async function loadSettings() {
       try {
@@ -10792,6 +10764,10 @@
       recallTerminal.loadAddon(recallFitAddon);
       recallTerminal.open(recallTerminalContainer);
       window.MINUTES_XTERM_THEME_QUERY.addEventListener('change', recallThemeHandler);
+      document.addEventListener('uizoomchange', () => {
+        recallTerminal.options.fontSize = getTerminalFontSize();
+        if (recallFitAddon) recallFitAddon.fit();
+      });
 
       let fitTimeout;
       recallResizeObserver = new ResizeObserver(() => {

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -10,6 +10,14 @@
       document.documentElement.dataset.platform = 'macos';
     }
   </script>
+  <script>
+    (function () {
+      var saved = parseFloat(localStorage.getItem('minutes.uiZoom'));
+      if (saved && saved >= 16 && saved <= 26) {
+        document.documentElement.style.setProperty('--text-scale-basis', saved);
+      }
+    })();
+  </script>
   <style>
     @font-face {
       font-family: 'Instrument Serif';
@@ -138,6 +146,26 @@
       --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
       --font-display: 'Instrument Serif', ui-serif, 'Iowan Old Style', Georgia, serif;
       --font-mono: 'Geist Mono', 'SF Mono', 'Menlo', monospace;
+
+      /* Scalable typography system, based roughly on Tailwind */
+      /* custom — below Tailwind minimum */
+      --text-badge:  0.5625rem;  /* 9px  — 1 rule; candidate for removal in design pass */
+      --text-2xs:    0.625rem;   /* 10px */
+      --text-meta:   0.6875rem;  /* 11px — 52 rules: labels, timestamps, helper text */
+
+      /* Tailwind-exact */
+      --text-xs:     0.75rem;    /* 12px */
+
+      /* custom — between Tailwind xs (12px) and sm (14px) */
+      --text-body:   0.8125rem;  /* 13px — 28 rules: primary prose, inputs, base button */
+
+      /* Tailwind-exact */
+      --text-sm:     0.875rem;   /* 14px — 15px also maps here (only intentional size change) */
+      --text-base:   1rem;       /* 16px */
+      --text-lg:     1.125rem;   /* 18px */
+      --text-xl:     1.25rem;    /* 20px */
+      --text-2xl:    1.5rem;     /* 24px — 22px folded here (+2px on 2 rules, see below) */
+      --text-5xl:    3rem;       /* 48px */
     }
 
     @media (prefers-color-scheme: light) {
@@ -217,6 +245,7 @@
 
     html {
       background: transparent;
+      font-size: calc(var(--text-scale-basis) * 1px);
     }
 
     body {
@@ -375,7 +404,7 @@
     }
 
     .recall-phase-label {
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text-secondary);
       white-space: nowrap;
@@ -398,7 +427,7 @@
     }
 
     .recall-context-label {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-tertiary);
       white-space: nowrap;
       overflow: hidden;
@@ -432,7 +461,7 @@
       margin: 0;
       white-space: pre-wrap;
       font-family: 'Geist Mono', 'SF Mono', Menlo, monospace;
-      font-size: 12px;
+      font-size: var(--text-xs);
       line-height: 1.6;
       color: var(--text-secondary);
     }
@@ -443,7 +472,7 @@
       border: none;
       background: transparent;
       color: var(--text-tertiary);
-      font-size: 14px;
+      font-size: var(--text-sm);
       cursor: pointer;
       line-height: 1;
     }
@@ -550,7 +579,7 @@
       background: var(--bg-elevated);
       color: var(--text);
       font-family: inherit;
-      font-size: 12px;
+      font-size: var(--text-xs);
       outline: none;
       -webkit-user-select: text;
       user-select: text;
@@ -574,7 +603,7 @@
       flex-direction: column;
       gap: 12px;
       color: var(--text-secondary);
-      font-size: 13px;
+      font-size: var(--text-body);
       padding: 12px 10px;
       background: var(--bg-elevated);
     }
@@ -596,7 +625,7 @@
       border-bottom-left-radius: 18px;
       border-bottom-right-radius: 18px;
       text-align: center;
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       flex-shrink: 0;
     }
@@ -616,7 +645,7 @@
     }
 
     .lifecycle-badge {
-      font-size: 9px;
+      font-size: var(--text-badge);
       font-weight: 500;
       padding: 1px 6px;
       border-radius: 999px;
@@ -769,7 +798,7 @@
       border-radius: 999px;
       background: var(--orange-tint-soft);
       color: var(--orange);
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-weight: 600;
       letter-spacing: 0.2px;
       white-space: nowrap;
@@ -807,7 +836,7 @@
     }
 
     .status-pill.recording {
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 3px 10px;
       width: auto;
       height: auto;
@@ -820,7 +849,7 @@
     }
 
     .status-pill.processing {
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 3px 10px;
       max-width: 96px;
       width: auto;
@@ -835,7 +864,7 @@
     }
 
     .status-pill.starting {
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 3px 10px;
       max-width: 96px;
       width: auto;
@@ -850,7 +879,7 @@
     }
 
     .status-pill.live {
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 3px 10px;
       width: auto;
       height: auto;
@@ -861,7 +890,7 @@
     }
 
     .status-pill.sensitive {
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 3px 10px;
       width: auto;
       height: auto;
@@ -912,7 +941,7 @@
       display: flex;
       align-items: center;
       gap: 8px;
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--live);
       letter-spacing: 0.3px;
@@ -943,7 +972,7 @@
     }
 
     .live-time {
-      font-size: 20px;
+      font-size: var(--text-xl);
       font-variant-numeric: tabular-nums;
       color: var(--text);
       font-family: var(--font-mono);
@@ -952,7 +981,7 @@
     }
 
     .live-utterances {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       margin-top: 2px;
     }
@@ -1030,7 +1059,7 @@
       display: flex;
       align-items: center;
       gap: 8px;
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 600;
       color: var(--red);
       letter-spacing: 0.3px;
@@ -1064,7 +1093,7 @@
     }
 
     .recording-time {
-      font-size: 20px;
+      font-size: var(--text-xl);
       font-variant-numeric: tabular-nums;
       color: var(--text);
       font-family: var(--font-mono);
@@ -1164,7 +1193,7 @@
     }
 
     .processing-summary {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       margin-top: 6px;
     }
@@ -1200,7 +1229,7 @@
     }
 
     .processing-job-title {
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text);
       min-width: 0;
@@ -1210,7 +1239,7 @@
     }
 
     .processing-job-state {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       letter-spacing: 0.08em;
       text-transform: uppercase;
       color: var(--accent);
@@ -1218,13 +1247,13 @@
     }
 
     .processing-job-detail {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       margin-top: 4px;
     }
 
     .processing-job-meta {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       margin-top: 4px;
       font-variant-numeric: tabular-nums;
@@ -1238,20 +1267,20 @@
     }
 
     .processing-title {
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 400;
       color: var(--accent);
       font-family: var(--font-display);
     }
 
     .processing-stage {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       margin-top: 2px;
     }
 
     .processing-elapsed {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       margin-top: 1px;
       font-variant-numeric: tabular-nums;
@@ -1300,7 +1329,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 14px;
+      font-size: var(--text-sm);
       flex-shrink: 0;
       background: var(--green-tint);
       color: var(--green);
@@ -1317,20 +1346,20 @@
     }
 
     .output-notice-title {
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 600;
       color: var(--text);
     }
 
     .output-notice-detail {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       margin-top: 3px;
       line-height: 1.45;
     }
 
     .output-notice-path {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       margin-top: 6px;
       font-family: var(--font-mono);
@@ -1367,7 +1396,7 @@
       background: var(--bg-elevated);
       color: var(--text);
       font-family: inherit;
-      font-size: 13px;
+      font-size: var(--text-body);
       outline: none;
       -webkit-user-select: text;
       user-select: text;
@@ -1395,7 +1424,7 @@
       background: var(--surface-fill);
       color: var(--text);
       font-family: inherit;
-      font-size: 13px;
+      font-size: var(--text-body);
       outline: none;
       -webkit-user-select: text;
       user-select: text;
@@ -1419,7 +1448,7 @@
       border-radius: 6px;
       background: var(--red-tint, rgba(255, 69, 58, 0.12));
       color: var(--red, #FF453A);
-      font-size: 11px;
+      font-size: var(--text-meta);
       line-height: 1.4;
     }
 
@@ -1432,7 +1461,7 @@
       position: absolute;
       left: 28px;
       top: 17px;
-      font-size: 16px;
+      font-size: var(--text-base);
       color: var(--text-secondary);
       pointer-events: none;
       z-index: 1;
@@ -1508,7 +1537,7 @@
       border: none !important;
       box-shadow: none !important;
       color: var(--text-secondary);
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 500;
       text-transform: none;
       letter-spacing: 0;
@@ -1528,7 +1557,7 @@
 
     .md-viewer-toolbar .md-viewer-mode-btn {
       font-family: var(--font-mono);
-      font-size: 10px;
+      font-size: var(--text-2xs);
       letter-spacing: 0.3px;
       text-transform: uppercase;
     }
@@ -1551,7 +1580,7 @@
       border: none;
       color: var(--text-secondary);
       cursor: pointer;
-      font-size: 16px;
+      font-size: var(--text-base);
       padding: 2px 6px;
       border-radius: 4px;
       line-height: 1;
@@ -1563,7 +1592,7 @@
     }
 
     .md-viewer-filename {
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-family: var(--font-mono);
       color: var(--text-secondary);
       white-space: nowrap;
@@ -1582,7 +1611,7 @@
       border: 1px solid var(--border);
       background: var(--surface-fill);
       color: var(--text-secondary);
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-family: var(--font-mono);
       letter-spacing: 0.08em;
       text-transform: uppercase;
@@ -1637,7 +1666,7 @@
     }
 
     .md-viewer-status {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       min-width: 88px;
       text-align: right;
@@ -1705,7 +1734,7 @@
     }
 
     .md-viewer-history-title {
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--fg);
       line-height: 1.35;
@@ -1715,7 +1744,7 @@
     }
 
     .md-viewer-history-meta {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--muted);
       display: flex;
       flex-wrap: wrap;
@@ -1725,7 +1754,7 @@
 
     .md-viewer-history-open {
       align-self: flex-start;
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 4px 8px;
     }
 
@@ -1737,7 +1766,7 @@
     }
 
     .md-viewer-review-title {
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text);
       text-transform: uppercase;
@@ -1745,7 +1774,7 @@
     }
 
     .md-viewer-review-meta {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       text-align: right;
     }
@@ -1764,7 +1793,7 @@
     }
 
     .md-viewer-review-label {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.08em;
@@ -1874,12 +1903,12 @@
 
     .artifact-template-title {
       font-family: var(--font-display);
-      font-size: 20px;
+      font-size: var(--text-xl);
       color: var(--text);
     }
 
     .artifact-template-sub {
-      font-size: 13px;
+      font-size: var(--text-body);
       color: var(--text-secondary);
       line-height: 1.5;
     }
@@ -1909,13 +1938,13 @@
     }
 
     .artifact-template-option-title {
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 600;
       color: var(--text);
     }
 
     .artifact-template-option-body {
-      font-size: 12px;
+      font-size: var(--text-xs);
       line-height: 1.5;
       color: var(--text-secondary);
       text-align: left;
@@ -1939,15 +1968,15 @@
     }
 
     .md-viewer-content h1 {
-      font-size: 22px;
+      font-size: var(--text-2xl);
     }
 
     .md-viewer-content h2 {
-      font-size: 18px;
+      font-size: var(--text-lg);
     }
 
     .md-viewer-content h3 {
-      font-size: 15px;
+      font-size: var(--text-sm);
     }
 
     .md-viewer-content h1:first-child,
@@ -1957,7 +1986,7 @@
     }
 
     .md-viewer-content p {
-      font-size: 13px;
+      font-size: var(--text-body);
       line-height: 1.6;
       color: var(--text);
       margin: 0.6em 0;
@@ -1965,7 +1994,7 @@
 
     .md-viewer-content ul,
     .md-viewer-content ol {
-      font-size: 13px;
+      font-size: var(--text-body);
       line-height: 1.6;
       color: var(--text);
       padding-left: 20px;
@@ -1978,7 +2007,7 @@
 
     .md-viewer-content code {
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: var(--text-xs);
       background: var(--surface-fill-strong);
       padding: 1px 5px;
       border-radius: 4px;
@@ -2003,7 +2032,7 @@
       padding: 4px 12px;
       margin: 0.6em 0;
       color: var(--text-secondary);
-      font-size: 13px;
+      font-size: var(--text-body);
     }
 
     .md-viewer-content hr {
@@ -2023,7 +2052,7 @@
 
     .md-viewer-content table {
       border-collapse: collapse;
-      font-size: 12px;
+      font-size: var(--text-xs);
       margin: 0.6em 0;
       width: 100%;
     }
@@ -2041,7 +2070,7 @@
     }
 
     .date-group {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-family: var(--font-mono);
       font-weight: 500;
       text-transform: uppercase;
@@ -2146,7 +2175,7 @@
     }
 
     .meeting-title {
-      font-size: 15px;
+      font-size: var(--text-sm);
       font-weight: 600;
       color: var(--text);
       white-space: nowrap;
@@ -2155,7 +2184,7 @@
     }
 
     .meeting-meta {
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-family: var(--font-mono);
       color: var(--text-secondary);
       margin-top: 3px;
@@ -2163,7 +2192,7 @@
     }
 
     .meeting-snippet {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       margin-top: 6px;
       line-height: 1.45;
@@ -2264,7 +2293,7 @@
       border: none;
       background: transparent;
       color: var(--text-tertiary);
-      font-size: 16px;
+      font-size: var(--text-base);
       cursor: pointer;
       display: flex;
       align-items: center;
@@ -2287,7 +2316,7 @@
     }
 
     .detail-title {
-      font-size: 18px;
+      font-size: var(--text-lg);
       font-family: var(--font-display);
       font-weight: 400;
       letter-spacing: -0.2px;
@@ -2302,7 +2331,7 @@
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
     }
 
@@ -2340,7 +2369,7 @@
     }
 
     .detail-bottom-cta-text {
-      font-size: 13px;
+      font-size: var(--text-body);
       color: var(--text-secondary);
       line-height: 1.4;
     }
@@ -2356,7 +2385,7 @@
       border: none;
       background: transparent;
       color: var(--text-tertiary);
-      font-size: 14px;
+      font-size: var(--text-sm);
       cursor: pointer;
       display: flex;
       align-items: center;
@@ -2386,7 +2415,7 @@
     }
 
     .detail-context-label {
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 700;
       letter-spacing: 0.5px;
       text-transform: uppercase;
@@ -2395,7 +2424,7 @@
     }
 
     .detail-context-body {
-      font-size: 13px;
+      font-size: var(--text-body);
       line-height: 1.5;
       color: var(--text-secondary);
       white-space: pre-wrap;
@@ -2410,7 +2439,7 @@
     .detail-action-item {
       display: flex;
       gap: 8px;
-      font-size: 13px;
+      font-size: var(--text-body);
       line-height: 1.45;
       color: var(--text-secondary);
     }
@@ -2428,7 +2457,7 @@
       color: var(--text);
       border-radius: 999px;
       padding: 4px 10px;
-      font-size: 12px;
+      font-size: var(--text-xs);
       line-height: 1.3;
       cursor: pointer;
     }
@@ -2440,7 +2469,7 @@
 
     .detail-action-check {
       flex-shrink: 0;
-      font-size: 14px;
+      font-size: var(--text-sm);
     }
 
     .detail-action-text {
@@ -2456,7 +2485,7 @@
     }
 
     .detail-speakers-label {
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 700;
       letter-spacing: 0.5px;
       text-transform: uppercase;
@@ -2469,13 +2498,13 @@
       align-items: center;
       gap: 8px;
       padding: 4px 0;
-      font-size: 13px;
+      font-size: var(--text-body);
     }
 
     .speaker-label {
       color: var(--text-tertiary);
       font-family: var(--font-mono, monospace);
-      font-size: 11px;
+      font-size: var(--text-meta);
       min-width: 80px;
     }
 
@@ -2485,7 +2514,7 @@
     }
 
     .speaker-badge {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       padding: 1px 6px;
       border-radius: 4px;
       font-weight: 600;
@@ -2509,7 +2538,7 @@
     }
 
     .speaker-confirm-btn {
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 2px 8px;
       border-radius: 4px;
       border: 1px solid var(--border);
@@ -2537,7 +2566,7 @@
     }
 
     .speaker-remember-btn {
-      font-size: 11px;
+      font-size: var(--text-meta);
       padding: 2px 8px;
       border-radius: 4px;
       border: 1px solid var(--border);
@@ -2571,7 +2600,7 @@
       margin: 0 20px 14px;
       padding: 10px 12px;
       border-radius: 10px;
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 500;
       border: 1px solid var(--border);
       background: var(--surface-fill);
@@ -2603,7 +2632,7 @@
     }
 
     .detail-section-title {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-family: var(--font-mono);
       font-weight: 600;
       letter-spacing: 0.4px;
@@ -2613,7 +2642,7 @@
     }
 
     .detail-section-body {
-      font-size: 13px;
+      font-size: var(--text-body);
       line-height: 1.55;
       color: var(--text-secondary);
       white-space: pre-wrap;
@@ -2633,7 +2662,7 @@
       padding: 28px 20px;
       text-align: center;
       color: var(--text-tertiary);
-      font-size: 12px;
+      font-size: var(--text-xs);
     }
 
     .empty-state {
@@ -2643,7 +2672,7 @@
     }
 
     .empty-state .title {
-      font-size: 20px;
+      font-size: var(--text-xl);
       font-family: var(--font-display);
       font-weight: 400;
       color: var(--text);
@@ -2651,7 +2680,7 @@
     }
 
     .empty-state .sub {
-      font-size: 12px;
+      font-size: var(--text-xs);
       margin-top: 6px;
       line-height: 1.5;
       color: var(--text-secondary);
@@ -2712,7 +2741,7 @@
     }
 
     .about-copy h2 {
-      font-size: 24px;
+      font-size: var(--text-2xl);
       font-family: var(--font-display);
       font-weight: 400;
       line-height: 1;
@@ -2721,7 +2750,7 @@
     }
 
     .about-copy p {
-      font-size: 13px;
+      font-size: var(--text-body);
       color: var(--text-secondary);
       line-height: 1.45;
     }
@@ -2731,7 +2760,7 @@
       flex-wrap: wrap;
       gap: 8px;
       margin-top: 10px;
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       line-height: 1.5;
     }
@@ -2755,7 +2784,7 @@
     }
 
     .about-item-title {
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 700;
       letter-spacing: 0.5px;
       text-transform: uppercase;
@@ -2764,7 +2793,7 @@
     }
 
     .about-item-body {
-      font-size: 13px;
+      font-size: var(--text-body);
       color: var(--text-secondary);
       line-height: 1.45;
     }
@@ -2772,7 +2801,7 @@
     .about-footer {
       padding-top: 14px;
       border-top: 1px solid var(--border);
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-tertiary);
       line-height: 1.45;
     }
@@ -2788,7 +2817,7 @@
     }
 
     .about-controls-copy {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.45;
     }
@@ -2808,7 +2837,7 @@
       background: var(--bg-elevated);
       color: var(--text);
       font: inherit;
-      font-size: 12px;
+      font-size: var(--text-xs);
       padding: 8px 10px;
     }
 
@@ -2827,7 +2856,7 @@
 
     .about-controls-meta {
       margin-top: 8px;
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       line-height: 1.45;
     }
@@ -2855,7 +2884,7 @@
 
     .dictation-recent-text {
       min-width: 0;
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.35;
       overflow: hidden;
@@ -2865,7 +2894,7 @@
 
     .dictation-recent-meta {
       margin-top: 3px;
-      font-size: 10px;
+      font-size: var(--text-2xs);
       color: var(--text-tertiary);
       line-height: 1.35;
     }
@@ -2889,7 +2918,7 @@
       margin-top: 14px;
       padding-top: 14px;
       border-top: 1px solid var(--border);
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.55;
     }
@@ -2951,7 +2980,7 @@
     }
 
     .readiness-title {
-      font-size: 18px;
+      font-size: var(--text-lg);
       font-family: var(--font-display);
       font-weight: 400;
       letter-spacing: -0.2px;
@@ -2960,7 +2989,7 @@
     }
 
     .readiness-sub {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.45;
     }
@@ -2991,13 +3020,13 @@
     }
 
     .readiness-item-title {
-      font-size: 14px;
+      font-size: var(--text-sm);
       font-weight: 600;
       color: var(--text);
     }
 
     .readiness-item-detail {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.45;
     }
@@ -3005,7 +3034,7 @@
     .readiness-state {
       padding: 3px 8px;
       border-radius: 999px;
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-weight: 700;
       letter-spacing: 0.4px;
       text-transform: uppercase;
@@ -3030,7 +3059,7 @@
     }
 
     .readiness-optional {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       margin-top: 8px;
       letter-spacing: 0.15px;
@@ -3049,7 +3078,7 @@
 
     .readiness-action-status {
       width: 100%;
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       line-height: 1.45;
     }
@@ -3060,7 +3089,7 @@
 
     .consent-script-label {
       font-family: var(--font-mono, monospace);
-      font-size: 11px;
+      font-size: var(--text-meta);
       text-transform: uppercase;
       letter-spacing: 0.14em;
       color: var(--text-secondary);
@@ -3119,7 +3148,7 @@
     }
 
     .recovery-title {
-      font-size: 18px;
+      font-size: var(--text-lg);
       font-family: var(--font-display);
       font-weight: 400;
       letter-spacing: -0.2px;
@@ -3128,7 +3157,7 @@
     }
 
     .recovery-sub {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.45;
     }
@@ -3141,7 +3170,7 @@
     .recovery-empty {
       text-align: center;
       color: var(--text-tertiary);
-      font-size: 12px;
+      font-size: var(--text-xs);
       padding: 28px 8px;
     }
 
@@ -3166,7 +3195,7 @@
     }
 
     .recovery-item-title {
-      font-size: 14px;
+      font-size: var(--text-sm);
       font-weight: 600;
       color: var(--text);
     }
@@ -3176,7 +3205,7 @@
       border-radius: 999px;
       background: var(--orange-tint);
       color: var(--orange);
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-weight: 700;
       letter-spacing: 0.4px;
       text-transform: uppercase;
@@ -3184,13 +3213,13 @@
     }
 
     .recovery-item-detail {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.45;
     }
 
     .recovery-item-path {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       margin-top: 8px;
       font-family: var(--font-mono);
@@ -3236,7 +3265,7 @@
 
     .footer-action-primary .btn-primary {
       min-height: 42px;
-      font-size: 14px;
+      font-size: var(--text-sm);
       font-weight: 600;
     }
 
@@ -3253,7 +3282,7 @@
       padding-left: 10px;
       padding-right: 10px;
       border-radius: var(--radius);
-      font-size: 12px;
+      font-size: var(--text-xs);
       white-space: nowrap;
     }
 
@@ -3262,7 +3291,7 @@
     }
 
     .footer-device-label {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-family: var(--font-mono);
       text-transform: uppercase;
       letter-spacing: 0.32px;
@@ -3293,7 +3322,7 @@
       border-radius: 8px;
       border: none;
       font-family: inherit;
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 500;
       cursor: pointer;
       transition:
@@ -3354,7 +3383,7 @@
       text-transform: uppercase;
       letter-spacing: 0.4px;
       font-weight: 600;
-      font-size: 11px;
+      font-size: var(--text-meta);
     }
 
     .btn-secondary:hover {
@@ -3364,7 +3393,7 @@
 
     .btn-sm {
       padding: 5px 12px;
-      font-size: 12px;
+      font-size: var(--text-xs);
     }
 
     .device-picker {
@@ -3373,7 +3402,7 @@
       border: 1px solid var(--border);
       border-radius: var(--radius);
       padding: 6px 8px;
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-family: inherit;
       max-width: 140px;
       cursor: pointer;
@@ -3398,7 +3427,7 @@
 
     .btn-icon {
       padding: 4px 7px;
-      font-size: 15px;
+      font-size: var(--text-sm);
       line-height: 1;
       border: none;
       background: transparent;
@@ -3431,7 +3460,7 @@
     }
 
     .upcoming-icon {
-      font-size: 16px;
+      font-size: var(--text-base);
       flex-shrink: 0;
     }
 
@@ -3441,7 +3470,7 @@
     }
 
     .upcoming-title {
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 500;
       color: var(--text);
       white-space: nowrap;
@@ -3450,7 +3479,7 @@
     }
 
     .upcoming-time {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--accent);
       font-weight: 500;
     }
@@ -3471,7 +3500,7 @@
     }
 
     .ambient-context-title {
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 700;
       letter-spacing: 0.5px;
       text-transform: uppercase;
@@ -3479,7 +3508,7 @@
     }
 
     .ambient-context-summary {
-      font-size: 13px;
+      font-size: var(--text-body);
       line-height: 1.5;
       color: var(--text-secondary);
       white-space: pre-wrap;
@@ -3511,12 +3540,12 @@
     }
 
     .call-detected-icon {
-      font-size: 16px;
+      font-size: var(--text-base);
       flex-shrink: 0;
     }
 
     .call-detected-title {
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 600;
       color: var(--text);
       flex: 1;
@@ -3533,7 +3562,7 @@
       border: none;
       background: transparent;
       color: var(--text-secondary);
-      font-size: 16px;
+      font-size: var(--text-base);
       line-height: 1;
       cursor: pointer;
       border-radius: 4px;
@@ -3572,26 +3601,26 @@
     }
 
     .call-ended-icon {
-      font-size: 16px;
+      font-size: var(--text-base);
       flex-shrink: 0;
     }
 
     .call-ended-title {
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 600;
       color: var(--text);
       min-width: 0;
     }
 
     .call-ended-subtitle {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--red);
       font-weight: 600;
       margin-top: 2px;
     }
 
     .call-ended-detail {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       margin-top: 6px;
       line-height: 1.35;
@@ -3662,7 +3691,7 @@
     }
 
     .update-banner-title {
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text);
       white-space: nowrap;
@@ -3671,14 +3700,14 @@
     }
 
     .update-banner-sub {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       margin-top: 4px;
       line-height: 1.45;
     }
 
     .update-banner-meta {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       margin-top: 6px;
       display: none;
@@ -3712,7 +3741,7 @@
     .update-banner-error {
       display: none;
       margin-top: 6px;
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--red);
       line-height: 1.4;
       font-weight: 600;
@@ -3739,7 +3768,7 @@
 
     .update-banner-notes-summary {
       cursor: pointer;
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text);
       list-style: none;
       user-select: none;
@@ -3764,7 +3793,7 @@
       max-height: 180px;
       overflow-y: auto;
       color: var(--text);
-      font-size: 12px;
+      font-size: var(--text-xs);
       line-height: 1.55;
       padding-right: 4px;
     }
@@ -3773,7 +3802,7 @@
     .update-banner-notes-body h2,
     .update-banner-notes-body h3 {
       font-family: var(--font-sans);
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       margin: 10px 0 6px;
     }
@@ -3790,7 +3819,7 @@
     .update-banner-notes-body li { margin-bottom: 3px; }
     .update-banner-notes-body code {
       font-family: var(--font-mono);
-      font-size: 11px;
+      font-size: var(--text-meta);
       background: var(--surface-fill-strong);
       padding: 1px 4px;
       border-radius: 4px;
@@ -3828,7 +3857,7 @@
 
     .update-banner-debug-summary {
       cursor: pointer;
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-family: var(--font-mono);
       letter-spacing: 0.3px;
       text-transform: uppercase;
@@ -3879,7 +3908,7 @@
     }
 
     .update-banner-actions .btn {
-      font-size: 11px;
+      font-size: var(--text-meta);
     }
 
     /* ── What's New modal ── */
@@ -3901,7 +3930,7 @@
     }
 
     .about-cli-title {
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 700;
       letter-spacing: 0.5px;
       text-transform: uppercase;
@@ -3910,7 +3939,7 @@
 
     .about-cli-status {
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
     }
 
@@ -3919,7 +3948,7 @@
     .about-cli-status.warn { color: #c96b4e; }
 
     .about-cli-detail {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-tertiary);
       line-height: 1.5;
       margin-bottom: 8px;
@@ -3927,7 +3956,7 @@
 
     .about-cli-detail code {
       font-family: var(--font-mono);
-      font-size: 11px;
+      font-size: var(--text-meta);
       background: var(--bg);
       border: 1px solid var(--border);
       border-radius: 4px;
@@ -3950,14 +3979,14 @@
     }
 
     .whats-new-cli-title {
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 600;
       margin-bottom: 6px;
       color: var(--text);
     }
 
     .whats-new-cli-body {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       line-height: 1.5;
       margin-bottom: 10px;
@@ -3965,7 +3994,7 @@
 
     .whats-new-cli-body code {
       font-family: var(--font-mono);
-      font-size: 11px;
+      font-size: var(--text-meta);
       background: var(--bg);
       border: 1px solid var(--border);
       border-radius: 4px;
@@ -4014,14 +4043,14 @@
     }
 
     .cli-setup-header h2 {
-      font-size: 18px;
+      font-size: var(--text-lg);
       font-family: var(--font-display);
       font-weight: 400;
       letter-spacing: -0.3px;
     }
 
     .cli-setup-body {
-      font-size: 13px;
+      font-size: var(--text-body);
       color: var(--text-secondary);
       line-height: 1.55;
       margin-bottom: 14px;
@@ -4033,7 +4062,7 @@
     .cli-setup-body code,
     .cli-setup-snippet {
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: var(--text-xs);
       background: var(--bg);
       border: 1px solid var(--border);
       border-radius: 6px;
@@ -4068,14 +4097,14 @@
 
     .cli-setup-bundle-path {
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: var(--text-xs);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
 
     .cli-setup-bundle-tag {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       margin-top: 2px;
     }
@@ -4086,7 +4115,7 @@
       background: rgba(201, 107, 78, 0.1);
       border: 1px solid rgba(201, 107, 78, 0.3);
       color: #c96b4e;
-      font-size: 12px;
+      font-size: var(--text-xs);
       line-height: 1.5;
       margin-bottom: 10px;
     }
@@ -4127,14 +4156,14 @@
     }
     .whats-new-header h2 {
       font-family: var(--font-display);
-      font-size: 20px;
+      font-size: var(--text-xl);
       font-weight: 400;
       color: var(--text);
       margin: 0;
     }
     .whats-new-header .whats-new-version {
       font-family: var(--font-mono);
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       margin-top: 4px;
     }
@@ -4143,7 +4172,7 @@
       overflow-y: auto;
       flex: 1;
       font-family: var(--font-sans);
-      font-size: 13px;
+      font-size: var(--text-body);
       line-height: 1.6;
       color: var(--text);
     }
@@ -4151,7 +4180,7 @@
       font-family: var(--font-sans);
       font-weight: 600;
       margin: 16px 0 8px;
-      font-size: 14px;
+      font-size: var(--text-sm);
       color: var(--text);
     }
     .whats-new-body h1:first-child, .whats-new-body h2:first-child, .whats-new-body h3:first-child {
@@ -4162,7 +4191,7 @@
     .whats-new-body li { margin-bottom: 4px; }
     .whats-new-body code {
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: var(--text-xs);
       background: var(--surface-fill-strong);
       padding: 1px 5px;
       border-radius: 4px;
@@ -4194,7 +4223,7 @@
     }
 
     .call-health-chip {
-      font-size: 11px;
+      font-size: var(--text-meta);
       border-radius: 999px;
       padding: 4px 8px;
       background: var(--surface-fill-hover);
@@ -4312,7 +4341,7 @@
     }
 
     .settings-title {
-      font-size: 20px;
+      font-size: var(--text-xl);
       font-family: var(--font-display);
     }
 
@@ -4334,11 +4363,11 @@
     .settings-shortcut-key {
       min-width: 140px;
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: var(--text-xs);
     }
 
     .settings-hint-link {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       cursor: pointer;
     }
@@ -4351,7 +4380,7 @@
       background: var(--neutral-tint);
       border: 1px solid var(--neutral-border);
       color: var(--text);
-      font-size: 13px;
+      font-size: var(--text-body);
       box-sizing: border-box;
     }
 
@@ -4383,7 +4412,7 @@
     }
 
     .settings-storage-meta {
-      font-size: 13px;
+      font-size: var(--text-body);
       color: var(--text-secondary);
       line-height: 1.8;
       padding: 0 4px;
@@ -4406,7 +4435,7 @@
     }
 
     .about-footer-small {
-      font-size: 11px;
+      font-size: var(--text-meta);
     }
 
     .settings-section-tight {
@@ -5626,18 +5655,18 @@
     }
 
     .onboarding-icon {
-      font-size: 48px;
+      font-size: var(--text-5xl);
       margin-bottom: 12px;
     }
 
     .onboarding-content h2 {
-      font-size: 22px;
+      font-size: var(--text-2xl);
       font-weight: 700;
       margin-bottom: 6px;
     }
 
     .onboarding-sub {
-      font-size: 13px;
+      font-size: var(--text-body);
       color: var(--text-secondary);
       margin-bottom: 24px;
     }
@@ -5675,7 +5704,7 @@
       border-radius: 50%;
       background: var(--bg-elevated);
       color: var(--text-secondary);
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 700;
       display: flex;
       align-items: center;
@@ -5689,13 +5718,13 @@
     }
 
     .step-title {
-      font-size: 14px;
+      font-size: var(--text-sm);
       font-weight: 500;
       flex: 1;
     }
 
     .step-status {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--green);
       font-weight: 600;
     }
@@ -5705,7 +5734,7 @@
     }
 
     .step-body p {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       margin-bottom: 10px;
     }
@@ -5741,7 +5770,7 @@
     }
 
     .progress-text {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
     }
   </style>
@@ -8822,6 +8851,35 @@
       }
     });
 
+    // UI font scale: Cmd/Ctrl +/-/0
+    document.addEventListener('keydown', (e) => {
+      const textBase = 16;
+      const textMax = 26;
+      
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+        if (e.key === '=' || e.key === '+') {
+          e.preventDefault();
+          const cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || textBase;
+          const next = Math.min(textMax, cur + 2);
+          document.documentElement.style.setProperty('--text-scale-basis', next);
+          localStorage.setItem('minutes.uiZoom', next);
+          if (recallTerminal) { recallTerminal.options.fontSize = getTerminalFontSize(); if (recallFitAddon) recallFitAddon.fit(); }
+        } else if (e.key === '-') {
+          e.preventDefault();
+          const cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || textBase;
+          const next = Math.max(textBase, cur - 2);
+          document.documentElement.style.setProperty('--text-scale-basis', next);
+          localStorage.setItem('minutes.uiZoom', next);
+          if (recallTerminal) { recallTerminal.options.fontSize = getTerminalFontSize(); if (recallFitAddon) recallFitAddon.fit(); }
+        } else if (e.key === '0') {
+          e.preventDefault();
+          document.documentElement.style.setProperty('--text-scale-basis', textBase);
+          localStorage.removeItem('minutes.uiZoom');
+          if (recallTerminal) { recallTerminal.options.fontSize = getTerminalFontSize(); if (recallFitAddon) recallFitAddon.fit(); }
+        }
+      }
+    });
+
     async function loadSettings() {
       try {
         const s = await invoke('cmd_get_settings');
@@ -10730,6 +10788,13 @@
       }
     }
 
+    function getTerminalFontSize() {
+      const basis = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')
+      ) || 16;
+      return Math.round(basis * 0.8125);
+    }
+
     // ── xterm.js initialization ──
     function initRecallTerminal() {
       if (recallInitialized) return;
@@ -10738,7 +10803,7 @@
       recallTerminal = new Terminal({
         theme: window.MINUTES_XTERM_THEME,
         fontFamily: "'Geist Mono', 'SF Mono', Menlo, monospace",
-        fontSize: 13,
+        fontSize: getTerminalFontSize(),
         lineHeight: 1.2,
         cursorBlink: true,
         cursorStyle: 'bar',

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -10,14 +10,8 @@
       document.documentElement.dataset.platform = 'macos';
     }
   </script>
-  <script>
-    (function () {
-      var saved = parseFloat(localStorage.getItem('minutes.uiZoom'));
-      if (saved && saved >= 16 && saved <= 26) {
-        document.documentElement.style.setProperty('--text-scale-basis', saved);
-      }
-    })();
-  </script>
+  <script src="scripts/ui-zoom.js"></script>
+  <link rel="stylesheet" href="styles/ui-zoom-tokens.css">
   <style>
     @font-face {
       font-family: 'Instrument Serif';
@@ -146,26 +140,6 @@
       --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
       --font-display: 'Instrument Serif', ui-serif, 'Iowan Old Style', Georgia, serif;
       --font-mono: 'Geist Mono', 'SF Mono', 'Menlo', monospace;
-
-      /* Scalable typography system, based roughly on Tailwind */
-      /* custom — below Tailwind minimum */
-      --text-badge:  0.5625rem;  /* 9px  — 1 rule; candidate for removal in design pass */
-      --text-2xs:    0.625rem;   /* 10px */
-      --text-meta:   0.6875rem;  /* 11px — 52 rules: labels, timestamps, helper text */
-
-      /* Tailwind-exact */
-      --text-xs:     0.75rem;    /* 12px */
-
-      /* custom — between Tailwind xs (12px) and sm (14px) */
-      --text-body:   0.8125rem;  /* 13px — 28 rules: primary prose, inputs, base button */
-
-      /* Tailwind-exact */
-      --text-sm:     0.875rem;   /* 14px — 15px also maps here (only intentional size change) */
-      --text-base:   1rem;       /* 16px */
-      --text-lg:     1.125rem;   /* 18px */
-      --text-xl:     1.25rem;    /* 20px */
-      --text-2xl:    1.5rem;     /* 24px — 22px folded here (+2px on 2 rules, see below) */
-      --text-5xl:    3rem;       /* 48px */
     }
 
     @media (prefers-color-scheme: light) {
@@ -245,7 +219,6 @@
 
     html {
       background: transparent;
-      font-size: calc(var(--text-scale-basis) * 1px);
     }
 
     body {
@@ -730,8 +703,8 @@
     .brand-mark {
       display: block;
       position: relative;
-      width: 34px;
-      height: 34px;
+      width: 2.125rem; /* 34px @ 16px base font size */
+      height: 2.125rem; /* 34px @ 16px base font size */
       flex-shrink: 0;
       overflow: hidden;
     }

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -1863,7 +1863,7 @@
     }
 
     .artifact-template-card {
-      width: min(560px, 100%);
+      width: min(48.4ch, 100vw - 32px); /* ~560px */
       background: var(--bg-elevated);
       border: 1px solid var(--border);
       border-radius: calc(var(--radius-lg) + 2px);
@@ -2230,7 +2230,7 @@
     }
 
     .detail-card {
-      width: min(760px, 100%);
+      width: min(71ch, 100vw - 32px); /* ~760px */
       max-height: calc(100vh - 40px);
       background: var(--bg);
       border: 1px solid var(--border);
@@ -2252,8 +2252,8 @@
     }
 
     .detail-header-copy {
-      min-width: 0;
-      flex: 1;
+      min-width: 16.5ch;
+      flex: 1 1 16.5ch;
     }
 
     .detail-close-x {
@@ -2317,8 +2317,9 @@
 
     .detail-actions {
       display: flex;
+      flex-wrap: wrap;
       gap: 8px;
-      flex-shrink: 0;
+      justify-content: flex-end;
       padding-right: 28px;
     }
 
@@ -2678,7 +2679,7 @@
     }
 
     .about-card {
-      width: min(520px, 100%);
+      width: min(48.4ch, 100vw - 32px); /* ~520px */
       max-height: calc(100vh - 40px);
       overflow-y: auto;
       background: var(--bg-elevated);
@@ -2932,7 +2933,7 @@
     }
 
     .readiness-card {
-      width: min(720px, 100%);
+      width: min(67.1ch, 100vw - 32px); /* ~720px */
       max-height: calc(100vh - 40px);
       background: var(--bg);
       border: 1px solid var(--border);
@@ -3094,7 +3095,7 @@
     }
 
     .recovery-card {
-      width: min(760px, 100%);
+      width: min(41ch, 100vw - 32px); /* ~440px */
       max-height: calc(100vh - 40px);
       background: var(--bg);
       border: 1px solid var(--border);
@@ -3565,6 +3566,7 @@
 
     .call-ended-info {
       min-width: 0;
+      padding-bottom: 12px;
     }
 
     .call-ended-head {
@@ -3996,7 +3998,7 @@
     .cli-setup-scrim.active { display: flex; }
 
     .cli-setup-modal {
-      width: min(48.4ch, 100vw - 32px);
+      width: min(48.4ch, 100vw - 32px); /* ~560px */
       max-height: calc(100vh - 40px);
       overflow-y: auto;
       background: var(--bg-elevated);
@@ -4117,7 +4119,7 @@
       background: var(--bg-elevated);
       border: 1px solid var(--border-mid);
       border-radius: var(--radius-lg);
-      width: min(41ch, 100vw - 32px);
+      width: min(41ch, 100vw - 32px); /* ~440px */
       max-height: calc(100vh - 64px);
       display: flex;
       flex-direction: column;
@@ -4309,7 +4311,7 @@
     }
 
     .settings-card {
-      width: min(580px, 100%);
+      width: min(54ch, 100vw - 32px); /* ~580px */
       max-height: calc(100vh - 40px);
     }
 

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -4023,7 +4023,7 @@
     .cli-setup-scrim.active { display: flex; }
 
     .cli-setup-modal {
-      width: min(560px, 100%);
+      width: min(48.4ch, 100vw - 32px);
       max-height: calc(100vh - 40px);
       overflow-y: auto;
       background: var(--bg-elevated);
@@ -4144,7 +4144,7 @@
       background: var(--bg-elevated);
       border: 1px solid var(--border-mid);
       border-radius: var(--radius-lg);
-      width: min(440px, calc(100vw - 32px));
+      width: min(41ch, 100vw - 32px);
       max-height: calc(100vh - 64px);
       display: flex;
       flex-direction: column;

--- a/tauri/src/meeting-prompt.html
+++ b/tauri/src/meeting-prompt.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Upcoming Meeting</title>
+  <script src="scripts/ui-zoom.js"></script>
+  <link rel="stylesheet" href="styles/ui-zoom-tokens.css">
   <style>
     @font-face {
       font-family: 'Instrument Serif';
@@ -127,7 +129,7 @@
     }
 
     .eyebrow {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-weight: 500;
       letter-spacing: 0.16em;
       text-transform: uppercase;
@@ -142,7 +144,7 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      font-size: 14px;
+      font-size: var(--text-sm);
       background: var(--accent-soft);
       color: var(--accent);
       flex-shrink: 0;
@@ -154,7 +156,7 @@
 
     .meeting-title {
       font-family: 'Instrument Serif', ui-serif, Georgia, serif;
-      font-size: 22px;
+      font-size: var(--text-2xl);
       line-height: 1.1;
       letter-spacing: -0.03em;
       color: var(--text);
@@ -175,7 +177,7 @@
       border-radius: 999px;
       background: var(--accent-soft);
       color: var(--accent);
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 500;
       letter-spacing: 0.12em;
       text-transform: uppercase;
@@ -193,7 +195,7 @@
       border: 1px solid var(--border);
       background: var(--surface-fill);
       color: var(--text-tertiary);
-      font-size: 13px;
+      font-size: var(--text-body);
       cursor: pointer;
       line-height: 1;
       flex-shrink: 0;
@@ -202,7 +204,7 @@
     .close-btn:hover { color: var(--text-secondary); background: var(--bg-hover); }
 
     .summary {
-      font-size: 12px;
+      font-size: var(--text-xs);
       line-height: 1.45;
       color: var(--text-secondary);
       min-height: 34px;
@@ -219,7 +221,7 @@
       border-radius: 8px;
       border: none;
       font-family: inherit;
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 500;
       cursor: pointer;
       transition: all 0.12s ease;
@@ -256,7 +258,7 @@
     .btn-secondary:active { transform: scale(0.97); }
 
     .error-text {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--red);
       display: none;
       line-height: 1.4;
@@ -269,7 +271,7 @@
       transform: translateX(-50%) translateY(30px);
       background: var(--accent);
       color: var(--bg);
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       padding: 6px 14px;
       border-radius: 20px;

--- a/tauri/src/note.html
+++ b/tauri/src/note.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Add Note</title>
+  <script src="scripts/ui-zoom.js"></script>
+  <link rel="stylesheet" href="styles/ui-zoom-tokens.css">
   <style>
     @font-face {
       font-family: 'Instrument Serif';
@@ -122,7 +124,7 @@
     }
 
     .label {
-      font-size: 11px;
+      font-size: var(--text-meta);
       font-weight: 500;
       letter-spacing: 0.14em;
       text-transform: uppercase;
@@ -131,14 +133,14 @@
 
     .title {
       font-family: 'Instrument Serif', ui-serif, Georgia, serif;
-      font-size: 26px;
+      font-size: var(--text-2xl);
       line-height: 0.95;
       letter-spacing: -0.03em;
       color: var(--text);
     }
 
     .subtitle {
-      font-size: 12px;
+      font-size: var(--text-xs);
       line-height: 1.45;
       color: var(--text-secondary);
       max-width: 320px;
@@ -161,7 +163,7 @@
       justify-content: space-between;
       gap: 10px;
       margin-bottom: 8px;
-      font-size: 10px;
+      font-size: var(--text-2xs);
       text-transform: uppercase;
       letter-spacing: 0.12em;
       color: var(--text-secondary);
@@ -185,7 +187,7 @@
       background: transparent;
       color: var(--text);
       font-family: inherit;
-      font-size: 14px;
+      font-size: var(--text-sm);
       line-height: 1.55;
       resize: none;
       outline: none;
@@ -209,7 +211,7 @@
     }
 
     .hint {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-secondary);
       line-height: 1.4;
     }
@@ -221,7 +223,7 @@
       background: var(--bg-hover);
       color: var(--text-secondary);
       font-family: 'Geist Mono', 'SF Mono', monospace;
-      font-size: 10px;
+      font-size: var(--text-2xs);
       border: 1px solid var(--border-mid);
     }
 
@@ -230,7 +232,7 @@
       border-radius: 8px;
       border: none;
       font-family: inherit;
-      font-size: 13px;
+      font-size: var(--text-body);
       font-weight: 500;
       cursor: pointer;
       transition: all 0.12s ease;
@@ -260,7 +262,7 @@
       transform: translateX(-50%) translateY(40px);
       background: var(--accent);
       color: var(--bg);
-      font-size: 12px;
+      font-size: var(--text-xs);
       font-weight: 600;
       padding: 6px 14px;
       border-radius: 20px;

--- a/tauri/src/palette/index.html
+++ b/tauri/src/palette/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Minutes Palette</title>
+  <script src="../scripts/ui-zoom.js"></script>
+  <link rel="stylesheet" href="../styles/ui-zoom-tokens.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -66,7 +68,7 @@
 
     .prefix {
       color: var(--accent);
-      font-size: 14px;
+      font-size: var(--text-sm);
       font-weight: 600;
       letter-spacing: -0.01em;
     }
@@ -77,7 +79,7 @@
       border: none;
       outline: none;
       color: var(--text);
-      font-size: 17px;
+      font-size: var(--text-lg);
       font-weight: 500;
       letter-spacing: -0.01em;
       caret-color: var(--accent);
@@ -88,7 +90,7 @@
     }
 
     .hint {
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
       font-variant-numeric: tabular-nums;
     }
@@ -132,7 +134,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 13px;
+      font-size: var(--text-body);
       flex-shrink: 0;
     }
 
@@ -142,7 +144,7 @@
     }
 
     .row .title {
-      font-size: 14px;
+      font-size: var(--text-sm);
       font-weight: 500;
       letter-spacing: -0.01em;
       white-space: nowrap;
@@ -151,7 +153,7 @@
     }
 
     .row .description {
-      font-size: 12px;
+      font-size: var(--text-xs);
       color: var(--text-secondary);
       margin-top: 1px;
       white-space: nowrap;
@@ -160,7 +162,7 @@
     }
 
     .row .badge {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-weight: 600;
       color: var(--text-tertiary);
       text-transform: uppercase;
@@ -175,7 +177,7 @@
       padding: 28px 18px;
       text-align: center;
       color: var(--text-tertiary);
-      font-size: 13px;
+      font-size: var(--text-body);
     }
 
     .footer {
@@ -183,7 +185,7 @@
       padding: 8px 18px;
       display: flex;
       gap: 16px;
-      font-size: 11px;
+      font-size: var(--text-meta);
       color: var(--text-tertiary);
     }
 
@@ -192,13 +194,13 @@
       border-radius: 3px;
       padding: 1px 5px;
       font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-      font-size: 10px;
+      font-size: var(--text-2xs);
       color: var(--text-secondary);
       margin-right: 4px;
     }
 
     .branding {
-      font-size: 10px;
+      font-size: var(--text-2xs);
       font-weight: 600;
       color: var(--text-tertiary);
       letter-spacing: 0.08em;

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -44,7 +44,9 @@
   });
 
   // On initial load: resize window proportionally to saved zoom.
-  // Skips the main window — its width is managed by the recall panel after load.
+  // Skips the main window — its dimensions are managed by applyRecallWindowLayout
+  // (which reads the zoom ratio at call time) so zoom is applied automatically on
+  // expand/collapse and on uizoomchange. Secondary windows are resized here.
   // Rust owns each window's base size and computes base * (zoom/16), so resizing
   // never reads the window's current dimensions (which would compound on reopen).
   window.addEventListener('DOMContentLoaded', function () {

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -2,11 +2,21 @@
   var ZOOM_KEY = 'minutes.uiZoom';
   var TEXT_BASE = 16;
   var TEXT_MAX = 26;
-  var channel = new BroadcastChannel(ZOOM_KEY);
+  var ZOOM_EVENT = 'uizoom:changed';
 
   function applyZoom(next) {
     document.documentElement.style.setProperty('--text-scale-basis', next);
     document.dispatchEvent(new CustomEvent('uizoomchange', { detail: { value: next } }));
+  }
+
+  function resizeWindow(zoom) {
+    if (!window.__TAURI__) return;
+    var webviewWindow = window.__TAURI__.webviewWindow;
+    if (!webviewWindow) return;
+    var win = webviewWindow.getCurrentWebviewWindow();
+    if (win.label === 'main') return;
+    window.__TAURI__.core.invoke('cmd_scale_window', { label: win.label, zoom: zoom })
+      .catch(function () {});
   }
 
   // Restore before CSS renders
@@ -15,9 +25,22 @@
     document.documentElement.style.setProperty('--text-scale-basis', saved);
   }
 
-  channel.onmessage = function (e) {
-    applyZoom(e.data.value);
-  };
+  // Cross-window zoom sync via Tauri events.
+  // BroadcastChannel is not guaranteed to propagate across separate WKWebView
+  // processes on macOS; Tauri events are the reliable cross-window signal.
+  // Skip if already at this value — Tauri emit echoes back to the sender, and
+  // the sender already applied locally in the keydown handler.
+  if (window.__TAURI__ && window.__TAURI__.event) {
+    window.__TAURI__.event.listen(ZOOM_EVENT, function (e) {
+      var value = e.payload.value;
+      var current = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')
+      ) || TEXT_BASE;
+      if (Math.abs(current - value) < 0.1) return;
+      applyZoom(value);
+      resizeWindow(value);
+    });
+  }
 
   document.addEventListener('keydown', function (e) {
     if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
@@ -39,14 +62,18 @@
     } else {
       return;
     }
+    // Apply locally immediately, then broadcast to other windows.
     applyZoom(next);
-    channel.postMessage({ value: next });
+    resizeWindow(next);
+    if (window.__TAURI__ && window.__TAURI__.event) {
+      window.__TAURI__.event.emit(ZOOM_EVENT, { value: next })
+        .catch(function () {});
+    }
   });
 
-  // On initial load: resize window proportionally to saved zoom.
-  // Skips the main window — its dimensions are managed by applyRecallWindowLayout
-  // (which reads the zoom ratio at call time) so zoom is applied automatically on
-  // expand/collapse and on uizoomchange. Secondary windows are resized here.
+  // On initial load: resize non-main window to persisted zoom.
+  // Main window is handled elsewhere.
+  
   // Rust owns each window's base size and computes base * (zoom/16), so resizing
   // never reads the window's current dimensions (which would compound on reopen).
   window.addEventListener('DOMContentLoaded', function () {

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -9,6 +9,7 @@
     document.dispatchEvent(new CustomEvent('uizoomchange', { detail: { value: next } }));
   }
 
+  // Restore before CSS renders
   var saved = parseFloat(localStorage.getItem(ZOOM_KEY));
   if (saved && saved >= TEXT_BASE && saved <= TEXT_MAX) {
     document.documentElement.style.setProperty('--text-scale-basis', saved);
@@ -20,7 +21,6 @@
 
   document.addEventListener('keydown', function (e) {
     if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
-
     var cur, next;
     if (e.key === '=' || e.key === '+') {
       e.preventDefault();
@@ -39,8 +39,23 @@
     } else {
       return;
     }
-
     applyZoom(next);
     channel.postMessage({ value: next });
+  });
+
+  // On initial load: resize window proportionally to saved zoom.
+  // Skips the main window — its width is managed by the recall panel after load.
+  // Delegates to Rust (cmd_scale_window) — JS-side setSize is silently ignored
+  // for these windows.
+  window.addEventListener('DOMContentLoaded', function () {
+    if (!window.__TAURI__) return;
+    var zoom = parseFloat(localStorage.getItem(ZOOM_KEY));
+    if (!zoom || zoom === TEXT_BASE || zoom < TEXT_BASE || zoom > TEXT_MAX) return;
+    var webviewWindow = window.__TAURI__.webviewWindow;
+    if (!webviewWindow) return;
+    var win = webviewWindow.getCurrentWebviewWindow();
+    if (win.label === 'main') return;
+    window.__TAURI__.core.invoke('cmd_scale_window', { label: win.label, zoom: zoom })
+      .catch(function () {});
   });
 })();

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -1,8 +1,8 @@
 (function () {
-  var ZOOM_KEY = 'minutes.uiZoom';
-  var TEXT_BASE = 16;
-  var TEXT_MAX = 26;
-  var ZOOM_EVENT = 'uizoom:changed';
+  const ZOOM_KEY = 'minutes.uiZoom';
+  const TEXT_BASE = 16;
+  const TEXT_MAX = 26;
+  const ZOOM_EVENT = 'uizoom:changed';
 
   function applyZoom(next) {
     document.documentElement.style.setProperty('--text-scale-basis', next);
@@ -11,16 +11,16 @@
 
   function resizeWindow(zoom) {
     if (!window.__TAURI__) return;
-    var webviewWindow = window.__TAURI__.webviewWindow;
+    const webviewWindow = window.__TAURI__.webviewWindow;
     if (!webviewWindow) return;
-    var win = webviewWindow.getCurrentWebviewWindow();
+    const win = webviewWindow.getCurrentWebviewWindow();
     if (win.label === 'main') return;
     window.__TAURI__.core.invoke('cmd_scale_window', { label: win.label, zoom: zoom })
       .catch(function () {});
   }
 
   // Restore before CSS renders
-  var saved = parseFloat(localStorage.getItem(ZOOM_KEY));
+  const saved = parseFloat(localStorage.getItem(ZOOM_KEY));
   if (saved && saved >= TEXT_BASE && saved <= TEXT_MAX) {
     document.documentElement.style.setProperty('--text-scale-basis', saved);
   }
@@ -32,8 +32,8 @@
   // the sender already applied locally in the keydown handler.
   if (window.__TAURI__ && window.__TAURI__.event) {
     window.__TAURI__.event.listen(ZOOM_EVENT, function (e) {
-      var value = e.payload.value;
-      var current = parseFloat(
+      const value = e.payload.value;
+      const current = parseFloat(
         getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')
       ) || TEXT_BASE;
       if (Math.abs(current - value) < 0.1) return;
@@ -44,15 +44,15 @@
 
   document.addEventListener('keydown', function (e) {
     if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
-    var cur, next;
+    let next;
     if (e.key === '=' || e.key === '+') {
       e.preventDefault();
-      cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || TEXT_BASE;
+      const cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || TEXT_BASE;
       next = Math.min(TEXT_MAX, cur + 2);
       localStorage.setItem(ZOOM_KEY, next);
     } else if (e.key === '-') {
       e.preventDefault();
-      cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || TEXT_BASE;
+      const cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || TEXT_BASE;
       next = Math.max(TEXT_BASE, cur - 2);
       localStorage.setItem(ZOOM_KEY, next);
     } else if (e.key === '0') {
@@ -78,11 +78,11 @@
   // never reads the window's current dimensions (which would compound on reopen).
   window.addEventListener('DOMContentLoaded', function () {
     if (!window.__TAURI__) return;
-    var zoom = parseFloat(localStorage.getItem(ZOOM_KEY));
+    const zoom = parseFloat(localStorage.getItem(ZOOM_KEY));
     if (!zoom || zoom === TEXT_BASE || zoom < TEXT_BASE || zoom > TEXT_MAX) return;
-    var webviewWindow = window.__TAURI__.webviewWindow;
+    const webviewWindow = window.__TAURI__.webviewWindow;
     if (!webviewWindow) return;
-    var win = webviewWindow.getCurrentWebviewWindow();
+    const win = webviewWindow.getCurrentWebviewWindow();
     if (win.label === 'main') return;
     window.__TAURI__.core.invoke('cmd_scale_window', { label: win.label, zoom: zoom })
       .catch(function () {});

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -1,0 +1,6 @@
+(function () {
+  var saved = parseFloat(localStorage.getItem('minutes.uiZoom'));
+  if (saved && saved >= 16 && saved <= 26) {
+    document.documentElement.style.setProperty('--text-scale-basis', saved);
+  }
+})();

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -45,8 +45,8 @@
 
   // On initial load: resize window proportionally to saved zoom.
   // Skips the main window — its width is managed by the recall panel after load.
-  // Delegates to Rust (cmd_scale_window) — JS-side setSize is silently ignored
-  // for these windows.
+  // Rust owns each window's base size and computes base * (zoom/16), so resizing
+  // never reads the window's current dimensions (which would compound on reopen).
   window.addEventListener('DOMContentLoaded', function () {
     if (!window.__TAURI__) return;
     var zoom = parseFloat(localStorage.getItem(ZOOM_KEY));

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -1,6 +1,46 @@
 (function () {
-  var saved = parseFloat(localStorage.getItem('minutes.uiZoom'));
-  if (saved && saved >= 16 && saved <= 26) {
+  var ZOOM_KEY = 'minutes.uiZoom';
+  var TEXT_BASE = 16;
+  var TEXT_MAX = 26;
+  var channel = new BroadcastChannel(ZOOM_KEY);
+
+  function applyZoom(next) {
+    document.documentElement.style.setProperty('--text-scale-basis', next);
+    document.dispatchEvent(new CustomEvent('uizoomchange', { detail: { value: next } }));
+  }
+
+  var saved = parseFloat(localStorage.getItem(ZOOM_KEY));
+  if (saved && saved >= TEXT_BASE && saved <= TEXT_MAX) {
     document.documentElement.style.setProperty('--text-scale-basis', saved);
   }
+
+  channel.onmessage = function (e) {
+    applyZoom(e.data.value);
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+
+    var cur, next;
+    if (e.key === '=' || e.key === '+') {
+      e.preventDefault();
+      cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || TEXT_BASE;
+      next = Math.min(TEXT_MAX, cur + 2);
+      localStorage.setItem(ZOOM_KEY, next);
+    } else if (e.key === '-') {
+      e.preventDefault();
+      cur = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--text-scale-basis')) || TEXT_BASE;
+      next = Math.max(TEXT_BASE, cur - 2);
+      localStorage.setItem(ZOOM_KEY, next);
+    } else if (e.key === '0') {
+      e.preventDefault();
+      next = TEXT_BASE;
+      localStorage.removeItem(ZOOM_KEY);
+    } else {
+      return;
+    }
+
+    applyZoom(next);
+    channel.postMessage({ value: next });
+  });
 })();

--- a/tauri/src/scripts/ui-zoom.js
+++ b/tauri/src/scripts/ui-zoom.js
@@ -43,7 +43,10 @@
   }
 
   document.addEventListener('keydown', function (e) {
-    if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+    // Allow Shift: on US layouts "+" is Shift+"=", so Cmd++ arrives as
+    // Cmd+Shift+"=" (e.key === "+"). The shifted forms of "-"/"0" produce
+    // different keys ("_"/")") that don't match below, so no false triggers.
+    if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
     let next;
     if (e.key === '=' || e.key === '+') {
       e.preventDefault();

--- a/tauri/src/styles/ui-zoom-tokens.css
+++ b/tauri/src/styles/ui-zoom-tokens.css
@@ -1,0 +1,25 @@
+:root {
+  --text-scale-basis: 16;
+
+  /* Scalable typography system, adapted from Tailwind */
+  /* custom — below Tailwind minimum */
+  --text-badge:  0.5625rem;  /* 9px  — 1 rule; candidate for removal in design pass */
+  --text-2xs:    0.625rem;   /* 10px */
+  --text-meta:   0.6875rem;  /* 11px — 52 rules: labels, timestamps, helper text */
+
+  /* Tailwind-exact */
+  --text-xs:     0.75rem;    /* 12px */
+
+  /* custom — between Tailwind xs (12px) and sm (14px) */
+  --text-body:   0.8125rem;  /* 13px — 28 rules: primary prose, inputs, base button */
+
+  /* Tailwind-exact */
+  --text-sm:     0.875rem;   /* 14px — one 15px rule also folded in here */
+  --text-base:   1rem;       /* 16px */
+  --text-lg:     1.125rem;   /* 18px - one 17px rule also folded in here */
+  --text-xl:     1.25rem;    /* 20px */
+  --text-2xl:    1.5rem;     /* 24px — three 22px rules also folded in here */
+  --text-5xl:    3rem;       /* 48px */
+
+  font-size: calc(var(--text-scale-basis) * 1px);
+}


### PR DESCRIPTION
## Summary

- Adds persistent UI zoom with `Cmd++` / `Cmd+-` / `Cmd+0` keyboard shortcuts, stored in Tauri store so it survives restarts
- Extracts shared zoom logic into `ui-zoom.js` + `ui-zoom-tokens.css` and syncs the zoom factor across all windows (dictation overlay, palette, meeting prompt, note) via Tauri events
- Scales window *dimensions* (both main and non-main windows) proportionally with the zoom factor so layouts don't clip

## Still to do
- Adjust layout of meeting detail (column width is way off)
- Scale the About modal width more effectively (more like "What's New")
- Scale the Settings modal width
- Test Artifact template overlay
- Test CLI setup scrim
- Add behavior to terminal.html if needed (doesn't seem to need it?)
- Palette window has a thin square-cornered outline showing outside the curved border radius -- may be pre-existing, but verify
- Naming adjustments for consistency
- Test thoroughly using the demo data
- Make some spacing adjustments where needed
- Discuss spacing tokens vs. ems when it comes to declaring heights

## What changed

| File | Change |
|---|---|
| `tauri/src-tauri/src/main.rs` | Zoom Tauri commands (`cmd_get_zoom`, `cmd_set_zoom`), cross-window sync via `zoom-changed` event, window resize logic |
| `tauri/src/scripts/ui-zoom.js` | Shared zoom bootstrap: reads stored factor, applies CSS `font-size` on `<html>`, listens for sync events |
| `tauri/src/styles/ui-zoom-tokens.css` | CSS custom props for all font-size tiers (9px–48px) as `rem` multiples of the zoom base |
| `tauri/src/index.html` | Imports shared zoom script/styles; `About` and `What's New` modal widths scale with zoom |
| `tauri/src/dictation-overlay.html` | Scalable overlay — imports shared zoom bootstrap |
| `tauri/src/meeting-prompt.html` | Imports shared zoom bootstrap |
| `tauri/src/note.html` | Imports shared zoom bootstrap |
| `tauri/src/palette/index.html` | Imports shared zoom bootstrap |

## Test plan

- [ ] `Cmd++` / `Cmd+-` increase/decrease font size across main window
- [ ] `Cmd+0` resets to default
- [ ] Zoom persists after app restart
- [ ] Dictation overlay, palette, note, and meeting-prompt windows match zoom level
- [ ] Window dimensions scale proportionally — no clipping at min/max zoom
- [ ] About and What's New modal widths scale correctly