### PR TITLE
docs: remove hardcoded personal Developer ID from tracked agent instructions (#426)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ global hotkeys), do **not** dogfood by repeatedly replacing
 Use the dedicated development app identity instead:
 
 ```bash
-export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Mathieu Silverstein (63TMLKT8HN)"
+export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
 ./scripts/install-dev-app.sh
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,13 +42,11 @@ open target/release/bundle/macos/Minutes.app   # Launch app
 
 - If the work touches TCC-sensitive features, do **not** keep replacing `/Applications/Minutes.app` with local rebuilds.
 - Use `./scripts/install-dev-app.sh` and test `~/Applications/Minutes Dev.app`.
-- If a stable local codesigning identity exists, export `MINUTES_DEV_SIGNING_IDENTITY` before running the script.
-- On this machine, the preferred identity is:
-  - `Developer ID Application: Mathieu Silverstein (63TMLKT8HN)`
-- Example:
+- If a stable local codesigning identity exists, export `MINUTES_DEV_SIGNING_IDENTITY` before running the script. This is machine-local — set it in your shell profile or a local (untracked) env file to your **own** signing identity; do not hardcode a specific identity here, since exporting an identity whose cert isn't in the local keychain makes the signing step abort. Without it, the script falls back to ad-hoc signing.
+- Example (substitute your own identity):
 
 ```bash
-export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Mathieu Silverstein (63TMLKT8HN)"
+export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
 ./scripts/install-dev-app.sh
 ```
 

--- a/docs/plans/macos-permission-center-2026-05-01.md
+++ b/docs/plans/macos-permission-center-2026-05-01.md
@@ -197,7 +197,7 @@ not raw `target/` binaries.
 Run with `~/Applications/Minutes Dev.app`, installed through:
 
 ```bash
-export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Mathieu Silverstein (63TMLKT8HN)"
+export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
 ./scripts/install-dev-app.sh --no-open
 ```
 

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -49,7 +49,7 @@ cargo clippy --all --no-default-features -- -D warnings  # Rust lints
 **macOS desktop note:**
 - For local TCC-sensitive dogfooding before release, rebuild the dev app with:
 ```bash
-export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Mathieu Silverstein (63TMLKT8HN)"
+export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
 ./scripts/install-dev-app.sh --no-open
 ```
 - Do not treat a raw local `/Applications/Minutes.app` copy as the canonical test surface for permission-sensitive features.

--- a/docs/release/updater-testing.md
+++ b/docs/release/updater-testing.md
@@ -8,7 +8,7 @@ release without touching the production install in `/Applications/Minutes.app`.
 Always use the signed development identity:
 
 ```bash
-export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Mathieu Silverstein (63TMLKT8HN)"
+export MINUTES_DEV_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
 ./scripts/install-dev-app.sh --no-open
 open -a "$HOME/Applications/Minutes Dev.app"
 ```


### PR DESCRIPTION
Fixes #426 (reported by @rymalia).

## Problem

`CLAUDE.md`, `AGENTS.md`, `docs/release/procedure.md`, and `docs/release/updater-testing.md` hardcoded a specific Developer ID — `Developer ID Application: Mathieu Silverstein (63TMLKT8HN)` — in a public repo, with copy-paste `export MINUTES_DEV_SIGNING_IDENTITY=…` examples.

As @rymalia noted, agents and careful humans follow these instructions literally, so exporting that identity on any machine without the cert makes `build.sh` / `install-dev-app.sh` **abort** at the re-sign step (they hit this during the #422/#424 dogfooding). And "on this machine" doesn't parse in a file that ships to every clone — it contradicts the repo's own open-source-contributor note.

## Fix

Keep the `MINUTES_DEV_SIGNING_IDENTITY` mechanism, but replace the hardcoded value with a generic `Your Name (TEAMID)` placeholder and note that the identity is machine-local (shell profile / an untracked env file), not tracked instructions. Without it, the scripts already fall back to ad-hoc signing.

(The `Mathieu Silverstein` string in `name_correction.rs` is unrelated test data for the name-correction logic — not a cert reference — so it's left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)