### PR TITLE
fix(scripts): revert engine-sherpa/vad-ort from default app-build features

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,17 +10,14 @@ fi
 
 export CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1"
 export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
-# Local app builds include the SOTA extras (engine-sherpa + vad-ort) when the
-# native toolchain can build them: sherpa-rs-sys needs cmake. Contributors
-# without cmake keep the lighter default instead of a broken build. Override
-# explicitly with MINUTES_BUILD_FEATURES to force either way.
+# engine-sherpa / vad-ort stay OPT-IN for app builds: their dynamic libraries
+# (libsherpa-onnx-c-api.dylib, libonnxruntime) are not bundled into the .app or
+# rpath'd into installed binaries yet, so a default build with them produces
+# apps/CLIs that crash at launch with dyld "Library not loaded" (#369, #395).
+# Opt in explicitly once packaging is solved:
+#   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa
 if [ -z "${MINUTES_BUILD_FEATURES+x}" ]; then
-    if command -v cmake >/dev/null 2>&1; then
-        MINUTES_BUILD_FEATURES="parakeet,metal,vad-ort,engine-sherpa"
-    else
-        echo "[minutes] cmake not found — building without vad-ort/engine-sherpa (brew install cmake to enable the sherpa stack)" >&2
-        MINUTES_BUILD_FEATURES="parakeet,metal"
-    fi
+    MINUTES_BUILD_FEATURES="parakeet,metal"
 fi
 
 # Ensure cargo runs through rustup so rust-toolchain.toml is honored.

--- a/scripts/install-dev-app.sh
+++ b/scripts/install-dev-app.sh
@@ -6,17 +6,14 @@ cd "$ROOT_DIR"
 
 export CXXFLAGS="${CXXFLAGS:-"-I$(xcrun --show-sdk-path)/usr/include/c++/v1"}"
 export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
-# Local app builds include the SOTA extras (engine-sherpa + vad-ort) when the
-# native toolchain can build them: sherpa-rs-sys needs cmake. Contributors
-# without cmake keep the lighter default instead of a broken build. Override
-# explicitly with MINUTES_BUILD_FEATURES to force either way.
+# engine-sherpa / vad-ort stay OPT-IN for app builds: their dynamic libraries
+# (libsherpa-onnx-c-api.dylib, libonnxruntime) are not bundled into the .app or
+# rpath'd into installed binaries yet, so a default build with them produces
+# apps/CLIs that crash at launch with dyld "Library not loaded" (#369, #395).
+# Opt in explicitly once packaging is solved:
+#   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa
 if [ -z "${MINUTES_BUILD_FEATURES+x}" ]; then
-    if command -v cmake >/dev/null 2>&1; then
-        MINUTES_BUILD_FEATURES="parakeet,metal,vad-ort,engine-sherpa"
-    else
-        echo "[minutes] cmake not found — building without vad-ort/engine-sherpa (brew install cmake to enable the sherpa stack)" >&2
-        MINUTES_BUILD_FEATURES="parakeet,metal"
-    fi
+    MINUTES_BUILD_FEATURES="parakeet,metal"
 fi
 
 # Match scripts/build.sh: route cargo through rustup so rust-toolchain.toml


### PR DESCRIPTION
Emergency revert of one piece of #396, verified live on the maintainer machine.

## What broke

With cmake present, the new default `MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa` builds fine but produces **broken artifacts**:

- The .app bundle has no `Contents/Frameworks`; the binary references `@rpath/libsherpa-onnx-c-api.dylib` and `@rpath/libonnxruntime.1.17.1.dylib` that are nowhere in the bundle. The app would crash at launch.
- An installed CLI (`cp target/release/minutes ~/.local/bin/`) dies immediately: `dyld: Library not loaded: @rpath/libonnxruntime.1.17.1.dylib ... no LC_RPATH's found`. Reproduced and then restored on the maintainer machine.

The features compile and pass `cargo check`/tests (which run from target where cargo arranges lib paths), which is why CI and the #396 review did not catch it. Only a real install exercise did.

## This PR

- Script defaults revert to `parakeet,metal` (explicit `MINUTES_BUILD_FEATURES` still always wins, including explicit-empty).
- The comment documents the exact dyld failure so nobody re-adds the default before packaging is solved.
- The tauri `engine-sherpa`/`vad-ort` passthrough features from #396 stay: opt-in remains correct and is the substrate for the packaging fix.

## The real fix (tracked on #369)

Sherpa/ort-in-app needs dylib bundling (Contents/Frameworks + install_name_tool rpaths, or tauri resources) or static linking. Until then sherpa remains CLI-source-build only, as #369 states.

Shipped without a codex review cycle: this is a revert to the long-standing pre-#396 default, with the failure reproduced live before and verified fixed after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)