### PR TITLE
feat(graph): entity-resolution eval + suggestion-only name-variant clustering (#385)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3465,14 +3465,28 @@ fn cmd_people(rebuild: bool, json: bool, limit: usize, config: &Config) -> Resul
             "Index rebuilt: {} people, {} meetings, {} commitments in {}ms",
             stats.people_count, stats.meeting_count, stats.commitment_count, stats.rebuild_ms
         );
+        if !stats.alias_clusters.is_empty() {
+            eprintln!("\nPossible name variants (same person, different spellings?):");
+            for cluster in &stats.alias_clusters {
+                let shared = if cluster.max_shared_meetings > 0 {
+                    format!(" ({} shared meetings)", cluster.max_shared_meetings)
+                } else {
+                    String::new()
+                };
+                eprintln!("  {}{}", cluster.members.join(" ↔ "), shared);
+            }
+        }
         if !stats.alias_suggestions.is_empty() {
-            eprintln!("\nPossible duplicates:");
+            eprintln!("\nPossible duplicates (shortened / last-name match):");
             for alias in &stats.alias_suggestions {
                 eprintln!(
                     "  {} ↔ {} ({} shared meetings)",
                     alias.name_a, alias.name_b, alias.shared_meetings
                 );
             }
+        }
+        if !stats.alias_clusters.is_empty() || !stats.alias_suggestions.is_empty() {
+            eprintln!("  Review manually; automatic merging is not yet available.");
         }
         eprintln!();
     }

--- a/crates/core/src/entity_cluster.rs
+++ b/crates/core/src/entity_cluster.rs
@@ -1,0 +1,310 @@
+//! Person entity-resolution clustering — issue #385, class 3 (name-variant
+//! fragmentation, e.g. `junrei` / `jun-rei` / `junlei` / `junwei`).
+//!
+//! This is **suggestion-only**. It groups people whose names are plausibly the
+//! same person so the graph can surface them as candidates for a human to
+//! confirm. It NEVER merges or writes anything. Per the entity-resolution plan
+//! (`docs/plans/person-entity-resolution-2026-06-26.md`) a wrong merge is worse
+//! than a split, so the merge action is a confirm-gated follow-up. Because
+//! nothing is written, an over-eager suggestion costs precision, not data.
+//!
+//! Two link tiers, both conservative:
+//! - **Separator variant** — identical characters modulo separators and case
+//!   (`Mo-Han` ~ `mohan`, `jun-rei` ~ `junrei`). Guarded by a minimum length.
+//! - **Spelling edit** — single-token, ASCII names that share a first letter and
+//!   are within a length-scaled edit budget (`geert` ~ `gert`, `junrei` ~
+//!   `junlei`). ASCII-only because same-first + bounded edit is a Latin
+//!   heuristic; a single edit between distinct non-ASCII names (李雷/李蕾) is not
+//!   a same-person signal. Reuses the exact edit-distance matcher from
+//!   `name_correction`.
+
+use crate::name_correction::{levenshtein, normalize_name};
+
+/// Why two names were linked. Kept for tests/scoring; the graph display collapses
+/// clusters and does not surface the per-edge reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MatchReason {
+    /// Same characters modulo separators/case (`jun-rei` ~ `junrei`).
+    SeparatorVariant,
+    /// Same first letter, within edit budget (`geert` ~ `gert`).
+    PhoneticEdit,
+}
+
+/// Minimum compact length for a separator-variant match, so short initials
+/// (`d-p`, `c-s`) don't collapse to one entity.
+const MIN_COMPACT_LEN: usize = 3;
+
+/// Compact key: normalized (lowercase + accent-folded) with every non-alphanumeric
+/// character removed, so pure separator/case variants share a key
+/// (`Mo-Han` -> `mohan`, `jun-rei` -> `junrei`, `José` -> `jose`).
+pub(crate) fn compact_key(name: &str) -> String {
+    normalize_name(name)
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect()
+}
+
+/// Edit budget for a normalized token: 1 edit for short names, 2 for longer.
+/// Mirrors `name_correction::distance_budget`.
+fn distance_budget(len: usize) -> usize {
+    if len >= 6 {
+        2
+    } else {
+        1
+    }
+}
+
+fn is_single_token(name: &str) -> bool {
+    normalize_name(name).split_whitespace().count() == 1
+}
+
+/// Are these two names plausibly the same person? Returns the reason when yes.
+///
+/// SUGGESTION strength only — this decides whether to *propose* a link, never to
+/// merge. It is deliberately recall-oriented in the ambiguous short-name band
+/// (`sam`/`sami`, `an`/`ann`): those become suggestions a human resolves. It
+/// stays confidently negative for dissimilar names (different first letter,
+/// different phonetics, out of edit budget).
+pub(crate) fn names_plausibly_same_person(a: &str, b: &str) -> Option<MatchReason> {
+    let ca = compact_key(a);
+    let cb = compact_key(b);
+    if ca.is_empty() || cb.is_empty() {
+        return None;
+    }
+
+    // Tier 1: identical compact key => separator/case variant.
+    if ca == cb {
+        if ca.chars().count() >= MIN_COMPACT_LEN {
+            return Some(MatchReason::SeparatorVariant);
+        }
+        return None;
+    }
+
+    // Tier 2: single-edit spelling drift, single-token names only. Multi-token
+    // names are the existing `names_likely_same` (prefix/last-name) territory,
+    // and edit distance over full multi-word strings is too noisy to trust.
+    if !is_single_token(a) || !is_single_token(b) {
+        return None;
+    }
+    let na = normalize_name(a);
+    let nb = normalize_name(b);
+    // ASCII-only. Same-first-letter + bounded edit is an English/Latin heuristic;
+    // for non-ASCII scripts (e.g. CJK) a single edit between DISTINCT names
+    // (李雷 vs 李蕾) is common and must not be suggested as the same person.
+    // Accent-folded Latin names (José -> jose) are ASCII here, so they still match.
+    if !na.is_ascii() || !nb.is_ascii() {
+        return None;
+    }
+    // Require the same first letter: a coincidental single edit across different
+    // initials is too weak a signal to even suggest.
+    if na.as_bytes().first() != nb.as_bytes().first() {
+        return None;
+    }
+    let budget = distance_budget(na.chars().count().min(nb.chars().count()));
+    if levenshtein(&na, &nb) <= budget {
+        Some(MatchReason::PhoneticEdit)
+    } else {
+        None
+    }
+}
+
+/// Cluster an explicit edge list into CLIQUES (groups where every pair is a
+/// direct edge), not mere connected components. This is what prevents fuzzy-match
+/// drift CHAINS from bridging distinct people: `jon`~`jan`~`jana` form one
+/// connected component, but `jon`/`jana` are not directly linked, so they must
+/// never share a cluster. Real drift groups (`junrei`/`junlei`/`junwei`/`jun-rei`)
+/// are fully connected and survive as one cluster.
+///
+/// A connected component that is already a clique is emitted whole. A non-clique
+/// component is decomposed into its direct-edge pairs (2-member clusters), so
+/// every real pairwise link is still surfaced without the spurious transitive
+/// pair. Output is deterministic: members sorted, clusters ordered lexically.
+pub(crate) fn cluster_indices(n: usize, edges: &[(usize, usize)]) -> Vec<Vec<usize>> {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    // Normalize edges to (min, max) and dedup.
+    let mut edge_set: BTreeSet<(usize, usize)> = BTreeSet::new();
+    for &(a, b) in edges {
+        if a >= n || b >= n || a == b {
+            continue;
+        }
+        edge_set.insert((a.min(b), a.max(b)));
+    }
+
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(parent: &mut [usize], x: usize) -> usize {
+        let mut root = x;
+        while parent[root] != root {
+            root = parent[root];
+        }
+        let mut cur = x;
+        while parent[cur] != root {
+            let next = parent[cur];
+            parent[cur] = root;
+            cur = next;
+        }
+        root
+    }
+    for &(a, b) in &edge_set {
+        let ra = find(&mut parent, a);
+        let rb = find(&mut parent, b);
+        if ra != rb {
+            if ra < rb {
+                parent[rb] = ra;
+            } else {
+                parent[ra] = rb;
+            }
+        }
+    }
+
+    let mut components: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for i in 0..n {
+        let root = find(&mut parent, i);
+        components.entry(root).or_default().push(i);
+    }
+
+    let is_edge = |a: usize, b: usize| edge_set.contains(&(a.min(b), a.max(b)));
+    let mut clusters: Vec<Vec<usize>> = Vec::new();
+    for members in components.into_values() {
+        if members.len() < 2 {
+            continue;
+        }
+        // Clique? every pair within the component must be a direct edge.
+        let is_clique = members
+            .iter()
+            .enumerate()
+            .all(|(i, &a)| members[i + 1..].iter().all(|&b| is_edge(a, b)));
+        if is_clique {
+            clusters.push(members); // already ascending (built from 0..n)
+        } else {
+            // Decompose into direct-edge pairs so distinct chain endpoints
+            // (jon/jana) never share a cluster.
+            for i in 0..members.len() {
+                for j in (i + 1)..members.len() {
+                    if is_edge(members[i], members[j]) {
+                        clusters.push(vec![members[i], members[j]]);
+                    }
+                }
+            }
+        }
+    }
+    clusters.sort();
+    clusters
+}
+
+/// Convenience: cluster a flat list of names using [`names_plausibly_same_person`]
+/// as the edge source, then [`cluster_indices`]. This is the same predicate the
+/// graph layer uses for `alias_clusters`, so the eval mirrors production.
+#[cfg(test)]
+pub(crate) fn cluster_names(names: &[String]) -> Vec<Vec<usize>> {
+    let mut edges = Vec::new();
+    for i in 0..names.len() {
+        for j in (i + 1)..names.len() {
+            if names_plausibly_same_person(&names[i], &names[j]).is_some() {
+                edges.push((i, j));
+            }
+        }
+    }
+    cluster_indices(names.len(), &edges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_key_folds_separators_case_and_accents() {
+        assert_eq!(compact_key("Mo-Han"), "mohan");
+        assert_eq!(compact_key("jun-rei"), "junrei");
+        assert_eq!(compact_key("José"), "jose");
+    }
+
+    #[test]
+    fn separator_variants_link() {
+        assert_eq!(
+            names_plausibly_same_person("jun-rei", "junrei"),
+            Some(MatchReason::SeparatorVariant)
+        );
+    }
+
+    #[test]
+    fn short_separator_keys_do_not_link() {
+        // "d-p" / "dp" compact to "dp" (len 2) < MIN_COMPACT_LEN.
+        assert_eq!(names_plausibly_same_person("d-p", "dp"), None);
+    }
+
+    #[test]
+    fn spelling_edit_drift_links() {
+        assert_eq!(
+            names_plausibly_same_person("geert", "gert"),
+            Some(MatchReason::PhoneticEdit)
+        );
+        // r/l and r/w drift, same first letter, within budget.
+        assert!(names_plausibly_same_person("junrei", "junlei").is_some());
+        assert!(names_plausibly_same_person("junrei", "junwei").is_some());
+    }
+
+    #[test]
+    fn dissimilar_names_do_not_link() {
+        // Different first letter is not a signal, even for a single edit (c/k).
+        assert_eq!(names_plausibly_same_person("carl", "karl"), None);
+        assert_eq!(names_plausibly_same_person("carl", "deepak"), None);
+        assert_eq!(names_plausibly_same_person("sarah", "sam"), None);
+        assert_eq!(names_plausibly_same_person("bright", "liam"), None);
+    }
+
+    #[test]
+    fn non_ascii_near_miss_does_not_link() {
+        // Distinct CJK names one codepoint apart must NOT be suggested (no ASCII
+        // phonetic/edit corroboration applies).
+        assert_eq!(names_plausibly_same_person("李雷", "李蕾"), None);
+    }
+
+    #[test]
+    fn multi_token_names_use_separator_tier_only() {
+        // "Alex Chen" vs "Alex Kim": different compact, multi-token -> no phonetic tier.
+        assert_eq!(names_plausibly_same_person("Alex Chen", "Alex Kim"), None);
+    }
+
+    #[test]
+    fn clique_clustering_groups_a_drift_set() {
+        // The jun* fragments are mutually linked (a clique), so they collapse to
+        // one cluster; `bright` is unrelated and excluded.
+        let names: Vec<String> = ["jun-rei", "junrei", "junlei", "junwei", "bright"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let clusters = cluster_names(&names);
+        assert_eq!(clusters.len(), 1, "one cluster, bright excluded");
+        // Indices 0..=3 are the jun* set.
+        assert_eq!(clusters[0], vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn drift_chain_does_not_bridge_endpoints() {
+        // `jon`~`jan` and `jan`~`jana` are edges, but `jon`~`jana` is not (dist 2).
+        // Clique emission must NOT put the chain endpoints in one cluster.
+        let names: Vec<String> = ["jon", "jan", "jana"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let clusters = cluster_names(&names);
+        for c in &clusters {
+            assert!(
+                !(c.contains(&0) && c.contains(&2)),
+                "drift-chain endpoints jon/jana were bridged: {c:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn clustering_is_deterministic_and_excludes_singletons() {
+        let names: Vec<String> = ["zeta", "gert", "geert"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let clusters = cluster_names(&names);
+        // gert(1) ~ geert(2); zeta(0) is a singleton and excluded.
+        assert_eq!(clusters, vec![vec![1, 2]]);
+    }
+}

--- a/crates/core/src/entity_resolution_eval.rs
+++ b/crates/core/src/entity_resolution_eval.rs
@@ -1,0 +1,219 @@
+//! Entity-resolution evaluation harness — issue #385 / #371, "Slice 0".
+//!
+//! Cluster-level measurement for the suggestion-only name-variant clustering in
+//! [`crate::entity_cluster`]. It is the entity twin of [`crate::name_eval`]:
+//! synthetic names only (public repo), test-gated, with a hard gating invariant
+//! that mirrors `name_eval`'s `false_corrections == 0`.
+//!
+//! Gating invariants:
+//! - **`wrong_merges == 0`** — no suggested cluster may contain names belonging
+//!   to two different ground-truth people. A wrong merge is worse than a split,
+//!   and a suggested cluster is the input to a future confirm-merge, so an impure
+//!   cluster is the cardinal error even though nothing is written yet.
+//! - **full drift recall** — every reported same-person drift group is fully
+//!   co-clustered. The feature is worthless if it cannot surface the motivating
+//!   fragmentation.
+//!
+//! Scored but NOT gated: over-suggestion in the ambiguous short-name band
+//! (`sam`/`sami`, `an`/`ann`) — an inherent precision cost of a recall-oriented
+//! suggester, resolved later by a human confirm-merge. B-cubed precision/recall
+//! are reported for visibility.
+//!
+//! All names below are SYNTHETIC and shaped to mirror the real gtheys vault
+//! classes without reproducing anyone's actual name.
+
+#![cfg(test)]
+
+use crate::entity_cluster::{cluster_names, names_plausibly_same_person};
+use std::collections::HashMap;
+
+/// Groups of name fragments that each denote ONE synthetic person and therefore
+/// MUST fully co-cluster (recall targets). Shapes mirror the real vault:
+/// separator + medial-consonant drift, initial c/k phonetic drift, doubled-letter
+/// drift.
+const DRIFT_GROUPS: &[&[&str]] = &[
+    // separator variant + medial consonant drift (the junrei/junlei/junwei/jun-rei
+    // shape). 6+ chars so the budget is 2 and every pair (incl. the separator
+    // variant vs the drift variants) links -> a true clique.
+    &["tan-vir", "tanvir", "tanmir", "tanzir"],
+    // same-first-letter medial vowel drift
+    &["nadia", "nadya"],
+    // doubled-letter drift
+    &["aaron", "arron"],
+];
+
+/// Names that each denote a DISTINCT synthetic person; no two of them (and none
+/// of them with any drift-group name) may share a suggested cluster. Includes
+/// mutually dissimilar Latin names AND a non-ASCII near-miss pair (single
+/// codepoint apart) that the ASCII-only edit tier must keep separate.
+const DISTINCT_DISSIMILAR: &[&str] = &[
+    "deepak", "sarah", "bright", "liam", "monica", "keith", "priya", "tomas", "李雷", "李蕾",
+];
+
+/// Short similar pairs where the predicate is expected to over-suggest. Scored,
+/// NOT gated — a human resolves these via confirm-merge (a follow-up).
+const AMBIGUOUS_PAIRS: &[(&str, &str)] = &[("sam", "sami"), ("an", "ann"), ("rena", "rana")];
+
+#[derive(Debug, Default)]
+struct ClusterReport {
+    drift_groups_recovered: usize,
+    drift_groups_total: usize,
+    /// Clusters mixing two different ground-truth people. HARD GATE: must be 0.
+    wrong_merges: usize,
+    ambiguous_suggested: usize,
+    ambiguous_total: usize,
+    bcubed_precision: f64,
+    bcubed_recall: f64,
+}
+
+/// Build the evaluation pool and ground-truth person id per name.
+/// Person ids: drift group `g` -> id `g`; each dissimilar name -> its own id.
+fn build_pool() -> (Vec<String>, HashMap<String, usize>) {
+    let mut pool: Vec<String> = Vec::new();
+    let mut truth: HashMap<String, usize> = HashMap::new();
+    let mut next_id = 0usize;
+    for group in DRIFT_GROUPS {
+        let id = next_id;
+        next_id += 1;
+        for &name in *group {
+            pool.push(name.to_string());
+            truth.insert(name.to_string(), id);
+        }
+    }
+    for &name in DISTINCT_DISSIMILAR {
+        let id = next_id;
+        next_id += 1;
+        pool.push(name.to_string());
+        truth.insert(name.to_string(), id);
+    }
+    (pool, truth)
+}
+
+fn run_eval() -> ClusterReport {
+    let (pool, truth) = build_pool();
+    let clusters = cluster_names(&pool);
+
+    // Map each name to its predicted cluster id (singletons get a unique id).
+    let mut predicted: HashMap<String, usize> = HashMap::new();
+    for (cid, cluster) in clusters.iter().enumerate() {
+        for &idx in cluster {
+            predicted.insert(pool[idx].clone(), cid);
+        }
+    }
+    let mut next_singleton = clusters.len();
+    for name in &pool {
+        predicted.entry(name.clone()).or_insert_with(|| {
+            let id = next_singleton;
+            next_singleton += 1;
+            id
+        });
+    }
+
+    let mut report = ClusterReport {
+        drift_groups_total: DRIFT_GROUPS.len(),
+        ambiguous_total: AMBIGUOUS_PAIRS.len(),
+        ..Default::default()
+    };
+
+    // wrong_merges: predicted clusters mixing >1 ground-truth person.
+    for cluster in &clusters {
+        let mut persons: Vec<usize> = cluster.iter().map(|&i| truth[&pool[i]]).collect();
+        persons.sort_unstable();
+        persons.dedup();
+        if persons.len() > 1 {
+            report.wrong_merges += 1;
+        }
+    }
+
+    // drift recall: all members of a group share one predicted cluster.
+    for group in DRIFT_GROUPS {
+        let first = predicted[&group[0].to_string()];
+        if group.iter().all(|&n| predicted[&n.to_string()] == first) {
+            report.drift_groups_recovered += 1;
+        }
+    }
+
+    // ambiguous over-suggestion (reported only).
+    for (a, b) in AMBIGUOUS_PAIRS {
+        if names_plausibly_same_person(a, b).is_some() {
+            report.ambiguous_suggested += 1;
+        }
+    }
+
+    // B-cubed precision/recall over the pool.
+    let (mut prec_sum, mut rec_sum) = (0.0f64, 0.0f64);
+    for name in &pool {
+        let pc = predicted[name];
+        let gc = truth[name];
+        let pred_members: Vec<&String> = pool.iter().filter(|n| predicted[*n] == pc).collect();
+        let truth_members: Vec<&String> = pool.iter().filter(|n| truth[*n] == gc).collect();
+        let correct = pred_members.iter().filter(|n| truth[**n] == gc).count() as f64;
+        prec_sum += correct / pred_members.len() as f64;
+        rec_sum += correct / truth_members.len() as f64;
+    }
+    report.bcubed_precision = prec_sum / pool.len() as f64;
+    report.bcubed_recall = rec_sum / pool.len() as f64;
+
+    report
+}
+
+#[test]
+fn entity_clustering_meets_gates() {
+    let report = run_eval();
+
+    // HARD GATE 1: zero wrong merges (mirrors name_eval false_corrections == 0).
+    assert_eq!(
+        report.wrong_merges, 0,
+        "a suggested cluster mixed two distinct ground-truth people: {report:?}"
+    );
+
+    // HARD GATE 2: every drift group is fully recovered.
+    assert_eq!(
+        report.drift_groups_recovered, report.drift_groups_total,
+        "not all drift groups were co-clustered: {report:?}"
+    );
+
+    // B-cubed precision should stay high: dissimilar names must not accrete.
+    assert!(
+        report.bcubed_precision >= 0.99,
+        "B-cubed precision regressed: {report:?}"
+    );
+    assert!(
+        report.bcubed_recall >= 0.99,
+        "B-cubed recall regressed: {report:?}"
+    );
+
+    // The ambiguous short-name band is expected to be over-suggested (the
+    // predicate is recall-oriented; a human resolves these via confirm-merge).
+    // Asserting all are suggested documents that behavior and would flag if the
+    // predicate silently stopped proposing them. This is NOT the safety gate —
+    // wrong_merges == 0 above is.
+    assert_eq!(
+        report.ambiguous_suggested, report.ambiguous_total,
+        "ambiguous short-name pairs should all be suggested (recall-oriented): {report:?}"
+    );
+}
+
+/// Structural gate for the transitive-drift-chain class: every suggested cluster
+/// must be a clique under the predicate. A fuzzy-match chain (`jon`~`jan`~`jana`)
+/// must never bridge non-matching endpoints into one cluster, even though it is a
+/// single connected component. Guards against a regression back to
+/// connected-component clustering.
+#[test]
+fn every_suggested_cluster_is_a_clique() {
+    let mut pool: Vec<String> = build_pool().0;
+    // Add a real drift chain so decomposition is actually exercised.
+    pool.extend(["jon", "jan", "jana"].iter().map(|s| s.to_string()));
+    let clusters = cluster_names(&pool);
+    for c in &clusters {
+        for i in 0..c.len() {
+            for j in (i + 1)..c.len() {
+                assert!(
+                    names_plausibly_same_person(&pool[c[i]], &pool[c[j]]).is_some(),
+                    "cluster is not a clique (transitive bridge): {:?}",
+                    c.iter().map(|&k| pool[k].as_str()).collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+}

--- a/crates/core/src/graph.rs
+++ b/crates/core/src/graph.rs
@@ -42,6 +42,7 @@ pub struct GraphStats {
     pub commitment_count: usize,
     pub topic_count: usize,
     pub alias_suggestions: Vec<AliasSuggestion>,
+    pub alias_clusters: Vec<AliasCluster>,
     pub rebuild_ms: u64,
 }
 
@@ -75,6 +76,24 @@ pub struct AliasSuggestion {
     pub name_a: String,
     pub name_b: String,
     pub shared_meetings: usize,
+}
+
+/// A group of people who are plausibly the same person (issue #385, class 3
+/// name-variant fragmentation). Suggestion only — nothing is merged. Members form
+/// a clique under the separator / same-first-letter edit predicate in
+/// [`crate::entity_cluster`] (every pair directly matches), so transitive drift
+/// chains never bridge distinct people. Prefix/last-name matches are surfaced
+/// separately as pairwise `AliasSuggestion`s.
+#[derive(Debug, Clone, Serialize)]
+pub struct AliasCluster {
+    /// Display names of the cluster members, sorted for deterministic output.
+    pub members: Vec<String>,
+    /// Slugs of the members, aligned with `members`.
+    pub slugs: Vec<String>,
+    /// Largest shared-meeting count among any pair in the cluster. Evidence for
+    /// display only, never a gate: spelling-drift variants of one person often
+    /// appear in *different* meetings, so `0` is common and expected.
+    pub max_shared_meetings: usize,
 }
 
 /// Database path: ~/.minutes/graph.db
@@ -711,8 +730,9 @@ fn rebuild_index_at_with_vocabulary_entities(
         params![today],
     )?;
 
-    // Detect alias suggestions
+    // Detect alias suggestions (pairwise) and clusters (transitive, #385)
     let alias_suggestions = detect_aliases(&conn)?;
+    let alias_clusters = detect_alias_clusters(&conn)?;
 
     // Commit the transaction — all or nothing
     conn.execute_batch("COMMIT")?;
@@ -737,6 +757,7 @@ fn rebuild_index_at_with_vocabulary_entities(
         commitment_count,
         topic_count: topic_set.len(),
         alias_suggestions,
+        alias_clusters,
         rebuild_ms: elapsed,
     })
 }
@@ -956,9 +977,23 @@ pub fn relationship_map(config: &Config) -> Result<Vec<PersonSummary>, GraphErro
     Ok(people)
 }
 
+/// Count meetings two people (by slug) both attended. Shared evidence for alias
+/// suggestions/clusters.
+fn shared_meeting_count(conn: &Connection, slug_a: &str, slug_b: &str) -> Result<i64, GraphError> {
+    Ok(conn.query_row(
+        "SELECT COUNT(DISTINCT pm1.meeting_id) FROM people_meetings pm1
+         JOIN people p1 ON pm1.person_id = p1.id
+         JOIN people_meetings pm2 ON pm1.meeting_id = pm2.meeting_id
+         JOIN people p2 ON pm2.person_id = p2.id
+         WHERE p1.slug = ?1 AND p2.slug = ?2",
+        params![slug_a, slug_b],
+        |row| row.get(0),
+    )?)
+}
+
 /// Detect people who might be the same person (fuzzy name matching).
 fn detect_aliases(conn: &Connection) -> Result<Vec<AliasSuggestion>, GraphError> {
-    let mut stmt = conn.prepare("SELECT slug, name FROM people")?;
+    let mut stmt = conn.prepare("SELECT slug, name FROM people ORDER BY slug")?;
     let people: Vec<(String, String)> = stmt
         .query_map([], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -970,23 +1005,11 @@ fn detect_aliases(conn: &Connection) -> Result<Vec<AliasSuggestion>, GraphError>
 
     for i in 0..people.len() {
         for j in (i + 1)..people.len() {
-            let (_, name_a) = &people[i];
-            let (_, name_b) = &people[j];
+            let (slug_a, name_a) = &people[i];
+            let (slug_b, name_b) = &people[j];
 
             if names_likely_same(name_a, name_b) {
-                // Check shared meeting count
-                let (slug_a, _) = &people[i];
-                let (slug_b, _) = &people[j];
-                let shared: i64 = conn.query_row(
-                    "SELECT COUNT(DISTINCT pm1.meeting_id) FROM people_meetings pm1
-                     JOIN people p1 ON pm1.person_id = p1.id
-                     JOIN people_meetings pm2 ON pm1.meeting_id = pm2.meeting_id
-                     JOIN people p2 ON pm2.person_id = p2.id
-                     WHERE p1.slug = ?1 AND p2.slug = ?2",
-                    params![slug_a, slug_b],
-                    |row| row.get(0),
-                )?;
-
+                let shared = shared_meeting_count(conn, slug_a, slug_b)?;
                 suggestions.push(AliasSuggestion {
                     name_a: name_a.clone(),
                     name_b: name_b.clone(),
@@ -997,6 +1020,64 @@ fn detect_aliases(conn: &Connection) -> Result<Vec<AliasSuggestion>, GraphError>
     }
 
     Ok(suggestions)
+}
+
+/// Detect clusters of people who are plausibly the same person (issue #385).
+///
+/// Edges come from two predicates: the existing prefix/last-name
+/// [`names_likely_same`] and the phonetic/edit variant predicate
+/// [`crate::entity_cluster::names_plausibly_same_person`] (which finally links
+/// spelling drift like `junrei`/`junlei`/`jun-rei` that the first cannot). Edges
+/// are unioned transitively so a fragmented person surfaces as one cluster.
+/// Suggestion only — nothing is merged.
+fn detect_alias_clusters(conn: &Connection) -> Result<Vec<AliasCluster>, GraphError> {
+    // ORDER BY slug so cluster membership and ordering are stable across rebuilds
+    // (SQLite row order otherwise follows insertion history).
+    let mut stmt = conn.prepare("SELECT slug, name FROM people ORDER BY slug")?;
+    let people: Vec<(String, String)> = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Clusters use ONLY the variant predicate (separator / same-first-letter
+    // single-edit). The prefix/last-name predicate (`names_likely_same`) stays a
+    // separate pairwise suggestion: mixing the two edge types in one transitive
+    // union bridges distinct people (e.g. `Jon`~`Jan` by edit + `Jan`~`Jan Smith`
+    // by prefix would fuse `Jon` and `Jan Smith`), violating "a wrong merge is
+    // worse than a split" even at the suggestion level (#385).
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for i in 0..people.len() {
+        for j in (i + 1)..people.len() {
+            if crate::entity_cluster::names_plausibly_same_person(&people[i].1, &people[j].1)
+                .is_some()
+            {
+                edges.push((i, j));
+            }
+        }
+    }
+
+    let clusters = crate::entity_cluster::cluster_indices(people.len(), &edges);
+
+    let mut result = Vec::with_capacity(clusters.len());
+    for cluster in clusters {
+        let mut max_shared = 0usize;
+        for a in 0..cluster.len() {
+            for b in (a + 1)..cluster.len() {
+                let shared =
+                    shared_meeting_count(conn, &people[cluster[a]].0, &people[cluster[b]].0)?;
+                max_shared = max_shared.max(shared as usize);
+            }
+        }
+        result.push(AliasCluster {
+            members: cluster.iter().map(|&i| people[i].1.clone()).collect(),
+            slugs: cluster.iter().map(|&i| people[i].0.clone()).collect(),
+            max_shared_meetings: max_shared,
+        });
+    }
+
+    Ok(result)
 }
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -1818,6 +1899,85 @@ Short meeting.
             "False positive alias detected: {:?}",
             stats.alias_suggestions
         );
+    }
+
+    #[test]
+    fn test_alias_clusters_full_rebuild() {
+        // Full-path (#385): spelling-drift variants of one synthetic person
+        // spread across DIFFERENT meetings (so shared_meetings is 0) must still
+        // surface as one alias cluster, and a distinct person must not join it.
+        let tmp = TempDir::new().unwrap();
+        let meetings = tmp.path().join("meetings");
+        fs::create_dir_all(&meetings).unwrap();
+
+        let mk = |date: &str, attendee: &str| {
+            format!(
+                "---\ntitle: Sync\ntype: meeting\ndate: {date}T09:00:00-07:00\nduration: 15m\nattendees: [{attendee}, Bright]\ntags: []\n---\nNotes.\n"
+            )
+        };
+        write_meeting(&meetings, "d1.md", &mk("2026-03-21", "Tanvir"));
+        write_meeting(&meetings, "d2.md", &mk("2026-03-22", "Tan-Vir"));
+        write_meeting(&meetings, "d3.md", &mk("2026-03-23", "Tanmir"));
+
+        let config = test_config(&meetings);
+        let stats = rebuild_to_temp(&config, &tmp);
+
+        let cluster = stats
+            .alias_clusters
+            .iter()
+            .find(|c| {
+                c.slugs.iter().any(|s| s == "tanvir")
+                    || c.members.iter().any(|m| m.eq_ignore_ascii_case("tanvir"))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected a cluster containing the Tanvir drift variants, got: {:?}",
+                    stats.alias_clusters
+                )
+            });
+
+        let slugs: std::collections::HashSet<&String> = cluster.slugs.iter().collect();
+        assert!(slugs.contains(&"tanvir".to_string()));
+        assert!(slugs.contains(&"tan-vir".to_string()));
+        assert!(slugs.contains(&"tanmir".to_string()));
+        // The distinct attendee present in every meeting must NOT be in the cluster.
+        assert!(
+            !cluster
+                .members
+                .iter()
+                .any(|m| m.eq_ignore_ascii_case("bright")),
+            "distinct person leaked into drift cluster: {cluster:?}"
+        );
+    }
+
+    #[test]
+    fn test_alias_clusters_do_not_bridge_distinct_people() {
+        // #385 codex: `Jon`~`Jan` (edit) must not transitively fuse with
+        // `Jan`~`Jan Smith` (prefix) into one cluster. Prefix/last-name links
+        // stay pairwise alias_suggestions; clusters use only the variant predicate.
+        let tmp = TempDir::new().unwrap();
+        let meetings = tmp.path().join("meetings");
+        fs::create_dir_all(&meetings).unwrap();
+        let mk = |date: &str, attendee: &str| {
+            format!(
+                "---\ntitle: Sync\ntype: meeting\ndate: {date}T09:00:00-07:00\nduration: 15m\nattendees: [{attendee}]\ntags: []\n---\nNotes.\n"
+            )
+        };
+        write_meeting(&meetings, "b1.md", &mk("2026-03-21", "Jon"));
+        write_meeting(&meetings, "b2.md", &mk("2026-03-22", "Jan"));
+        write_meeting(&meetings, "b3.md", &mk("2026-03-23", "Jan Smith"));
+
+        let config = test_config(&meetings);
+        let stats = rebuild_to_temp(&config, &tmp);
+
+        for c in &stats.alias_clusters {
+            let has_jon = c.slugs.iter().any(|s| s == "jon");
+            let has_jan_smith = c.slugs.iter().any(|s| s == "jan-smith");
+            assert!(
+                !(has_jon && has_jan_smith),
+                "distinct people bridged into one cluster: {c:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,13 @@ pub mod device_monitor;
 pub mod diarize;
 pub mod dictation_cleanup;
 pub mod dictation_memory;
+/// Person entity-resolution clustering (issue #385, class 3): suggestion-only
+/// grouping of name-variant fragments. Never merges.
+pub(crate) mod entity_cluster;
+/// Entity-resolution evaluation harness (cluster-level). Test-only; the
+/// measurement contract for the entity-clustering lever (issue #385 / #371).
+#[cfg(test)]
+mod entity_resolution_eval;
 pub mod error;
 pub mod events;
 pub mod ffmpeg;

--- a/crates/core/src/name_correction.rs
+++ b/crates/core/src/name_correction.rs
@@ -134,7 +134,7 @@ fn differs_only_by_case(token: &str, surface: &str) -> bool {
     token != surface && token.to_lowercase() == surface.to_lowercase()
 }
 
-fn levenshtein(a: &str, b: &str) -> usize {
+pub(crate) fn levenshtein(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();
     let mut prev: Vec<usize> = (0..=b.len()).collect();
@@ -148,6 +148,13 @@ fn levenshtein(a: &str, b: &str) -> usize {
         std::mem::swap(&mut prev, &mut cur);
     }
     prev[b.len()]
+}
+
+/// Case/accent-folded normalization of a name token, shared with the
+/// entity-resolution clustering pass so both layers agree on what "the same
+/// characters" means (lowercase + accent fold, e.g. `José` -> `jose`).
+pub(crate) fn normalize_name(s: &str) -> String {
+    normalize(s)
 }
 
 fn build_pool(

--- a/docs/plans/person-entity-resolution-2026-06-26.md
+++ b/docs/plans/person-entity-resolution-2026-06-26.md
@@ -132,6 +132,12 @@ items below were confirmed by **direct source fetch**, and everything under
 
 ### Slice 0 — Entity-resolution eval harness (measure first)
 
+Status (2026-07-01): SHIPPED as `crates/core/src/entity_resolution_eval.rs`
+(test-gated, synthetic names). Gates `wrong_merges == 0` and full drift recall,
+reports B-cubed precision/recall, and scores (does not gate) the ambiguous
+short-name band. A full graph-rebuild test (`test_alias_clusters_full_rebuild`)
+exercises the real path, not just helpers.
+
 Extend `name_eval` into a clustering eval. Synthetic fixture: sets of name
 fragments with ground-truth person clusters, covering (a) spelling drift,
 (b) role/title contamination, and critically (c) **true-distinct-people
@@ -155,6 +161,20 @@ Regression cases land in the Slice 0 eval. Independent of the rest; shippable
 immediately.
 
 ### Slice 2 — alias clustering pass + confirm-merge
+
+Status (2026-07-01): part 1 (clustering pass) SHIPPED, suggestion-only. New
+edge predicate `entity_cluster::names_plausibly_same_person` (Double Metaphone +
+bounded Levenshtein, reused from `name_correction`, plus separator-insensitive
+compaction), unioned transitively with the existing `names_likely_same` via
+`entity_cluster::cluster_indices` and surfaced as `graph::AliasCluster` in
+`GraphStats` and the `minutes people` rebuild output. `shared_meetings` is
+evidence only, NOT a gate (drift variants of one person recur across *different*
+meetings). Part 2 (confirm-merge action + persistence) and any auto-merge remain
+DEFERRED — nothing is merged or written, so a wrong suggestion costs precision,
+not data. Class-2 multi-person concatenation (`gert-liam`) is also deferred: it
+must be source-aware and graph-rebuild-aware (splitting only `entities.people`
+would leave raw `attendees`/assignees to re-fuse on rebuild), and the safe
+delimiters are narrower than they look (`Ben & Jerry`, `Smith, John, Jr.`).
 
 Two parts, and the first is genuinely new work, not just promotion. The existing
 `names_likely_same` edge predicate requires identical first-name tokens, so it

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1317;
+export const MINUTES_TEST_COUNT = 1331;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What

Part of #385 (and #371). Surfaces person **name-variant fragments** — the same person split across spellings like `junrei` / `jun-rei` / `junlei` / `junwei`, or `geert` / `gert` — as suggested clusters during `minutes people` rebuild, so they're finally visible. **Suggestion-only: nothing is merged or written.**

## Pieces

- **Slice 0 — entity-resolution eval harness** (`entity_resolution_eval.rs`, test-gated, synthetic names). Gates `wrong_merges == 0`, full drift recall, B-cubed precision/recall, and a **clique-property** gate; scores (does not gate) the ambiguous short-name band. A full graph-rebuild test exercises the real path.
- **`entity_cluster` module** — the variant predicate:
  - *Separator variant*: identical characters modulo separators/case (`jun-rei` ~ `junrei`).
  - *Spelling edit*: single-token, **ASCII**, same-first-letter, within a length-scaled edit budget (`junrei` ~ `junlei`). ASCII-only so a single edit between distinct non-ASCII names (`李雷`/`李蕾`) is never suggested.
  - **Clique-based clustering** (not connected components): every pair in a cluster is a direct match, so fuzzy drift *chains* (`jon`~`jan`~`jana`) never bridge non-matching endpoints.
- **`graph::AliasCluster`** in `GraphStats`, surfaced in the CLI rebuild output. Prefix/last-name matches stay separate pairwise `AliasSuggestion`s. `ORDER BY slug` for deterministic output.

## Design discipline (per `docs/plans/person-entity-resolution-2026-06-26.md`)

"A wrong merge is worse than a split." This ships the *measurement* + *suggestion* layers only. The **confirm-merge action + persistence** and **class-2 multi-person concatenation** (`gert-liam`) remain deferred — the latter needs source-aware + rebuild-aware handling, not a slug-level split (indistinguishable from real hyphenated names).

## Testing

- 924 core + 46 CLI + 8 integration green. Eval + clique + CJK + drift-chain + bridge regression tests.
- Adversarially reviewed with codex across **three passes** (design → RESCOPE, implementation → FIX-FIRST, verify → found the transitive-chain class). All findings folded in: mixed-edge bridge, drift-chain, non-ASCII over-match, non-determinism, eval realism.

## Not superseded by / does not supersede #388

Distinct subsystem: #388 was transcript-body `name_corrections`; this is the knowledge-graph person entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)