### PR TITLE
fix(core): static sherpa linking on macOS — opt-in engine-sherpa builds are self-contained (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,8 @@ minutes setup --diarization
 minutes setup --sherpa        # downloads the int8 ONNX model (~670MB) + sets engine = "sherpa"
 # If you select sherpa without the feature/model, transcription auto-falls-back
 # to Whisper (the bundled default), so a recording never breaks. See docs/SHERPA-ENGINE.md.
+# macOS sherpa builds are self-contained (static). On Linux/Windows, run from the
+# repo (cargo run) rather than copying the binary out of target/ — details in the doc.
 
 # Alternative: use Parakeet engine (opt-in, local GPU via parakeet.cpp)
 # Requires (1) parakeet.cpp installed (https://github.com/Frikallo/parakeet.cpp)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -50,7 +50,6 @@ cpal = { workspace = true }
 hound = { workspace = true }
 notify = { workspace = true }
 whisper-rs = { workspace = true, optional = true }
-sherpa-rs = { version = "0.6.8", default-features = false, features = ["download-binaries", "static"], optional = true }
 symphonia = { workspace = true }
 ureq = { workspace = true }
 fs2 = { workspace = true }
@@ -73,15 +72,25 @@ cidre = { version = "0.15.0", default-features = false, features = ["at", "av", 
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSRunningApplication", "NSWorkspace", "libc"] }
 objc2-av-foundation = { version = "0.3.2", default-features = false, features = ["AVCaptureDevice", "AVMediaFormat"] }
+# Static sherpa-onnx on macOS so opt-in engine-sherpa builds produce apps/CLIs
+# with no dangling @rpath dylib refs (the #369 packaging blocker; verified by
+# real launch + transcription). `default-features = false` drops upstream `tts`.
+sherpa-rs = { version = "0.6.8", default-features = false, features = ["download-binaries", "static"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = "5.14.0"
+# Dynamic on Linux: sherpa-rs-sys's `static` panics in build.rs here unless a
+# global RUSTFLAGS relocation hack is set. CLI-from-source stays the Linux path.
+sherpa-rs = { version = "0.6.8", default-features = false, features = ["download-binaries"], optional = true }
 
 # Native hotkey (CGEventTap) uses raw FFI — no extra crate deps needed.
 # The macOS frameworks are linked automatically via #[link(name = "...")]
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
+# Dynamic on Windows, as before the macOS static fix (CI builds this gate on
+# all three platforms; static archives are only wired up for macOS).
+sherpa-rs = { version = "0.6.8", default-features = false, features = ["download-binaries"], optional = true }
 
 [dev-dependencies]
 hound = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,8 +31,9 @@ denoise = ["dep:nnnoiseless"]
 vad-ort = ["streaming", "dep:ort", "dep:ndarray"]
 # Opt-in SOTA transcription engine: sherpa-onnx + parakeet-tdt-0.6b-v3 (multilingual,
 # no Python), in-process via sherpa-rs. Off by default; whisper.cpp stays the default.
-# Validated to coexist with `diarize`/`vad-ort`'s ort (separate onnxruntime, hidden
-# symbols). No parakeet/ort dep -> no rc.10/rc.12 conflict.
+# Linkage is per-target (see the [target.*] sherpa-rs deps below): macOS static
+# (self-contained binaries, #369), Linux/Windows dynamic (run from target layout).
+# Coexists with `diarize`/`vad-ort`'s ort either way; no parakeet/ort dep here.
 engine-sherpa = ["dep:sherpa-rs"]
 
 [dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -50,7 +50,7 @@ cpal = { workspace = true }
 hound = { workspace = true }
 notify = { workspace = true }
 whisper-rs = { workspace = true, optional = true }
-sherpa-rs = { version = "0.6.8", optional = true }
+sherpa-rs = { version = "0.6.8", default-features = false, features = ["download-binaries", "static"], optional = true }
 symphonia = { workspace = true }
 ureq = { workspace = true }
 fs2 = { workspace = true }

--- a/crates/core/src/sherpa_engine.rs
+++ b/crates/core/src/sherpa_engine.rs
@@ -1,9 +1,12 @@
 //! sherpa-onnx transcription engine (feature `engine-sherpa`, opt-in, off by default).
 //!
-//! In-process via the `sherpa-rs` crate (no Python). Validated 2026-06-24 to
-//! coexist with the existing `ort`-based pyannote/vad path: `sherpa-rs-sys`
-//! statically embeds onnxruntime with hidden symbols (no `links = onnxruntime`
-//! manifest), while the app's `ort` dependency is linked separately.
+//! In-process via the `sherpa-rs` crate (no Python). Linkage differs by target
+//! (see the per-target `sherpa-rs` deps in Cargo.toml): on macOS sherpa-onnx is
+//! linked STATICALLY so opt-in app/CLI binaries are self-contained (#369); on
+//! Linux/Windows it stays DYNAMIC (upstream's static path needs a global
+//! RUSTFLAGS hack there), so binaries must run from the cargo target layout.
+//! Either way it coexists with the `ort`-based pyannote/vad path: sherpa's
+//! onnxruntime symbols stay separate from the app's `ort` dependency.
 //! parakeet-tdt-0.6b-v3 is multilingual (FR/ES/etc.) with correct orthography.
 //!
 //! Scaffold scope: model directory is resolved from `MINUTES_SHERPA_MODEL_DIR`.

--- a/crates/core/src/sherpa_engine.rs
+++ b/crates/core/src/sherpa_engine.rs
@@ -3,8 +3,7 @@
 //! In-process via the `sherpa-rs` crate (no Python). Validated 2026-06-24 to
 //! coexist with the existing `ort`-based pyannote/vad path: `sherpa-rs-sys`
 //! statically embeds onnxruntime with hidden symbols (no `links = onnxruntime`
-//! manifest), `ort` ships its own dynamic onnxruntime, and macOS two-level
-//! namespacing keeps them separate (both happen to be onnxruntime 1.17.1).
+//! manifest), while the app's `ort` dependency is linked separately.
 //! parakeet-tdt-0.6b-v3 is multilingual (FR/ES/etc.) with correct orthography.
 //!
 //! Scaffold scope: model directory is resolved from `MINUTES_SHERPA_MODEL_DIR`.
@@ -102,6 +101,10 @@ fn build_recognizer(config: &Config) -> Result<TransducerRecognizer, String> {
         debug: false,
         ..Default::default()
     };
+    tracing::info!(
+        model_dir = %dir.display(),
+        "loading sherpa-onnx transducer recognizer"
+    );
     TransducerRecognizer::new(cfg).map_err(|e| format!("failed to load sherpa model: {e}"))
 }
 
@@ -119,6 +122,11 @@ pub fn transcribe_segments(samples: &[f32], config: &Config) -> Result<Vec<(u64,
             segments.push((start_ms, text));
         }
     }
+    tracing::info!(
+        samples = samples.len(),
+        segments = segments.len(),
+        "sherpa-onnx transcription complete"
+    );
     Ok(segments)
 }
 

--- a/docs/SHERPA-ENGINE.md
+++ b/docs/SHERPA-ENGINE.md
@@ -22,6 +22,15 @@ rm -f ~/.local/bin/minutes && cp target/release/minutes ~/.local/bin/minutes
 minutes setup --sherpa     # downloads the int8 ONNX model + sets engine = "sherpa"
 ```
 
+> **Platform note.** On macOS, `engine-sherpa` links sherpa-onnx statically, so
+> the binary is self-contained and the copy above just works. On Linux and
+> Windows, sherpa-rs still links dynamic libraries (`libsherpa-onnx-c-api`,
+> `libonnxruntime`) that live in the cargo `target/` tree: a binary copied out
+> of `target/` fails at startup with a library-not-found error. On those
+> platforms run from the repo (`cargo run --release -p minutes-cli --features
+> engine-sherpa -- ...`) or put the libraries on your loader path yourself.
+> Installable Linux/Windows packaging is tracked in #369.
+
 `minutes setup --sherpa` downloads the four model files (with a size-floor
 integrity check) and writes `transcription.engine = "sherpa"` to your config, so
 no manual edit is needed. If the binary lacks the `engine-sherpa` feature, setup

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,11 +10,10 @@ fi
 
 export CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1"
 export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
-# engine-sherpa / vad-ort stay OPT-IN for app builds: their dynamic libraries
-# (libsherpa-onnx-c-api.dylib, libonnxruntime) are not bundled into the .app or
-# rpath'd into installed binaries yet, so a default build with them produces
-# apps/CLIs that crash at launch with dyld "Library not loaded" (#369, #395).
-# Opt in explicitly once packaging is solved:
+# engine-sherpa / vad-ort stay OPT-IN for app builds pending the #369 release
+# decision. Packaging is fixed for opt-in local builds: sherpa links statically
+# and the existing ort path does not leave dangling runtime dylib references.
+# Opt in explicitly:
 #   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa
 if [ -z "${MINUTES_BUILD_FEATURES+x}" ]; then
     MINUTES_BUILD_FEATURES="parakeet,metal"

--- a/scripts/install-dev-app.sh
+++ b/scripts/install-dev-app.sh
@@ -6,11 +6,10 @@ cd "$ROOT_DIR"
 
 export CXXFLAGS="${CXXFLAGS:-"-I$(xcrun --show-sdk-path)/usr/include/c++/v1"}"
 export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
-# engine-sherpa / vad-ort stay OPT-IN for app builds: their dynamic libraries
-# (libsherpa-onnx-c-api.dylib, libonnxruntime) are not bundled into the .app or
-# rpath'd into installed binaries yet, so a default build with them produces
-# apps/CLIs that crash at launch with dyld "Library not loaded" (#369, #395).
-# Opt in explicitly once packaging is solved:
+# engine-sherpa / vad-ort stay OPT-IN for app builds pending the #369 release
+# decision. Packaging is fixed for opt-in local builds: sherpa links statically
+# and the existing ort path does not leave dangling runtime dylib references.
+# Opt in explicitly:
 #   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa
 if [ -z "${MINUTES_BUILD_FEATURES+x}" ]; then
     MINUTES_BUILD_FEATURES="parakeet,metal"
@@ -63,14 +62,19 @@ run_with_ort_retry() {
 }
 
 OPEN_AFTER_INSTALL=1
+INSTALL_AFTER_BUILD=1
 for arg in "$@"; do
   case "$arg" in
     --no-open)
       OPEN_AFTER_INSTALL=0
       ;;
+    --target-only)
+      OPEN_AFTER_INSTALL=0
+      INSTALL_AFTER_BUILD=0
+      ;;
     *)
       echo "Unknown option: $arg" >&2
-      echo "Usage: ./scripts/install-dev-app.sh [--no-open]" >&2
+      echo "Usage: ./scripts/install-dev-app.sh [--no-open] [--target-only]" >&2
       exit 1
       ;;
   esac
@@ -144,35 +148,50 @@ fi
 echo "=== Verifying bundle seal (strict) ==="
 codesign --verify --deep --strict "$BUILD_APP" && echo "  Seal OK"
 
-echo "=== Installing ${DEV_PRODUCT_NAME}.app to ${INSTALL_DIR} ==="
-mkdir -p "$INSTALL_DIR"
-rm -rf "$INSTALL_APP"
-cp -rf "$BUILD_APP" "$INSTALL_APP"
+if [[ "$INSTALL_AFTER_BUILD" == "1" ]]; then
+  echo "=== Installing ${DEV_PRODUCT_NAME}.app to ${INSTALL_DIR} ==="
+  mkdir -p "$INSTALL_DIR"
+  rm -rf "$INSTALL_APP"
+  cp -rf "$BUILD_APP" "$INSTALL_APP"
 
-echo "=== Running native hotkey diagnostic from installed dev app ==="
-set +e
-./scripts/diagnose-desktop-hotkey.sh "$INSTALL_APP"
-DIAG_EXIT=$?
-set -e
+  echo "=== Running native hotkey diagnostic from installed dev app ==="
+  set +e
+  ./scripts/diagnose-desktop-hotkey.sh "$INSTALL_APP"
+  DIAG_EXIT=$?
+  set -e
+else
+  DIAG_EXIT="skipped"
+fi
 
 echo ""
-echo "Installed app: $INSTALL_APP"
+if [[ "$INSTALL_AFTER_BUILD" == "1" ]]; then
+  echo "Installed app: $INSTALL_APP"
+else
+  echo "Built app: $BUILD_APP"
+fi
 echo "Bundle id: com.useminutes.desktop.dev"
 echo "Build features: $MINUTES_BUILD_FEATURES"
 echo "Signing mode: $SIGN_MODE"
 echo "Hotkey diagnostic exit code: $DIAG_EXIT"
 echo "  0 = CGEventTap started successfully"
 echo "  2 = Input Monitoring / macOS identity is still blocking the hotkey"
-echo ""
-echo "For TCC-sensitive testing, launch only this installed dev app."
-echo "Avoid the repo symlink (./Minutes.app), raw target bundles, or ad-hoc builds."
+if [[ "$INSTALL_AFTER_BUILD" == "1" ]]; then
+  echo ""
+  echo "For TCC-sensitive testing, launch only this installed dev app."
+  echo "Avoid the repo symlink (./Minutes.app), raw target bundles, or ad-hoc builds."
+fi
 if [[ "$SIGN_MODE" == "adhoc" ]]; then
   echo ""
   echo "Tip: export MINUTES_DEV_SIGNING_IDENTITY to a consistent local signing identity"
   echo "if you want more stable macOS permission behavior across rebuilds."
 fi
 
-if [[ "$OPEN_AFTER_INSTALL" == "1" ]]; then
+if [[ "$INSTALL_AFTER_BUILD" == "0" ]]; then
+  echo ""
+  echo "Target-only mode: launch $BUILD_APP directly for packaging checks."
+fi
+
+if [[ "$OPEN_AFTER_INSTALL" == "1" && "$INSTALL_AFTER_BUILD" == "1" ]]; then
   echo ""
   echo "=== Launching ${DEV_PRODUCT_NAME}.app ==="
   open -a "$INSTALL_APP"


### PR DESCRIPTION
## What

Fixes the concrete #369 packaging blocker found in #395/#397: opt-in `engine-sherpa` builds produced binaries referencing `@rpath/libsherpa-onnx-c-api.dylib` and `@rpath/libonnxruntime.1.17.1.dylib` that nothing bundled — apps crashed at launch, installed CLIs died with dyld "Library not loaded".

## Fix

**macOS: link sherpa-onnx statically.** `sherpa-rs` moves to per-target deps: macOS uses `default-features = false, features = ["download-binaries", "static"]` (upstream ships osx static archives; dropping defaults also drops unused `tts`). No bundling, no rpath surgery — binaries are self-contained.

**Linux/Windows: dynamic, as before.** sherpa-rs-sys's `static` panics in build.rs on Linux without a global `RUSTFLAGS` relocation hack, and CI deliberately builds the `engine-sherpa` gate on all three platforms. Docs now state the platform split plainly (macOS copy-anywhere; Linux/Windows run from the cargo target layout).

Also: two `tracing::info` success logs in `sherpa_engine` (recognizer load, transcription complete) so a real sherpa run is distinguishable from the whisper fallback — the same honesty principle as #396 — and `install-dev-app.sh --target-only` for packaging verification without touching `~/Applications`.

## Verification (real runs, both platforms)

macOS (maintainer machine):
- `MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa ./scripts/install-dev-app.sh --target-only`: bundle builds, seal verifies, **zero** `@rpath`/sherpa/onnxruntime refs in app binary, bundled sidecar CLI, and standalone CLI.
- Launched the built app from target/: process alive >10s.
- Copied the CLI to a temp dir and ran a **real sherpa transcription** of `crates/assets/demo.wav` with a temp config: correct transcript, `sherpa-onnx transcription complete` in logs, **no** "falling back to whisper".
- Re-verified after the per-target split: build clean, still 0 dangling refs.

Linux (this box):
- The exact CI gate `cargo build -p minutes-core --no-default-features --features engine-sherpa` fails on `static` (upstream panic), passes with the per-target scoping — including `--locked` and the combined `diarize,vad-ort,engine-sherpa` build.

Plus: 911 core tests green, fmt clean, llms.txt in sync, default builds verified unchanged (no sherpa in default feature graph, no new refs).

## Review provenance

Implemented by a codex session on the maintainer's macOS machine against a full acceptance-criteria brief; cross-platform CI risk caught and fixed in review here (Linux static panic); fresh-context codex adversarial review then verified Cargo semantics/`--locked`/tts-drop/`--target-only` and flagged the doc gaps fixed in the final commit. NOTICE/third-party attribution for the statically embedded runtime is deliberately tied to the #369 release decision (nothing distributes the feature yet).

## What this unlocks / what stays open on #369

Local macOS opt-in builds (`MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa`) now produce working apps and CLIs — the dev-app SOTA batch testing path is real. Still open on #369: whether release binaries ship sherpa (size/notarization/NOTICE), Linux/Windows install packaging, and sherpa-live (does not exist; live remains whisper/parakeet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)