### PR TITLE
fix(screen-context): stop the screen-capture thread on every record-loop exit; make Screen Recording permission failures visible

### DIFF
--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -1196,36 +1196,7 @@ fn record_to_wav_dual_source(
     );
     emit_recording_started(started_context);
 
-    let _screen_handle = if config.screen_context.enabled {
-        if !crate::screen::check_screen_permission() {
-            eprintln!("[minutes] Screen context disabled — grant Screen Recording permission in System Settings > Privacy & Security");
-            None
-        } else {
-            let screen_dir = crate::screen::screens_dir_for(output_path);
-            match crate::screen::start_capture(
-                &screen_dir,
-                std::time::Duration::from_secs(config.screen_context.interval_secs),
-                Arc::clone(&stop_flag),
-            ) {
-                Ok(handle) => {
-                    eprintln!(
-                        "[minutes] Screen context capture enabled (every {}s)",
-                        config.screen_context.interval_secs
-                    );
-                    Some(handle)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "screen capture init failed: {} — continuing without screen context",
-                        e
-                    );
-                    None
-                }
-            }
-        }
-    } else {
-        None
-    };
+    let _screen_handle = start_screen_capture_if_enabled(config, output_path, &stop_flag);
 
     let preflight_intent = config
         .recording
@@ -1254,6 +1225,9 @@ fn record_to_wav_dual_source(
 
         if crate::pid::check_and_clear_sentinel() {
             tracing::info!("stop sentinel detected — stopping dual-source recording");
+            // Set the shared flag so everything watching it (screen capture,
+            // live sidecar, streams) winds down like on Ctrl+C (#423).
+            stop_flag.store(true, Ordering::Relaxed);
             break;
         }
 
@@ -1590,36 +1564,7 @@ pub fn record_to_wav_with_lifecycle(
     let mut current_device_name = device_name;
 
     // Start screen context capture if enabled (with permission check)
-    let _screen_handle = if config.screen_context.enabled {
-        if !crate::screen::check_screen_permission() {
-            eprintln!("[minutes] Screen context disabled — grant Screen Recording permission in System Settings > Privacy & Security");
-            None
-        } else {
-            let screen_dir = crate::screen::screens_dir_for(output_path);
-            match crate::screen::start_capture(
-                &screen_dir,
-                std::time::Duration::from_secs(config.screen_context.interval_secs),
-                Arc::clone(&stop_flag),
-            ) {
-                Ok(handle) => {
-                    eprintln!(
-                        "[minutes] Screen context capture enabled (every {}s)",
-                        config.screen_context.interval_secs
-                    );
-                    Some(handle)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "screen capture init failed: {} — continuing without screen context",
-                        e
-                    );
-                    None
-                }
-            }
-        }
-    } else {
-        None
-    };
+    let _screen_handle = start_screen_capture_if_enabled(config, output_path, &stop_flag);
 
     // Safety guard for auto-stop on silence, time cap, disk space
     let preflight_intent = config
@@ -1638,6 +1583,9 @@ pub fn record_to_wav_with_lifecycle(
 
         if crate::pid::check_and_clear_sentinel() {
             tracing::info!("stop sentinel detected — stopping recording");
+            // Set the shared flag so everything watching it (screen capture,
+            // live sidecar, streams) winds down like on Ctrl+C (#423).
+            stop_flag.store(true, Ordering::Relaxed);
             break;
         }
 
@@ -1806,6 +1754,68 @@ fn emit_recording_started(started_context: Option<RecordingStartedContext>) {
             context.capabilities,
         ));
     }
+}
+
+/// Start screen-context capture for a recording when enabled in config.
+/// Returns None (and reports the failure) when the Screen Recording
+/// permission probe fails; recording continues without screenshots.
+fn start_screen_capture_if_enabled(
+    config: &crate::config::Config,
+    output_path: &Path,
+    stop_flag: &Arc<AtomicBool>,
+) -> Option<crate::screen::ScreenCaptureHandle> {
+    if !config.screen_context.enabled {
+        return None;
+    }
+
+    if !crate::screen::check_screen_permission() {
+        report_screen_permission_failure(output_path);
+        return None;
+    }
+
+    let screen_dir = crate::screen::screens_dir_for(output_path);
+    match crate::screen::start_capture(
+        &screen_dir,
+        std::time::Duration::from_secs(config.screen_context.interval_secs),
+        Arc::clone(stop_flag),
+    ) {
+        Ok(handle) => {
+            eprintln!(
+                "[minutes] Screen context capture enabled (every {}s)",
+                config.screen_context.interval_secs
+            );
+            Some(handle)
+        }
+        Err(e) => {
+            tracing::warn!(
+                "screen capture init failed: {} — continuing without screen context",
+                e
+            );
+            None
+        }
+    }
+}
+
+/// Surface a failed Screen Recording permission probe at recording start.
+/// stderr is discarded for GUI launches and System Settings can show a stale
+/// grant as enabled after the app's signature changes, so the failure must
+/// also reach the structured log, the event stream, and the desktop (#424).
+fn report_screen_permission_failure(output_path: &Path) {
+    let message = "Screen context is enabled but Screen Recording permission is unavailable — recording continues without screenshots. If System Settings already shows Minutes as enabled, the grant is stale: toggle it off and on under Privacy & Security > Screen & System Audio Recording, then restart the recording.";
+
+    eprintln!("[minutes] {}", message);
+    crate::logging::log_error(
+        "screen_context",
+        &output_path.display().to_string(),
+        message,
+    );
+    crate::events::append_event(crate::events::MinutesEvent::ScreenContextUnavailable {
+        reason: "screen-recording-permission".into(),
+        message: message.into(),
+    });
+    send_desktop_notification(
+        "Screen context is on, but Screen Recording permission is missing or stale — this recording will have no screenshots. Re-enable it in System Settings > Privacy & Security.",
+    );
 }
 
 /// Spawn a live transcript sidecar thread that receives audio samples and
@@ -2476,6 +2486,11 @@ pub fn preflight_recording_with_native_call_capture(
 
 /// Send a macOS notification when silence is detected during recording.
 fn send_silence_notification_msg(body: &str) {
+    send_desktop_notification(body);
+}
+
+/// Send a desktop notification (macOS notification center; stderr elsewhere).
+fn send_desktop_notification(body: &str) {
     #[cfg(target_os = "macos")]
     {
         let script = format!(
@@ -2486,7 +2501,7 @@ fn send_silence_notification_msg(body: &str) {
             .args(["-e", &script])
             .output()
         {
-            Ok(_) => tracing::debug!("safety notification sent"),
+            Ok(_) => tracing::debug!("desktop notification sent"),
             Err(e) => tracing::warn!("failed to send notification: {}", e),
         }
     }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -352,6 +352,15 @@ pub enum MinutesEvent {
         offset_ms: u64,
         duration_ms: u64,
     },
+    /// Screen-context capture could not start for a recording (e.g. the macOS
+    /// Screen Recording permission is missing, or stale after the app's
+    /// signature changed). Recording continues without screenshots; agents
+    /// and the desktop app can surface this to the user (#424).
+    #[serde(rename = "screen_context.unavailable")]
+    ScreenContextUnavailable {
+        reason: String,
+        message: String,
+    },
     /// Append-only agent commentary. This never mutates human-authored notes.
     #[serde(rename = "agent.annotation")]
     AgentAnnotation {
@@ -1653,6 +1662,32 @@ mod tests {
         assert!(json.contains("\"seq\":42"));
         assert!(json.contains("\"event_type\":\"NoteAdded\""));
         assert!(json.contains("\"text\":\"Important point\""));
+    }
+
+    #[test]
+    fn screen_context_unavailable_serializes_dotted_name() {
+        let envelope = EventEnvelope {
+            v: EVENT_SCHEMA_VERSION,
+            seq: 7,
+            timestamp: Local::now(),
+            event: MinutesEvent::ScreenContextUnavailable {
+                reason: "screen-recording-permission".into(),
+                message: "Screen Recording permission is unavailable.".into(),
+            },
+        };
+
+        let value = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(value["event_type"], "screen_context.unavailable");
+        assert_eq!(value["reason"], "screen-recording-permission");
+
+        let parsed: EventEnvelope =
+            serde_json::from_str(&serde_json::to_string(&envelope).unwrap()).unwrap();
+        match parsed.event {
+            MinutesEvent::ScreenContextUnavailable { reason, .. } => {
+                assert_eq!(reason, "screen-recording-permission");
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -39,6 +39,7 @@ pub fn check_all(config: &Config) -> Vec<HealthItem> {
         diarization_status(config),
         mic_status(),
         check_system_audio_capture(config),
+        screen_recording_status(config),
         calendar_status(config),
         watcher_status(config),
         output_dir_status(config),
@@ -332,6 +333,93 @@ pub fn mic_status() -> HealthItem {
     }
 }
 
+/// Check screen-context capture readiness for recordings started from this
+/// process's environment.
+///
+/// macOS: probes Screen Recording permission with a real capture attempt
+/// (same check the recording path uses), which also catches the stale-grant
+/// case: after an app's code signature changes, System Settings still shows
+/// it as enabled while macOS silently denies capture and never re-prompts
+/// (#424). Note TCC grants are per-identity — run from a terminal this
+/// validates CLI recordings, not the desktop app; the app's own probe at
+/// recording start raises a notification when it fails.
+pub fn screen_recording_status(config: &Config) -> HealthItem {
+    if !config.screen_context.enabled {
+        return HealthItem {
+            label: "Screen recording".into(),
+            state: "ready".into(),
+            detail:
+                "Screen-context capture disabled. Enable with [screen_context] enabled = true in config.toml."
+                    .into(),
+            optional: true,
+        };
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if crate::screen::check_screen_permission() {
+            HealthItem {
+                label: "Screen recording".into(),
+                state: "ready".into(),
+                detail: format!(
+                    "Screen Recording permission granted for this environment — recordings started here will capture screenshots every {}s. The desktop app's grant is separate; if it fails at recording start, a notification is raised.",
+                    config.screen_context.interval_secs
+                ),
+                optional: true,
+            }
+        } else {
+            HealthItem {
+                label: "Screen recording".into(),
+                state: "attention".into(),
+                detail: "Screen-context capture is enabled but Screen Recording permission is unavailable in this environment — recordings started here will have no screenshots. If System Settings shows the app as enabled, the grant is stale: toggle it off and on under Privacy & Security > Screen & System Audio Recording."
+                    .into(),
+                optional: true,
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Mirrors capture_screenshot's tool order (scrot, then gnome-screenshot).
+        let tool = ["scrot", "gnome-screenshot"].into_iter().find(|tool| {
+            std::process::Command::new(tool)
+                .arg("--version")
+                .output()
+                .is_ok()
+        });
+        match tool {
+            Some(tool) => HealthItem {
+                label: "Screen recording".into(),
+                state: "ready".into(),
+                detail: format!(
+                    "Screenshots will be captured with {} every {}s during recordings.",
+                    tool, config.screen_context.interval_secs
+                ),
+                optional: true,
+            },
+            None => HealthItem {
+                label: "Screen recording".into(),
+                state: "attention".into(),
+                detail: "Screen-context capture is enabled but no screenshot tool was found — install scrot or gnome-screenshot, or recordings will have no screenshots."
+                    .into(),
+                optional: true,
+            },
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        HealthItem {
+            label: "Screen recording".into(),
+            state: "attention".into(),
+            detail:
+                "Screen-context capture is not supported on this platform — recordings will have no screenshots."
+                    .into(),
+            optional: true,
+        }
+    }
+}
+
 /// Check macOS calendar access (macOS only, returns unavailable on other platforms).
 pub fn calendar_status(config: &Config) -> HealthItem {
     if !config.calendar.enabled {
@@ -522,6 +610,21 @@ mod tests {
                 item.state
             );
         }
+    }
+
+    #[test]
+    fn screen_recording_health_is_ready_when_disabled() {
+        let config = Config::default();
+        assert!(
+            !config.screen_context.enabled,
+            "screen context should be disabled by default"
+        );
+        let item = screen_recording_status(&config);
+
+        assert_eq!(item.label, "Screen recording");
+        assert_eq!(item.state, "ready");
+        assert!(item.optional);
+        assert!(item.detail.contains("disabled"));
     }
 
     #[test]

--- a/crates/core/src/screen.rs
+++ b/crates/core/src/screen.rs
@@ -76,9 +76,18 @@ pub fn start_capture(
     }
 
     let dir = output_dir.to_path_buf();
+    // The handle owns a second stop flag alongside the caller's shared one:
+    // not every record-loop exit path sets the shared flag (e.g. the
+    // `minutes stop` sentinel and safety-guard auto-stop), and Drop joins the
+    // capture thread — without a handle-owned signal, drop would block while
+    // screenshots keep being taken after the recording ends (#423).
+    let own_stop = Arc::new(AtomicBool::new(false));
     let thread_stop = stop_flag.clone();
+    let thread_own_stop = own_stop.clone();
 
     let handle = std::thread::spawn(move || {
+        let should_stop =
+            || thread_stop.load(Ordering::Relaxed) || thread_own_stop.load(Ordering::Relaxed);
         let mut index: u32 = 0;
         let start = std::time::Instant::now();
 
@@ -92,7 +101,7 @@ pub fn start_capture(
         // which is usually taken before the meeting content is on screen)
         let first_sleep_end = std::time::Instant::now() + interval;
         while std::time::Instant::now() < first_sleep_end {
-            if thread_stop.load(Ordering::Relaxed) {
+            if should_stop() {
                 tracing::info!(
                     captures = 0,
                     "screen capture stopped (before first capture)"
@@ -102,7 +111,7 @@ pub fn start_capture(
             std::thread::sleep(Duration::from_millis(250));
         }
 
-        while !thread_stop.load(Ordering::Relaxed) && index < MAX_SCREENSHOTS {
+        while !should_stop() && index < MAX_SCREENSHOTS {
             let elapsed = start.elapsed().as_secs();
             let filename = format!("screen-{:04}-{:04}s.png", index, elapsed);
             let path = dir.join(&filename);
@@ -124,7 +133,7 @@ pub fn start_capture(
             // Sleep in small increments so we can respond to stop quickly
             let sleep_end = std::time::Instant::now() + interval;
             while std::time::Instant::now() < sleep_end {
-                if thread_stop.load(Ordering::Relaxed) {
+                if should_stop() {
                     break;
                 }
                 std::thread::sleep(Duration::from_millis(250));
@@ -135,6 +144,7 @@ pub fn start_capture(
     });
 
     Ok(ScreenCaptureHandle {
+        stop: own_stop,
         thread: Some(handle),
     })
 }
@@ -239,17 +249,20 @@ pub fn list_screenshots(dir: &Path) -> Vec<PathBuf> {
 }
 
 /// Handle that represents an active screen capture session.
-/// The capture thread runs until the stop_flag is set.
-/// Joining the thread on drop ensures no screenshots are captured
-/// after recording stops.
+/// The capture thread runs until the shared stop_flag is set or the handle
+/// is dropped. Dropping signals the handle-owned stop flag before joining,
+/// so no screenshots are captured after recording stops regardless of
+/// whether the caller's exit path set the shared flag (#423).
 pub struct ScreenCaptureHandle {
+    stop: Arc<AtomicBool>,
     thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl Drop for ScreenCaptureHandle {
     fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
         if let Some(handle) = self.thread.take() {
-            // Wait for the capture thread to finish (it checks stop_flag every 250ms)
+            // Wait for the capture thread to finish (it checks the flags every 250ms)
             handle.join().ok();
         }
     }
@@ -272,5 +285,30 @@ mod tests {
         assert!(files[0].to_str().unwrap().contains("0000"));
         assert!(files[1].to_str().unwrap().contains("0001"));
         assert!(files[2].to_str().unwrap().contains("0002"));
+    }
+
+    // Regression test for #423: `minutes stop` breaks the record loop without
+    // setting the shared stop flag, so drop must stop the thread on its own.
+    // The interval is long enough that the thread stays in its pre-first-capture
+    // wait, so the test never takes a real screenshot.
+    #[test]
+    fn drop_stops_capture_thread_without_external_stop_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let external_stop = Arc::new(AtomicBool::new(false));
+        let handle =
+            start_capture(dir.path(), Duration::from_secs(3600), external_stop.clone()).unwrap();
+
+        let started = std::time::Instant::now();
+        drop(handle);
+
+        // The capture thread polls every 250ms; well under 5s means the join
+        // returned because drop signaled its own stop, not the 1h interval.
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "drop blocked on the capture thread: took {:?}",
+            started.elapsed()
+        );
+        assert!(!external_stop.load(Ordering::Relaxed));
+        assert!(list_screenshots(dir.path()).is_empty());
     }
 }

--- a/docs/development/desktop-development.md
+++ b/docs/development/desktop-development.md
@@ -161,6 +161,30 @@ as a different identity until proven otherwise.
 For contributors using ad-hoc signing, repeated prompts are more likely. That
 is expected until you switch to a stable local signing identity.
 
+## Screen Recording never re-prompts (stale-grant trap)
+
+Microphone and Screen Recording behave differently after a signing-identity
+change, and the asymmetry is a trap (#424):
+
+- **Microphone** self-heals: macOS re-prompts on the next launch and the
+  recording keeps working.
+- **Screen Recording** silently dies: the grant stays keyed to the old
+  identity, System Settings still shows Minutes toggled ON, and macOS never
+  re-prompts. Recordings look healthy (waveform, transcript, summary) but
+  produce zero screenshots.
+
+Recovery: System Settings → Privacy & Security → Screen & System Audio
+Recording → toggle Minutes off and on, then restart the recording.
+
+Fast liveness check after any identity change: start a recording **from the
+app** and confirm `~/.minutes/screens/current/` appears within ~20 seconds.
+`minutes health` (with `[screen_context] enabled = true`) probes the
+permission with a real capture attempt, but TCC grants are per-identity — run
+from a terminal it validates CLI recordings, not the app's grant. The app
+path is validated at recording start: a failed probe is reported to
+`~/.minutes/logs/minutes.log`, `~/.minutes/events.jsonl`
+(`screen_context.unavailable`), and a desktop notification.
+
 ## Guidance for AI agents
 
 When working in this repo:

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1365;
+export const MINUTES_TEST_COUNT = 1368;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Fixes #423. Fixes #424 — grouped as discussed on both issues, since they share `screen.rs`.

### #423 — capture thread outliving the recording

- `ScreenCaptureHandle` owns a second stop flag, set in `Drop` before the `join()`, so no caller exit path can leak the thread. This also covers the safety-guard auto-stop and reconnect-failure breaks, which had the same latent leak as the sentinel path.
- The stop-sentinel breaks in both record loops now set the shared `stop_flag`, so the live sidecar and streams wind down the same as on Ctrl+C.
- Regression test uses a long interval so the thread stays in its pre-first-capture wait — the test never captures a real frame.
- Verified against the original repro: a live recording stopped via `minutes stop` exited within seconds (previously: blocked in `pthread_join` while screenshotting the post-meeting desktop toward the 60-frame cap).

### #424 — silent permission failure

Screen Recording failures are now visible through four surfaces (was: one `eprintln!` that GUI launches discard):

- `~/.minutes/logs/minutes.log` — structured error (step `screen_context`)
- `~/.minutes/events.jsonl` — new `screen_context.unavailable` event, available to agents and future event consumers
- a desktop notification at recording start (reusing the safety-guard notification path) — the immediate user-visible signal for the app's own failed probe, which is exactly the stale-grant case
- `minutes health` — new "Screen recording" item that probes with a real capture attempt, catching the stale grant that System Settings displays as enabled. It validates the environment it runs in (from a terminal: CLI recordings — the app path is covered by the recording-time notification above); on Linux it checks for a screenshot tool, and on unsupported platforms it reports that honestly instead of promising screenshots.

All messages name the recovery explicitly (toggle off/on; macOS never re-prompts for Screen Recording). The duplicated startup block in the two record paths is factored into `start_screen_capture_if_enabled`, and a contributor-docs section documents the mic/screen TCC asymmetry.

**Testing**: 931 core lib tests (3 new) and the CLI suite pass; clippy incl. `--tests` at `-D warnings` (default and `--all --no-default-features`) and `rustfmt --check` clean; `site/lib/release.ts` regenerated for the new test count. Two Tauri tests fail identically on clean `upstream/main` in my environment — pre-existing/environmental, not from this change.

