### PR TITLE
feat(site): SEO wedge pages — security pillar, HIPAA answer, superwhisper compare

### DIFF
--- a/docs/plans/seo-plan.md
+++ b/docs/plans/seo-plan.md
@@ -1,0 +1,125 @@
+# SEO Plan — useminutes.app
+
+*Researched 2026-07-11 with Ahrefs (US, subdomains mode). Volumes are monthly US searches; difficulty (KD) is Ahrefs 0–100; CPC in USD.*
+
+## TL;DR
+
+useminutes.app has **370 live referring domains but ranks for 1 keyword (~19 visits/mo)** — link authority with no content to spend it on. Competitors split into two groups: the funded cloud players (Otter, Fireflies) win non-branded search with utility pages and templates, while the close-in competitors (Granola, superwhisper, Fathom) do **essentially zero non-branded SEO** — Granola's entire footprint is its own brand name. The privacy/compliance and local/on-device clusters are nearly uncontested (KD 0–13) and are queries cloud competitors structurally cannot win. Plan: ~15 pages across 5 clusters, comparison and compliance first.
+
+## Baseline (2026-07-11)
+
+| Metric | useminutes.app |
+|---|---|
+| Live referring domains | 370 (991 backlinks) |
+| Organic keywords | 1 |
+| Organic traffic | ~19/mo |
+| Existing SEO-relevant routes | `/compare`, `/writing`, `/docs`, `/proof`, `/for-agents` |
+
+The refdomain-to-keyword ratio is the headline: most young sites have the opposite problem. New pages here should rank unusually fast for their difficulty tier.
+
+## Competitive findings
+
+### Granola (granola.ai)
+~100% branded traffic ("granola ai" 15k/mo etc.). Non-branded attempts are weak: a follow-up-email-template post and accidental rankings for "claude dangerously skip permissions". **No moat in non-branded search.** They rank #14+ for "ai note taking" (KD 83) and gain nothing from it.
+
+### superwhisper (superwhisper.com)
+Branded ("superwhisper" 1.9k/mo) plus scattered low positions on whisper-adjacent terms. Does not own "whisper dictation app", "local speech to text", or even "mac whisper" (MacWhisper outranks them). The dictation long tail is open.
+
+### Otter (otter.ai) — the playbook to learn from
+Non-branded traffic comes from three page types:
+1. **Utility/tool pages**: `/free-ai-transcription` (298 kw), `/mp3-to-text` (178 kw), `/audio-to-text`, `/video-to-text`, `/podcast-transcription`. Format-intent pages that convert.
+2. **Legality content**: one post ("is it illegal to record someone without permission") ranks for 132 keywords. Recording-consent law is a durable, linkable topic.
+3. **Anti-bot pain, hosted on their own help center**: "remove otter ai from teams", "how to disable otter ai", "stop otter notetaker from joining meetings" — hundreds of monthly searches from people trying to *get rid of* meeting bots. Otter is forced to rank for its own churn queries. **Minutes' botless capture is the product-answer to this search demand.**
+
+### Fireflies (fireflies.ai)
+Templates work: "meeting minutes templates" post ranks #2 for "meeting minutes" (13k/mo, 142 keywords). The rest is thin listicle spam (memes, team names) — volume without intent; do not copy.
+
+### Fathom (fathom.video)
+Nearly all branded + help-center. No content program to speak of.
+
+**Net read:** only the cloud incumbents do real SEO, and they cannot follow Minutes into the privacy/local clusters without arguing against their own architecture.
+
+## Keyword clusters (priority order)
+
+### Cluster 1 — Alternative/comparison (bottom-funnel, effectively free)
+
+| Keyword | Vol/mo | KD | Notes |
+|---|---|---|---|
+| granola alternative | 210 | 0 | `/compare/granola-vs-minutes` exists (#431) |
+| otter alternative | 90 | 2 | Cluster TP ~900 |
+| superwhisper alternative | 53 | ~0 | Dictation beachhead |
+| whisper app alternative(s) | 165 | 0 | Careful: mixed intent with defunct confession app |
+| is otter ai hipaa compliant | 50 | 0 | Attack page; bridges to Cluster 2 |
+
+**Pages:** `/compare/granola`, `/compare/otter`, `/compare/superwhisper`, `/compare/macwhisper`, `/compare/fireflies`, `/compare/fathom`. One honest axis per page: on-device vs cloud, owned markdown vs SaaS lock-in, botless capture vs meeting bots. Include a real feature table and a "when X is the better choice" section — honesty ranks and earns AI-answer citations.
+
+### Cluster 2 — Privacy/compliance for regulated industries (the wedge)
+
+| Keyword | Vol/mo | KD | CPC | Notes |
+|---|---|---|---|---|
+| hipaa compliant ai note taker | 200 | — | — | Core wedge term |
+| hipaa compliant transcription | 150 | 2 | $5.00 | KD 2 at $5 CPC = advertisers pay, nobody competes organically |
+| legal transcription software | 84 | 10 | $8.00 | Cluster traffic potential 44,000 |
+| is otter ai hipaa compliant | 50 | 0 | — | The honest answer ("only on Business tier w/ BAA, audio still leaves the device") sells Minutes |
+| ai notes for therapists | 46 | 59 | $9.00 | Crowded by medical-scribe SaaS; angle: notes that never leave the laptop |
+| attorney client privilege ai | 30 | — | — | Legal privilege + AI notetakers is a genuinely unanswered question |
+| offline transcription software | 20 | 0 | $1.50 | |
+
+**Pages:** a `/private` or `/security` architecture pillar page (on-device processing, 0600 perms, no cloud, open source = auditable), plus posts: "HIPAA-compliant AI note-taking: why on-device changes the analysis", "AI notetakers and attorney–client privilege", "Is [Otter/Fireflies/Granola] HIPAA compliant?" (one page per competitor, factual). Important nuance: **do not claim "HIPAA compliant" as a product certification** — the accurate and *stronger* claim is that audio/transcripts never leave the device, so there's no third-party disclosure and no BAA needed. That framing is also unique content no cloud vendor can write.
+
+### Cluster 3 — Botless capture / anti-meeting-bot (demand proven by competitors' churn queries)
+
+Search demand: "remove otter ai from teams", "how to disable otter ai", "stop fireflies from joining meetings" — plus etiquette queries about bots in meetings. Cloud vendors rank for these defensively; Minutes can rank for them offensively.
+
+**Pages:** "How to remove AI notetaker bots from your meetings (Zoom/Meet/Teams)" — a genuinely helpful guide that ends with "or use a notetaker that never joins as a participant". Plus "AI meeting notes without a bot" as a positioning page.
+
+### Cluster 4 — Local/on-device + whisper.cpp (owns the developer/self-hoster identity)
+
+| Keyword | Vol/mo | KD |
+|---|---|---|
+| local speech to text | 100 | 13 |
+| whisper transcription app | 150 | 55 |
+| whisper dictation app | 99 | — |
+| best local speech to text | 60 | — |
+| whisper.cpp local speech to text | 45 | — |
+| mac dictation app | 50 | — |
+| on device transcription | 20 | — |
+| self hosted transcription | 10 | — |
+
+**Pages:** "The best local speech-to-text apps (2026)" (include competitors honestly), "whisper.cpp vs parakeet.cpp for local transcription" (unique first-party expertise — nobody else ships both), "Local dictation on macOS: complete guide". These earn developer links, which compounds every other cluster.
+
+### Cluster 5 — Head terms (later, via the clusters above)
+
+"ai meeting notes" (1,146/mo, KD 52, TP 22k), "meeting transcription software" (478/mo, KD 53), "ai note taker" (12.6k/mo, KD 72). Don't target directly in year one — the homepage + internal links from clusters 1–4 accrue relevance; revisit when 30+ pages are live and DR-supporting links land.
+
+**Skip:** Fireflies-style filler (memes, team names), "ai medical scribe" (KD 65, funded vertical SaaS — Freed/Heidi territory; Minutes is not an EHR scribe).
+
+## GEO (AI-answer optimization)
+
+For this audience, being the cited answer in ChatGPT/Claude/Perplexity for "private Granola alternative" or "AI notetaker that doesn't send audio to the cloud" likely matters as much as Google position.
+
+- No Brand Radar report exists in the Ahrefs account yet — **set one up** tracking Minutes vs Granola/Otter/Fireflies/Fathom/superwhisper on prompts like "best private ai note taker", "granola alternative", "local transcription app", "hipaa compliant meeting notes".
+- Comparison pages should use extractable structures: direct answer in the first paragraph, feature tables, FAQ blocks with schema.org markup.
+- The GitHub repo + docs are already the strongest GEO asset (LLMs cite OSS readmes heavily). `llms.txt` + `llms-full.txt` already ship (generated); keep README claims aligned with site claims.
+
+## Technical/site checklist
+
+- Per-page `metadata` (title/description/OG) for every new route; comparison pages need `Product` + `FAQPage` structured data.
+- `sitemap.xml` + `robots.txt` (verify present in `site/`).
+- `/writing` becomes the blog surface; `/compare` becomes an index of per-competitor pages.
+- Internal linking: every cluster page links to the relevant compare pages and to download/quick-start. Homepage links to the pillar pages.
+- All pages follow DESIGN.md (cream, Instrument Serif/Sans, Geist Mono transcript cards — the transcript card is itself a differentiated SERP screenshot asset).
+
+## Sequencing
+
+**Weeks 1–2 (highest ROI):** retarget `/compare` → `/compare/granola` + add Otter and superwhisper pages; publish "Is Otter AI HIPAA compliant?" and the on-device security pillar. ~6 pages, all KD ≤ 2 targets.
+
+**Weeks 3–6:** compliance posts (HIPAA analysis, attorney–client privilege), anti-bot guide, "best local speech to text" roundup, whisper.cpp vs parakeet.cpp. Set up Brand Radar + llms.txt.
+
+**Weeks 7–12:** remaining compare pages (Fireflies, Fathom, MacWhisper, Krisp), mac dictation guide, legal-transcription page, meeting-minutes template page (Fireflies-proven, aligns with the product's markdown output).
+
+**Measure:** Ahrefs rank tracking on ~30 target keywords; Brand Radar share-of-voice monthly; conversion = downloads/GitHub stars from organic landing pages.
+
+## Expectations
+
+Honest ceiling: this niche's search volumes are hundreds, not tens of thousands, per term. Realistic outcome at 90 days: 1,000–3,000 organic visits/mo, heavily switch-intent, plus AI-answer citations that don't show in analytics. The strategic value is owning the *category language* ("on-device conversation memory") before a funded competitor decides to.

--- a/site/app/compare/page.tsx
+++ b/site/app/compare/page.tsx
@@ -35,6 +35,12 @@ const pages = [
     blurb:
       "Best if you are choosing between two open-source local-first tools: a notepad you write in versus a memory layer your agents query.",
   },
+  {
+    title: "Minutes vs superwhisper",
+    href: "/compare/superwhisper-vs-minutes",
+    blurb:
+      "Best if you are choosing between a polished dictation tool and an open-source conversation memory layer where dictation is one of four capture modes.",
+  },
 ] as const;
 
 export default function CompareHubPage() {

--- a/site/app/compare/superwhisper-vs-minutes/page.tsx
+++ b/site/app/compare/superwhisper-vs-minutes/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from "next";
+import { ComparePage } from "@/components/compare-page";
+
+export const metadata: Metadata = {
+  title: "Minutes vs superwhisper",
+  description:
+    "Minutes vs superwhisper: both transcribe on your device, but superwhisper is a polished dictation tool while Minutes is an open-source conversation memory layer for meetings, memos, and agents. A sourced, fit-based comparison.",
+  alternates: {
+    canonical: "/compare/superwhisper-vs-minutes",
+  },
+};
+
+const comparisonRows = [
+  {
+    label: "Best for",
+    competitor: "Polished voice-to-text dictation into any app, on Mac, Windows, and iOS",
+    minutes: "On-device conversation memory: meetings, voice memos, and dictation your agents can query",
+  },
+  {
+    label: "Core job",
+    competitor: "Speak, get clean formatted text where you're typing",
+    minutes: "Capture conversations, transcribe and diarize them, keep a searchable markdown record",
+  },
+  {
+    label: "Where transcription runs",
+    competitor: "On-device by default; optional cloud models (recommended on Intel Macs)",
+    minutes: "On-device always (whisper.cpp or parakeet.cpp) — there is no cloud path",
+  },
+  {
+    label: "AI formatting / summarization",
+    competitor: "Predefined and custom modes, using local or cloud AI models",
+    minutes: "Optional and explicit: Claude via MCP or a local LLM you configure; nothing calls a cloud unless you set it up",
+  },
+  {
+    label: "Durable output",
+    competitor: "Text inserted into the app you're using",
+    minutes: "Markdown files with YAML frontmatter, action items, and decisions, on your own disk",
+  },
+  {
+    label: "Meetings and speakers",
+    competitor: "Meeting recording and file transcription",
+    minutes: "Diarized speakers, confidence-aware attribution, action items, and a meeting lifecycle",
+  },
+  {
+    label: "Agent / MCP surface",
+    competitor: "None that we could find — built for humans typing with their voice",
+    minutes: "MCP server (31 tools), CLI, SDK, and a Claude Code plugin over your local files",
+  },
+  {
+    label: "Open source",
+    competitor: "No",
+    minutes: "Yes, MIT",
+  },
+  {
+    label: "Platforms",
+    competitor: "macOS, Windows, iOS",
+    minutes: "macOS menu bar app + CLI (open source, builds from source elsewhere)",
+  },
+  {
+    label: "Pricing",
+    competitor: "Free tier; Pro subscription (yearly discount), lifetime and enterprise options",
+    minutes: "Open source and free to run yourself",
+  },
+] as const;
+
+const sources = [
+  { label: "superwhisper website and pricing", href: "https://superwhisper.com" },
+  { label: "Minutes for agents", href: "https://useminutes.app/for-agents" },
+  { label: "Minutes MCP reference", href: "https://useminutes.app/docs/mcp/tools" },
+  { label: "Minutes on GitHub", href: "https://github.com/silverstein/minutes" },
+] as const;
+
+export default function SuperwhisperVsMinutesPage() {
+  return (
+    <ComparePage
+      competitorName="superwhisper"
+      competitorLabel="superwhisper"
+      markdownHref="/compare/superwhisper-vs-minutes.md"
+      lastReviewed="2026-07-11"
+      heroSummary="superwhisper and Minutes agree on the thing this category usually gets wrong: your voice should be transcribed on your device, not in someone's cloud. The difference is the job. superwhisper is a polished dictation tool — speak, and clean text lands in whatever app you're typing in. Minutes treats dictation as one input to a bigger system: an open-source conversation memory that records meetings, diarizes speakers, and writes markdown files your AI agents can query. Different jobs, with honest overlap."
+      quickVerdictCompetitor="you want the most refined dedicated dictation experience — custom per-app modes, 100+ languages, iOS and Windows support — and you're happy paying a subscription for a closed-source tool."
+      quickVerdictMinutes="dictation is one mode of a bigger need — recording meetings, keeping voice memos, and building a private, searchable memory of your conversations that Claude and other agents can use — and you want it open source and free."
+      comparisonRows={comparisonRows as any}
+      competitorWins={[
+        "The dictation experience itself is more polished: predefined and custom modes format your speech differently per app (email vs Slack vs prose), and that focus shows.",
+        "Platform reach is wider today — macOS, Windows, and iOS — where Minutes is macOS-first.",
+        "If you never record meetings and never want a durable transcript archive, a dedicated dictation tool is the simpler purchase.",
+      ]}
+      minutesWins={[
+        "It's a memory layer, not just an input method: meetings and memos become diarized, searchable markdown with action items and decisions — a record you own, not text that vanishes into whatever app you pasted it into.",
+        "It's open source (MIT) and free. You can read the capture, transcription, and storage code instead of trusting a privacy page.",
+        "Your agents can use it: Claude, Codex, and any MCP client query your conversation history through 31 MCP tools, a CLI, an SDK, and a Claude Code plugin.",
+      ]}
+      workflowSection={[
+        "The overlap is real: Minutes has a dictation mode too — speak, and the text lands in your clipboard and a daily note. But the two tools point in different directions from there. superwhisper optimizes the moment of typing: its modes reshape your words for the app you're in, and the output's job is to be pasted. Minutes optimizes what happens after the conversation: every meeting, memo, and dictation becomes a timestamped markdown file that search, the CLI, and MCP tools can reach.",
+        "A useful test: a month from now, will you want to ask an assistant 'what did I say about this?' If no, you want a dictation tool. If yes, you want a memory layer — dictation included.",
+      ]}
+      chooseSection={[
+        "Pick superwhisper if your entire need is voice-to-text into other apps and you want the most polished version of that, across Mac, Windows, and iPhone.",
+        "Pick Minutes if you want one local pipeline for meetings, voice memos, and dictation, with a durable markdown record your agents can query — and you'd rather run open source than subscribe to closed source.",
+        "Running both is coherent, but most people discover the memory layer makes the standalone dictation tool redundant — or vice versa, if they never record conversations at all.",
+      ]}
+      notRightFitSection={[
+        "Minutes is not the right first choice if you want best-in-class dictation UX on iOS or Windows today, or if per-app text formatting modes are the feature you'd actually use daily. superwhisper is better at that.",
+        "It's also not the fit if you find markdown files, a CLI, and agent workflows to be complexity you don't want. A single-purpose dictation app is legitimately simpler.",
+      ]}
+      evaluatedSection={[
+        "This is a fit-based comparison, not a teardown, reviewed on 2026-07-11 against superwhisper's public website and pricing, linked below. superwhisper's local-by-default transcription with optional cloud models, its mode system, platform list, and pricing tiers are drawn from its own site.",
+        "The Minutes side is grounded in its public agent-facing docs, generated MCP reference, and open-source repository. Where a claim depends on current pricing or feature scope, the official source is linked.",
+      ]}
+      sources={sources as any}
+    />
+  );
+}

--- a/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
@@ -1,0 +1,305 @@
+import type { Metadata } from "next";
+import { PublicFooter } from "@/components/public-footer";
+
+export const metadata: Metadata = {
+  title: "Is Otter.ai HIPAA compliant?",
+  description:
+    "Yes — but only on the Enterprise plan with a signed BAA, as of July 2025. Basic, Pro, and Business plans cannot be used for PHI. What that means, and the on-device alternative that removes the BAA question entirely.",
+  alternates: {
+    canonical: "/resources/is-otter-ai-hipaa-compliant",
+  },
+};
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Is Otter.ai HIPAA compliant?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Conditionally. Otter.ai announced HIPAA compliance in July 2025, but per its help center it is only available to Enterprise plan customers who sign a Business Associate Agreement (BAA). Users on Basic, Pro, or Business plans cannot obtain a BAA and cannot use Otter for protected health information in a compliant way.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does Otter.ai sign a Business Associate Agreement (BAA)?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, for Enterprise plan customers only, through its sales and account management process. Without a signed BAA in place, Otter is not acting as a HIPAA business associate.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I use Otter's free, Pro, or Business plan for patient conversations?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. Per Otter's help center, HIPAA compliance is restricted to the Enterprise plan with a signed BAA. Recording conversations containing PHI on other plans would be an impermissible disclosure to a vendor with no BAA.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Do on-device transcription tools need a BAA?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. A BAA is required when a vendor receives, stores, or processes PHI on your behalf. Software that transcribes entirely on your own device — such as open-source tools built on whisper.cpp, like Minutes — never transmits the conversation to a vendor, so there is no business associate relationship to paper over. Your own HIPAA obligations (device encryption, access controls) still apply.",
+      },
+    },
+  ],
+} as const;
+
+const sources = [
+  {
+    label: "Otter.ai Help Center: HIPAA",
+    href: "https://help.otter.ai/hc/en-us/articles/33975072019991-HIPAA-Otter-ai",
+  },
+  {
+    label: "Otter.ai blog: Otter.ai Achieves HIPAA Compliance",
+    href: "https://otter.ai/blog/otter-ai-achieves-hipaa-compliance",
+  },
+  {
+    label: "HHS: Business Associate Contracts",
+    href: "https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html",
+  },
+  { label: "Minutes security & privacy architecture", href: "https://useminutes.app/security" },
+  { label: "Minutes on GitHub", href: "https://github.com/silverstein/minutes" },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function IsOtterAiHipaaCompliantPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a href="/resources/is-otter-ai-hipaa-compliant.md" className="hover:text-[var(--accent)]">
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          Is Otter.ai HIPAA compliant?
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          Short answer: yes, since July 2025 — but only on the Enterprise plan, and only with a
+          signed Business Associate Agreement. Most answers you&rsquo;ll find online are out of
+          date in one direction or the other. Here is the current state, sourced from
+          Otter&rsquo;s own documentation, and the architectural question worth asking before you
+          buy your way out of the problem.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-07-11
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            Sourced answer
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-12 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Quick answer
+        </p>
+        <div className="mt-4 space-y-3 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              Otter.ai is HIPAA compliant only for Enterprise customers with a signed BAA.
+            </span>{" "}
+            Otter announced HIPAA compliance in July 2025 following an independent assessment. Per
+            its help center, the BAA is available exclusively on the Enterprise plan, arranged
+            through sales.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              On Basic, Pro, and Business plans, the answer is no.
+            </span>{" "}
+            No BAA is available on those tiers, so recording conversations that contain protected
+            health information on them is an impermissible disclosure to a vendor — regardless of
+            how good Otter&rsquo;s general security is.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="What A BAA Does — And What It Doesn't" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            A Business Associate Agreement makes it lawful for a vendor to receive and process PHI
+            on your behalf, and binds the vendor to HIPAA&rsquo;s safeguards. It is a legal
+            instrument, not an architectural one. With a signed BAA, your patient conversations
+            still travel to Otter&rsquo;s cloud, are still transcribed on Otter&rsquo;s servers,
+            and still live in Otter&rsquo;s storage — the disclosure is permitted and governed,
+            not eliminated.
+          </p>
+          <p>
+            That distinction matters when you think about breach surface. A BAA obligates the
+            vendor to report breaches; it does not make the vendor unbreachable. Every cloud
+            notetaker with a BAA is still a third party holding your patients&rsquo; conversations.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Checklist If You Stay With Otter" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>Using Otter with PHI in a compliant way requires all of the following:</p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>An Enterprise plan — not Basic, Pro, or Business.</li>
+            <li>A BAA actually signed with Otter before any PHI is recorded, not after.</li>
+            <li>
+              Workspace policies that keep PHI recordings inside the covered workspace — a
+              clinician&rsquo;s personal Pro account doesn&rsquo;t inherit the organization&rsquo;s
+              BAA.
+            </li>
+            <li>
+              Your own HIPAA obligations: consent workflows for recording, access controls, and
+              minimum-necessary practices don&rsquo;t transfer to the vendor.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Question Under The Question" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            The reason a BAA is needed at all is that the audio leaves your machine. There is a
+            second way to resolve the HIPAA question: use transcription that runs entirely on your
+            own device, so no vendor ever receives the conversation. No third party, no business
+            associate, no BAA to negotiate — the legal question dissolves because the disclosure
+            never happens.
+          </p>
+          <p>
+            That&rsquo;s the architecture{" "}
+            <span className="font-medium text-[var(--text)]">Minutes</span> is built on: audio is
+            captured and transcribed on your device with whisper.cpp, and the record is markdown on
+            your own disk with owner-only file permissions. It&rsquo;s open source, so this claim
+            is verifiable in code rather than asserted on a trust page. To be precise about the
+            framing: no local tool is &ldquo;HIPAA certified&rdquo; — HIPAA governs covered
+            entities and their vendors. On-device processing removes the vendor from the equation;
+            securing the device (disk encryption, access control) remains your responsibility, as
+            it already is for your EHR workstation.
+          </p>
+          <p>
+            If your compliance team&rsquo;s core question is &ldquo;where does the audio go?&rdquo;,
+            the on-device answer is one sentence long.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Which Fits Your Situation" />
+        <div className="overflow-x-auto rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] shadow-[var(--shadow-panel)]">
+          <table className="min-w-full border-collapse text-left">
+            <thead>
+              <tr className="border-b border-[color:var(--border)]">
+                <th className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+                  Your situation
+                </th>
+                <th className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+                  Reasonable path
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-[color:var(--border)]">
+                <td className="px-4 py-4 align-top text-[14px] leading-7 text-[var(--text)]">
+                  Large org, already on Otter Enterprise, wants team features
+                </td>
+                <td className="px-4 py-4 align-top text-[14px] leading-7 text-[var(--text-secondary)]">
+                  Sign the BAA, lock recording to the covered workspace, audit regularly
+                </td>
+              </tr>
+              <tr className="border-b border-[color:var(--border)]">
+                <td className="px-4 py-4 align-top text-[14px] leading-7 text-[var(--text)]">
+                  Solo practitioner or small practice on a consumer/Pro plan
+                </td>
+                <td className="px-4 py-4 align-top text-[14px] leading-7 text-[var(--text-secondary)]">
+                  Stop recording PHI with it today — no BAA is available at your tier. Consider
+                  on-device transcription instead
+                </td>
+              </tr>
+              <tr>
+                <td className="px-4 py-4 align-top text-[14px] leading-7 text-[var(--text)]">
+                  Any practice whose bar is &ldquo;patient audio never touches a third party&rdquo;
+                </td>
+                <td className="px-4 py-4 align-top text-[14px] leading-7 text-[var(--text-secondary)]">
+                  On-device tools are the only architecture that meets it — a BAA governs
+                  disclosure, it doesn&rsquo;t prevent it
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            See the on-device architecture
+          </a>
+          <a
+            href="/compare/otter-vs-minutes"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Minutes vs Otter
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-6 text-[13px] leading-6 text-[var(--text-tertiary)]">
+          This page is informational, not legal advice. Verify plan details and BAA terms with
+          Otter and your compliance counsel before recording PHI with any tool.
+        </p>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/robots.ts
+++ b/site/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://useminutes.app/sitemap.xml",
+  };
+}

--- a/site/app/security/page.tsx
+++ b/site/app/security/page.tsx
@@ -1,0 +1,263 @@
+import type { Metadata } from "next";
+import { PublicFooter } from "@/components/public-footer";
+
+export const metadata: Metadata = {
+  title: "Security — audio that never leaves your device",
+  description:
+    "Minutes' security model is architectural, not contractual: capture, transcription, diarization, and storage all run on your own machine. No vendor cloud to trust, breach, or subpoena — and it's open source, so you can verify every claim in code.",
+  alternates: {
+    canonical: "/security",
+  },
+};
+
+const pipeline = [
+  {
+    step: "Capture",
+    detail: "Mic and system audio, recorded on your machine (cpal)",
+  },
+  {
+    step: "Transcribe",
+    detail: "whisper.cpp or parakeet.cpp, running on your CPU/GPU",
+  },
+  {
+    step: "Diarize",
+    detail: "pyannote ONNX models, local — speaker labels never computed in a cloud",
+  },
+  {
+    step: "Store",
+    detail: "Markdown + YAML frontmatter on your own disk, 0600 owner-only permissions",
+  },
+] as const;
+
+const guarantees = [
+  {
+    title: "No audio upload, ever",
+    body: "There is no code path that sends your recordings to a server. Transcription is not 'private-by-policy' — the cloud client simply doesn't exist.",
+  },
+  {
+    title: "Files you own outright",
+    body: "The durable record is plain markdown in ~/meetings on your disk, written with 0600 permissions. Grep it, back it up, delete it — no export button between you and your data.",
+  },
+  {
+    title: "No account, no vendor database",
+    body: "There's nothing to sign up for, so there's no server-side profile of your conversations to breach or subpoena.",
+  },
+  {
+    title: "Open source, MIT",
+    body: "Every claim on this page is verifiable in the repository — capture, transcription, and storage are readable Rust, not a trust-center PDF.",
+  },
+] as const;
+
+const sources = [
+  { label: "Minutes on GitHub (MIT)", href: "https://github.com/silverstein/minutes" },
+  { label: "Minutes for agents", href: "https://useminutes.app/for-agents" },
+  { label: "Is Otter.ai HIPAA compliant?", href: "/resources/is-otter-ai-hipaa-compliant" },
+  { label: "Compare Minutes", href: "/compare" },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function SecurityPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a href="/security.md" className="hover:text-[var(--accent)]">
+            page.md
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+          <a href="/docs" className="hover:text-[var(--accent)]">
+            docs
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Security &amp; Privacy
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          Nothing to trust. Nothing to breach. Nothing to subpoena.
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          Cloud notetakers answer the security question with policies: encryption in transit,
+          deletion windows, SOC 2 reports, BAAs. Minutes answers it with architecture. Your
+          conversations are captured, transcribed, diarized, and stored on your own machine — so
+          the promises those policies exist to make are simply not needed. &ldquo;We delete your
+          audio after processing&rdquo; is a policy. &ldquo;We never had your audio&rdquo; is an
+          architecture.
+        </p>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="The Pipeline" />
+        <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+          <div className="flex items-center justify-between gap-3">
+            <p className="font-mono text-[13px] font-medium text-[var(--text)]">
+              Every step, on your device
+            </p>
+            <span className="rounded-full bg-[var(--accent-soft)] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--accent)]">
+              Stays on device
+            </span>
+          </div>
+          <ol className="mt-5">
+            {pipeline.map((item, i) => (
+              <li key={item.step}>
+                <div className="rounded-[6px] border border-[color:var(--border)] bg-[var(--bg)] px-4 py-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="font-mono text-[13px] text-[var(--text)]">{item.step}</span>
+                    <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--accent)]">
+                      on-device
+                    </span>
+                  </div>
+                  <p className="mt-1 font-mono text-[11px] leading-5 text-[var(--text-secondary)]">
+                    {item.detail}
+                  </p>
+                </div>
+                {i < pipeline.length - 1 ? (
+                  <div
+                    className="flex justify-center py-1.5 text-[15px] text-[var(--text-tertiary)]"
+                    aria-hidden="true"
+                  >
+                    ↓
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="What That Buys You" />
+        <div className="grid gap-5 lg:grid-cols-2">
+          {guarantees.map((g) => (
+            <div
+              key={g.title}
+              className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
+            >
+              <h2 className="font-serif text-[20px] text-[var(--text)]">{g.title}</h2>
+              <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">{g.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="What Does Touch The Network" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            A security page you can trust has to be honest about the exceptions, so here is the
+            complete list. Minutes downloads transcription and diarization models once, at setup.
+            If you install updates, those come over the network too. And if you explicitly
+            configure an LLM for automated summarization, your transcript text goes wherever you
+            pointed it — at a local model via Ollama (the private default posture), or at a cloud
+            provider if you choose one and supply a key.
+          </p>
+          <p>
+            What is never in that traffic: your audio and your transcripts, unless you yourself
+            configured a summarizer to receive them. Out of the box, Minutes needs no API key and
+            sends conversation content nowhere. When Claude summarizes a meeting through MCP, it
+            reads local files through tools you granted — visible in your agent&rsquo;s tool log,
+            not a background sync.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="For Regulated Work" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">Healthcare.</span> HIPAA&rsquo;s
+            business-associate machinery exists because vendors receive PHI. On-device processing
+            means no vendor receives anything — there is no business associate, so there is no BAA
+            to negotiate. Your own obligations (disk encryption, access control, recording consent)
+            remain, exactly as they do for the workstation your EHR runs on. See our full analysis:{" "}
+            <a
+              href="/resources/is-otter-ai-hipaa-compliant"
+              className="text-[var(--accent)] hover:underline"
+            >
+              Is Otter.ai HIPAA compliant?
+            </a>
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Legal.</span> Privilege analyses get
+            harder every time a third party touches client communications. A transcript that never
+            leaves the attorney&rsquo;s machine involves no third-party disclosure to argue about.
+            (Informational, not legal advice — run it past your ethics counsel.)
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">EU / GDPR.</span> Cloud notetakers
+            make you evaluate a processor, sign a DPA, and check data-residency maps. With
+            on-device processing there is no processor and no transfer — the data never leaves the
+            controller&rsquo;s machine.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Verify It Yourself" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Minutes is MIT-licensed and the entire pipeline is readable Rust. Audio capture lives
+            in <code className="rounded-[3px] bg-[var(--bg-hover)] px-1.5 py-0.5 font-mono text-[13px]">crates/core/src/capture.rs</code>,
+            transcription in{" "}
+            <code className="rounded-[3px] bg-[var(--bg-hover)] px-1.5 py-0.5 font-mono text-[13px]">crates/core/src/transcribe.rs</code>,
+            and output permissions where files are written. Don&rsquo;t take an SEO page&rsquo;s
+            word for an architecture claim — read the code, or have your security team do it.
+            That&rsquo;s the point of shipping it open.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="https://github.com/silverstein/minutes"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            Read the source
+          </a>
+          <a
+            href="/compare"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Compare architectures
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Related" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://useminutes.app";
+
+const routes = [
+  "/",
+  "/compare",
+  "/compare/fireflies-vs-minutes",
+  "/compare/granola-vs-minutes",
+  "/compare/hyprnote-vs-minutes",
+  "/compare/otter-vs-minutes",
+  "/compare/superwhisper-vs-minutes",
+  "/docs",
+  "/docs/agent-integrations",
+  "/docs/errors",
+  "/docs/mcp/tools",
+  "/docs/using-minutes",
+  "/dojo",
+  "/for-agents",
+  "/proof",
+  "/resources/best-mcp-meeting-memory-tools",
+  "/resources/best-meeting-tools-for-claude-code-and-codex",
+  "/resources/is-otter-ai-hipaa-compliant",
+  "/resources/open-source-alternatives-to-granola-ai",
+  "/security",
+  "/writing",
+  "/writing/governance-built-in-not-retrofitted",
+] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return routes.map((route) => ({
+    url: `${BASE_URL}${route}`,
+    changeFrequency: "weekly",
+    priority: route === "/" ? 1 : 0.7,
+  }));
+}

--- a/site/components/public-footer.tsx
+++ b/site/components/public-footer.tsx
@@ -19,6 +19,10 @@ export function PublicFooter() {
           Proof
         </a>
         <span aria-hidden="true">·</span>
+        <a href="/security" className="hover:text-[var(--accent)]">
+          Security
+        </a>
+        <span aria-hidden="true">·</span>
         <a href="/compare" className="hover:text-[var(--accent)]">
           Compare
         </a>

--- a/site/public/compare/superwhisper-vs-minutes.md
+++ b/site/public/compare/superwhisper-vs-minutes.md
@@ -1,0 +1,50 @@
+# Minutes vs superwhisper
+
+Last reviewed: 2026-07-11
+
+superwhisper and Minutes agree on the thing this category usually gets wrong: your voice should be transcribed on your device, not in someone's cloud. The difference is the job. superwhisper is a polished dictation tool — speak, and clean text lands in whatever app you're typing in. Minutes treats dictation as one input to a bigger system: an open-source conversation memory that records meetings, diarizes speakers, and writes markdown files your AI agents can query.
+
+## Quick verdict
+
+- Choose **superwhisper** if you want the most refined dedicated dictation experience — custom per-app modes, 100+ languages, iOS and Windows support — and you're happy paying a subscription for a closed-source tool.
+- Choose **Minutes** if dictation is one mode of a bigger need — recording meetings, keeping voice memos, and building a private, searchable memory of your conversations that Claude and other agents can use — and you want it open source and free.
+
+## At a glance
+
+- Core job — superwhisper: speak, get clean formatted text where you're typing; Minutes: capture conversations, transcribe and diarize them, keep a searchable markdown record
+- Where transcription runs — superwhisper: on-device by default, optional cloud models (recommended on Intel Macs); Minutes: on-device always (whisper.cpp / parakeet.cpp), no cloud path
+- AI formatting — superwhisper: predefined and custom modes using local or cloud models; Minutes: optional and explicit (Claude via MCP or a local LLM you configure)
+- Durable output — superwhisper: text inserted into the app you're using; Minutes: markdown files with YAML frontmatter, action items, and decisions
+- Meetings and speakers — superwhisper: meeting recording and file transcription; Minutes: diarized speakers, confidence-aware attribution, action items, meeting lifecycle
+- Agent/MCP surface — superwhisper: none we could find; Minutes: MCP server (31 tools), CLI, SDK, Claude Code plugin
+- Open source — superwhisper: no; Minutes: yes, MIT
+- Platforms — superwhisper: macOS, Windows, iOS; Minutes: macOS menu bar app + CLI (open source)
+- Pricing — superwhisper: free tier, Pro subscription, lifetime and enterprise options; Minutes: open source and free
+
+## Where superwhisper wins
+
+- More polished dictation: per-app custom modes (email vs Slack vs prose), 100+ languages
+- Wider platform reach today: macOS, Windows, iOS
+- Simpler purchase if you never record meetings and never want a transcript archive
+
+## Where Minutes wins
+
+- A memory layer, not just an input method: meetings and memos become diarized, searchable markdown with action items — a record you own
+- Open source (MIT) and free: read the capture, transcription, and storage code instead of trusting a privacy page
+- Agent-native: Claude, Codex, and any MCP client query your conversation history through 31 MCP tools, a CLI, an SDK, and a Claude Code plugin
+
+## A useful test
+
+A month from now, will you want to ask an assistant "what did I say about this?" If no, you want a dictation tool. If yes, you want a memory layer — dictation included.
+
+## When Minutes is not the right fit
+
+- When you want best-in-class dictation UX on iOS or Windows today, or per-app formatting modes are your daily feature
+- When markdown files, a CLI, and agent workflows are complexity you don't want — a single-purpose dictation app is legitimately simpler
+
+## Sources
+
+- https://superwhisper.com
+- https://useminutes.app/for-agents
+- https://useminutes.app/docs/mcp/tools
+- https://github.com/silverstein/minutes

--- a/site/public/resources/is-otter-ai-hipaa-compliant.md
+++ b/site/public/resources/is-otter-ai-hipaa-compliant.md
@@ -1,0 +1,45 @@
+# Is Otter.ai HIPAA compliant?
+
+Last reviewed: 2026-07-11
+
+Short answer: yes, since July 2025 — but only on the Enterprise plan, and only with a signed Business Associate Agreement (BAA). Most answers online are out of date in one direction or the other.
+
+## Quick answer
+
+- **Otter.ai is HIPAA compliant only for Enterprise customers with a signed BAA.** Otter announced HIPAA compliance in July 2025 following an independent assessment. Per its help center, the BAA is available exclusively on the Enterprise plan, arranged through sales.
+- **On Basic, Pro, and Business plans, the answer is no.** No BAA is available on those tiers, so recording conversations containing protected health information (PHI) on them is an impermissible disclosure to a vendor — regardless of how good Otter's general security is.
+
+## What a BAA does — and what it doesn't
+
+A BAA makes it lawful for a vendor to receive and process PHI on your behalf, and binds the vendor to HIPAA's safeguards. It is a legal instrument, not an architectural one. With a signed BAA, patient conversations still travel to Otter's cloud, are still transcribed on Otter's servers, and still live in Otter's storage — the disclosure is permitted and governed, not eliminated. A BAA obligates the vendor to report breaches; it does not make the vendor unbreachable.
+
+## The checklist if you stay with Otter
+
+Using Otter with PHI compliantly requires all of:
+
+- An Enterprise plan — not Basic, Pro, or Business
+- A BAA actually signed before any PHI is recorded
+- Workspace policies keeping PHI recordings inside the covered workspace (a clinician's personal Pro account doesn't inherit the organization's BAA)
+- Your own HIPAA obligations: recording consent, access controls, minimum-necessary practices
+
+## The question under the question
+
+The reason a BAA is needed at all is that the audio leaves your machine. The second way to resolve the HIPAA question: transcription that runs entirely on your own device, so no vendor ever receives the conversation. No third party, no business associate, no BAA — the legal question dissolves because the disclosure never happens.
+
+That's the architecture Minutes is built on: audio is captured and transcribed on-device with whisper.cpp, and the record is markdown on your own disk with owner-only file permissions. It's open source (MIT), so the claim is verifiable in code. To be precise: no local tool is "HIPAA certified" — HIPAA governs covered entities and their vendors. On-device processing removes the vendor from the equation; securing the device (disk encryption, access control) remains your responsibility, as it already is for your EHR workstation.
+
+## Which fits your situation
+
+- Large org already on Otter Enterprise wanting team features → sign the BAA, lock recording to the covered workspace, audit regularly
+- Solo practitioner or small practice on a consumer/Pro plan → stop recording PHI with it today; no BAA is available at your tier. Consider on-device transcription
+- Any practice whose bar is "patient audio never touches a third party" → on-device tools are the only architecture that meets it
+
+## Sources
+
+- https://help.otter.ai/hc/en-us/articles/33975072019991-HIPAA-Otter-ai
+- https://otter.ai/blog/otter-ai-achieves-hipaa-compliance
+- https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html
+- https://useminutes.app/security
+- https://github.com/silverstein/minutes
+
+This page is informational, not legal advice. Verify plan details and BAA terms with Otter and your compliance counsel before recording PHI with any tool.

--- a/site/public/security.md
+++ b/site/public/security.md
@@ -1,0 +1,39 @@
+# Minutes — Security & Privacy
+
+Last reviewed: 2026-07-11
+
+Cloud notetakers answer the security question with policies: encryption in transit, deletion windows, SOC 2 reports, BAAs. Minutes answers it with architecture. Your conversations are captured, transcribed, diarized, and stored on your own machine. "We delete your audio after processing" is a policy. "We never had your audio" is an architecture.
+
+## The pipeline — every step on your device
+
+1. **Capture** — mic and system audio, recorded on your machine (cpal)
+2. **Transcribe** — whisper.cpp or parakeet.cpp, running on your CPU/GPU
+3. **Diarize** — pyannote ONNX models, local; speaker labels never computed in a cloud
+4. **Store** — markdown + YAML frontmatter on your own disk, 0600 owner-only permissions
+
+## What that buys you
+
+- **No audio upload, ever.** There is no code path that sends recordings to a server. The cloud client doesn't exist.
+- **Files you own outright.** The durable record is plain markdown in ~/meetings, written with 0600 permissions. Grep it, back it up, delete it.
+- **No account, no vendor database.** Nothing to sign up for; no server-side profile of your conversations to breach or subpoena.
+- **Open source, MIT.** Every claim here is verifiable in the repository — readable Rust, not a trust-center PDF.
+
+## What does touch the network (the honest list)
+
+- Transcription and diarization models are downloaded once, at setup
+- Updates, if you install them
+- If you explicitly configure an LLM for automated summarization, transcript text goes where you pointed it — a local model via Ollama (the private default posture), or a cloud provider if you choose one and supply a key
+
+What is never in that traffic: your audio and transcripts, unless you yourself configured a summarizer to receive them. Out of the box, Minutes needs no API key and sends conversation content nowhere. When Claude summarizes a meeting through MCP, it reads local files through tools you granted — visible in your agent's tool log, not a background sync.
+
+## For regulated work
+
+- **Healthcare.** HIPAA's business-associate machinery exists because vendors receive PHI. On-device processing means no vendor receives anything — no business associate, no BAA to negotiate. Your own obligations (disk encryption, access control, recording consent) remain, as they do for your EHR workstation. See: https://useminutes.app/resources/is-otter-ai-hipaa-compliant
+- **Legal.** A transcript that never leaves the attorney's machine involves no third-party disclosure to argue about. (Informational, not legal advice.)
+- **EU / GDPR.** No processor, no DPA, no transfer — the data never leaves the controller's machine.
+
+## Verify it yourself
+
+Minutes is MIT-licensed and the pipeline is readable Rust: audio capture in `crates/core/src/capture.rs`, transcription in `crates/core/src/transcribe.rs`. Don't take a web page's word for an architecture claim — read the code, or have your security team do it.
+
+- https://github.com/silverstein/minutes


### PR DESCRIPTION
## What

Ships the weeks-1–2 pages from the new SEO plan (`docs/plans/seo-plan.md`, included in this PR):

- **`/security`** — on-device architecture pillar. Pipeline diagram (capture → transcribe → diarize → store, all on-device), an honest "what does touch the network" section (model downloads, updates, opt-in summarizers), and regulated-work framing for HIPAA / legal privilege / GDPR.
- **`/resources/is-otter-ai-hipaa-compliant`** — sourced answer page: Otter is HIPAA compliant since July 2025 but **Enterprise-plan-only with a signed BAA** (verified against Otter's help center). Explains what a BAA does and doesn't do, then bridges to the on-device alternative. FAQPage JSON-LD included. Targets "is otter ai hipaa compliant" (50/mo, KD 0).
- **`/compare/superwhisper-vs-minutes`** — dictation-beachhead comparison (superwhisper alternative, 53/mo, KD ~0). Honest fit-based framing: both transcribe locally; the difference is dictation tool vs conversation-memory layer.
- **`sitemap.ts` + `robots.ts`** — the site had neither.
- Footer "Security" link, compare-hub entry, and `.md` twins for all three pages.

## Why

Ahrefs research (full write-up in `docs/plans/seo-plan.md`): useminutes.app has 370 referring domains but ranks for exactly 1 keyword — link authority with no content to spend it on. The compliance cluster ("hipaa compliant transcription": KD 2, $5 CPC) and dictation cluster are nearly uncontested, and cloud competitors can't answer these queries without arguing against their own architecture.

## Verification

- `npm run build` green — all 26 routes prerender, including `/sitemap.xml` and `/robots.txt`
- Otter HIPAA facts verified against Otter's official help center + blog (July 2025 announcement); page carries a not-legal-advice note
- superwhisper facts from its official site; pricing described qualitatively to avoid staleness
- All pages follow DESIGN.md (existing ComparePage component / resource-page pattern; no new fonts, colors, or radii)

🤖 Generated with [Claude Code](https://claude.com/claude-code)