### PR TITLE
fix(scripts): build.sh --install can hollow out /Applications/Minutes.app (#422)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -154,7 +154,25 @@ echo ""
 # Install to /Applications if --install flag is passed
 if [[ " $* " == *" --install "* ]]; then
     echo "=== Installing app to /Applications ==="
-    cp -rf target/release/bundle/macos/Minutes.app /Applications/
+    # Never copy INTO the existing bundle: macOS App Management can deny the
+    # write mid-copy and `cp -rf` leaves /Applications/Minutes.app hollowed out
+    # (skeleton dir, files gone) — the app is destroyed, not just stale (#422).
+    # Stage to a fresh sibling path first (App Management denial surfaces there,
+    # harmlessly), then atomically swap only after the staged copy succeeds.
+    STAGING="/Applications/.Minutes.app.installing.$$"
+    rm -rf "$STAGING" 2>/dev/null || true
+    if ! ditto target/release/bundle/macos/Minutes.app "$STAGING" 2>/tmp/minutes-install-err.$$; then
+        echo "  ERROR: could not write to /Applications — the existing app was NOT touched." >&2
+        sed 's/^/    /' /tmp/minutes-install-err.$$ >&2 2>/dev/null || true
+        rm -rf "$STAGING" /tmp/minutes-install-err.$$ 2>/dev/null || true
+        echo "  This is usually macOS App Management: grant your terminal" >&2
+        echo "  System Settings → Privacy & Security → App Management, then re-run." >&2
+        exit 1
+    fi
+    rm -f /tmp/minutes-install-err.$$ 2>/dev/null || true
+    # Staged copy succeeded, so /Applications is writable — swap is now safe.
+    rm -rf "/Applications/Minutes.app" 2>/dev/null || true
+    mv "$STAGING" "/Applications/Minutes.app"
     echo "  Installed to /Applications/Minutes.app"
 fi
 


### PR DESCRIPTION
Fixes #422 (reported by @rymalia).

## Bug

`./scripts/build.sh --install` runs `cp -rf target/release/bundle/macos/Minutes.app /Applications/`, which copies **into** the existing bundle. When macOS **App Management** denies the write (e.g. the terminal lacks the permission), `cp -rf` deletes what it can but can't write the replacements — leaving `/Applications/Minutes.app` **hollowed out** (directory skeleton, every file gone, no `Info.plist`, no binaries). The app is destroyed, not just stale.

## Fix

Never copy into the existing bundle. Stage to a fresh sibling path first, where an App-Management denial surfaces *harmlessly*, and only touch the real bundle after the staged copy proves `/Applications` is writable:

1. `ditto` the built app to `/Applications/.Minutes.app.installing.$$` (a new path).
2. If that fails → clean up, print the App-Management guidance, `exit 1` — **the existing app is never touched.**
3. If it succeeds → `rm -rf` the old bundle + `mv` the staged copy in (atomic, same volume).

`ditto` is also the macOS-recommended tool for copying app bundles (preserves attributes/signatures better than `cp`).

## Scope

`install-dev-app.sh` isn't affected: it `rm -rf`s the target first (so no copy-into-existing-bundle) and targets `~/Applications` (not App-Management-protected).

## Testing

`bash -n` clean. The actual App-Management-denial path can't be reproduced without revoking the permission, so this is logic-verified (the fix's whole point is that a denied write lands on the staging path, not the live bundle). The happy path is a straightforward `ditto`→`rm`→`mv` swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)