### PR TITLE
feat(sherpa): VAD-based segmentation — speech boundaries instead of fixed 15s windows (#369)

### DIFF
--- a/crates/core/src/sherpa_engine.rs
+++ b/crates/core/src/sherpa_engine.rs
@@ -69,15 +69,20 @@ pub fn model_files_present(dir: &std::path::Path) -> bool {
     })
 }
 
-/// Window length for batch transcription. Sherpa transducers are fed in ~15 s
-/// windows: this yields utterance-granularity timestamps (sufficient for the
-/// `[SPEAKER_X m:ss]` transcript format + diarization overlap-mapping), keeps
-/// each decode within the length offline transducers handle best (very long
-/// single decodes degrade), and uses ONLY safe high-level sherpa-rs calls -- no
-/// unsafe per-token FFI in the default transcription path. Per-token timestamp
-/// precision is tracked as an upstream sherpa-rs follow-up.
 #[cfg(feature = "engine-sherpa")]
-const WINDOW_SAMPLES: usize = 16_000 * 15;
+const SAMPLE_RATE: usize = 16_000;
+#[cfg(feature = "engine-sherpa")]
+const FIXED_WINDOW_SAMPLES: usize = SAMPLE_RATE * 15;
+#[cfg(feature = "engine-sherpa")]
+const SHERPA_MAX_REGION_SAMPLES: usize = SAMPLE_RATE * 30;
+#[cfg(feature = "engine-sherpa")]
+const SHERPA_MIN_SPLIT_SEGMENT_SAMPLES: usize = SAMPLE_RATE;
+#[cfg(feature = "engine-sherpa")]
+const SHERPA_PADDING_SAMPLES: usize = SAMPLE_RATE / 5; // 200 ms
+#[cfg(feature = "engine-sherpa")]
+const SHERPA_MERGE_GAP_SAMPLES: usize = SAMPLE_RATE * 3 / 10; // 300 ms
+#[cfg(feature = "engine-sherpa")]
+const ENERGY_WINDOW_SAMPLES: usize = SAMPLE_RATE / 10; // 100 ms
 
 #[cfg(feature = "engine-sherpa")]
 fn build_recognizer(config: &Config) -> Result<TransducerRecognizer, String> {
@@ -111,15 +116,198 @@ fn build_recognizer(config: &Config) -> Result<TransducerRecognizer, String> {
     TransducerRecognizer::new(cfg).map_err(|e| format!("failed to load sherpa model: {e}"))
 }
 
-/// Transcribe 16 kHz mono f32 in ~15 s windows, returning `(start_ms, text)` for
-/// each non-empty window. The window start time gives a timestamp the pipeline
-/// uses for the `[m:ss]` transcript format and diarization speaker-mapping.
+#[cfg(feature = "engine-sherpa")]
+fn fixed_window_ranges(samples_len: usize) -> Vec<(usize, usize)> {
+    (0..samples_len)
+        .step_by(FIXED_WINDOW_SAMPLES)
+        .map(|start| (start, (start + FIXED_WINDOW_SAMPLES).min(samples_len)))
+        .filter(|(start, end)| end > start)
+        .collect()
+}
+
+#[cfg(feature = "engine-sherpa")]
+fn pad_merge_and_split_regions(
+    samples: &[f32],
+    speech_regions: &[(usize, usize)],
+) -> Vec<(usize, usize)> {
+    if speech_regions.is_empty() {
+        return Vec::new();
+    }
+
+    let mut padded = Vec::with_capacity(speech_regions.len());
+    for &(start, end) in speech_regions {
+        if end <= start || start >= samples.len() {
+            continue;
+        }
+        padded.push((
+            start.saturating_sub(SHERPA_PADDING_SAMPLES),
+            (end + SHERPA_PADDING_SAMPLES).min(samples.len()),
+        ));
+    }
+    if padded.is_empty() {
+        return Vec::new();
+    }
+
+    padded.sort_unstable_by_key(|(start, _)| *start);
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(padded.len());
+    for (start, end) in padded {
+        if let Some((_, last_end)) = merged.last_mut() {
+            if start.saturating_sub(*last_end) < SHERPA_MERGE_GAP_SAMPLES {
+                *last_end = (*last_end).max(end);
+                continue;
+            }
+        }
+        merged.push((start, end));
+    }
+
+    let mut bounded = Vec::with_capacity(merged.len());
+    for (start, end) in merged {
+        split_long_region(samples, start, end, &mut bounded);
+    }
+    bounded
+}
+
+#[cfg(feature = "engine-sherpa")]
+fn split_long_region(samples: &[f32], mut start: usize, end: usize, out: &mut Vec<(usize, usize)>) {
+    while end.saturating_sub(start) > SHERPA_MAX_REGION_SAMPLES {
+        let hard_end = (start + SHERPA_MAX_REGION_SAMPLES).min(end);
+        let split = find_low_energy_split(samples, start, hard_end).unwrap_or(hard_end);
+        let split = split.clamp(
+            start + SHERPA_MIN_SPLIT_SEGMENT_SAMPLES,
+            hard_end.max(start + SHERPA_MIN_SPLIT_SEGMENT_SAMPLES),
+        );
+        out.push((start, split));
+        start = split;
+    }
+    if end > start {
+        out.push((start, end));
+    }
+}
+
+#[cfg(feature = "engine-sherpa")]
+fn find_low_energy_split(samples: &[f32], start: usize, hard_end: usize) -> Option<usize> {
+    let search_start = start + SHERPA_MIN_SPLIT_SEGMENT_SAMPLES;
+    let search_end = hard_end.saturating_sub(SHERPA_MIN_SPLIT_SEGMENT_SAMPLES);
+    if search_end <= search_start {
+        return None;
+    }
+
+    let mut best: Option<(usize, f32)> = None;
+    let mut window_start = search_start;
+    while window_start + ENERGY_WINDOW_SAMPLES <= search_end {
+        let window = &samples[window_start..window_start + ENERGY_WINDOW_SAMPLES];
+        let rms = rms(window);
+        if best.map(|(_, best_rms)| rms < best_rms).unwrap_or(true) {
+            best = Some((window_start + ENERGY_WINDOW_SAMPLES / 2, rms));
+        }
+        window_start += ENERGY_WINDOW_SAMPLES;
+    }
+    best.map(|(split, _)| split)
+}
+
+#[cfg(feature = "engine-sherpa")]
+fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    (samples
+        .iter()
+        .map(|sample| (*sample as f64) * (*sample as f64))
+        .sum::<f64>()
+        / samples.len() as f64)
+        .sqrt() as f32
+}
+
+#[cfg(all(feature = "engine-sherpa", feature = "whisper"))]
+fn vad_speech_regions(samples: &[f32], config: &Config) -> Result<Vec<(usize, usize)>, String> {
+    let vad_path = crate::transcribe::resolve_vad_model_path(config)
+        .ok_or_else(|| "Silero VAD model not found".to_string())?;
+    let vad_path = vad_path
+        .to_str()
+        .ok_or_else(|| format!("Silero VAD path is not UTF-8: {}", vad_path.display()))?;
+
+    let mut ctx_params = whisper_rs::WhisperVadContextParams::default();
+    ctx_params.set_n_threads(
+        std::thread::available_parallelism()
+            .map(|count| count.get() as i32)
+            .unwrap_or(4)
+            .min(4),
+    );
+
+    let mut params = whisper_rs::WhisperVadParams::default();
+    params.set_threshold(0.2);
+    params.set_min_speech_duration(150);
+    params.set_min_silence_duration(500);
+    params.set_speech_pad(80);
+
+    let mut ctx = whisper_rs::WhisperVadContext::new(vad_path, ctx_params)
+        .map_err(|e| format!("failed to initialize Silero VAD: {e}"))?;
+    let detected = ctx
+        .segments_from_samples(params, samples)
+        .map_err(|e| format!("failed to run Silero VAD: {e}"))?;
+
+    let segment_count = detected.num_segments();
+    let mut regions = Vec::with_capacity(segment_count.max(0) as usize);
+    for index in 0..segment_count {
+        let segment = detected
+            .get_segment(index)
+            .ok_or_else(|| format!("Silero VAD segment {index} disappeared"))?;
+        let start = ((segment.start * 10.0).round().max(0.0) as usize * SAMPLE_RATE / 1000)
+            .min(samples.len());
+        let end = ((segment.end * 10.0).round().max(0.0) as usize * SAMPLE_RATE / 1000)
+            .min(samples.len());
+        if end > start {
+            regions.push((start, end));
+        }
+    }
+
+    Ok(regions)
+}
+
+#[cfg(feature = "engine-sherpa")]
+fn transcription_ranges(samples: &[f32], config: &Config) -> Vec<(usize, usize)> {
+    #[cfg(feature = "whisper")]
+    {
+        match vad_speech_regions(samples, config) {
+            Ok(regions) => {
+                let ranges = pad_merge_and_split_regions(samples, &regions);
+                if !ranges.is_empty() {
+                    tracing::info!(
+                        samples = samples.len(),
+                        vad_regions = regions.len(),
+                        transcription_ranges = ranges.len(),
+                        "sherpa transcription using Silero VAD segmentation"
+                    );
+                    return ranges;
+                }
+                tracing::warn!(
+                    samples = samples.len(),
+                    "Silero VAD produced no sherpa speech ranges; falling back to fixed windows"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "Silero VAD unavailable for sherpa transcription; falling back to fixed windows"
+                );
+            }
+        }
+    }
+
+    fixed_window_ranges(samples.len())
+}
+
+/// Transcribe 16 kHz mono f32, returning `(start_ms, text)` for each non-empty
+/// speech segment. When Silero VAD is available, sherpa receives speech-boundary
+/// regions with padding, tiny-gap merge, and long-region splitting. If VAD is
+/// unavailable or fails, this falls back to the legacy 15 s fixed windows.
 #[cfg(feature = "engine-sherpa")]
 pub fn transcribe_segments(samples: &[f32], config: &Config) -> Result<Vec<(u64, String)>, String> {
     let mut recognizer = build_recognizer(config)?;
     let mut segments = Vec::new();
-    for (i, window) in samples.chunks(WINDOW_SAMPLES).enumerate() {
-        let start_ms = (i * WINDOW_SAMPLES) as u64 * 1000 / 16_000;
+    for (start, end) in transcription_ranges(samples, config) {
+        let window = &samples[start..end];
+        let start_ms = start as u64 * 1000 / SAMPLE_RATE as u64;
         let text = recognizer.transcribe(16_000, window).trim().to_string();
         if !text.is_empty() {
             segments.push((start_ms, text));
@@ -189,5 +377,76 @@ mod tests {
         }
         assert!(model_files_present(&tmp));
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(feature = "engine-sherpa")]
+    fn samples(seconds: usize, amplitude: f32) -> Vec<f32> {
+        vec![amplitude; seconds * SAMPLE_RATE]
+    }
+
+    #[test]
+    #[cfg(feature = "engine-sherpa")]
+    fn sherpa_vad_ranges_align_to_speech_boundaries_and_merge_tiny_gaps() {
+        let mut audio = samples(1, 0.0);
+        audio.extend(samples(2, 0.05));
+        audio.extend(vec![0.0; SHERPA_MERGE_GAP_SAMPLES / 2]);
+        audio.extend(samples(2, 0.05));
+        audio.extend(samples(4, 0.0));
+        audio.extend(samples(2, 0.05));
+
+        let first_start = SAMPLE_RATE;
+        let first_end = first_start + SAMPLE_RATE * 2;
+        let second_start = first_end + SHERPA_MERGE_GAP_SAMPLES / 2;
+        let second_end = second_start + SAMPLE_RATE * 2;
+        let third_start = second_end + SAMPLE_RATE * 4;
+        let third_end = third_start + SAMPLE_RATE * 2;
+
+        let ranges = pad_merge_and_split_regions(
+            &audio,
+            &[
+                (first_start, first_end),
+                (second_start, second_end),
+                (third_start, third_end),
+            ],
+        );
+
+        assert_eq!(
+            ranges,
+            vec![
+                (
+                    first_start - SHERPA_PADDING_SAMPLES,
+                    second_end + SHERPA_PADDING_SAMPLES
+                ),
+                (
+                    third_start - SHERPA_PADDING_SAMPLES,
+                    (third_end + SHERPA_PADDING_SAMPLES).min(audio.len())
+                )
+            ],
+            "speech-boundary ranges should merge tiny gaps instead of using 15s cuts"
+        );
+        assert_ne!(ranges[0].1, FIXED_WINDOW_SAMPLES);
+    }
+
+    #[test]
+    #[cfg(feature = "engine-sherpa")]
+    fn sherpa_vad_ranges_split_long_regions_at_low_energy_gap() {
+        let mut audio = samples(10, 0.05);
+        audio.extend(samples(1, 0.0));
+        audio.extend(samples(25, 0.05));
+        let speech_end = audio.len();
+
+        let ranges = pad_merge_and_split_regions(&audio, &[(0, speech_end)]);
+
+        assert_eq!(
+            ranges,
+            vec![
+                (0, SAMPLE_RATE * 10 + ENERGY_WINDOW_SAMPLES / 2),
+                (SAMPLE_RATE * 10 + ENERGY_WINDOW_SAMPLES / 2, speech_end)
+            ],
+            "long speech regions should split at the quietest internal gap"
+        );
+        assert!(ranges
+            .iter()
+            .all(|(start, end)| end - start <= SHERPA_MAX_REGION_SAMPLES));
     }
 }

--- a/crates/core/src/sherpa_engine.rs
+++ b/crates/core/src/sherpa_engine.rs
@@ -17,6 +17,12 @@ use std::path::PathBuf;
 // Path/resolution helpers below are always compiled (pure std/Config) so the
 // CLI `setup` command can install + locate models without enabling the engine.
 // Only the sherpa-rs transcription path requires the `engine-sherpa` feature.
+#[cfg(all(
+    feature = "engine-sherpa",
+    feature = "vad-ort",
+    not(feature = "whisper")
+))]
+use crate::vad::VadEngine;
 #[cfg(feature = "engine-sherpa")]
 use sherpa_rs::transducer::{TransducerConfig, TransducerRecognizer};
 
@@ -83,6 +89,31 @@ const SHERPA_PADDING_SAMPLES: usize = SAMPLE_RATE / 5; // 200 ms
 const SHERPA_MERGE_GAP_SAMPLES: usize = SAMPLE_RATE * 3 / 10; // 300 ms
 #[cfg(feature = "engine-sherpa")]
 const ENERGY_WINDOW_SAMPLES: usize = SAMPLE_RATE / 10; // 100 ms
+#[cfg(all(
+    feature = "engine-sherpa",
+    feature = "vad-ort",
+    not(feature = "whisper")
+))]
+const ORT_SILERO_WINDOW_SAMPLES: usize = 512;
+
+#[cfg(feature = "engine-sherpa")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SherpaTranscriptionRange {
+    decode_start: usize,
+    decode_end: usize,
+    speech_start: usize,
+}
+
+#[cfg(feature = "engine-sherpa")]
+impl SherpaTranscriptionRange {
+    fn new(decode_start: usize, decode_end: usize, speech_start: usize) -> Self {
+        Self {
+            decode_start,
+            decode_end,
+            speech_start,
+        }
+    }
+}
 
 #[cfg(feature = "engine-sherpa")]
 fn build_recognizer(config: &Config) -> Result<TransducerRecognizer, String> {
@@ -117,11 +148,17 @@ fn build_recognizer(config: &Config) -> Result<TransducerRecognizer, String> {
 }
 
 #[cfg(feature = "engine-sherpa")]
-fn fixed_window_ranges(samples_len: usize) -> Vec<(usize, usize)> {
+fn fixed_window_ranges(samples_len: usize) -> Vec<SherpaTranscriptionRange> {
     (0..samples_len)
         .step_by(FIXED_WINDOW_SAMPLES)
-        .map(|start| (start, (start + FIXED_WINDOW_SAMPLES).min(samples_len)))
-        .filter(|(start, end)| end > start)
+        .map(|start| {
+            SherpaTranscriptionRange::new(
+                start,
+                (start + FIXED_WINDOW_SAMPLES).min(samples_len),
+                start,
+            )
+        })
+        .filter(|range| range.decode_end > range.decode_start)
         .collect()
 }
 
@@ -129,7 +166,7 @@ fn fixed_window_ranges(samples_len: usize) -> Vec<(usize, usize)> {
 fn pad_merge_and_split_regions(
     samples: &[f32],
     speech_regions: &[(usize, usize)],
-) -> Vec<(usize, usize)> {
+) -> Vec<SherpaTranscriptionRange> {
     if speech_regions.is_empty() {
         return Vec::new();
     }
@@ -139,36 +176,46 @@ fn pad_merge_and_split_regions(
         if end <= start || start >= samples.len() {
             continue;
         }
-        padded.push((
+        padded.push(SherpaTranscriptionRange::new(
             start.saturating_sub(SHERPA_PADDING_SAMPLES),
-            (end + SHERPA_PADDING_SAMPLES).min(samples.len()),
+            end.saturating_add(SHERPA_PADDING_SAMPLES)
+                .min(samples.len()),
+            start,
         ));
     }
     if padded.is_empty() {
         return Vec::new();
     }
 
-    padded.sort_unstable_by_key(|(start, _)| *start);
-    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(padded.len());
-    for (start, end) in padded {
-        if let Some((_, last_end)) = merged.last_mut() {
-            if start.saturating_sub(*last_end) < SHERPA_MERGE_GAP_SAMPLES {
-                *last_end = (*last_end).max(end);
+    padded.sort_unstable_by_key(|range| range.decode_start);
+    let mut merged: Vec<SherpaTranscriptionRange> = Vec::with_capacity(padded.len());
+    for range in padded {
+        if let Some(last) = merged.last_mut() {
+            if range.decode_start.saturating_sub(last.decode_end) < SHERPA_MERGE_GAP_SAMPLES {
+                last.decode_end = last.decode_end.max(range.decode_end);
+                last.speech_start = last.speech_start.min(range.speech_start);
                 continue;
             }
         }
-        merged.push((start, end));
+        merged.push(range);
     }
 
     let mut bounded = Vec::with_capacity(merged.len());
-    for (start, end) in merged {
-        split_long_region(samples, start, end, &mut bounded);
+    for range in merged {
+        split_long_region(samples, range, &mut bounded);
     }
     bounded
 }
 
 #[cfg(feature = "engine-sherpa")]
-fn split_long_region(samples: &[f32], mut start: usize, end: usize, out: &mut Vec<(usize, usize)>) {
+fn split_long_region(
+    samples: &[f32],
+    range: SherpaTranscriptionRange,
+    out: &mut Vec<SherpaTranscriptionRange>,
+) {
+    let mut start = range.decode_start;
+    let end = range.decode_end;
+    let mut speech_start = range.speech_start;
     while end.saturating_sub(start) > SHERPA_MAX_REGION_SAMPLES {
         let hard_end = (start + SHERPA_MAX_REGION_SAMPLES).min(end);
         let split = find_low_energy_split(samples, start, hard_end).unwrap_or(hard_end);
@@ -176,11 +223,18 @@ fn split_long_region(samples: &[f32], mut start: usize, end: usize, out: &mut Ve
             start + SHERPA_MIN_SPLIT_SEGMENT_SAMPLES,
             hard_end.max(start + SHERPA_MIN_SPLIT_SEGMENT_SAMPLES),
         );
-        out.push((start, split));
+        out.push(SherpaTranscriptionRange::new(start, split, speech_start));
         start = split;
+        speech_start = split;
     }
     if end > start {
-        out.push((start, end));
+        if end - start < SHERPA_MIN_SPLIT_SEGMENT_SAMPLES {
+            if let Some(last) = out.last_mut() {
+                last.decode_end = end;
+                return;
+            }
+        }
+        out.push(SherpaTranscriptionRange::new(start, end, speech_start));
     }
 }
 
@@ -192,6 +246,7 @@ fn find_low_energy_split(samples: &[f32], start: usize, hard_end: usize) -> Opti
         return None;
     }
 
+    let region_rms = rms(&samples[start..hard_end]);
     let mut best: Option<(usize, f32)> = None;
     let mut window_start = search_start;
     while window_start + ENERGY_WINDOW_SAMPLES <= search_end {
@@ -202,7 +257,13 @@ fn find_low_energy_split(samples: &[f32], start: usize, hard_end: usize) -> Opti
         }
         window_start += ENERGY_WINDOW_SAMPLES;
     }
-    best.map(|(split, _)| split)
+    best.and_then(|(split, best_rms)| {
+        if best_rms < region_rms * 0.25 {
+            Some(split)
+        } else {
+            None
+        }
+    })
 }
 
 #[cfg(feature = "engine-sherpa")]
@@ -264,26 +325,109 @@ fn vad_speech_regions(samples: &[f32], config: &Config) -> Result<Vec<(usize, us
     Ok(regions)
 }
 
+#[cfg(all(
+    feature = "engine-sherpa",
+    feature = "vad-ort",
+    not(feature = "whisper")
+))]
+fn resolve_silero_onnx_path(config: &Config) -> Option<PathBuf> {
+    let vad_model = &config.transcription.vad_model;
+    if vad_model.is_empty() {
+        return None;
+    }
+
+    let model_dir = &config.transcription.model_path;
+    let candidates = [
+        model_dir.join(format!("{vad_model}.onnx")),
+        model_dir.join("silero-vad-v6.2.0.onnx"),
+        model_dir.join("silero_vad.onnx"),
+    ];
+    for candidate in &candidates {
+        if candidate.exists() {
+            return Some(candidate.clone());
+        }
+    }
+
+    let direct = PathBuf::from(vad_model);
+    if direct.exists() {
+        return Some(direct);
+    }
+
+    None
+}
+
+#[cfg(all(
+    feature = "engine-sherpa",
+    feature = "vad-ort",
+    not(feature = "whisper")
+))]
+fn vad_speech_regions(samples: &[f32], config: &Config) -> Result<Vec<(usize, usize)>, String> {
+    let vad_path = resolve_silero_onnx_path(config)
+        .ok_or_else(|| "Silero ONNX VAD model not found".to_string())?;
+    let mut vad = crate::silero_vad::OrtSileroVad::new_catching_unwind(&vad_path)
+        .map_err(|e| format!("failed to initialize ort-Silero VAD: {e}"))?;
+
+    let mut regions = Vec::new();
+    let mut active_start: Option<usize> = None;
+    let mut position = 0usize;
+    while position < samples.len() {
+        let end = (position + ORT_SILERO_WINDOW_SAMPLES).min(samples.len());
+        let chunk = &samples[position..end];
+        let rms = rms(chunk);
+        let result = vad.process(chunk, rms);
+        if !vad.is_healthy() {
+            return Err("ort-Silero VAD became unhealthy during sherpa segmentation".to_string());
+        }
+
+        if result.speaking {
+            active_start.get_or_insert(position);
+        } else if let Some(start) = active_start.take() {
+            regions.push((start, end));
+        }
+
+        position = end;
+    }
+
+    if let Some(start) = active_start {
+        regions.push((start, samples.len()));
+    }
+
+    Ok(regions)
+}
+
 #[cfg(feature = "engine-sherpa")]
-fn transcription_ranges(samples: &[f32], config: &Config) -> Vec<(usize, usize)> {
-    #[cfg(feature = "whisper")]
+fn vad_segmented_ranges(
+    samples: &[f32],
+    vad_result: Result<Vec<(usize, usize)>, String>,
+) -> Result<Vec<SherpaTranscriptionRange>, String> {
+    vad_result.map(|regions| {
+        let ranges = pad_merge_and_split_regions(samples, &regions);
+        if ranges.is_empty() {
+            tracing::info!(
+                samples = samples.len(),
+                vad_regions = regions.len(),
+                "Silero VAD produced no sherpa speech ranges; returning silence"
+            );
+            return Vec::new();
+        }
+
+        tracing::info!(
+            samples = samples.len(),
+            vad_regions = regions.len(),
+            transcription_ranges = ranges.len(),
+            "sherpa transcription using Silero VAD segmentation"
+        );
+        ranges
+    })
+}
+
+#[cfg(feature = "engine-sherpa")]
+fn transcription_ranges(samples: &[f32], config: &Config) -> Vec<SherpaTranscriptionRange> {
+    #[cfg(any(feature = "whisper", feature = "vad-ort"))]
     {
-        match vad_speech_regions(samples, config) {
-            Ok(regions) => {
-                let ranges = pad_merge_and_split_regions(samples, &regions);
-                if !ranges.is_empty() {
-                    tracing::info!(
-                        samples = samples.len(),
-                        vad_regions = regions.len(),
-                        transcription_ranges = ranges.len(),
-                        "sherpa transcription using Silero VAD segmentation"
-                    );
-                    return ranges;
-                }
-                tracing::warn!(
-                    samples = samples.len(),
-                    "Silero VAD produced no sherpa speech ranges; falling back to fixed windows"
-                );
+        match vad_segmented_ranges(samples, vad_speech_regions(samples, config)) {
+            Ok(ranges) => {
+                return ranges;
             }
             Err(error) => {
                 tracing::warn!(
@@ -300,14 +444,15 @@ fn transcription_ranges(samples: &[f32], config: &Config) -> Vec<(usize, usize)>
 /// Transcribe 16 kHz mono f32, returning `(start_ms, text)` for each non-empty
 /// speech segment. When Silero VAD is available, sherpa receives speech-boundary
 /// regions with padding, tiny-gap merge, and long-region splitting. If VAD is
-/// unavailable or fails, this falls back to the legacy 15 s fixed windows.
+/// unavailable or fails, this falls back to the legacy 15 s fixed windows. If
+/// VAD runs successfully and finds no speech, this returns no segments.
 #[cfg(feature = "engine-sherpa")]
 pub fn transcribe_segments(samples: &[f32], config: &Config) -> Result<Vec<(u64, String)>, String> {
     let mut recognizer = build_recognizer(config)?;
     let mut segments = Vec::new();
-    for (start, end) in transcription_ranges(samples, config) {
-        let window = &samples[start..end];
-        let start_ms = start as u64 * 1000 / SAMPLE_RATE as u64;
+    for range in transcription_ranges(samples, config) {
+        let window = &samples[range.decode_start..range.decode_end];
+        let start_ms = range.speech_start as u64 * 1000 / SAMPLE_RATE as u64;
         let text = recognizer.transcribe(16_000, window).trim().to_string();
         if !text.is_empty() {
             segments.push((start_ms, text));
@@ -413,18 +558,66 @@ mod tests {
         assert_eq!(
             ranges,
             vec![
-                (
+                SherpaTranscriptionRange::new(
                     first_start - SHERPA_PADDING_SAMPLES,
-                    second_end + SHERPA_PADDING_SAMPLES
+                    second_end + SHERPA_PADDING_SAMPLES,
+                    first_start,
                 ),
-                (
+                SherpaTranscriptionRange::new(
                     third_start - SHERPA_PADDING_SAMPLES,
-                    (third_end + SHERPA_PADDING_SAMPLES).min(audio.len())
+                    (third_end + SHERPA_PADDING_SAMPLES).min(audio.len()),
+                    third_start,
                 )
             ],
             "speech-boundary ranges should merge tiny gaps instead of using 15s cuts"
         );
-        assert_ne!(ranges[0].1, FIXED_WINDOW_SAMPLES);
+        assert_ne!(ranges[0].decode_end, FIXED_WINDOW_SAMPLES);
+    }
+
+    #[test]
+    #[cfg(feature = "engine-sherpa")]
+    fn sherpa_vad_empty_success_returns_no_ranges() {
+        let audio = samples(30, 0.0);
+
+        let ranges = vad_segmented_ranges(&audio, Ok(Vec::new())).unwrap();
+
+        assert!(
+            ranges.is_empty(),
+            "successful VAD with no speech must not fall back to fixed windows"
+        );
+        assert_ne!(ranges, fixed_window_ranges(audio.len()));
+    }
+
+    #[test]
+    #[cfg(feature = "engine-sherpa")]
+    fn sherpa_vad_error_falls_back_to_fixed_windows() {
+        let audio = samples(30, 0.0);
+
+        let ranges = vad_segmented_ranges(&audio, Err("init failed".to_string()))
+            .unwrap_or_else(|_| fixed_window_ranges(audio.len()));
+
+        assert_eq!(ranges, fixed_window_ranges(audio.len()));
+    }
+
+    #[test]
+    #[cfg(feature = "engine-sherpa")]
+    fn sherpa_vad_range_reports_unpadded_speech_start() {
+        let audio = samples(15, 0.05);
+        let region_start = SAMPLE_RATE * 10;
+        let region_end = SAMPLE_RATE * 12;
+
+        let ranges = pad_merge_and_split_regions(&audio, &[(region_start, region_end)]);
+
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(
+            ranges[0].decode_start,
+            region_start - SHERPA_PADDING_SAMPLES
+        );
+        assert_eq!(ranges[0].speech_start, region_start);
+        assert_eq!(
+            ranges[0].speech_start as u64 * 1000 / SAMPLE_RATE as u64,
+            10_000
+        );
     }
 
     #[test]
@@ -440,13 +633,30 @@ mod tests {
         assert_eq!(
             ranges,
             vec![
-                (0, SAMPLE_RATE * 10 + ENERGY_WINDOW_SAMPLES / 2),
-                (SAMPLE_RATE * 10 + ENERGY_WINDOW_SAMPLES / 2, speech_end)
+                SherpaTranscriptionRange::new(0, SAMPLE_RATE * 10 + ENERGY_WINDOW_SAMPLES / 2, 0),
+                SherpaTranscriptionRange::new(
+                    SAMPLE_RATE * 10 + ENERGY_WINDOW_SAMPLES / 2,
+                    speech_end,
+                    SAMPLE_RATE * 10 + ENERGY_WINDOW_SAMPLES / 2,
+                )
             ],
             "long speech regions should split at the quietest internal gap"
         );
         assert!(ranges
             .iter()
-            .all(|(start, end)| end - start <= SHERPA_MAX_REGION_SAMPLES));
+            .all(|range| range.decode_end - range.decode_start <= SHERPA_MAX_REGION_SAMPLES));
+    }
+
+    #[test]
+    #[cfg(feature = "engine-sherpa")]
+    fn sherpa_vad_ranges_absorb_tiny_final_tail() {
+        let audio = vec![0.05; SHERPA_MAX_REGION_SAMPLES + SHERPA_MIN_SPLIT_SEGMENT_SAMPLES / 2];
+
+        let ranges = pad_merge_and_split_regions(&audio, &[(0, audio.len())]);
+
+        assert_eq!(
+            ranges,
+            vec![SherpaTranscriptionRange::new(0, audio.len(), 0)]
+        );
     }
 }

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1352;
+export const MINUTES_TEST_COUNT = 1358;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What

Replaces the sherpa engine's fixed ~15-second windowing with **Silero-VAD speech-region segmentation**, reusing the same VAD the batch path already uses. Speech regions are padded 200ms, gaps <300ms merged, and runs >30s split at internal low-energy points (or the hard boundary). Falls back to fixed-window cleanly when no VAD is available.

## Why

Fixed-window chunking was *the* reason sherpa lost the real-meeting A/B on #369 — it cut mid-utterance, hallucinated text over silence, and dropped words at seams.

## Result (real 75-min meeting A/B, full data on #369)

| Signal | fixed-window sherpa | **VAD-sherpa** | parakeet |
|---|---|---|---|
| Words | 11,971 | 12,057 | 12,723 |
| Casing / punctuation | poor | **tied with parakeet** | best |
| Domain vocab (medication/pharmacist) | — | **identical to parakeet** | — |
| Proper names | — | slightly behind | best |

The seam-dropped-word bug is fixed ("the future's coming for you, Dan" now renders correctly). Sherpa went from "loses badly" to **competitive by a hair**. Parakeet remains the recommended default (edges it on names + completeness); sherpa is now a legitimate opt-in alternative rather than a broken experiment.

## Review

Fresh-context adversarial review (FIX-FIRST) caught and fixed three correctness issues before this PR:
- **Silence handling:** an empty-but-successful VAD result now returns *no* transcription (was falling back to fixed-window → ~40 decodes over silence → the exact hallucination this change prevents). Only VAD *errors* fall back.
- **Timestamp accuracy:** segments now report the *unpadded* speech start (was 200ms early, which could misattribute diarization turns in tight turn-taking).
- **Feature contract:** the VAD path now compiles + behaves correctly for both `whisper` and ORT-only `vad-ort` builds, with clean fixed-window fallback where no VAD exists.

Unit tests cover speech-boundary alignment, long-region split, tiny-gap merge, all-silence, and unpadded-timestamp reporting. 918 core tests + 9 sherpa tests (three feature combos) green; fmt clean. Graceful fallback throughout (same honest-degradation principle as #396/#398/#409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)