### PR TITLE
Product-honest streaming-transcript hero reveal

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -145,7 +145,9 @@ Consistent rounding. Landing is slightly sharper than the app. Never fully squar
 - **Panel open/close:** 0.2s ease-out
 - **Recording pulse:** 1s ease-in-out, infinite — the only animation that loops
 
-No bounces, no entrance animations, no scroll-driven effects. Utility-grade motion.
+No bounces, no scroll-driven effects, no decorative entrance animations. Utility-grade motion.
+
+**One sanctioned exception — product-honest reveals.** Motion that *demonstrates how the product actually behaves* is not decoration and is allowed, held to the same restraint as everything else. The landing hero's transcript card streams its lines in once on load, mirroring how Minutes streams real transcription — the same instinct as "show real progress (streamed partials), never spinners" under Interaction craft. Such reveals must: play once (never loop), finish under ~2.5s, use the standard 160–260ms ease per element, and be gated behind `prefers-reduced-motion: no-preference` so the reduce path renders the final state instantly. If a reveal doesn't teach the viewer something true about the product, it's decoration — cut it.
 
 ## Component Patterns
 
@@ -250,6 +252,7 @@ Every state must be visible in every surface (tray, app, CLI output).
 | 2026-04-08 | Transcript output as hero visual | Real diarized output in Geist Mono replaces the existing DemoPlayer gif. The product's output is the aesthetic. |
 | 2026-04-08 | Warm near-black (#0D0D0B) not pure black | Slightly warm undertone unifies dark mode with the cream light mode surfaces. |
 | 2026-04-08 | No gradients, no glows, no illustration | Information density is the aesthetic. The only decoration is well-set type. |
+| 2026-07-10 | Sanctioned "product-honest reveal" exception to the no-entrance-animation rule | Resolves the tension between "no entrance animations" (Motion) and "show streamed partials, never spinners" (Interaction craft). The hero transcript streams in once to mirror real transcription; reduce-motion renders it static. Reveals that don't demonstrate real product behavior remain banned. |
 
 ## Interaction craft
 

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -88,3 +88,39 @@ button {
     gap: 8px 10px;
   }
 }
+
+/* Streaming-transcript hero reveal. Product-honest, not decorative: it mirrors
+   how Minutes streams real transcription in (see DESIGN.md → Motion). Plays
+   once on load, and only when the user has not asked to reduce motion — under
+   `reduce`, no rule applies and every line is visible immediately. */
+@media (prefers-reduced-motion: no-preference) {
+  .stream-card .transcript-grid > span,
+  .stream-card .stream-actions {
+    opacity: 0;
+    animation: stream-in 200ms ease forwards;
+  }
+  .stream-card .transcript-grid > span:nth-child(-n + 3) {
+    animation-delay: 0.35s;
+  }
+  .stream-card .transcript-grid > span:nth-child(n + 4):nth-child(-n + 6) {
+    animation-delay: 1s;
+  }
+  .stream-card .transcript-grid > span:nth-child(n + 7) {
+    animation-delay: 1.65s;
+  }
+  .stream-card .stream-actions {
+    animation-delay: 2.35s;
+    animation-duration: 260ms;
+  }
+}
+
+@keyframes stream-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -150,7 +150,7 @@ function SectionLabel({ n, label }: { n: string; label: string }) {
 
 function TranscriptCard() {
   return (
-    <div className="overflow-hidden rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] text-left shadow-[var(--shadow-panel)]">
+    <div className="stream-card overflow-hidden rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] text-left shadow-[var(--shadow-panel)]">
       <div className="flex flex-col gap-3 border-b border-[color:var(--border)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
@@ -195,7 +195,7 @@ function TranscriptCard() {
           </span>
         </div>
 
-        <div className="border-t border-[color:var(--border)] pt-5">
+        <div className="stream-actions border-t border-[color:var(--border)] pt-5">
           <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
             Action Items
           </p>


### PR DESCRIPTION
The hero transcript card streams its lines in once on load, mirroring how Minutes streams real transcription.

- **CSS-only** (staggered `animation-delay`) — no JS, no hydration flash.
- **Reduce-motion safe by construction**: gated behind `prefers-reduced-motion: no-preference`, so the reduce path renders the final state instantly.
- Plays once (no loop), finishes ~2.5s, 160–260ms ease per element.
- **DESIGN.md amended**: sanctions "product-honest reveals" as an exception to the no-entrance-animation rule, resolving the standing contradiction with the "streamed partials, never spinners" interaction-craft rule. Decision logged 2026-07-10.

Reviewed live on a preview deploy. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)