### PR TITLE
feat(dictation): surface output destination in Settings

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -5298,6 +5298,16 @@
         </div>
         <div class="about-controls">
           <div class="about-controls-group">
+            <div class="about-controls-copy">Where dictated text goes</div>
+            <select id="settings-dictation-destination" class="settings-field">
+              <option value="insert">Type at cursor — inserts into the app you're in (needs Accessibility)</option>
+              <option value="clipboard">Copy to clipboard — paste it yourself</option>
+            </select>
+            <div class="about-controls-meta">"Type at cursor" pastes the transcript straight into the focused app. macOS asks for Accessibility permission the first time; until granted it falls back to the clipboard.</div>
+          </div>
+        </div>
+        <div class="about-controls">
+          <div class="about-controls-group">
             <div class="about-controls-copy">Dictation whisper model</div>
             <select id="settings-dictation-model" class="settings-field">
               <option value="tiny">tiny — fastest, lower quality</option>
@@ -9474,6 +9484,9 @@
         }
         // Dictation settings
         if (s.dictation) {
+          // Empty/unset destination means the compiled default (insert).
+          document.getElementById('settings-dictation-destination').value =
+            (s.dictation.destination && s.dictation.destination !== '') ? s.dictation.destination : 'insert';
           document.getElementById('settings-dictation-model').value = s.dictation.model || 'base';
           setSettingsToggle('settings-dictation-daily-note', s.dictation.daily_note_log !== false);
           document.getElementById('settings-dictation-silence').value = String(s.dictation.silence_timeout_ms || 2000);
@@ -10345,6 +10358,7 @@
         document.getElementById('settings-dictation-shortcut-status').textContent = String(e2);
       }
     });
+    document.getElementById('settings-dictation-destination').addEventListener('change', (e) => invoke('cmd_set_setting', { section: 'dictation', key: 'destination', value: e.target.value }));
     document.getElementById('settings-dictation-model').addEventListener('change', (e) => invoke('cmd_set_setting', { section: 'dictation', key: 'model', value: e.target.value }));
     document.getElementById('settings-dictation-silence').addEventListener('change', (e) => invoke('cmd_set_setting', { section: 'dictation', key: 'silence_timeout_ms', value: e.target.value }));
     document.getElementById('settings-dictation-daily-note').addEventListener('click', async () => {


### PR DESCRIPTION
## What

Adds a **"Where dictated text goes"** selector to the DICTATION section of Settings — insert-at-cursor vs copy-to-clipboard — with a note about the one-time macOS Accessibility grant and the clipboard fallback.

## Why

Found while dogfooding dictation v1 (#403): an existing user whose config had `destination = "clipboard"` got **no signal** that dictation can now type directly at the cursor. The new insert default only applies to configs that don't set a destination, so the people who already dictate — exactly the ones who'd want this — were silently opted out with no way to discover it in the UI. This makes the choice visible and switchable.

## Implementation

Pure frontend (`index.html`): a `<select>` plus load/save wiring through the existing `cmd_set_setting` `dictation/destination` path (backend already supported it). Empty/unset renders as the compiled default (insert). Follows the exact pattern of the adjacent dictation selects (model, silence timeout).

## Testing

- `node --check` on the extracted inline JS passes.
- Needs the standard dev-app click-test (Settings → Capture → Dictation): the selector loads the current value, switching it persists to config, and the fallback note reads clearly. Building onto the dev app now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)