### PR TITLE
feat(cli): `minutes people merge` confirm-merge for name-variant clusters (#385)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,12 @@ minutes list                                      # Recent recordings
 ```bash
 minutes people                                     # Who you talk to, how often, about what
 minutes people --rebuild                           # Rebuild the relationship index
+minutes people merge junrei junlei jun-rei          # Confirm variants are one person (canonical first)
 minutes commitments                                # All open + overdue commitments
 minutes commitments --person alex                   # What did I promise Alex?
 ```
 
-Tracks people, commitments, topics, and relationship health across every meeting. Detects when you're losing touch with someone. Suggests duplicate contacts ("Sarah Chen" ↔ "Sarah"). Powered by a SQLite index rebuilt from your markdown in <50ms.
+Tracks people, commitments, topics, and relationship health across every meeting. Detects when you're losing touch with someone. Suggests duplicate contacts ("Sarah Chen" ↔ "Sarah") and name-variant fragments a transcriber spelled several ways ("junrei" ↔ "junlei" ↔ "jun-rei"). `minutes people --rebuild` prints a ready-to-run `minutes people merge` command under each suggested cluster; confirming it records a durable alias so every variant collapses to the canonical person on future rebuilds. Powered by a SQLite index rebuilt from your markdown in <50ms.
 
 ### Cross-meeting intelligence
 ```bash

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -622,6 +622,10 @@ enum Commands {
 
     /// Show relationship overview: top contacts, commitments, losing-touch alerts
     People {
+        /// Subcommand (e.g. `merge`); omit to list the relationship graph
+        #[command(subcommand)]
+        action: Option<PeopleAction>,
+
         /// Force full index rebuild from markdown files
         #[arg(long)]
         rebuild: bool,
@@ -1176,6 +1180,30 @@ enum SensitiveAction {
 }
 
 #[derive(Subcommand)]
+enum PeopleAction {
+    /// Confirm that several people are the same person and collapse them.
+    ///
+    /// Records a durable person alias (in the local vocabulary) so future
+    /// transcripts, search, and graph rebuilds resolve every variant spelling to
+    /// the canonical one. The first argument is the surviving canonical name; the
+    /// rest are its variants. Accepts slugs (from the "Possible name variants"
+    /// suggestions) or exact names.
+    Merge {
+        /// Canonical (surviving) person: a slug or exact name.
+        canonical: String,
+        /// Variant people to fold into the canonical: slugs or exact names.
+        #[arg(required = true)]
+        aliases: Vec<String>,
+        /// Skip the automatic graph rebuild (run `minutes people --rebuild` later).
+        #[arg(long)]
+        no_rebuild: bool,
+        /// Output raw JSON instead of formatted text
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum VocabularyAction {
     /// List local vocabulary entries
     List {
@@ -1652,10 +1680,27 @@ fn main() -> Result<()> {
         } => cmd_consistency(owner.as_deref(), stale_after_days, &config),
         Commands::Person { name } => cmd_person(&name, &config),
         Commands::People {
+            action,
             rebuild,
             json,
             limit,
-        } => cmd_people(rebuild, json, limit, &config),
+        } => match action {
+            Some(PeopleAction::Merge {
+                canonical,
+                aliases,
+                no_rebuild,
+                json: merge_json,
+            }) => cmd_people_merge(
+                &canonical,
+                &aliases,
+                no_rebuild,
+                // Accept `--json` whether typed on `people` or on `merge`, so the
+                // otherwise-inert parent flag isn't silently ignored.
+                json || merge_json,
+                &config,
+            ),
+            None => cmd_people(rebuild, json, limit, &config),
+        },
         Commands::Vocabulary { action } => cmd_vocabulary(action, &config),
         Commands::Commitments { person, json } => cmd_commitments(person.as_deref(), json, &config),
         Commands::Research {
@@ -3455,6 +3500,203 @@ fn cmd_person(name: &str, config: &Config) -> Result<()> {
     Ok(())
 }
 
+/// Shell-quote a token for a copy-pasteable command (slugs rarely need it).
+fn shell_quote_arg(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        s.to_string()
+    } else {
+        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+    }
+}
+
+/// Render the ready-to-run merge command for a suggested cluster. `slugs[0]` is
+/// the highest-evidence spelling (canonical); the rest fold into it.
+fn format_merge_command(slugs: &[String]) -> String {
+    let quoted: Vec<String> = slugs.iter().map(|s| shell_quote_arg(s)).collect();
+    format!("minutes people merge {}", quoted.join(" "))
+}
+
+#[derive(Serialize)]
+struct PeopleMergeOutput {
+    canonical: String,
+    aliases: Vec<String>,
+    unresolved: Vec<String>,
+    saved: bool,
+    rebuilt: bool,
+    people_before: Option<usize>,
+    people_after: Option<usize>,
+}
+
+/// Resolve a slug-or-name token to a graph person's display name. Exact match on
+/// slug or (case-insensitively) on name; never fuzzy. Returns `(name, resolved)`;
+/// an unresolved token is passed through literally so a person not yet in the
+/// graph can still be named, but the caller warns about it.
+fn resolve_person_token(
+    token: &str,
+    people: &[minutes_core::graph::PersonSummary],
+) -> (String, bool) {
+    let t = token.trim();
+    if let Some(p) = people.iter().find(|p| p.slug.eq_ignore_ascii_case(t)) {
+        return (p.name.clone(), true);
+    }
+    let name_matches: Vec<&minutes_core::graph::PersonSummary> = people
+        .iter()
+        .filter(|p| p.name.eq_ignore_ascii_case(t))
+        .collect();
+    if name_matches.len() == 1 {
+        return (name_matches[0].name.clone(), true);
+    }
+    (t.to_string(), false)
+}
+
+fn cmd_people_merge(
+    canonical: &str,
+    aliases: &[String],
+    no_rebuild: bool,
+    json: bool,
+    config: &Config,
+) -> Result<()> {
+    use minutes_core::graph;
+    use minutes_core::vocabulary;
+
+    // Best-effort: resolve slugs/names against the current graph. If the graph
+    // isn't built yet, fall back to treating every token as a literal name.
+    let people = graph::relationship_map(config).unwrap_or_default();
+
+    let (canonical_name, canonical_resolved) = resolve_person_token(canonical, &people);
+    let mut unresolved: Vec<String> = Vec::new();
+    if !canonical_resolved {
+        unresolved.push(canonical.trim().to_string());
+    }
+
+    // Resolve aliases; drop any that equal the canonical after resolution.
+    let mut alias_names: Vec<String> = Vec::new();
+    for a in aliases {
+        let (name, resolved) = resolve_person_token(a, &people);
+        if !resolved {
+            unresolved.push(a.trim().to_string());
+        }
+        if name.eq_ignore_ascii_case(&canonical_name)
+            || alias_names.iter().any(|n| n.eq_ignore_ascii_case(&name))
+        {
+            continue;
+        }
+        alias_names.push(name);
+    }
+
+    if alias_names.is_empty() {
+        anyhow::bail!(
+            "nothing to merge: no variant distinct from canonical \"{}\"",
+            canonical_name
+        );
+    }
+
+    if !unresolved.is_empty() {
+        eprintln!(
+            "  Note: not currently in the graph, treated as literal name(s): {}",
+            unresolved.join(", ")
+        );
+    }
+
+    // Persist the confirmed merge as a Person vocabulary entry (canonical +
+    // variant aliases). On rebuild the canonicalizer routes every variant to the
+    // canonical slug; the vocabulary survives the graph.db wipe.
+    let path = vocabulary::default_path();
+    let mut store = vocabulary::load().map_err(|e| anyhow::anyhow!("{}", e))?;
+    let now = Local::now().to_rfc3339();
+    store.entries.push(vocabulary::VocabularyEntry {
+        kind: vocabulary::VocabularyKind::Person,
+        canonical: canonical_name.clone(),
+        aliases: alias_names.clone(),
+        priority: vocabulary::VocabularyPriority::Normal,
+        source: vocabulary::VocabularySource::Manual,
+        created_at: Some(now.clone()),
+        updated_at: Some(now),
+        ..vocabulary::VocabularyEntry::default()
+    });
+
+    let normalized = match store.normalized() {
+        Ok(s) => s,
+        Err(e) => {
+            // Fail closed on alias conflict; name the offending entry + recovery.
+            if let vocabulary::VocabularyError::AliasConflict {
+                alias, existing, ..
+            } = &e
+            {
+                let existing_id = vocabulary::load()
+                    .ok()
+                    .and_then(|s| {
+                        s.entries
+                            .into_iter()
+                            .find(|entry| {
+                                entry.kind == vocabulary::VocabularyKind::Person
+                                    && entry.canonical.eq_ignore_ascii_case(existing)
+                            })
+                            .map(|entry| entry.id)
+                    })
+                    .unwrap_or_default();
+                anyhow::bail!(
+                    "\"{alias}\" is already a confirmed variant of \"{existing}\"{}. \
+                     Merge into \"{existing}\" instead (make it the canonical), or remove that entry first{}.",
+                    if existing_id.is_empty() { String::new() } else { format!(" (vocabulary entry {existing_id})") },
+                    if existing_id.is_empty() { String::new() } else { format!(": minutes vocabulary remove {existing_id}") }
+                );
+            }
+            return Err(anyhow::anyhow!("{}", e));
+        }
+    };
+    vocabulary::save_at(&path, &normalized).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let people_before = Some(people.len());
+    let mut rebuilt = false;
+    let mut people_after = None;
+    if !no_rebuild {
+        match graph::rebuild_index(config) {
+            Ok(stats) => {
+                rebuilt = true;
+                people_after = Some(stats.people_count);
+            }
+            Err(e) => {
+                eprintln!(
+                    "  Saved the merge, but the graph rebuild failed ({e}). \
+                     Run `minutes people --rebuild` to apply it."
+                );
+            }
+        }
+    }
+
+    if json {
+        let out = PeopleMergeOutput {
+            canonical: canonical_name,
+            aliases: alias_names,
+            unresolved,
+            saved: true,
+            rebuilt,
+            people_before,
+            people_after,
+        };
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        eprintln!(
+            "Merged {} variant(s) into \"{}\": {}",
+            alias_names.len(),
+            canonical_name,
+            alias_names.join(", ")
+        );
+        if rebuilt {
+            if let (Some(b), Some(a)) = (people_before, people_after) {
+                eprintln!("  Graph rebuilt: {b} → {a} people.");
+            }
+        } else if no_rebuild {
+            eprintln!("  Not rebuilt (--no-rebuild). Run `minutes people --rebuild` to apply.");
+        }
+    }
+    Ok(())
+}
+
 fn cmd_people(rebuild: bool, json: bool, limit: usize, config: &Config) -> Result<()> {
     use minutes_core::graph;
 
@@ -3474,6 +3716,9 @@ fn cmd_people(rebuild: bool, json: bool, limit: usize, config: &Config) -> Resul
                     String::new()
                 };
                 eprintln!("  {}{}", cluster.members.join(" ↔ "), shared);
+                // slugs[0] is the highest-evidence spelling (canonical); the rest
+                // fold into it. This is a ready-to-run confirm-merge.
+                eprintln!("    merge: {}", format_merge_command(&cluster.slugs));
             }
         }
         if !stats.alias_suggestions.is_empty() {
@@ -3484,9 +3729,6 @@ fn cmd_people(rebuild: bool, json: bool, limit: usize, config: &Config) -> Resul
                     alias.name_a, alias.name_b, alias.shared_meetings
                 );
             }
-        }
-        if !stats.alias_clusters.is_empty() || !stats.alias_suggestions.is_empty() {
-            eprintln!("  Review manually; automatic merging is not yet available.");
         }
         eprintln!();
     }
@@ -7129,6 +7371,63 @@ mod tests {
             confidence,
             source: minutes_core::diarize::AttributionSource::Llm,
         }
+    }
+
+    #[test]
+    fn shell_quote_arg_leaves_slugs_bare_and_quotes_spaces() {
+        assert_eq!(shell_quote_arg("jun-rei"), "jun-rei");
+        assert_eq!(shell_quote_arg("junrei_v2"), "junrei_v2");
+        assert_eq!(shell_quote_arg("Jun Rei"), "\"Jun Rei\"");
+        assert_eq!(shell_quote_arg("a\"b"), "\"a\\\"b\"");
+    }
+
+    #[test]
+    fn format_merge_command_uses_first_slug_as_canonical() {
+        let slugs = vec![
+            "junrei".to_string(),
+            "junlei".to_string(),
+            "jun-rei".to_string(),
+        ];
+        assert_eq!(
+            format_merge_command(&slugs),
+            "minutes people merge junrei junlei jun-rei"
+        );
+        // A name with a space gets quoted.
+        let slugs = vec!["jun rei".to_string(), "junlei".to_string()];
+        assert_eq!(
+            format_merge_command(&slugs),
+            "minutes people merge \"jun rei\" junlei"
+        );
+    }
+
+    #[test]
+    fn resolve_person_token_matches_slug_then_name_else_literal() {
+        let people = vec![minutes_core::graph::PersonSummary {
+            slug: "jun-rei".into(),
+            name: "Jun Rei".into(),
+            meeting_count: 3,
+            last_seen: String::new(),
+            days_since: 0.0,
+            open_commitments: 0,
+            top_topics: vec![],
+            score: 0.0,
+            losing_touch: false,
+        }];
+        // slug match (case-insensitive) -> display name, resolved
+        assert_eq!(
+            resolve_person_token("JUN-REI", &people),
+            ("Jun Rei".into(), true)
+        );
+        // exact name match -> resolved
+        assert_eq!(
+            resolve_person_token("jun rei", &people),
+            ("Jun Rei".into(), true)
+        );
+        // no match -> literal, unresolved
+        assert_eq!(
+            resolve_person_token("Bobby", &people),
+            ("Bobby".into(), false)
+        );
     }
 
     #[test]

--- a/crates/core/src/graph.rs
+++ b/crates/core/src/graph.rs
@@ -1032,11 +1032,18 @@ fn detect_aliases(conn: &Connection) -> Result<Vec<AliasSuggestion>, GraphError>
 /// Suggestion only — nothing is merged.
 fn detect_alias_clusters(conn: &Connection) -> Result<Vec<AliasCluster>, GraphError> {
     // ORDER BY slug so cluster membership and ordering are stable across rebuilds
-    // (SQLite row order otherwise follows insertion history).
-    let mut stmt = conn.prepare("SELECT slug, name FROM people ORDER BY slug")?;
-    let people: Vec<(String, String)> = stmt
+    // (SQLite row order otherwise follows insertion history). meeting_count is
+    // carried so each cluster can put its highest-evidence spelling first — that
+    // is the sensible default canonical for a suggested merge, rather than an
+    // arbitrary alphabetical spelling that might be a typo (#385).
+    let mut stmt = conn.prepare("SELECT slug, name, meeting_count FROM people ORDER BY slug")?;
+    let people: Vec<(String, String, i64)> = stmt
         .query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
         })?
         .filter_map(|r| r.ok())
         .collect();
@@ -1070,9 +1077,18 @@ fn detect_alias_clusters(conn: &Connection) -> Result<Vec<AliasCluster>, GraphEr
                 max_shared = max_shared.max(shared as usize);
             }
         }
+        // Order members by evidence (meeting_count desc, then slug for stability)
+        // so members[0]/slugs[0] is the suggested canonical spelling.
+        let mut ordered: Vec<usize> = cluster.clone();
+        ordered.sort_by(|&a, &b| {
+            people[b]
+                .2
+                .cmp(&people[a].2)
+                .then_with(|| people[a].0.cmp(&people[b].0))
+        });
         result.push(AliasCluster {
-            members: cluster.iter().map(|&i| people[i].1.clone()).collect(),
-            slugs: cluster.iter().map(|&i| people[i].0.clone()).collect(),
+            members: ordered.iter().map(|&i| people[i].1.clone()).collect(),
+            slugs: ordered.iter().map(|&i| people[i].0.clone()).collect(),
             max_shared_meetings: max_shared,
         });
     }
@@ -1947,6 +1963,58 @@ Short meeting.
                 .iter()
                 .any(|m| m.eq_ignore_ascii_case("bright")),
             "distinct person leaked into drift cluster: {cluster:?}"
+        );
+    }
+
+    #[test]
+    fn test_confirmed_merge_collapses_variants_on_rebuild() {
+        // #385 confirm-merge durability: a Person vocabulary entry (canonical +
+        // variant aliases) must collapse the fragmented people into one on the
+        // next rebuild, with all meetings re-pointed to the canonical slug. This
+        // is the persistence contract the `minutes people merge` command relies on.
+        let tmp = TempDir::new().unwrap();
+        let meetings = tmp.path().join("meetings");
+        fs::create_dir_all(&meetings).unwrap();
+        let mk = |date: &str, attendee: &str| {
+            format!(
+                "---\ntitle: Sync\ntype: meeting\ndate: {date}T09:00:00-07:00\nduration: 15m\nattendees: [{attendee}]\ntags: []\n---\nNotes.\n"
+            )
+        };
+        write_meeting(&meetings, "a.md", &mk("2026-03-21", "Junrei"));
+        write_meeting(&meetings, "b.md", &mk("2026-03-22", "Junlei"));
+        write_meeting(&meetings, "c.md", &mk("2026-03-23", "Jun-Rei"));
+
+        let config = test_config(&meetings);
+        let db = tmp.path().join("graph.db");
+
+        // Without a confirmed merge: three fragmented people.
+        let stats = rebuild_index_at(&config, &db).unwrap();
+        assert_eq!(stats.people_count, 3, "expected 3 fragments before merge");
+
+        // Confirmed merge = a Person vocab entry (canonical + aliases), the exact
+        // shape `minutes people merge` writes.
+        let merged = vec![EntityRef {
+            slug: "junrei".into(),
+            label: "Junrei".into(),
+            aliases: vec!["Junlei".into(), "Jun-Rei".into()],
+        }];
+        let stats = rebuild_index_at_with_vocabulary_entities(&config, &db, merged).unwrap();
+        assert_eq!(
+            stats.people_count, 1,
+            "variants must collapse to one person"
+        );
+
+        let conn = open_db(&db).unwrap();
+        let (slug, name, meetings_count): (String, String, i64) = conn
+            .query_row("SELECT slug, name, meeting_count FROM people", [], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+            })
+            .unwrap();
+        assert_eq!(slug, "junrei");
+        assert_eq!(name, "Junrei");
+        assert_eq!(
+            meetings_count, 3,
+            "all three meetings re-point to the canonical"
         );
     }
 

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -195,6 +195,12 @@ impl VocabularyStore {
                 if existing.source != VocabularySource::Manual {
                     existing.source = entry.source;
                 }
+                // Advance the audit timestamp to the most recent of the two so a
+                // later merge (which adds aliases) refreshes `updated_at`. Using
+                // max never regresses to an older stamp and never blanks an
+                // existing one when the incoming entry has no timestamp.
+                existing.updated_at =
+                    std::cmp::max(existing.updated_at.clone(), entry.updated_at.clone());
             } else {
                 merged.insert(key, entry);
             }
@@ -508,6 +514,79 @@ mod tests {
         assert_eq!(merged.entries.len(), 1);
         assert_eq!(merged.entries[0].aliases, vec!["Elijah", "Eli"]);
         assert_eq!(merged.entries[0].priority, VocabularyPriority::High);
+    }
+
+    #[test]
+    fn merge_refreshes_updated_at_when_aliases_added() {
+        // Two same-canonical entries with different timestamps; combining them
+        // adds an alias, so updated_at should advance to the newer stamp.
+        let store = VocabularyStore {
+            entries: vec![
+                VocabularyEntry {
+                    kind: VocabularyKind::Person,
+                    canonical: "Junrei".into(),
+                    aliases: vec!["Junlei".into()],
+                    updated_at: Some("2026-07-01T00:00:00+00:00".into()),
+                    ..VocabularyEntry::default()
+                },
+                VocabularyEntry {
+                    kind: VocabularyKind::Person,
+                    canonical: "Junrei".into(),
+                    aliases: vec!["Jun-Rei".into()],
+                    updated_at: Some("2026-07-02T00:00:00+00:00".into()),
+                    ..VocabularyEntry::default()
+                },
+            ],
+        }
+        .normalized()
+        .unwrap();
+        assert_eq!(store.entries.len(), 1);
+        assert_eq!(store.entries[0].aliases, vec!["Junlei", "Jun-Rei"]);
+        assert_eq!(
+            store.entries[0].updated_at.as_deref(),
+            Some("2026-07-02T00:00:00+00:00"),
+            "updated_at should advance to the newer merge"
+        );
+    }
+
+    #[test]
+    fn merge_updated_at_never_regresses_or_blanks() {
+        // Newer entry first, older second, plus an entry with no timestamp: the
+        // merged updated_at must be the newest present, never the older one, and
+        // never None.
+        let store = VocabularyStore {
+            entries: vec![
+                VocabularyEntry {
+                    kind: VocabularyKind::Person,
+                    canonical: "Junrei".into(),
+                    aliases: vec!["Junlei".into()],
+                    updated_at: Some("2026-07-05T00:00:00+00:00".into()),
+                    ..VocabularyEntry::default()
+                },
+                VocabularyEntry {
+                    kind: VocabularyKind::Person,
+                    canonical: "Junrei".into(),
+                    aliases: vec!["Jun-Rei".into()],
+                    updated_at: Some("2026-07-01T00:00:00+00:00".into()),
+                    ..VocabularyEntry::default()
+                },
+                VocabularyEntry {
+                    kind: VocabularyKind::Person,
+                    canonical: "Junrei".into(),
+                    aliases: vec!["Junwei".into()],
+                    updated_at: None,
+                    ..VocabularyEntry::default()
+                },
+            ],
+        }
+        .normalized()
+        .unwrap();
+        assert_eq!(store.entries.len(), 1);
+        assert_eq!(
+            store.entries[0].updated_at.as_deref(),
+            Some("2026-07-05T00:00:00+00:00"),
+            "must keep the newest stamp, never regress or blank"
+        );
     }
 
     #[test]

--- a/docs/plans/person-entity-resolution-2026-06-26.md
+++ b/docs/plans/person-entity-resolution-2026-06-26.md
@@ -169,12 +169,24 @@ compaction), unioned transitively with the existing `names_likely_same` via
 `entity_cluster::cluster_indices` and surfaced as `graph::AliasCluster` in
 `GraphStats` and the `minutes people` rebuild output. `shared_meetings` is
 evidence only, NOT a gate (drift variants of one person recur across *different*
-meetings). Part 2 (confirm-merge action + persistence) and any auto-merge remain
-DEFERRED — nothing is merged or written, so a wrong suggestion costs precision,
-not data. Class-2 multi-person concatenation (`gert-liam`) is also deferred: it
-must be source-aware and graph-rebuild-aware (splitting only `entities.people`
-would leave raw `attendees`/assignees to re-fuse on rebuild), and the safe
-delimiters are narrower than they look (`Ben & Jerry`, `Smith, John, Jr.`).
+meetings).
+
+Status (2026-07-02): part 2 (confirm-merge action + persistence) SHIPPED as
+`minutes people merge <canonical> <variant...>`. Persistence reuses the
+vocabulary store (no new graph routing): the command writes a `Person`
+`VocabularyEntry{canonical, aliases}`, which `load_vocabulary_person_entities`
+feeds into the `PersonCanonicalizer` on rebuild, collapsing every variant to the
+canonical slug and re-pointing meetings/commitments. It survives the `graph.db`
+wipe because vocabulary.toml is not derived. Canonical is evidence-ranked in the
+suggested command (highest `meeting_count` first); `validate_alias_conflicts`
+fail-closes on a variant already bound to a different canonical (named error +
+recovery command); the graph auto-rebuilds (or `--no-rebuild`), reporting
+saved/rebuilt separately. Auto-merge is still NOT done — merges are
+human-confirmed only. Class-2 multi-person concatenation (`gert-liam`) also
+remains DEFERRED: it must be source-aware and graph-rebuild-aware (splitting only
+`entities.people` would leave raw `attendees`/assignees to re-fuse on rebuild),
+and the safe delimiters are narrower than they look (`Ben & Jerry`, `Smith, John,
+Jr.`).
 
 Two parts, and the first is genuinely new work, not just promotion. The existing
 `names_likely_same` edge predicate requires identical first-name tokens, so it

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1338;
+export const MINUTES_TEST_COUNT = 1344;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What

Continues #385. Turns the suggestion-only name-variant clusters from #390 into a durable, applied merge.

`minutes people merge <canonical> <variant...>` confirms that several fragmented people are one person and collapses them. `minutes people --rebuild` now prints a ready-to-run merge command under each "Possible name variants" cluster.

```bash
minutes people --rebuild
#   Possible name variants (same person, different spellings?):
#     Junrei ↔ Junlei ↔ Jun-Rei
#       merge: minutes people merge junrei junlei jun-rei
minutes people merge junrei junlei jun-rei
#   Merged 2 variant(s) into "Junrei": Junlei, Jun-Rei
#   Graph rebuilt: 3 → 1 people.
```

## How it works (zero new persistence code)

A confirmed merge is persisted as a `Person` entry in the local vocabulary store (`canonical` + variant `aliases`). On graph rebuild, `load_vocabulary_person_entities` feeds it to the `PersonCanonicalizer`, which routes every variant mention to the canonical slug and re-points meetings/commitments. It survives the `graph.db` wipe because `vocabulary.toml` is not derived. This reuses the existing canonicalization path end to end.

## Details

- **Args accept slugs** (from the printed suggestion) **or exact names**; exact match only — slug (case-insensitive), then unique exact name — never fuzzy. Unresolved tokens pass through as literals with a warning.
- **Canonical is evidence-ranked** in the suggested command (`meeting_count` desc, then slug), so the surviving spelling is the highest-evidence one, not an arbitrary/typo variant.
- **Conflict fail-closed**: if a variant already belongs to a different canonical, it errors without writing, names the conflicting vocabulary entry, and prints the exact recovery command.
- **Auto-rebuilds** (or `--no-rebuild`); reports `saved` / `rebuilt` separately so a save-but-rebuild-failure is honest.
- `--json` accepted on either `people` or `merge`.
- Still **human-confirmed only** — no auto-merge.

## Testing

- 934 core + 49 CLI green. New: a core durability test (`test_confirmed_merge_collapses_variants_on_rebuild`) proving the vocab entry collapses 3 fragments → 1 with all meetings re-pointed; CLI tests for quoting, evidence-ranked command formatting, exact token resolution; vocabulary `updated_at` refresh + no-regress/no-blank tests.
- Adversarially reviewed with codex across three passes — plan (PROCEED-WITH-CHANGES), implementation (FIX-FIRST: parent `--json` ignored, `updated_at` stale), re-verify (**SHIP**). All findings fixed, plus a timestamp-regression edge case caught during review.

## Deferred (tracked on #385)

Class-2 multi-person concatenation (`gert-liam`), an "absorb/repoint" path for the conflict case, and a merge MCP tool. Non-blocking nits: inert parent `--rebuild`/`--limit` before `merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)