### PR TITLE
fix(speaker-mapping): bound timeout, lean agent invocation, kill subprocess tree (#382)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -318,6 +318,12 @@ pub struct SummarizationConfig {
     /// Issue #243: when this budget is exceeded the pipeline emits a
     /// `processing_warnings` entry and promotes status to `degraded`.
     pub agent_timeout_secs: u64,
+    /// Timeout (seconds) for the Level-1 speaker-mapping LLM call specifically.
+    /// Speaker mapping is a tiny JSON classification task, not a full agent run,
+    /// so it gets a much tighter bound than `agent_timeout_secs`. Issue #382: the
+    /// agent path could hang the full (previously hardcoded 120s) budget on MCP
+    /// init and ship meetings anonymous. Clamped to [5, 120] at the call site.
+    pub speaker_mapping_timeout_secs: u64,
     pub chunk_max_tokens: usize,
     pub ollama_url: String,
     pub ollama_model: String,
@@ -1039,6 +1045,7 @@ impl Default for SummarizationConfig {
             engine: "none".into(),
             agent_command: "claude".into(),
             agent_timeout_secs: 300,
+            speaker_mapping_timeout_secs: 30,
             chunk_max_tokens: 4000,
             ollama_url: "http://localhost:11434".into(),
             ollama_model: "llama3.2".into(),

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -921,11 +921,33 @@ fn write_agent_prompt_file(
 fn prepare_agent_invocation(
     agent_cmd: &str,
     prompt: &str,
+    lean: bool,
 ) -> Result<AgentInvocation, Box<dyn std::error::Error>> {
     if matches_agent_binary(agent_cmd, "claude") {
+        // `lean` (#382): speaker mapping is a tiny text->JSON classification, not a
+        // full agent run. Run claude with NO MCP servers and NO tools so it can't
+        // hang on MCP/tool init (loading the user's own Minutes MCP server was a
+        // prime suspect for the 120s hang). `--strict-mcp-config` + an empty
+        // `{"mcpServers":{}}` guarantees zero MCP startup; `--tools ""` disables
+        // tools; plain single-shot print mode.
+        let args = if lean {
+            vec![
+                "-p".into(),
+                "--strict-mcp-config".into(),
+                "--mcp-config".into(),
+                "{\"mcpServers\":{}}".into(),
+                "--tools".into(),
+                String::new(),
+                "--output-format".into(),
+                "text".into(),
+                "-".into(),
+            ]
+        } else {
+            vec!["-p".into(), "-".into()]
+        };
         return Ok(AgentInvocation {
             cmd: agent_cmd.to_string(),
-            args: vec!["-p".into(), "-".into()],
+            args,
             stdin_payload: Some(prompt.as_bytes().to_vec()),
             cleanup_path: None,
         });
@@ -1080,7 +1102,7 @@ fn summarize_with_agent_impl_timeout(
 
     tracing::info!(agent = %agent_cmd, prompt_len = prompt.len(), "summarizing via agent CLI");
 
-    let invocation = prepare_agent_invocation(&agent_cmd, &prompt)?;
+    let invocation = prepare_agent_invocation(&agent_cmd, &prompt, false)?;
     let cleanup_path = invocation.cleanup_path.clone();
 
     // AIDEV-NOTE: Use Stdio::null() when no stdin payload is needed (e.g. pi, opencode
@@ -1929,7 +1951,7 @@ fn run_title_refinement_via_agent(
 ) -> Result<String, Box<dyn std::error::Error>> {
     use std::io::Write;
 
-    let invocation = prepare_agent_invocation(agent_cmd, prompt)?;
+    let invocation = prepare_agent_invocation(agent_cmd, prompt, false)?;
     let cleanup_path = invocation.cleanup_path.clone();
     // Same fix as summarize_with_agent_impl_timeout (#288): file-arg agents
     // (pi, opencode) have no stdin payload, and an unclosed piped stdin makes
@@ -2249,7 +2271,8 @@ fn run_speaker_mapping_via_agent(
         config.summarization.agent_command.clone()
     };
     let agent_cmd = resolve_agent_path(&agent_cmd);
-    let invocation = prepare_agent_invocation(&agent_cmd, prompt)?;
+    // Speaker mapping runs the agent in `lean` mode (no MCP, no tools): #382.
+    let invocation = prepare_agent_invocation(&agent_cmd, prompt, true)?;
     let cleanup_path = invocation.cleanup_path.clone();
     // Same fix as summarize_with_agent_impl_timeout (#288): file-arg agents
     // (pi, opencode) have no stdin payload, and an unclosed piped stdin makes
@@ -2259,18 +2282,26 @@ fn run_speaker_mapping_via_agent(
     } else {
         std::process::Stdio::null()
     };
-    let mut child = std::process::Command::new(&invocation.cmd)
+    let mut command = std::process::Command::new(&invocation.cmd);
+    command
         .args(&invocation.args)
         .stdin(stdin_stdio)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| {
-            if let Some(path) = cleanup_path.as_ref() {
-                let _ = std::fs::remove_file(path);
-            }
-            format!("Agent '{}' not found: {}", agent_cmd, e)
-        })?;
+        .stderr(std::process::Stdio::piped());
+    // Put the agent in its own process group so a timeout can kill the WHOLE tree
+    // (#382): `claude` spawns MCP/tool child processes that would otherwise leak as
+    // stuck agents if we killed only the direct child.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let mut child = command.spawn().map_err(|e| {
+        if let Some(path) = cleanup_path.as_ref() {
+            let _ = std::fs::remove_file(path);
+        }
+        format!("Agent '{}' not found: {}", agent_cmd, e)
+    })?;
     if let Some(bytes) = invocation.stdin_payload.clone() {
         let mut stdin = child
             .stdin
@@ -2280,8 +2311,17 @@ fn run_speaker_mapping_via_agent(
             stdin.write_all(&bytes).ok();
         });
     }
-    let timeout = std::time::Duration::from_secs(120);
+    // Tight, dedicated bound for speaker mapping (#382): a tiny JSON task must never
+    // burn the full agent budget. Clamp to a sane range so config can't reintroduce
+    // the old 120s+ hang or set an unusably short deadline.
+    let timeout = std::time::Duration::from_secs(
+        config
+            .summarization
+            .speaker_mapping_timeout_secs
+            .clamp(5, 120),
+    );
     let start = std::time::Instant::now();
+    let child_pid = child.id();
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
@@ -2300,7 +2340,11 @@ fn run_speaker_mapping_via_agent(
             }
             Ok(None) => {
                 if start.elapsed() > timeout {
+                    // Signal the whole group first (terminates MCP/tool children the
+                    // agent spawned), then the direct child, then reap to avoid a zombie.
+                    kill_process_group(child_pid);
                     child.kill().ok();
+                    let _ = child.wait();
                     if let Some(path) = cleanup_path.as_ref() {
                         let _ = std::fs::remove_file(path);
                     }
@@ -2312,6 +2356,28 @@ fn run_speaker_mapping_via_agent(
         }
     }
 }
+
+/// Signal the process group led by `pid`. The speaker-mapping agent is spawned as a
+/// group leader (`process_group(0)`), so `kill(-pid)` reaches the MCP/tool children
+/// it started, not just the direct child (#382). No-op on non-Unix; the caller also
+/// kills the direct child via `Child::kill`.
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    let pgid: libc::pid_t = -(pid as libc::pid_t);
+    // Safety: a plain kill(2) syscall.
+    let rc = unsafe { libc::kill(pgid, libc::SIGKILL) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        // ESRCH = the group already exited; anything else is a real (rare) failure
+        // of the leak guard, worth a breadcrumb since this whole bug was silent.
+        if err.raw_os_error() != Some(libc::ESRCH) {
+            tracing::debug!(pid, error = %err, "speaker-mapping group kill failed");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(_pid: u32) {}
 
 fn parse_speaker_mapping(
     response: &str,
@@ -2835,7 +2901,7 @@ PARTICIPANTS:
     fn prepare_agent_invocation_for_codex_skips_git_repo_check() {
         // Regression: summaries run in a non-repo job dir; without the bypass
         // Codex refuses to start and the summary degrades.
-        let invocation = prepare_agent_invocation("codex", "sensitive prompt").unwrap();
+        let invocation = prepare_agent_invocation("codex", "sensitive prompt", false).unwrap();
         assert_eq!(invocation.cmd, "codex");
         assert_eq!(
             invocation.args,
@@ -2849,11 +2915,30 @@ PARTICIPANTS:
     }
 
     #[test]
+    fn prepare_agent_invocation_claude_lean_disables_mcp_and_tools() {
+        // #382: speaker mapping must run claude with no MCP servers and no tools so
+        // it can't hang on MCP/tool init. Non-lean keeps the plain `-p -` form.
+        let lean = prepare_agent_invocation("claude", "p", true).unwrap();
+        assert!(lean.args.iter().any(|a| a == "--strict-mcp-config"));
+        assert!(lean.args.iter().any(|a| a == "--mcp-config"));
+        assert!(lean.args.iter().any(|a| a == "{\"mcpServers\":{}}"));
+        assert!(lean
+            .args
+            .windows(2)
+            .any(|w| w[0] == "--tools" && w[1].is_empty()));
+        assert!(lean.args.iter().any(|a| a == "-")); // prompt still on stdin
+
+        let plain = prepare_agent_invocation("claude", "p", false).unwrap();
+        assert_eq!(plain.args, vec!["-p", "-"]);
+        assert!(!plain.args.iter().any(|a| a == "--strict-mcp-config"));
+    }
+
+    #[test]
     fn prepare_agent_invocation_for_gemini_skips_workspace_trust() {
         // Regression (#280-adjacent): Gemini refuses to run in an untrusted
         // workspace ("not running in a trusted directory"), so the non-repo
         // job dir degraded summaries until --skip-trust was passed.
-        let invocation = prepare_agent_invocation("gemini", "sensitive prompt").unwrap();
+        let invocation = prepare_agent_invocation("gemini", "sensitive prompt", false).unwrap();
         assert_eq!(invocation.cmd, "gemini");
         assert_eq!(invocation.args, vec!["-p", "-", "--skip-trust"]);
         assert_eq!(
@@ -2866,7 +2951,8 @@ PARTICIPANTS:
     #[test]
     fn prepare_agent_invocation_for_opencode_uses_message_before_file_and_no_stdin() {
         with_temp_home(|home| {
-            let invocation = prepare_agent_invocation("opencode", "sensitive prompt").unwrap();
+            let invocation =
+                prepare_agent_invocation("opencode", "sensitive prompt", false).unwrap();
             assert_eq!(invocation.cmd, "opencode");
             assert_eq!(invocation.args[0], "run");
             assert_eq!(
@@ -2886,7 +2972,7 @@ PARTICIPANTS:
     #[test]
     fn prepare_agent_invocation_for_pi_uses_private_file_and_no_tools() {
         with_temp_home(|home| {
-            let invocation = prepare_agent_invocation("pi", "sensitive prompt").unwrap();
+            let invocation = prepare_agent_invocation("pi", "sensitive prompt", false).unwrap();
             assert_eq!(invocation.cmd, "pi");
             let arg_prefix = invocation.args[..7]
                 .iter()

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -55,6 +55,7 @@ So `minutes record --device "MacBook Pro Microphone"` always wins over `[recordi
 | `openai_compatible_api_key_env` | unset | Optional environment variable name containing the API key. Leave blank for local servers. The desktop app can also save a gateway key in macOS Keychain and use that runtime secret for non-local endpoints without rewriting shared config. |
 | `mistral_model` | `"mistral-large-latest"` | Mistral API model |
 | `chunk_max_tokens` | `4000` | Max tokens per chunk when splitting long transcripts |
+| `speaker_mapping_timeout_secs` | `30` | Tight timeout for the Level-1 speaker-naming LLM call. On the agent path it also runs with no MCP servers and no tools so it can't hang on init. Clamped to [5, 120]. |
 
 For Pi coding-agent support, use `engine = "agent"` with `agent_command = "pi"`.
 Minutes invokes Pi in non-interactive, no-tools mode. This is distinct from

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 53;
-export const MINUTES_TEST_COUNT = 1268;
+export const MINUTES_TEST_COUNT = 1289;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Closes #382.

## Root cause (confirmed in code)
Level-1 speaker mapping runs through the configured summarization engine. On the default no-API-key path (`engine = "auto"/"agent"`), it called `run_speaker_mapping_via_agent`, which spawned the full Claude agent CLI (tool/MCP-enabled) and waited on a **hardcoded 120s** (not the configurable `agent_timeout_secs`), with no retry. On real multi-party calls it consistently hit the cap with zero output, so meetings shipped anonymous except the recorder — visible only in the JSON log. The prompt is already truncated to ~3KB, so payload size isn't the cause; MCP/tool init is (possibly loading the user's own Minutes MCP server).

## Fix (agent path only)
1. **Lean claude invocation** — speaker mapping now runs `claude -p --strict-mcp-config --mcp-config '{"mcpServers":{}}' --tools "" --output-format text` (no MCP, no tools, plain completion). It's a tiny text→JSON classification; it never needed an agent loop. Flags verified against the installed `claude` 2.1.195.
2. **Dedicated clamped timeout** — new `summarization.speaker_mapping_timeout_secs` (default **30**, clamped `[5,120]`) replaces the hardcoded 120s. No retry on timeout (a persistent MCP hang would only double the wait — per codex).
3. **Subprocess-tree kill** — the agent is spawned in its own process group; on timeout the whole group is killed (`libc::kill(-pgid)`) then the direct child, then reaped. Prevents claude's MCP/tool children leaking as stuck agents (codex flagged this as a blocker in plan review).

## What's deliberately unchanged / preserved
- Graceful degradation: a failed mapping returns no LLM attributions; the deterministic stem-based recorder self-attribution and its **stem-only gate are kept** (the gate is a correctness decision — you can't reliably ID the recorder without per-source stems). A hung mapping never discards a good diarization.
- Degraded runs don't inject low-confidence names, so the #365 aggressive-name-correction participant pool isn't widened.

## Deferred (own follow-up)
`minutes redo-speaker-mapping` and frontmatter health surfacing — codex flagged the redo command's brittle markdown parsing and `minutes → claude → minutes MCP` re-entrancy, which deserve a proper source-of-truth contract. **Recovery in the meantime: reprocess the affected meetings once this lands** (mapping now completes instead of hanging).

## Verification
- Process history checked first to avoid overwriting rationale: the 120s cap originated in a "prevent processing hangs" commit (this tightens that intent); recent attribution ships (#364/#365) are a separate post-pass layer.
- **Plan and implementation both adversarially reviewed via codex — no blockers.** Codex confirmed the process-group/`kill(-pid)` race-safety, pipe/reap correctness, argv shape, clamp, and non-lean/non-unix paths are all clean.
- 857 core tests pass (incl. a new test asserting the lean claude args), clippy + fmt clean.
- Lean flags verified live on macOS (claude 2.1.195) — accepted and fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
