### PR TITLE
fix(core): ort-silero VAD init panic degrades to whisper-silero instead of crashing the recording sidecar (#408)

### DIFF
--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -1329,7 +1329,8 @@ mod tests {
 
     #[test]
     fn combine_results_joins_text_and_duration() {
-        let config = Config::default();
+        let mut config = Config::default();
+        config.dictation.destination = "clipboard".into();
         let results = vec![
             DictationResult {
                 raw_text: "first sentence.".into(),

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -1253,6 +1253,29 @@ struct RecordingSidecarVad {
 #[cfg(feature = "whisper")]
 impl RecordingSidecarVad {
     fn new(config: &Config) -> Self {
+        #[cfg(feature = "vad-ort")]
+        {
+            return Self::new_with_ort_constructor(
+                config,
+                crate::silero_vad::OrtSileroVad::new_catching_unwind,
+            );
+        }
+        #[cfg(not(feature = "vad-ort"))]
+        {
+            Self::new_without_ort(config)
+        }
+    }
+
+    #[cfg(feature = "vad-ort")]
+    fn new_with_ort_constructor(
+        config: &Config,
+        ort_constructor: impl FnOnce(
+            &Path,
+        ) -> Result<
+            crate::silero_vad::OrtSileroVad,
+            crate::silero_vad::OrtSileroError,
+        >,
+    ) -> Self {
         // Pick the engine the user asked for. When ort-silero is
         // requested but unavailable (feature off, ONNX missing, or
         // load failure), fall through to whisper-silero with an
@@ -1276,7 +1299,15 @@ impl RecordingSidecarVad {
         #[cfg(feature = "vad-ort")]
         if want_ort {
             if let Some(onnx_path) = crate::transcribe::resolve_silero_onnx_path(config) {
-                match crate::silero_vad::OrtSileroVad::new(&onnx_path) {
+                let ort_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    ort_constructor(&onnx_path)
+                }))
+                .unwrap_or_else(|payload| {
+                    Err(crate::silero_vad::OrtSileroError::Panic(
+                        crate::silero_vad::panic_payload_message(payload),
+                    ))
+                });
+                match ort_result {
                     Ok(engine) => {
                         tracing::info!(
                             vad_engine = "ort-silero",
@@ -1291,7 +1322,7 @@ impl RecordingSidecarVad {
                         tracing::warn!(
                             onnx_model = %onnx_path.display(),
                             error = %e,
-                            "ort-Silero load failed — falling back to whisper-silero"
+                            "ort-silero VAD failed to initialize; falling back to whisper-silero"
                         );
                     }
                 }
@@ -1304,6 +1335,67 @@ impl RecordingSidecarVad {
             }
         }
         #[cfg(not(feature = "vad-ort"))]
+        if want_ort {
+            tracing::warn!(
+                "ort-silero requested but this build was not compiled with the `vad-ort` \
+                 feature — falling back to whisper-silero"
+            );
+        }
+
+        if let Some(vad_path) = crate::transcribe::resolve_vad_model_path(config) {
+            match SileroSidecarVad::new(&vad_path) {
+                Ok(vad) => {
+                    tracing::info!(
+                        vad_engine = "whisper-silero",
+                        vad_model = %vad_path.display(),
+                        "recording sidecar using whisper-Silero VAD"
+                    );
+                    return Self {
+                        backend: RecordingSidecarVadBackend::Silero(vad),
+                    };
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        vad_model = %vad_path.display(),
+                        error = %e,
+                        "failed to initialize Silero VAD for recording sidecar — falling back to energy VAD"
+                    );
+                }
+            }
+        } else {
+            tracing::warn!(
+                "Silero VAD model unavailable for recording sidecar — falling back to energy VAD"
+            );
+        }
+
+        tracing::info!(vad_engine = "energy", "recording sidecar using energy VAD");
+        Self {
+            backend: RecordingSidecarVadBackend::Energy(Vad::new()),
+        }
+    }
+
+    #[cfg(not(feature = "vad-ort"))]
+    fn new_without_ort(config: &Config) -> Self {
+        // Pick the engine the user asked for. When ort-silero is
+        // requested but unavailable (feature off, ONNX missing, or
+        // load failure), fall through to whisper-silero with an
+        // explicit warn — silent fallback is the support footgun
+        // codex flagged in the spec review.
+        let requested = config.transcription.vad_engine.trim().to_lowercase();
+        let want_ort = matches!(requested.as_str(), "ort-silero" | "ort" | "silero-ort");
+        if !requested.is_empty()
+            && !want_ort
+            && !matches!(
+                requested.as_str(),
+                "whisper-silero" | "silero" | "whisper" | "default"
+            )
+        {
+            tracing::warn!(
+                requested = %requested,
+                "unknown transcription.vad_engine value — falling through to whisper-silero"
+            );
+        }
+
         if want_ort {
             tracing::warn!(
                 "ort-silero requested but this build was not compiled with the `vad-ort` \
@@ -3171,6 +3263,33 @@ mod tests {
         );
         silero.force_failed_for_test(true);
         assert!(!<SileroSidecarVad as VadEngine>::is_healthy(&silero));
+    }
+
+    #[cfg(all(feature = "whisper", feature = "streaming", feature = "vad-ort"))]
+    #[test]
+    fn ort_silero_init_panic_falls_back_to_whisper_silero() {
+        let default_config = Config::default();
+        let Some(vad_model) = crate::transcribe::resolve_vad_model_path(&default_config) else {
+            eprintln!("[ort_fallback] skipping: no whisper-Silero VAD model installed");
+            return;
+        };
+
+        let dir = tempdir().unwrap();
+        std::fs::copy(&vad_model, dir.path().join("ggml-silero-v6.2.0.bin")).unwrap();
+        std::fs::write(dir.path().join("silero-vad-v6.2.0.onnx"), b"dummy onnx").unwrap();
+
+        let mut config = default_config;
+        config.transcription.model_path = dir.path().to_path_buf();
+        config.transcription.vad_model = "silero-v6.2.0".into();
+        config.transcription.vad_engine = "ort-silero".into();
+
+        let vad = RecordingSidecarVad::new_with_ort_constructor(&config, |_onnx_path| {
+            panic!("Failed to initialize ORT API")
+        });
+        assert!(
+            matches!(vad.backend, RecordingSidecarVadBackend::Silero(_)),
+            "ort-silero init panic must fall back to whisper-silero"
+        );
     }
 
     /// Look up the canonical Silero model paths for parity tests.

--- a/crates/core/src/silero_vad.rs
+++ b/crates/core/src/silero_vad.rs
@@ -40,6 +40,7 @@ use crate::vad::{VadEngine, VadResult};
 use ndarray::{Array1, Array2, Array3};
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 
 /// Number of carry samples prepended to each chunk before inference.
@@ -92,6 +93,15 @@ impl OrtSileroVad {
     /// it for the life of the recording.
     pub fn new(silero_vad_path: &Path) -> Result<Self, OrtSileroError> {
         Self::with_params(silero_vad_path, SmoothingParams::whisper_silero_defaults())
+    }
+
+    /// Build a fresh session, converting ORT init panics into normal
+    /// constructor errors so the recording sidecar can fall back.
+    pub fn new_catching_unwind(silero_vad_path: &Path) -> Result<Self, OrtSileroError> {
+        match catch_unwind(AssertUnwindSafe(|| Self::new(silero_vad_path))) {
+            Ok(result) => result,
+            Err(payload) => Err(OrtSileroError::Panic(panic_payload_message(payload))),
+        }
     }
 
     /// Build with custom smoothing parameters. Mostly useful for
@@ -372,6 +382,8 @@ impl VadEngine for OrtSileroVad {
 /// failure rather than starting a doomed engine.
 #[derive(Debug, thiserror::Error)]
 pub enum OrtSileroError {
+    #[error("ort init panicked: {0}")]
+    Panic(String),
     #[error("ort session builder: {0}")]
     SessionBuilder(String),
     #[error("ort model load: {0}")]
@@ -380,6 +392,16 @@ pub enum OrtSileroError {
     Inference(String),
     #[error("Silero ONNX schema mismatch (Silero release changed contract?): {0}")]
     SchemaMismatch(String),
+}
+
+pub(crate) fn panic_payload_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
 }
 
 #[cfg(test)]
@@ -426,6 +448,14 @@ mod tests {
         let engine = engine.unwrap();
         assert!(engine.is_healthy());
         assert_eq!(engine.name(), "ort-silero");
+    }
+
+    #[test]
+    fn panic_payload_message_preserves_ort_init_text() {
+        let error = OrtSileroError::Panic(panic_payload_message(Box::new(
+            "Failed to initialize ORT API",
+        )));
+        assert!(error.to_string().contains("Failed to initialize ORT API"));
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1350;
+export const MINUTES_TEST_COUNT = 1352;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Closes #408.

## Incident
A live recording on the SOTA dev build (`parakeet,metal,vad-ort,engine-sherpa`) died mid-meeting: `live-transcript-status.json` showed `state: failed`, `diagnostic: "sidecar panicked: Failed to initialize ORT API"`. The mic kept recording to WAV the whole time — only the live-transcript sidecar crashed. Config had `vad_engine = "ort-silero"`; the previous dev build didn't compile `vad-ort` so it silently fell back, but the SOTA build actually tried to init ORT and the `ort` crate **panicked** (`OrtGetApiBase().GetApi()` → null → `.expect("Failed to initialize ORT API")`) instead of returning an error — below the `Result` boundary the fallback chain relied on.

## Fix
A VAD init failure must never crash a live recording. `OrtSileroVad::new_catching_unwind` wraps construction in `catch_unwind`, converting a panic into `OrtSileroError::Panic`, so ORT init failure now follows the **same** recoverable path as a missing model or an uncompiled feature: **ort-silero → whisper-silero → energy**, with an honest `tracing::warn!`. Same honest-degradation principle as #395/#396. Regression test `ort_silero_init_panic_falls_back_to_whisper_silero` injects the exact incident panic and asserts fallback to `Silero` with nothing escaping.

## Review
Fresh-context adversarial review found no blockers: `AssertUnwindSafe` narrowly scoped to construction; ort's global API pointer uses `OnceLock`/`call_once_force` (a caught init panic isn't permanently poisoned); whisper-silero uses whisper-rs (no ort), isolating the fallback. Tests (`vad-ort,streaming` + `--no-default-features`), fmt, clippy green.

## Root cause: narrowed, not fixed here
The two-static-onnxruntime hypothesis was **refuted in `cargo test`** — co-compiling `engine-sherpa` + `vad-ort` still inits ORT fine in a debug binary. The panic only manifests in the packaged, signed .app process (release linkage + init order), so root-causing needs an app-bundle repro. Tracked on #408, feeds #369. **This PR closes the incident class regardless.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)