### PR TITLE
feat(cli): `minutes redo-speaker-mapping` recovery command + speaker-mapping health (#384)

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,17 @@ minutes voices --json       # JSON output
 minutes voices --delete     # Remove all profiles
 ```
 
+**Recover a failed mapping (Level 1).** If a meeting shipped with anonymous `SPEAKER_n` labels (the Level-1 call timed out, errored, or ran before attendees were known), re-run just the speaker mapping without reprocessing the audio:
+
+```bash
+minutes redo-speaker-mapping <meeting>                          # dry run: show the proposed map
+minutes redo-speaker-mapping <meeting> --apply                  # write speaker_map + a speaker_mapping health block
+minutes redo-speaker-mapping <meeting> --engine ollama --apply  # override the engine for this run
+minutes redo-speaker-mapping <meeting> --json                   # machine-readable output
+```
+
+`<meeting>` is a path or a search term. The command never downgrades an existing High-confidence attribution, and it records a `speaker_mapping:` health block in the frontmatter (status `ok` / `empty` / `skipped`, plus the model, speaker/attendee counts, and timing) so a meeting that shipped anonymous is both greppable and re-runnable.
+
 **Privacy**: Voice enrollment is self-only (no enrolling others). Level 3 confirmed profiles require explicit opt-in per person. Voice embeddings are stored locally in `~/.minutes/voices.db` with 0600 permissions. Nothing leaves your machine.
 
 > **Platform notes:** Calendar integration (auto-detecting meeting attendees) requires macOS. Screen context capture works on macOS and Linux. The voice memo pipeline works on all platforms — any folder sync (iCloud, Dropbox, Google Drive, Syncthing) can feed the watcher. The `minutes service install` auto-start command requires macOS (launchd); on Linux, use systemd or cron. Speaker diarization (`pyannote-rs`) works on all platforms (CLI, Tauri app, and via MCP). All other features — recording, transcription, search, action items, person profiles — work on all platforms.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -724,6 +724,24 @@ enum Commands {
         apply: bool,
     },
 
+    /// Re-run speaker mapping on an existing meeting (recovery for failed/missing maps)
+    RedoSpeakerMapping {
+        /// Path to meeting .md file, or a search term to find one
+        meeting: String,
+
+        /// Actually write the new speaker map (default: dry-run showing what would change)
+        #[arg(long)]
+        apply: bool,
+
+        /// Override the summarization engine for this run (e.g. "agent", "ollama", "mistral")
+        #[arg(long)]
+        engine: Option<String>,
+
+        /// Emit machine-readable JSON instead of human output
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Process an audio file through the pipeline
     Process {
         /// Path to audio file (.wav, .m4a, .mp3)
@@ -1663,6 +1681,12 @@ fn main() -> Result<()> {
         } => cmd_export(content_type, output, &config),
         Commands::Ingest { path, all, dry_run } => cmd_ingest(path, all, dry_run, &config),
         Commands::Clean { meeting, apply } => cmd_clean(&meeting, apply, &config),
+        Commands::RedoSpeakerMapping {
+            meeting,
+            apply,
+            engine,
+            json,
+        } => cmd_redo_speaker_mapping(&meeting, apply, engine, json, &config),
         Commands::Process {
             path,
             content_type,
@@ -4224,6 +4248,345 @@ fn cmd_ingest(path: Option<PathBuf>, all: bool, dry_run: bool, config: &Config) 
     Ok(())
 }
 
+/// Resolve a single meeting `.md` file from a path or search term.
+///
+/// Both branches canonicalize the result and require it to live under the
+/// meetings directory, so neither a crafted path nor a symlinked search hit can
+/// point a mutating command at a file outside the user's meetings.
+fn resolve_single_meeting(meeting: &str, config: &Config) -> Result<std::path::PathBuf> {
+    let meetings_dir = &config.output_dir;
+    let meetings_canonical = meetings_dir
+        .canonicalize()
+        .unwrap_or_else(|_| meetings_dir.clone());
+    let ensure_contained = |canonical: std::path::PathBuf| -> Result<std::path::PathBuf> {
+        if !canonical.starts_with(&meetings_canonical) {
+            anyhow::bail!(
+                "path {} is outside the meetings directory ({})",
+                canonical.display(),
+                meetings_dir.display()
+            );
+        }
+        Ok(canonical)
+    };
+
+    let path = std::path::PathBuf::from(meeting);
+    if path.exists() {
+        return ensure_contained(path.canonicalize()?);
+    }
+
+    // Restrict the search to meetings so a memo/dictation never resolves here.
+    let filters = minutes_core::search::SearchFilters {
+        content_type: Some("meeting".into()),
+        since: None,
+        attendee: None,
+        intent_kind: None,
+        owner: None,
+        recorded_by: None,
+    };
+    let results = minutes_core::search::search(meeting, config, &filters)?;
+    if results.is_empty() {
+        anyhow::bail!("no meeting found matching: {}", meeting);
+    }
+    let canonical = ensure_contained(results[0].path.canonicalize()?)?;
+    eprintln!("  Matched: {}", canonical.display());
+    Ok(canonical)
+}
+
+/// Extract the body of the `## Transcript` section. Scans line-by-line so a
+/// fenced code block or a heading like `## Transcript cleanup notes` cannot be
+/// mistaken for the real transcript: only an H2 whose text is exactly
+/// `Transcript` (outside any code fence) opens the section, and the next real H2
+/// closes it. Returns `None` when there is no such section.
+fn transcript_section(body: &str) -> Option<String> {
+    // Track which marker opened the current fence so a `~~~` line inside a
+    // ``` block (or vice versa) is treated as content, not as a fence toggle.
+    let mut fence: Option<char> = None;
+    let mut found = false;
+    let mut collected: Vec<&str> = Vec::new();
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        let marker = if trimmed.starts_with("```") {
+            Some('`')
+        } else if trimmed.starts_with("~~~") {
+            Some('~')
+        } else {
+            None
+        };
+        if let Some(m) = marker {
+            match fence {
+                None => fence = Some(m),                 // open a fence
+                Some(open) if open == m => fence = None, // close only on a matching marker
+                Some(_) => {}                            // other marker inside a fence: content
+            }
+            if found {
+                collected.push(line);
+            }
+            continue;
+        }
+        if fence.is_none() {
+            if let Some(rest) = line.strip_prefix("## ") {
+                if found {
+                    break; // next section ends the transcript
+                }
+                if rest.trim() == "Transcript" {
+                    found = true;
+                    continue;
+                }
+            }
+        }
+        if found {
+            collected.push(line);
+        }
+    }
+    if !found {
+        return None;
+    }
+    Some(collected.join("\n").trim_start_matches('\n').to_string())
+}
+
+/// Merge a freshly-computed speaker map into the existing one without ever
+/// downgrading an existing High-confidence attribution. Fresh entries (Medium at
+/// most, from the LLM) fill in or refresh anything not already High-confidence.
+fn merge_speaker_map(
+    existing: &[minutes_core::diarize::SpeakerAttribution],
+    fresh: &[minutes_core::diarize::SpeakerAttribution],
+) -> Vec<minutes_core::diarize::SpeakerAttribution> {
+    use minutes_core::diarize::Confidence;
+    use std::collections::BTreeMap;
+
+    fn rank(c: Confidence) -> u8 {
+        match c {
+            Confidence::High => 2,
+            Confidence::Medium => 1,
+            Confidence::Low => 0,
+        }
+    }
+
+    let mut by_label: BTreeMap<String, minutes_core::diarize::SpeakerAttribution> = BTreeMap::new();
+    // Fold existing entries, keeping the highest-confidence one per label. This
+    // guards against a malformed frontmatter that lists the same label twice
+    // (e.g. High then Medium) silently dropping the High before merge.
+    for a in existing {
+        match by_label.get(&a.speaker_label) {
+            Some(cur) if rank(cur.confidence) >= rank(a.confidence) => {}
+            _ => {
+                by_label.insert(a.speaker_label.clone(), a.clone());
+            }
+        }
+    }
+    // Apply fresh results only where the retained existing entry is not High.
+    for a in fresh {
+        match by_label.get(&a.speaker_label) {
+            Some(cur) if cur.confidence == Confidence::High => {} // never downgrade
+            _ => {
+                by_label.insert(a.speaker_label.clone(), a.clone());
+            }
+        }
+    }
+    by_label.into_values().collect()
+}
+
+/// Re-run Level-1 speaker mapping on an existing meeting and (with `--apply`)
+/// write the merged map plus a `speaker_mapping` health block. Recovery path for
+/// meetings whose mapping failed, timed out, or never ran.
+fn cmd_redo_speaker_mapping(
+    meeting: &str,
+    apply: bool,
+    engine: Option<String>,
+    json: bool,
+    config: &Config,
+) -> Result<()> {
+    let path = resolve_single_meeting(meeting, config)?;
+    let content = std::fs::read_to_string(&path)?;
+    let (fm_str, body) = minutes_core::markdown::split_frontmatter(&content);
+    if fm_str.is_empty() {
+        anyhow::bail!(
+            "{} is not a meeting file (no YAML frontmatter)",
+            path.display()
+        );
+    }
+    let fm: minutes_core::markdown::Frontmatter = serde_yaml::from_str(fm_str)
+        .map_err(|e| anyhow::anyhow!("could not parse frontmatter in {}: {e}", path.display()))?;
+
+    // Only meetings carry diarized speaker labels. Refuse memos/dictation so we
+    // never write a speaker map (or call the LLM) on a non-meeting file.
+    if fm.r#type != minutes_core::markdown::ContentType::Meeting {
+        anyhow::bail!(
+            "{} is type {:?}, not a meeting; redo-speaker-mapping only operates on meetings",
+            path.display(),
+            fm.r#type
+        );
+    }
+
+    // Source-of-truth contract: we map the diarized transcript against the
+    // recorded attendee pool. If either is missing there is nothing to do, and
+    // we say exactly which side is missing rather than silently producing junk.
+    let transcript = transcript_section(body);
+    let labels: Vec<String> = transcript
+        .as_deref()
+        .map(minutes_core::summarize::extract_speaker_labels_pub)
+        .unwrap_or_default();
+    let attendees = fm.normalized_attendees();
+
+    // Engine override (validated lazily by the summarizer).
+    let mut cfg = config.clone();
+    if let Some(e) = &engine {
+        cfg.summarization.engine = e.clone();
+    }
+    let model = minutes_core::summarize::speaker_mapping_model_hint(&cfg);
+
+    // Contract failures short-circuit to a `skipped` health block.
+    let skip_reason: Option<&str> = if transcript.is_none() {
+        Some("no ## Transcript section in this meeting")
+    } else if labels.is_empty() {
+        Some("no anonymous SPEAKER_n labels remain to remap")
+    } else if attendees.is_empty() {
+        Some("no attendees recorded to map against; add attendees: to the frontmatter and retry")
+    } else {
+        None
+    };
+
+    if let Some(reason) = skip_reason {
+        let health = minutes_core::markdown::SpeakerMappingHealth {
+            status: "skipped".into(),
+            model,
+            diarized_speakers: labels.len(),
+            mapped_speakers: 0,
+            attendees: attendees.len(),
+            duration_ms: None,
+            reason: Some(reason.to_string()),
+            last_run: Some(Local::now().to_rfc3339()),
+        };
+        report_redo_result(
+            &path,
+            apply,
+            json,
+            &fm.speaker_map,
+            &fm.speaker_map,
+            &health,
+            config,
+        )?;
+        return Ok(());
+    }
+
+    let transcript = transcript.expect("transcript present past contract check");
+    let started = std::time::Instant::now();
+    let fresh = minutes_core::summarize::map_speakers(&transcript, &attendees, &cfg, None);
+    let duration_ms = started.elapsed().as_millis() as u64;
+    let merged = merge_speaker_map(&fm.speaker_map, &fresh);
+
+    let health = minutes_core::markdown::SpeakerMappingHealth {
+        status: if fresh.is_empty() {
+            "empty".into()
+        } else {
+            "ok".into()
+        },
+        model,
+        diarized_speakers: labels.len(),
+        mapped_speakers: fresh.len(),
+        attendees: attendees.len(),
+        duration_ms: Some(duration_ms),
+        reason: if fresh.is_empty() {
+            Some("mapper ran but produced no confident matches".into())
+        } else {
+            None
+        },
+        last_run: Some(Local::now().to_rfc3339()),
+    };
+
+    report_redo_result(
+        &path,
+        apply,
+        json,
+        &fm.speaker_map,
+        &merged,
+        &health,
+        config,
+    )?;
+    Ok(())
+}
+
+/// Apply (when `--apply`) then render the outcome of a redo run.
+///
+/// The write happens BEFORE any output so a failed write returns an error
+/// instead of first printing a success line/JSON the caller would trust. On
+/// `--apply` the `speaker_mapping` health block is always recorded (so a re-run
+/// is visible in the frontmatter) even when the map itself did not change.
+fn report_redo_result(
+    path: &std::path::Path,
+    apply: bool,
+    json: bool,
+    before: &[minutes_core::diarize::SpeakerAttribution],
+    after: &[minutes_core::diarize::SpeakerAttribution],
+    health: &minutes_core::markdown::SpeakerMappingHealth,
+    _config: &Config,
+) -> Result<()> {
+    let map_changed = before != after;
+    let mut frontmatter_written = false;
+
+    // Write first: if this fails we propagate the error and emit no success output.
+    if apply {
+        let health_owned = health.clone();
+        if map_changed {
+            let after_owned = after.to_vec();
+            minutes_core::markdown::update_frontmatter(path, move |f| {
+                f.speaker_map = after_owned;
+                f.speaker_mapping = Some(health_owned);
+            })?;
+        } else {
+            minutes_core::markdown::update_frontmatter(path, move |f| {
+                f.speaker_mapping = Some(health_owned);
+            })?;
+        }
+        frontmatter_written = true;
+    }
+
+    if json {
+        let payload = serde_json::json!({
+            "path": path.display().to_string(),
+            "map_changed": map_changed,
+            "written": frontmatter_written,
+            "health": health,
+            "speaker_map": after,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_envelope("redo-speaker-mapping", payload))?
+        );
+        return Ok(());
+    }
+
+    println!("Meeting: {}", path.display());
+    println!(
+        "  status: {} ({} of {} labels named, {} attendees)",
+        health.status, health.mapped_speakers, health.diarized_speakers, health.attendees
+    );
+    if let Some(reason) = &health.reason {
+        println!("  reason: {reason}");
+    }
+    if after.is_empty() {
+        println!("  map: (none)");
+    } else {
+        for a in after {
+            println!(
+                "  map: {} -> {} [{:?}, {:?}]",
+                a.speaker_label, a.name, a.confidence, a.source
+            );
+        }
+    }
+    if frontmatter_written {
+        if map_changed {
+            println!("  written: speaker_map + speaker_mapping health updated");
+        } else {
+            println!("  written: speaker_mapping health updated (map unchanged)");
+        }
+    } else {
+        println!("  (dry run: re-run with --apply to write)");
+    }
+
+    Ok(())
+}
+
 fn cmd_clean(meeting: &str, apply: bool, config: &Config) -> Result<()> {
     let meetings_dir = &config.output_dir;
 
@@ -6739,6 +7102,96 @@ mod tests {
         }
         std::fs::remove_dir_all(&dir).ok();
         result
+    }
+
+    fn attr(
+        label: &str,
+        name: &str,
+        confidence: minutes_core::diarize::Confidence,
+    ) -> minutes_core::diarize::SpeakerAttribution {
+        minutes_core::diarize::SpeakerAttribution {
+            speaker_label: label.into(),
+            name: name.into(),
+            confidence,
+            source: minutes_core::diarize::AttributionSource::Llm,
+        }
+    }
+
+    #[test]
+    fn merge_speaker_map_never_downgrades_high() {
+        use minutes_core::diarize::Confidence;
+        let existing = vec![attr("SPEAKER_00", "Sarah", Confidence::High)];
+        let fresh = vec![
+            attr("SPEAKER_00", "Someone Else", Confidence::Medium),
+            attr("SPEAKER_01", "Dan", Confidence::Medium),
+        ];
+        let merged = merge_speaker_map(&existing, &fresh);
+        let s0 = merged
+            .iter()
+            .find(|a| a.speaker_label == "SPEAKER_00")
+            .unwrap();
+        assert_eq!(s0.name, "Sarah", "existing High must survive");
+        assert_eq!(s0.confidence, Confidence::High);
+        let s1 = merged
+            .iter()
+            .find(|a| a.speaker_label == "SPEAKER_01")
+            .unwrap();
+        assert_eq!(s1.name, "Dan", "fresh fills in unmapped labels");
+    }
+
+    #[test]
+    fn merge_speaker_map_preserves_high_on_duplicate_existing_labels() {
+        use minutes_core::diarize::Confidence;
+        // Malformed frontmatter: same label listed twice, High then Medium.
+        let existing = vec![
+            attr("SPEAKER_00", "Sarah", Confidence::High),
+            attr("SPEAKER_00", "sarah lower", Confidence::Medium),
+        ];
+        // Even with an empty fresh map, the High entry must not be lost.
+        let merged = merge_speaker_map(&existing, &[]);
+        let s0 = merged
+            .iter()
+            .find(|a| a.speaker_label == "SPEAKER_00")
+            .unwrap();
+        assert_eq!(s0.name, "Sarah");
+        assert_eq!(s0.confidence, Confidence::High);
+        assert_eq!(merged.len(), 1, "duplicate labels collapse to one");
+    }
+
+    #[test]
+    fn transcript_section_requires_exact_heading() {
+        // A look-alike heading must not be treated as the transcript.
+        let body = "## Transcript cleanup notes\n\n[SPEAKER_00 0:00] not the transcript\n";
+        assert!(transcript_section(body).is_none());
+    }
+
+    #[test]
+    fn transcript_section_ignores_fenced_code_block() {
+        // A `## Transcript` line inside a code fence must be ignored; the real
+        // section after the fence is the one that wins.
+        let body = "## Summary\n\n```\n## Transcript\n[SPEAKER_99 0:00] fake\n```\n\n## Transcript\n\n[SPEAKER_00 0:00] real line\n";
+        let t = transcript_section(body).expect("real transcript section found");
+        assert!(t.contains("real line"));
+        assert!(!t.contains("fake"));
+    }
+
+    #[test]
+    fn transcript_section_handles_mixed_fence_markers() {
+        // A backtick fence whose body contains a `~~~` line must NOT be treated
+        // as closed by that tilde line; the fake `## Transcript` inside stays
+        // ignored and the real section after the fence wins.
+        let body = "## Summary\n\n```\n~~~\n## Transcript\n[SPEAKER_99 0:00] fake\n```\n\n## Transcript\n\n[SPEAKER_00 0:00] real line\n";
+        let t = transcript_section(body).expect("real transcript section found");
+        assert!(t.contains("real line"));
+        assert!(!t.contains("fake"));
+    }
+
+    #[test]
+    fn transcript_section_extracts_first_and_stops_at_next_h2() {
+        let body = "## Transcript\n\n[SPEAKER_00 0:00] hello\n\n## Action Items\n\n- do thing\n";
+        let t = transcript_section(body).unwrap();
+        assert!(t.contains("hello"));
+        assert!(!t.contains("Action Items"));
     }
 
     #[test]

--- a/crates/core/src/daily_notes.rs
+++ b/crates/core/src/daily_notes.rs
@@ -306,6 +306,7 @@ mod tests {
             speaker_map: vec![],
             name_corrections: Vec::new(),
             recording_health: None,
+            speaker_mapping: None,
             processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,

--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -142,7 +142,7 @@ pub enum AttributionSource {
 }
 
 /// A mapping from an anonymous speaker label to a real person.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SpeakerAttribution {
     pub speaker_label: String,
     pub name: String,

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -1203,6 +1203,7 @@ fn write_dictation_file(text: &str, duration_secs: f64, config: &Config) -> Opti
         speaker_map: vec![],
         name_corrections: Vec::new(),
         recording_health: None,
+        speaker_mapping: None,
         template: None,
         filter_diagnosis: None,
     };

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -1808,6 +1808,7 @@ mod tests {
                 speaker_map: vec![],
                 name_corrections: Vec::new(),
                 recording_health: None,
+                speaker_mapping: None,
                 processing_warnings: Vec::new(),
                 template: None,
                 filter_diagnosis: Some("silence strip removed ALL audio".into()),

--- a/crates/core/src/knowledge_extract.rs
+++ b/crates/core/src/knowledge_extract.rs
@@ -240,6 +240,7 @@ mod tests {
             speaker_map: vec![],
             name_corrections: Vec::new(),
             recording_health: None,
+            speaker_mapping: None,
             processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -134,6 +134,37 @@ pub struct ProcessingWarning {
     pub message: Option<String>,
 }
 
+/// Health of the Level-1 speaker-naming (`speaker_mapping`) step, surfaced in
+/// frontmatter so a meeting that shipped anonymous is greppable and re-runnable
+/// (#382/#384). Counts are recorded separately from confidence so "a map exists"
+/// is never confused with "every speaker was named".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SpeakerMappingHealth {
+    /// `ok` (some labels named), `empty` (ran, no confident matches), `skipped`
+    /// (no anonymous labels or no attendees to map against). Mirrors the
+    /// `speaker_mapping` JSONL `outcome` vocabulary.
+    pub status: String,
+    /// Engine/model hint used (e.g. `agent:claude`).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub model: String,
+    /// Distinct diarization speaker labels present (proxy for the raw diarization
+    /// speaker count, which needs the audio and so isn't recoverable on a redo).
+    pub diarized_speakers: usize,
+    /// How many of those labels received a name.
+    pub mapped_speakers: usize,
+    /// Size of the attendee pool offered to the mapper.
+    pub attendees: usize,
+    /// Wall-clock of the mapping call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Machine-readable reason when `status` is not `ok`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// RFC3339 timestamp of the most recent mapping run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct RecordingHealth {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -288,6 +319,11 @@ pub struct Frontmatter {
     pub name_corrections: Vec<crate::name_correction::NameCorrection>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recording_health: Option<RecordingHealth>,
+    /// Health of the Level-1 speaker-naming step. Lets a meeting be greppable for
+    /// "naming failed / incomplete" instead of the failure living only in the JSON
+    /// log (#384). `None` for meetings processed before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speaker_mapping: Option<SpeakerMappingHealth>,
     /// Slug of the template applied to this recording, if any.
     /// Recorded so a Phase 2 reprocessor knows which template produced the
     /// summary. `None` means no template was passed (legacy / default flow).
@@ -1001,6 +1037,81 @@ fn resolve_collision(dir: &Path, filename: &str) -> PathBuf {
     dir.join(format!("{}-{}.md", stem, ts))
 }
 
+/// Surgically update only a meeting's frontmatter, preserving the body
+/// (summary / notes / transcript) byte-for-byte.
+///
+/// Unlike [`rewrite`], which regenerates the whole file from passed-in sections,
+/// this parses the existing frontmatter, applies `update`, re-serializes only the
+/// YAML block, and splices it back in front of the original body. Fail-closed:
+/// refuses files without parseable frontmatter, validates the result parses
+/// before swapping, and writes atomically via a tmp sibling while preserving the
+/// original file mode (#384).
+///
+/// This is a generic frontmatter updater: it does NOT enforce `type: meeting`.
+/// Callers that should only touch meetings must check `frontmatter.r#type`
+/// themselves (see `cmd_redo_speaker_mapping`).
+pub fn update_frontmatter<F>(path: &Path, update: F) -> Result<(), MarkdownError>
+where
+    F: FnOnce(&mut Frontmatter),
+{
+    let original = fs::read_to_string(path)?;
+    // Take the body slice straight from `split_frontmatter` so we share its exact
+    // boundary semantics. `body` is a suffix slice of `original`, so splicing it
+    // back verbatim preserves every body byte even for oddly-fenced inputs (no
+    // second, subtly-different offset computation that could drop bytes; #384).
+    let (fm_str, body) = split_frontmatter(&original);
+    if fm_str.is_empty() {
+        return Err(MarkdownError::RenameRefused(
+            "not a meeting file (no frontmatter)".into(),
+        ));
+    }
+    let mut frontmatter: Frontmatter = serde_yaml::from_str(fm_str)
+        .map_err(|e| MarkdownError::RenameRefused(format!("frontmatter does not parse: {e}")))?;
+
+    update(&mut frontmatter);
+
+    let serialized = serde_yaml::to_string(&frontmatter)
+        .map_err(|e| MarkdownError::SerializationError(e.to_string()))?;
+    let new_fm_text = serialized.trim_end_matches('\n');
+
+    let new_content = format!("---\n{}\n---\n{}", new_fm_text, body);
+
+    // Atomic write through a tmp sibling, preserving the original file mode.
+    let tmp_path = path.with_extension("md.fmupdate.tmp");
+    if let Err(e) = fs::write(&tmp_path, &new_content) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(MarkdownError::Io(e));
+    }
+    let original_mode = preserved_file_mode(path);
+    if let Err(e) = set_permissions(&tmp_path, original_mode) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+
+    // Parse-after-write validation: confirm the result still parses before swapping.
+    match fs::read_to_string(&tmp_path) {
+        Ok(written) => {
+            let (wfm, _) = split_frontmatter(&written);
+            if wfm.is_empty() || serde_yaml::from_str::<Frontmatter>(wfm).is_err() {
+                let _ = fs::remove_file(&tmp_path);
+                return Err(MarkdownError::SerializationError(
+                    "post-write frontmatter validation failed".into(),
+                ));
+            }
+        }
+        Err(e) => {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(MarkdownError::Io(e));
+        }
+    }
+
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(MarkdownError::Io(e));
+    }
+    Ok(())
+}
+
 /// Set file permissions to the given mode (Unix only; no-op on Windows).
 fn set_permissions(path: &Path, _mode: u32) -> Result<(), MarkdownError> {
     #[cfg(unix)]
@@ -1104,6 +1215,7 @@ mod tests {
             speaker_map: vec![],
             name_corrections: Vec::new(),
             recording_health: None,
+            speaker_mapping: None,
             processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,
@@ -1658,6 +1770,100 @@ mod tests {
         // Hand-edited section must survive.
         assert!(content.contains("## Custom Section From User"));
         assert!(content.contains("Hand-edited stuff"));
+    }
+
+    #[test]
+    fn update_frontmatter_preserves_body_byte_for_byte() {
+        let dir = TempDir::new().unwrap();
+        // Body with unicode, emoji, trailing spaces, and a markdown rule that
+        // contains "---" to make sure we never confuse it with the fence.
+        let body = "## Summary\n\nWent well café 🎤\n\n---\n\n## Custom Notes\n\n- trailing spaces   \n\n## Transcript\n\n[SPEAKER_00 00:00] Hi\n[SPEAKER_01 00:05] Hello\n";
+        let path = write_meeting(
+            &dir,
+            "2026-04-07-redo.md",
+            "title: \"Redo Test\"\ntype: meeting\ndate: 2026-04-07T10:00:00-07:00\nduration: 0\n",
+            body,
+        );
+        let original = std::fs::read_to_string(&path).unwrap();
+        let (_, orig_body) = split_frontmatter(&original);
+        let orig_body = orig_body.to_string();
+
+        update_frontmatter(&path, |fm| {
+            fm.speaker_mapping = Some(SpeakerMappingHealth {
+                status: "ok".into(),
+                model: "agent:claude".into(),
+                diarized_speakers: 2,
+                mapped_speakers: 2,
+                attendees: 2,
+                duration_ms: Some(1234),
+                reason: None,
+                last_run: Some("2026-06-30T12:00:00-07:00".into()),
+            });
+        })
+        .unwrap();
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        let (updated_fm, updated_body) = split_frontmatter(&updated);
+
+        // The body must be preserved exactly.
+        assert_eq!(orig_body, updated_body);
+        // The new field must have landed and round-trip through serde.
+        assert!(updated_fm.contains("speaker_mapping:"));
+        let parsed: Frontmatter = serde_yaml::from_str(updated_fm).unwrap();
+        let health = parsed.speaker_mapping.expect("speaker_mapping written");
+        assert_eq!(health.status, "ok");
+        assert_eq!(health.mapped_speakers, 2);
+        assert_eq!(health.duration_ms, Some(1234));
+    }
+
+    #[test]
+    fn update_frontmatter_preserves_body_with_glued_closing_fence() {
+        // Regression (#384): a closing fence glued to body text with no newline
+        // anywhere after it. `split_frontmatter` keeps the trailing bytes; the
+        // earlier bespoke offset math in `update_frontmatter` dropped them. Now
+        // both share `split_frontmatter`'s body, so nothing is lost.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("glued.md");
+        let original = "---\ntitle: \"Glued\"\ntype: meeting\ndate: 2026-04-07T10:00:00-07:00\nduration: 0\n---BODYBYTES";
+        std::fs::write(&path, original).unwrap();
+
+        let (_, orig_body) = split_frontmatter(original);
+        assert_eq!(orig_body, "BODYBYTES"); // sanity: the bytes we must not lose
+
+        update_frontmatter(&path, |fm| {
+            fm.speaker_mapping = Some(SpeakerMappingHealth {
+                status: "skipped".into(),
+                model: "none".into(),
+                diarized_speakers: 0,
+                mapped_speakers: 0,
+                attendees: 0,
+                duration_ms: None,
+                reason: Some("test".into()),
+                last_run: None,
+            });
+        })
+        .unwrap();
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        let (_, updated_body) = split_frontmatter(&updated);
+        assert_eq!(updated_body, "BODYBYTES");
+    }
+
+    #[test]
+    fn update_frontmatter_refuses_non_meeting_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("not-a-meeting.md");
+        let original = "# Just markdown\n\nNo frontmatter here.\n";
+        std::fs::write(&path, original).unwrap();
+
+        let err = update_frontmatter(&path, |fm| {
+            fm.title = "Hijacked".into();
+        })
+        .unwrap_err();
+        assert!(matches!(err, MarkdownError::RenameRefused(_)));
+
+        // File must be untouched.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
     }
 
     #[test]

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -1611,6 +1611,7 @@ pub fn write_transcript_artifact(
         speaker_map: vec![],
         name_corrections: Vec::new(),
         recording_health: context.recording_health.clone(),
+        speaker_mapping: None,
         processing_warnings: Vec::new(),
         template: context.template.as_ref().map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
@@ -2641,6 +2642,7 @@ where
         speaker_map,
         name_corrections,
         recording_health,
+        speaker_mapping: None,
         template: template.map(|t| t.slug().to_string()),
         filter_diagnosis: if status == Some(OutputStatus::NoSpeech) {
             // Prefer the all-noise-suppression diagnosis when it fired; it
@@ -4956,6 +4958,7 @@ mod tests {
             speaker_map: vec![],
             name_corrections: Vec::new(),
             recording_health: None,
+            speaker_mapping: None,
             processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,
@@ -6466,6 +6469,7 @@ mod tests {
             }],
             name_corrections: Vec::new(),
             recording_health: None,
+            speaker_mapping: None,
             processing_warnings: Vec::new(),
             template: None,
             filter_diagnosis: None,

--- a/crates/core/src/sensitive.rs
+++ b/crates/core/src/sensitive.rs
@@ -380,6 +380,7 @@ fn write_artifact(
         speaker_map: vec![],
         name_corrections: Vec::new(),
         recording_health: None,
+        speaker_mapping: None,
         template: None,
         filter_diagnosis: None,
     };

--- a/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
+++ b/crates/core/src/snapshots/minutes_core__markdown__tests__json_schema_generates_valid_schema.snap
@@ -172,6 +172,17 @@ expression: schema
         "$ref": "#/$defs/SpeakerAttribution"
       }
     },
+    "speaker_mapping": {
+      "description": "Health of the Level-1 speaker-naming step. Lets a meeting be greppable for\n\"naming failed / incomplete\" instead of the failure living only in the JSON\nlog (#384). `None` for meetings processed before this field existed.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SpeakerMappingHealth"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "status": {
       "anyOf": [
         {
@@ -659,6 +670,67 @@ expression: schema
         "name",
         "confidence",
         "source"
+      ]
+    },
+    "SpeakerMappingHealth": {
+      "description": "Health of the Level-1 speaker-naming (`speaker_mapping`) step, surfaced in\nfrontmatter so a meeting that shipped anonymous is greppable and re-runnable\n(#382/#384). Counts are recorded separately from confidence so \"a map exists\"\nis never confused with \"every speaker was named\".",
+      "type": "object",
+      "properties": {
+        "attendees": {
+          "description": "Size of the attendee pool offered to the mapper.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        },
+        "diarized_speakers": {
+          "description": "Distinct diarization speaker labels present (proxy for the raw diarization\nspeaker count, which needs the audio and so isn't recoverable on a redo).",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        },
+        "duration_ms": {
+          "description": "Wall-clock of the mapping call.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "last_run": {
+          "description": "RFC3339 timestamp of the most recent mapping run.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mapped_speakers": {
+          "description": "How many of those labels received a name.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        },
+        "model": {
+          "description": "Engine/model hint used (e.g. `agent:claude`).",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Machine-readable reason when `status` is not `ok`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "description": "`ok` (some labels named), `empty` (ran, no confident matches), `skipped`\n(no anonymous labels or no attendees to map against). Mirrors the\n`speaker_mapping` JSONL `outcome` vocabulary.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "diarized_speakers",
+        "mapped_speakers",
+        "attendees"
       ]
     },
     "Visibility": {

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -711,7 +711,7 @@ pub(crate) fn summarization_model_hint(config: &Config, has_screen_context: bool
     }
 }
 
-pub(crate) fn speaker_mapping_model_hint(config: &Config) -> String {
+pub fn speaker_mapping_model_hint(config: &Config) -> String {
     match config.summarization.engine.as_str() {
         "none" | "auto" | "agent" => configured_agent_hint(config),
         "claude" => "anthropic:claude-sonnet-4-20250514".into(),

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -6,8 +6,8 @@ export const MINUTES_RELEASE_VERSION = "0.19.0";
 export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
-export const MINUTES_CLI_COMMAND_COUNT = 54;
-export const MINUTES_TEST_COUNT = 1304;
+export const MINUTES_CLI_COMMAND_COUNT = 55;
+export const MINUTES_TEST_COUNT = 1313;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What

Closes #384.

Adds a recovery command for meetings that shipped with anonymous `SPEAKER_n` labels because Level-1 speaker mapping timed out, errored, or ran before attendees were known. It re-runs just the mapping (no audio reprocessing) and records a `speaker_mapping` health block in the frontmatter so the state is greppable and re-runnable.

```bash
minutes redo-speaker-mapping <meeting>                          # dry run: show the proposed map
minutes redo-speaker-mapping <meeting> --apply                  # write speaker_map + a speaker_mapping health block
minutes redo-speaker-mapping <meeting> --engine ollama --apply  # override the engine for this run
minutes redo-speaker-mapping <meeting> --json                   # machine-readable output
```

`<meeting>` is a path or a search term.

## Highlights

- **Dry-run by default.** Only `--apply` writes. `--json` reports `map_changed` and `written` accurately for every dry-run/apply and changed/unchanged combination, and the write happens before any success output so a failed write returns an error instead of a misleading success line.
- **Never destroys good data.** Merge never downgrades an existing High-confidence attribution (even across duplicate labels in malformed frontmatter). The command refuses non-meeting files, and skips clearly when there is no `## Transcript`, no anonymous labels, or no attendees, naming which side is missing.
- **Surgical frontmatter write.** New `markdown::update_frontmatter` reuses `split_frontmatter`'s body slice to preserve the body byte-for-byte, writes atomically through a mode-preserving tmp sibling, validates the result parses before swapping, and cleans up the tmp file on every error path.
- **Robust transcript detection.** Fence-aware, exact-`## Transcript`-heading scanner, so a code sample or a `## Transcript cleanup notes` heading is never mistaken for the real transcript (handles mixed ``` / `~~~` fences).
- **New `SpeakerMappingHealth` frontmatter block:** `status` (ok/empty/skipped), model hint, diarized/mapped speaker counts, attendee count, timing, and `last_run`.

## Health block example

```yaml
speaker_mapping:
  status: empty
  model: agent:claude
  diarized_speakers: 2
  mapped_speakers: 0
  attendees: 2
  duration_ms: 2009
  reason: mapper ran but produced no confident matches
  last_run: 2026-07-01T00:00:00-07:00
```

## Testing

- 7 new tests (2 markdown body-preservation + non-meeting refusal, 5 CLI merge/transcript cases). Full suite green: 906 core + 46 CLI + 8 integration.
- End-to-end verified: memo refusal, fenced-fake-transcript exclusion, `--apply` body byte-identical (sha), search-term + containment, no stray tmp files.
- Adversarially reviewed with codex across two passes. All 7 findings fixed (non-meeting mutation, body-splice byte drop on glued fences, JSON success-before-write, loose transcript matching including mixed fences, duplicate-label High downgrade, search containment/symlink, tmp cleanup) and each is covered by a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)