### PR TITLE
feat(site): SEO content wave 2 — privilege, anti-bot, local STT roundup, engine post

### DIFF
--- a/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
+++ b/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
@@ -1,0 +1,267 @@
+import type { Metadata } from "next";
+import { PublicFooter } from "@/components/public-footer";
+
+export const metadata: Metadata = {
+  title: "AI notetakers and attorney–client privilege",
+  description:
+    "Privilege depends on confidentiality, and cloud AI notetakers put a third party inside your client conversations. What ABA Formal Opinion 512 says, the questions to ask any vendor, and why on-device transcription changes the analysis.",
+  alternates: {
+    canonical: "/resources/ai-notetakers-attorney-client-privilege",
+  },
+};
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Does using an AI notetaker waive attorney–client privilege?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "There is no blanket answer — waiver is fact-specific and courts have not squarely resolved cloud AI notetakers. The risk vector is clear, though: privilege depends on confidentiality, and sending client conversations to a third-party cloud service is a disclosure that opposing counsel can probe. Vendor terms allowing human review or model training make the argument harder to defend.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What does ABA Formal Opinion 512 say about AI tools and confidentiality?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "ABA Formal Opinion 512 (July 2024) addresses generative AI under Model Rule 1.6: lawyers must evaluate a tool's data handling before inputting client information, may need informed client consent for self-learning tools, and remain responsible for understanding where client data goes. It does not ban AI tools; it requires lawyers to actually understand the data flow.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Do I need consent to record client meetings?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Recording-consent law is separate from privilege and varies by state: some states require all-party consent, others one-party. Best practice for client conversations is explicit consent regardless of state law — it is also the professional norm.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How does on-device transcription change the privilege analysis?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "If transcription runs entirely on the attorney's own machine and the transcript is a local file, no third party ever receives the communication — there is no vendor disclosure to analyze, no terms of service governing client data, and no vendor to subpoena. The remaining duties are the familiar ones: device security and access control.",
+      },
+    },
+  ],
+} as const;
+
+const sources = [
+  {
+    label: "ABA Formal Opinion 512: Generative Artificial Intelligence Tools (July 2024)",
+    href: "https://www.americanbar.org/content/dam/aba/administrative/professional_responsibility/ethics-opinions/aba-formal-opinion-512.pdf",
+  },
+  {
+    label: "RCFP Reporter's Recording Guide (state-by-state consent law)",
+    href: "https://www.rcfp.org/reporters-recording-guide/",
+  },
+  { label: "Minutes security & privacy architecture", href: "/security" },
+  {
+    label: "Is Otter.ai HIPAA compliant? (the parallel analysis for healthcare)",
+    href: "/resources/is-otter-ai-hipaa-compliant",
+  },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function AiNotetakersPrivilegePage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a
+            href="/resources/ai-notetakers-attorney-client-privilege.md"
+            className="hover:text-[var(--accent)]"
+          >
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          AI notetakers and attorney&ndash;client privilege
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          Privilege has one load-bearing wall: confidentiality. An AI notetaker that streams your
+          client conversations to a vendor&rsquo;s cloud puts a third party inside that wall, and
+          nobody — not the vendor, not the bar, not yet a court — has given lawyers a clean
+          answer on what that does to privilege. Here is the current state of the analysis, and
+          the architectural choice that makes most of it moot.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-07-11
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            Not legal advice
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-12 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Quick answer
+        </p>
+        <div className="mt-4 space-y-3 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              Waiver is fact-specific and unsettled — but the risk vector is not.
+            </span>{" "}
+            Privilege requires confidentiality; a cloud notetaker is a disclosure to a third
+            party under that vendor&rsquo;s terms. Whether that disclosure defeats privilege will
+            depend on the vendor&rsquo;s data handling, your diligence, and a judge — three
+            things you don&rsquo;t fully control.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              On-device transcription removes the third party entirely.
+            </span>{" "}
+            A transcript generated and stored on the attorney&rsquo;s own machine involves no
+            outside disclosure to argue about. The confidentiality question collapses back to the
+            one you already answer daily: is your laptop secure?
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="What The Bar Has Actually Said" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            The closest authoritative guidance is{" "}
+            <span className="font-medium text-[var(--text)]">ABA Formal Opinion 512</span> (July
+            2024) on generative AI. Its core demand is unglamorous: before client information
+            goes into an AI tool, the lawyer must actually understand the tool&rsquo;s data
+            handling — who can access inputs, whether they train models, how long they&rsquo;re
+            retained — and in some cases obtain informed client consent. Competence about the
+            tool is part of the duty of confidentiality, not separate from it.
+          </p>
+          <p>
+            Applied to meeting notetakers, that means reading the vendor&rsquo;s terms the way
+            opposing counsel would: Does the vendor&rsquo;s staff have access to transcripts for
+            &ldquo;service improvement&rdquo;? Are recordings used for model training, by them or
+            their subprocessors? What happens to your clients&rsquo; conversations under a
+            subpoena served on the vendor? Every &ldquo;yes&rdquo; and &ldquo;unclear&rdquo; is
+            material you may someday have to defend.
+          </p>
+          <p>
+            Separately from privilege, recording consent law applies: some states require
+            all-party consent to record a conversation, others one-party. For client meetings,
+            explicit consent is the professional norm regardless of what your state minimally
+            permits — the RCFP guide linked below has the state-by-state map.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Vendor Questions That Matter" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>If you&rsquo;re evaluating any cloud notetaker for client work, get written answers to:</p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>Where is audio transcribed, and by which subprocessors?</li>
+            <li>Is any human review of transcripts possible, ever, for any purpose?</li>
+            <li>Are recordings or transcripts used to train models — theirs or anyone&rsquo;s?</li>
+            <li>What is the retention period, and is deletion verifiable?</li>
+            <li>What is their process when they receive legal process for your data?</li>
+            <li>Will they sign confidentiality terms that survive their standard ToS?</li>
+          </ul>
+          <p>
+            Notice what this list is: a due-diligence file you must build and maintain for a
+            vendor whose entire involvement is optional.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Architectural Answer" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Every question above exists because the conversation leaves your machine. Run
+            transcription on-device instead, and the third party disappears: no vendor receives
+            the communication, no terms of service govern it, no subpoena served on a vendor can
+            reach it, and there is no &ldquo;service improvement&rdquo; clause to parse. That is
+            the design of <span className="font-medium text-[var(--text)]">Minutes</span> — open
+            source, on-device transcription and diarization, transcripts as markdown files on
+            your own disk with owner-only permissions. The privilege analysis returns to familiar
+            ground: secure the device, control access by matter, and document client consent to
+            recording.
+          </p>
+          <p>
+            What on-device does <em>not</em> do: it doesn&rsquo;t satisfy consent law for you,
+            secure an unencrypted laptop, or make a transcript less discoverable in litigation —
+            your own files are always discoverable. It removes the third-party disclosure
+            question, which is the one you can&rsquo;t fix after the fact.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            See the on-device architecture
+          </a>
+          <a
+            href="/compare"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Compare notetakers
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-6 text-[13px] leading-6 text-[var(--text-tertiary)]">
+          This page is informational, not legal advice. Privilege and consent questions are
+          jurisdiction- and fact-specific — consult your ethics counsel before adopting any
+          recording tool for client work.
+        </p>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/best-local-speech-to-text/page.tsx
+++ b/site/app/resources/best-local-speech-to-text/page.tsx
@@ -1,0 +1,231 @@
+import type { Metadata } from "next";
+import { PublicFooter } from "@/components/public-footer";
+
+export const metadata: Metadata = {
+  title: "The best local speech-to-text apps (2026)",
+  description:
+    "A fit-based guide to on-device transcription: MacWhisper, superwhisper, Buzz, Vibe, whisper.cpp, and Minutes — matched to the job you're actually hiring for, with honest disclosure of which one is ours.",
+  alternates: {
+    canonical: "/resources/best-local-speech-to-text",
+  },
+};
+
+const tools = [
+  {
+    name: "Minutes",
+    bestFor: "Meetings, voice memos, and conversation memory for AI agents",
+    detail:
+      "Open source (MIT), free. Records and transcribes on-device (whisper.cpp or parakeet.cpp), diarizes speakers, and writes markdown with action items that Claude and other MCP clients can query. macOS menu bar app + CLI.",
+    license: "Open source, free",
+  },
+  {
+    name: "MacWhisper",
+    bestFor: "Polished Mac GUI for transcribing audio and video files",
+    detail:
+      "The most refined drag-and-drop Whisper experience on macOS: batch file transcription, system-audio capture, subtitle export. Free with smaller models; Pro is a one-time purchase. Closed source.",
+    license: "Freemium, one-time Pro",
+  },
+  {
+    name: "superwhisper",
+    bestFor: "Dictation into any app",
+    detail:
+      "Speak and get clean, per-app formatted text wherever you're typing. Local models by default, with optional cloud models. macOS, Windows, and iOS. Closed source, subscription with a lifetime option.",
+    license: "Freemium, subscription",
+  },
+  {
+    name: "Buzz",
+    bestFor: "Free open-source transcription on Windows, Mac, and Linux",
+    detail:
+      "Cross-platform Whisper GUI that runs fully offline: import files, transcribe, translate, export. Not fancy, reliably maintained, genuinely free.",
+    license: "Open source, free",
+  },
+  {
+    name: "Vibe",
+    bestFor: "Free open-source batch transcription with a modern UI",
+    detail:
+      "Cross-platform (Tauri-based) offline transcription supporting 90+ languages, batch processing, and multiple export formats. A strong zero-cost default for file transcription.",
+    license: "Open source, free",
+  },
+  {
+    name: "whisper.cpp",
+    bestFor: "Developers, scripting, and embedding",
+    detail:
+      "The C/C++ engine most tools on this page are built on. CLI-first, runs everywhere, no UI. If you're comfortable in a terminal, it's the most flexible option there is — several apps here (including ours) are interfaces to it.",
+    license: "Open source, free",
+  },
+] as const;
+
+const sources = [
+  { label: "Minutes on GitHub", href: "https://github.com/silverstein/minutes" },
+  { label: "MacWhisper", href: "https://goodsnooze.gumroad.com/l/macwhisper" },
+  { label: "superwhisper", href: "https://superwhisper.com" },
+  { label: "Buzz on GitHub", href: "https://github.com/chidiwilliams/buzz" },
+  { label: "Vibe on GitHub", href: "https://github.com/thewh1teagle/vibe" },
+  { label: "whisper.cpp on GitHub", href: "https://github.com/ggml-org/whisper.cpp" },
+  {
+    label: "whisper.cpp vs parakeet.cpp — our engine comparison",
+    href: "/writing/whisper-cpp-vs-parakeet-cpp",
+  },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function BestLocalSpeechToTextPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a href="/resources/best-local-speech-to-text.md" className="hover:text-[var(--accent)]">
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          The best local speech-to-text apps
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          &ldquo;Local&rdquo; is the whole point here: every tool on this page transcribes on
+          your own hardware, so your audio never touches a vendor&rsquo;s server. But
+          &ldquo;best&rdquo; depends entirely on the job — dictating an email, transcribing a
+          folder of interviews, and remembering every meeting you&rsquo;ve had are three
+          different problems. Full disclosure up front: Minutes is our tool. We&rsquo;ll tell
+          you exactly when it&rsquo;s the wrong pick.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-07-11
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            Fit-based resource
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-12 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Quick answer
+        </p>
+        <div className="mt-4 space-y-3 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            For <span className="font-medium text-[var(--text)]">transcribing files with a nice Mac GUI</span>,
+            get MacWhisper. For <span className="font-medium text-[var(--text)]">dictation</span>,
+            get superwhisper. For{" "}
+            <span className="font-medium text-[var(--text)]">free cross-platform transcription</span>,
+            get Buzz or Vibe. For{" "}
+            <span className="font-medium text-[var(--text)]">scripting and embedding</span>, use
+            whisper.cpp directly.
+          </p>
+          <p>
+            For <span className="font-medium text-[var(--text)]">meetings and conversation memory</span> —
+            diarized speakers, action items, and an archive your AI agents can search — that&rsquo;s
+            the job Minutes exists for, and the one none of the file-transcriber tools attempt.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="The Tools, By Job" />
+        <div className="grid gap-4">
+          {tools.map((tool) => (
+            <div
+              key={tool.name}
+              className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="font-serif text-[22px] text-[var(--text)]">{tool.name}</h2>
+                <span className="rounded-full bg-[var(--bg-hover)] px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+                  {tool.license}
+                </span>
+              </div>
+              <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+                {tool.bestFor}
+              </p>
+              <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">
+                {tool.detail}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="How To Actually Choose" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Ask what happens to the transcript after it exists. If the answer is &ldquo;I read it
+            once and file it,&rdquo; any file transcriber above will serve you well — pick by
+            platform and budget. If the answer is &ldquo;I paste it somewhere else,&rdquo; you
+            want dictation, which is superwhisper&rsquo;s specialty (and a mode Minutes includes).
+          </p>
+          <p>
+            If the answer is &ldquo;I want to ask questions about it later&rdquo; — what did we
+            decide, who said what, what&rsquo;s still open — you need structure the moment of
+            transcription: speaker labels, timestamps, action items, and files an assistant can
+            search. That&rsquo;s the memory-layer job, and it&rsquo;s where Minutes is the only
+            tool on this list actually built for it. It&rsquo;s also overkill if you just want
+            subtitles for a video file — use MacWhisper or Vibe for that and keep your life
+            simple.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            Why on-device matters
+          </a>
+          <a
+            href="/writing/whisper-cpp-vs-parakeet-cpp"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Engine deep-dive
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -1,0 +1,261 @@
+import type { Metadata } from "next";
+import { PublicFooter } from "@/components/public-footer";
+
+export const metadata: Metadata = {
+  title: "How to remove AI notetaker bots from your meetings",
+  description:
+    "Step-by-step: stop Otter, Fireflies, and other AI bots from joining your Zoom, Google Meet, and Teams calls — yours and other people's — plus the capture architecture that never needed a bot in the first place.",
+  alternates: {
+    canonical: "/resources/remove-ai-notetaker-bots-from-meetings",
+  },
+};
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How do I stop Otter from automatically joining my meetings?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "In Otter's settings, disable auto-join for calendar events (Otter Assistant / OtterPilot settings), or disconnect your calendar entirely so Otter can't see meeting links. To remove it from a live call, use the meeting platform's participant list to remove the bot like any attendee. Otter's help center documents both paths.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How do I remove Fireflies (Fred) from a meeting?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Remove the Fireflies notetaker from the participant list as host, and in Fireflies settings change the autojoin rule (or disconnect the calendar) so it stops joining future calls. Fireflies' guide documents removal and autojoin settings.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I block all AI notetaker bots from my meetings?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Largely, yes: enable the waiting room, require sign-in, and admit only human participants — bots arrive as visible guest participants and can be denied or removed. But you cannot disable another attendee's bot from your side except by removing it per meeting or setting an organizational policy.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is there a way to get AI meeting notes without any bot?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes — device-side capture. Tools like Minutes (open source, on-device) record audio directly on the participant's machine, so no bot ever appears in the meeting, and with Minutes the audio is also transcribed locally rather than uploaded. You should still tell participants you're recording; the difference is architectural, not a way around consent.",
+      },
+    },
+  ],
+} as const;
+
+const sources = [
+  {
+    label: "Otter help: remove Otter Notetaker from your meeting (Zoom, Meet, Teams)",
+    href: "https://help.otter.ai/hc/en-us/articles/14288936562199-Remove-Otter-Notetaker-from-your-meeting-Zoom-Google-Meet-or-Microsoft-Teams",
+  },
+  {
+    label: "Otter help: stop Otter Notetaker from automatically joining meetings",
+    href: "https://help.otter.ai/hc/en-us/articles/12906714508823-Stop-Otter-Notetaker-from-automatically-joining-your-meetings",
+  },
+  {
+    label: "Fireflies guide: remove Fireflies from a meeting or stop it from joining",
+    href: "https://guide.fireflies.ai/articles/7098191513-how-to-remove-fireflies-from-a-meeting-or-stop-it-from-joining",
+  },
+  { label: "Minutes security & privacy architecture", href: "/security" },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function RemoveNotetakerBotsPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a
+            href="/resources/remove-ai-notetaker-bots-from-meetings.md"
+            className="hover:text-[var(--accent)]"
+          >
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          How to remove AI notetaker bots from your meetings
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          The most-searched questions about AI notetakers aren&rsquo;t &ldquo;which one is
+          best&rdquo; — they&rsquo;re &ldquo;how do I get this thing out of my call.&rdquo;
+          Fair. Here&rsquo;s the complete removal guide for the common bots, the settings that
+          stop them coming back, and the honest limits of what you can control when the bot
+          belongs to someone else.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-07-11
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            How-to guide
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Why The Bot Keeps Showing Up" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Bot notetakers join meetings the same way a person does: they read a connected
+            calendar, find the meeting link, and dial in as a participant. That means there are
+            exactly three levers — the calendar connection that feeds it links, the vendor
+            setting that tells it to auto-join, and the meeting platform&rsquo;s participant
+            controls. Every fix below is one of those three.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Removing Your Own Bot" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">Otter (OtterPilot / Otter Notetaker).</span>{" "}
+            To stop it joining everything: Otter settings → turn off auto-join for calendar
+            events, or disconnect Google/Microsoft calendar entirely so it never sees links. To
+            eject it from one live meeting: open the participant list in Zoom/Meet/Teams and
+            remove it like any attendee. Both procedures are in Otter&rsquo;s help center,
+            linked below.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Fireflies (Fred).</span> Same
+            pattern: Fireflies settings → autojoin rules (change to invite-only or off, or
+            disconnect the calendar), and remove the notetaker from the participant list
+            mid-call. Fireflies&rsquo; own guide is linked below.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Anything else.</span> The pattern
+            generalizes: find the calendar connection and sever it, find the auto-join rule and
+            turn it off. If a bot has no calendar access, it has no way to find your meetings.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Blocking Other People's Bots" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            This is the part vendors&rsquo; help pages soft-pedal: you cannot disable a
+            colleague&rsquo;s or client&rsquo;s bot from your side. What you can do as host:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              Enable the waiting room / lobby and admit only humans — bots arrive as visible
+              guest participants with names like &ldquo;Otter Notetaker&rdquo; or
+              &ldquo;Fireflies.ai Notetaker.&rdquo;
+            </li>
+            <li>Require signed-in participants, which blocks most anonymous bot joins.</li>
+            <li>Remove the bot from the participant list; in Zoom, removed participants can be barred from rejoining.</li>
+            <li>
+              Say it out loud: &ldquo;please drop the notetaker for this one&rdquo; is now normal
+              meeting etiquette, and the human who owns the bot can kill it in one click.
+            </li>
+          </ul>
+          <p>
+            For organizations, the durable fix is policy plus platform controls: several
+            platforms let admins restrict which apps and guest domains can join meetings at the
+            tenant level.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Version Of This Problem That Solves Itself" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Notice that every step above is managing a symptom. The bot exists because
+            cloud notetakers need a way to get your meeting&rsquo;s audio onto their servers,
+            and joining the call as a fake participant is that way. Capture the audio on the
+            participant&rsquo;s own device instead, and the entire category of problem
+            disappears — nothing joins the call, nothing shows up in the participant list,
+            nothing needs admitting or ejecting.
+          </p>
+          <p>
+            That&rsquo;s how <span className="font-medium text-[var(--text)]">Minutes</span>{" "}
+            works: it records device-side, transcribes locally with whisper.cpp, and writes
+            markdown to your own disk — no bot <em>and</em> no cloud. (Granola is also botless,
+            though it transcribes in the cloud — see our{" "}
+            <a
+              href="/compare/granola-vs-minutes"
+              className="text-[var(--accent)] hover:underline"
+            >
+              comparison
+            </a>
+            .) One thing device-side capture does not change: tell people you&rsquo;re
+            recording. The bot&rsquo;s one virtue was announcing itself; without it, consent is
+            on you, where it belonged anyway.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            How botless capture works
+          </a>
+          <a
+            href="/compare"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Compare notetakers
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -18,13 +18,17 @@ const routes = [
   "/dojo",
   "/for-agents",
   "/proof",
+  "/resources/ai-notetakers-attorney-client-privilege",
+  "/resources/best-local-speech-to-text",
   "/resources/best-mcp-meeting-memory-tools",
   "/resources/best-meeting-tools-for-claude-code-and-codex",
   "/resources/is-otter-ai-hipaa-compliant",
   "/resources/open-source-alternatives-to-granola-ai",
+  "/resources/remove-ai-notetaker-bots-from-meetings",
   "/security",
   "/writing",
   "/writing/governance-built-in-not-retrofitted",
+  "/writing/whisper-cpp-vs-parakeet-cpp",
 ] as const;
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/site/app/writing/page.tsx
+++ b/site/app/writing/page.tsx
@@ -11,6 +11,13 @@ export const metadata: Metadata = {
 
 const posts = [
   {
+    slug: "whisper-cpp-vs-parakeet-cpp",
+    date: "2026-07-11",
+    title: "whisper.cpp vs parakeet.cpp for local transcription",
+    summary:
+      "We ship both engines in production. Real numbers on accuracy and Apple Silicon speed, why Whisper is still the default, and the build friction nobody mentions.",
+  },
+  {
     slug: "governance-built-in-not-retrofitted",
     date: "2026-06-10",
     title: "Governance built in, not retrofitted",

--- a/site/app/writing/whisper-cpp-vs-parakeet-cpp/page.tsx
+++ b/site/app/writing/whisper-cpp-vs-parakeet-cpp/page.tsx
@@ -1,0 +1,190 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "whisper.cpp vs parakeet.cpp for local transcription — minutes",
+  description:
+    "We ship both engines in an open-source transcription pipeline. Real numbers on accuracy, speed on Apple Silicon, language coverage, and the build friction nobody mentions.",
+  alternates: {
+    canonical: "/writing/whisper-cpp-vs-parakeet-cpp",
+  },
+};
+
+const benchmarks = [
+  { engine: "Whisper", model: "small (our default)", params: "244M", wer: "3.4%", speed: "~200ms" },
+  { engine: "Whisper", model: "medium", params: "769M", wer: "2.9%", speed: "~600ms" },
+  { engine: "Whisper", model: "large-v3", params: "1.55B", wer: "2.4%", speed: "~1.5s" },
+  { engine: "Parakeet", model: "tdt-ctc-110m", params: "110M", wer: "2.4%", speed: "~27ms" },
+  { engine: "Parakeet", model: "tdt-600m", params: "600M", wer: "1.7%", speed: "~520ms" },
+] as const;
+
+export default function Post() {
+  return (
+    <div className="mx-auto max-w-[680px] px-6 pb-16 sm:px-8">
+      <nav className="flex items-center justify-between border-b border-[color:var(--border)] py-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-x-6 text-sm text-[var(--text-secondary)]">
+          <a href="/writing" className="hover:text-[var(--accent)]">
+            Writing
+          </a>
+          <a
+            href="https://github.com/silverstein/minutes"
+            className="hover:text-[var(--accent)]"
+          >
+            GitHub
+          </a>
+        </div>
+      </nav>
+
+      <article className="pt-14">
+        <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+          2026-07-11 · Mat Silverstein
+        </p>
+        <h1 className="font-serif text-[36px] leading-[1.05] tracking-[-0.04em] text-[var(--text)] sm:text-[42px]">
+          whisper.cpp vs parakeet.cpp for local transcription
+        </h1>
+
+        <div className="mt-8 space-y-5 text-[16px] leading-[1.75] text-[var(--text-secondary)]">
+          <p>
+            Minutes ships both engines: whisper.cpp as the default, parakeet.cpp behind an opt-in
+            build flag. That means we&apos;ve had to make both work in production — batch
+            transcription, live meeting transcription, dictation, folder-watcher processing — on
+            the same audio, on the same machines. This is what we&apos;ve learned, with the
+            numbers and the friction included.
+          </p>
+
+          <h2 className="pt-4 font-serif text-[26px] leading-tight tracking-[-0.02em] text-[var(--text)]">
+            The numbers
+          </h2>
+          <p>
+            Parakeet is NVIDIA&apos;s FastConformer architecture;{" "}
+            <a
+              href="https://github.com/Frikallo/parakeet.cpp"
+              className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+            >
+              parakeet.cpp
+            </a>{" "}
+            is its ggml-style local port with Metal acceleration on Apple Silicon. LibriSpeech
+            clean word-error rates, with speed measured on 10 seconds of audio on an M-series GPU:
+          </p>
+
+          <div className="overflow-x-auto rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)]">
+            <table className="min-w-full border-collapse text-left">
+              <thead>
+                <tr className="border-b border-[color:var(--border)]">
+                  {["Engine", "Model", "Params", "WER", "Speed"].map((h) => (
+                    <th
+                      key={h}
+                      className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {benchmarks.map((row) => (
+                  <tr
+                    key={`${row.engine}-${row.model}`}
+                    className="border-b border-[color:var(--border)] last:border-b-0"
+                  >
+                    <td className="px-4 py-3 font-mono text-[13px] text-[var(--text)]">{row.engine}</td>
+                    <td className="px-4 py-3 font-mono text-[13px] text-[var(--text-secondary)]">{row.model}</td>
+                    <td className="px-4 py-3 font-mono text-[13px] text-[var(--text-secondary)]">{row.params}</td>
+                    <td className="px-4 py-3 font-mono text-[13px] text-[var(--text-secondary)]">{row.wer}</td>
+                    <td className="px-4 py-3 font-mono text-[13px] text-[var(--text-secondary)]">{row.speed}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p>
+            Read that table twice. Parakeet&apos;s 110M-parameter model matches Whisper
+            large-v3&apos;s accuracy with 14× fewer parameters, and transcribes 10 seconds of
+            audio in 27 milliseconds where large-v3 takes a second and a half. The 600M model
+            beats everything in its class at 1.7% WER. On raw accuracy-per-parameter and speed,
+            it isn&apos;t close.
+          </p>
+
+          <h2 className="pt-4 font-serif text-[26px] leading-tight tracking-[-0.02em] text-[var(--text)]">
+            So why is Whisper still our default?
+          </h2>
+          <p>
+            <span className="font-medium text-[var(--text)]">Languages.</span> Whisper covers 99
+            languages. Parakeet&apos;s tdt-600m covers 25 European ones, and the 110M model is
+            English-only. If your meetings might contain Japanese, Hindi, Arabic, or Mandarin,
+            the comparison is over before it starts.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Zero-friction install.</span>{" "}
+            whisper.cpp has mature prebuilt distribution everywhere. parakeet.cpp has no binary
+            releases as of this writing: you build it yourself with CMake — and on macOS you need
+            full Xcode for the Metal shader compiler, plus CMake 3.31.x specifically, because a
+            bundled dependency trips on CMake 4. Then you download a 2.4&nbsp;GB .nemo file from
+            HuggingFace and convert it to safetensors with a small Python venv. We documented the
+            whole path and it&apos;s reliable — but it&apos;s an afternoon, not a{" "}
+            <span className="font-mono text-[14px]">brew install</span>.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Streaming partials.</span> Our
+            dictation overlay depends on fast mid-utterance partial results, and Whisper&apos;s
+            streaming behavior is what makes that feel live. Even with Parakeet enabled, Minutes
+            keeps Whisper powering dictation partials and uses Parakeet at utterance finalization.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Fallback maturity.</span> A
+            transcription engine in production needs an answer for &quot;the engine failed
+            mid-meeting.&quot; Whisper is compiled into every Minutes build, so Parakeet paths
+            fall back to it automatically — warmup error, sidecar unreachable, or a single failed
+            utterance. The reverse arrangement wouldn&apos;t work today.
+          </p>
+
+          <h2 className="pt-4 font-serif text-[26px] leading-tight tracking-[-0.02em] text-[var(--text)]">
+            When Parakeet is clearly worth it
+          </h2>
+          <p>
+            English or major-European-language audio on Apple Silicon, especially live
+            transcription. The latency difference is not subtle: for real-time meeting
+            transcription, a warm Parakeet sidecar turns per-utterance transcription from
+            &quot;noticeable lag&quot; into &quot;effectively instant,&quot; and on long batch
+            jobs the throughput gap compounds. One contributor runs Parakeet through
+            NVIDIA&apos;s NeMo on an RTX 3090: a 68-minute French meeting transcribes in about
+            3.5 minutes, with quality that beats Whisper large-v3 on mixed-language audio.
+          </p>
+
+          <h2 className="pt-4 font-serif text-[26px] leading-tight tracking-[-0.02em] text-[var(--text)]">
+            The honest recommendation
+          </h2>
+          <p>
+            Start with Whisper — it&apos;s the default for a reason: universal language coverage,
+            no build step, battle-tested fallbacks. If you&apos;re on Apple Silicon, work mostly
+            in English or European languages, and care about live latency or long batch jobs,
+            the parakeet.cpp build is worth the afternoon. Minutes lets both coexist in one
+            binary and switches per-path in config, so this isn&apos;t a marriage either way.
+          </p>
+          <p>
+            The full setup guide, including every build pitfall we hit, is in{" "}
+            <a
+              href="https://github.com/silverstein/minutes/blob/main/docs/architecture/parakeet.md"
+              className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+            >
+              docs/architecture/parakeet.md
+            </a>
+            . Benchmarks are the upstream projects&apos; published LibriSpeech numbers; speed
+            figures are from parakeet.cpp&apos;s measurements on M-series GPUs. Minutes is MIT
+            licensed —{" "}
+            <a
+              href="https://github.com/silverstein/minutes"
+              className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"
+            >
+              the pipeline code is on GitHub
+            </a>
+            .
+          </p>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/site/public/resources/ai-notetakers-attorney-client-privilege.md
+++ b/site/public/resources/ai-notetakers-attorney-client-privilege.md
@@ -1,0 +1,44 @@
+# AI notetakers and attorney–client privilege
+
+Last reviewed: 2026-07-11 · Not legal advice
+
+Privilege has one load-bearing wall: confidentiality. An AI notetaker that streams client conversations to a vendor's cloud puts a third party inside that wall — and no court has given lawyers a clean answer on what that does to privilege.
+
+## Quick answer
+
+- **Waiver is fact-specific and unsettled — but the risk vector is not.** Privilege requires confidentiality; a cloud notetaker is a disclosure to a third party under that vendor's terms. Whether it defeats privilege depends on the vendor's data handling, your diligence, and a judge — three things you don't fully control.
+- **On-device transcription removes the third party entirely.** A transcript generated and stored on the attorney's own machine involves no outside disclosure to argue about. The confidentiality question collapses to the one you already answer daily: is your laptop secure?
+
+## What the bar has actually said
+
+ABA Formal Opinion 512 (July 2024) on generative AI: before client information goes into an AI tool, the lawyer must understand the tool's data handling — who can access inputs, whether they train models, retention — and in some cases obtain informed client consent. Competence about the tool is part of the duty of confidentiality.
+
+Applied to notetakers, read the vendor's terms the way opposing counsel would: staff access for "service improvement"? Model training by them or subprocessors? What happens under a subpoena served on the vendor?
+
+Separately, recording-consent law applies (all-party vs one-party states — see the RCFP state-by-state guide). For client meetings, explicit consent is the professional norm regardless of state minimums.
+
+## The vendor questions that matter
+
+- Where is audio transcribed, and by which subprocessors?
+- Is any human review of transcripts possible, ever?
+- Are recordings/transcripts used to train models?
+- What is the retention period; is deletion verifiable?
+- What is their process on receiving legal process for your data?
+- Will they sign confidentiality terms that survive their standard ToS?
+
+That list is a due-diligence file you must build for a vendor whose entire involvement is optional.
+
+## The architectural answer
+
+Every question above exists because the conversation leaves your machine. Run transcription on-device and the third party disappears: no vendor receives the communication, no ToS governs it, no vendor subpoena can reach it. That's the design of Minutes — open source, on-device transcription and diarization, transcripts as markdown on your own disk with owner-only permissions.
+
+What on-device does NOT do: satisfy consent law for you, secure an unencrypted laptop, or make a transcript less discoverable — your own files are always discoverable. It removes the third-party disclosure question, which is the one you can't fix after the fact.
+
+## Sources
+
+- ABA Formal Opinion 512 (July 2024): https://www.americanbar.org/content/dam/aba/administrative/professional_responsibility/ethics-opinions/aba-formal-opinion-512.pdf
+- RCFP Reporter's Recording Guide: https://www.rcfp.org/reporters-recording-guide/
+- Minutes security architecture: https://useminutes.app/security
+- Parallel analysis for healthcare: https://useminutes.app/resources/is-otter-ai-hipaa-compliant
+
+Informational only — consult your ethics counsel before adopting any recording tool for client work.

--- a/site/public/resources/best-local-speech-to-text.md
+++ b/site/public/resources/best-local-speech-to-text.md
@@ -1,0 +1,35 @@
+# The best local speech-to-text apps (2026)
+
+Last reviewed: 2026-07-11
+
+Every tool here transcribes on your own hardware — your audio never touches a vendor's server. "Best" depends on the job. Full disclosure: Minutes is our tool; we say when it's the wrong pick.
+
+## Quick answer
+
+- Transcribing files with a nice Mac GUI → **MacWhisper**
+- Dictation into any app → **superwhisper**
+- Free cross-platform transcription → **Buzz** or **Vibe**
+- Scripting and embedding → **whisper.cpp** directly
+- Meetings and conversation memory (diarized speakers, action items, agent-searchable archive) → **Minutes**
+
+## The tools, by job
+
+- **Minutes** (open source, free) — meetings, voice memos, and conversation memory for AI agents. On-device transcription (whisper.cpp or parakeet.cpp), speaker diarization, markdown output with action items, MCP server for Claude and other agents. macOS menu bar app + CLI. https://github.com/silverstein/minutes
+- **MacWhisper** (freemium, one-time Pro) — the most polished drag-and-drop Whisper GUI on macOS: batch files, system audio, subtitle export. Closed source.
+- **superwhisper** (freemium, subscription) — dictation with per-app formatting modes. Local models by default, optional cloud. macOS, Windows, iOS. Closed source.
+- **Buzz** (open source, free) — cross-platform Whisper GUI (Windows/Mac/Linux): import, transcribe, translate, export. Reliable and genuinely free. https://github.com/chidiwilliams/buzz
+- **Vibe** (open source, free) — modern cross-platform offline transcription, 90+ languages, batch processing. https://github.com/thewh1teagle/vibe
+- **whisper.cpp** (open source, free) — the C/C++ engine most tools on this page are built on. CLI-first, runs everywhere. https://github.com/ggml-org/whisper.cpp
+
+## How to choose
+
+Ask what happens to the transcript after it exists:
+
+- "I read it once and file it" → any file transcriber; pick by platform and budget
+- "I paste it somewhere else" → dictation; superwhisper's specialty (also a Minutes mode)
+- "I want to ask questions about it later" → you need structure at transcription time: speaker labels, timestamps, action items, agent-searchable files. That's the memory-layer job and it's what Minutes is built for. (It's overkill for subtitling a video file — use MacWhisper or Vibe for that.)
+
+## Related
+
+- Why on-device matters: https://useminutes.app/security
+- Engine deep-dive: https://useminutes.app/writing/whisper-cpp-vs-parakeet-cpp

--- a/site/public/resources/remove-ai-notetaker-bots-from-meetings.md
+++ b/site/public/resources/remove-ai-notetaker-bots-from-meetings.md
@@ -1,0 +1,40 @@
+# How to remove AI notetaker bots from your meetings
+
+Last reviewed: 2026-07-11
+
+Bot notetakers join meetings the way a person does: they read a connected calendar, find the link, and dial in as a participant. There are exactly three levers — the calendar connection, the vendor's auto-join setting, and the meeting platform's participant controls.
+
+## Removing your own bot
+
+**Otter (OtterPilot / Otter Notetaker)**
+- Stop it joining everything: Otter settings → turn off auto-join for calendar events, or disconnect Google/Microsoft calendar entirely
+- Eject from a live meeting: open the participant list in Zoom/Meet/Teams and remove it like any attendee
+- Otter's docs: https://help.otter.ai/hc/en-us/articles/12906714508823-Stop-Otter-Notetaker-from-automatically-joining-your-meetings and https://help.otter.ai/hc/en-us/articles/14288936562199-Remove-Otter-Notetaker-from-your-meeting-Zoom-Google-Meet-or-Microsoft-Teams
+
+**Fireflies (Fred)**
+- Fireflies settings → autojoin rules (invite-only or off), or disconnect the calendar
+- Remove the notetaker from the participant list mid-call
+- Fireflies' guide: https://guide.fireflies.ai/articles/7098191513-how-to-remove-fireflies-from-a-meeting-or-stop-it-from-joining
+
+**Anything else** — same pattern: sever the calendar connection, turn off the auto-join rule. No calendar access, no way to find your meetings.
+
+## Blocking other people's bots
+
+You cannot disable a colleague's bot from your side. As host you can:
+
+- Enable the waiting room/lobby and admit only humans (bots appear as guests named "Otter Notetaker", "Fireflies.ai Notetaker", etc.)
+- Require signed-in participants
+- Remove the bot from the participant list (Zoom can bar rejoining)
+- Just ask — "please drop the notetaker for this one" is normal etiquette now
+- Org-level: tenant policies restricting which apps/guest domains can join
+
+## The version of this problem that solves itself
+
+Every step above manages a symptom. The bot exists because cloud notetakers need your meeting audio on their servers, and joining as a fake participant is how they get it. Capture audio on the participant's own device instead and the category disappears: nothing joins the call, nothing to admit or eject.
+
+That's how Minutes works — device-side recording, local transcription (whisper.cpp), markdown on your own disk. No bot and no cloud. (Granola is also botless, though it transcribes in the cloud.) One thing device-side capture doesn't change: tell people you're recording. The bot's one virtue was announcing itself; without it, consent is on you — where it belonged anyway.
+
+## Related
+
+- How botless capture works: https://useminutes.app/security
+- Compare notetakers: https://useminutes.app/compare


### PR DESCRIPTION
## What

Four content pages — weeks 3–6 of the SEO plan (kept internal in gitignored `docs/marketing/`):

- **`/writing/whisper-cpp-vs-parakeet-cpp`** — first-party engine comparison using the benchmark table and production fallback details from `docs/architecture/parakeet.md`. Content nobody else can write: we ship both engines.
- **`/resources/best-local-speech-to-text`** — by-job roundup (MacWhisper, superwhisper, Buzz, Vibe, whisper.cpp, Minutes) with explicit "Minutes is ours, here's when NOT to pick it" disclosure. Targets "local speech to text" (100/mo, KD 13) + "best local speech to text".
- **`/resources/ai-notetakers-attorney-client-privilege`** — sourced legal-industry wedge page: ABA Formal Opinion 512, RCFP consent-law guide, vendor due-diligence checklist, FAQPage JSON-LD, prominent not-legal-advice framing.
- **`/resources/remove-ai-notetaker-bots-from-meetings`** — genuinely helpful removal guide (Otter/Fireflies settings + host controls, sourced to their own help docs) targeting the churn queries competitors are forced to rank for ("remove otter ai from teams", "how to disable otter ai"). Ends at botless device-side capture, with an honest consent note.

Plus: 4 new sitemap routes, `.md` twins for the three resource pages, writing-index entry.

## Verification

- `npm run build` green — all 30 routes prerender
- Otter/Fireflies removal steps sourced to their own help-center articles (linked on-page)
- ABA Op. 512 and RCFP links verified as canonical sources
- Roundup tool facts cross-checked against current landscape; prices kept qualitative to avoid staleness
- Design: existing resource/writing page patterns only; no new fonts/colors/radii

🤖 Generated with [Claude Code](https://claude.com/claude-code)