### PR TITLE
feat(site): SEO wave 4 — HIPAA capstone, recording-legality guide, adversarial review fixes

### DIFF
--- a/site/app/compare/fathom-vs-minutes/page.tsx
+++ b/site/app/compare/fathom-vs-minutes/page.tsx
@@ -18,13 +18,13 @@ const comparisonRows = [
   },
   {
     label: "Capture method",
-    competitor: "Bot or bot-free (desktop app), per meeting — Zoom, Meet, Teams, Slack Huddles",
+    competitor: "Bot, or bot-free via desktop app (beta), per meeting — Zoom, Meet, Teams, Slack Huddles",
     minutes: "Always botless — records device-side, works for in-person conversations too",
   },
   {
     label: "Where audio is processed",
-    competitor: "Fathom's cloud, after the meeting ends; AI via Anthropic, OpenAI, and Google",
-    minutes: "On your device (whisper.cpp or parakeet.cpp); nothing is uploaded",
+    competitor: "Fathom's cloud; AI via Anthropic, OpenAI, and Google",
+    minutes: "On your device (whisper.cpp or parakeet.cpp); audio is never uploaded",
   },
   {
     label: "Where recordings live",
@@ -58,7 +58,7 @@ const comparisonRows = [
   },
   {
     label: "Pricing",
-    competitor: "Free (unlimited recording); Premium $20, Team $19, Business $34 per user/mo; Enterprise custom",
+    competitor: "Free (unlimited recording); Premium $20, Team $19, Business $34 per user/mo billed monthly ($16/$15/$25 annually); Enterprise custom",
     minutes: "Open source and free to run yourself",
   },
 ] as const;
@@ -72,7 +72,7 @@ const architecture = {
     steps: [
       {
         label: "Capture",
-        detail: "bot in the call, or bot-free via desktop app",
+        detail: "bot in the call, or bot-free via desktop app (beta)",
         offDevice: false,
       },
       {
@@ -110,7 +110,7 @@ const architecture = {
       },
     ],
     footnote:
-      "Nothing is uploaded. There is no retention policy to configure because there is no vendor copy to retain — the only copy is yours.",
+      "Nothing is uploaded by default — the only network traffic is one-time model downloads, plus transcript text if you explicitly configure an LLM summarizer (local via Ollama, or a provider you choose). There is no retention policy to configure because there is no vendor copy to retain — the only copy is yours.",
   },
 } as const;
 
@@ -124,6 +124,7 @@ const sources = [
   { label: "Fathom MCP docs", href: "https://developers.fathom.ai/mcp-docs" },
   { label: "Minutes for agents", href: "https://useminutes.app/for-agents" },
   { label: "Minutes MCP reference", href: "https://useminutes.app/docs/mcp/tools" },
+  { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
 
 export default function FathomVsMinutesPage() {
@@ -133,7 +134,7 @@ export default function FathomVsMinutesPage() {
       competitorLabel="Fathom"
       markdownHref="/compare/fathom-vs-minutes.md"
       lastReviewed="2026-07-11"
-      heroSummary="Fathom is the strongest free offer in cloud meeting notes — unlimited recording at $0, polished summaries, CRM sync, and now a bot-free capture option. Minutes draws the line somewhere Fathom doesn't: your conversation never leaves your machine at all. Fathom processes and stores every meeting in its US cloud, with AI running through Anthropic, OpenAI, and Google; Minutes transcribes on-device and writes markdown to your own disk. Which trade you should make depends on whether 'free and polished' or 'never uploaded' is your constraint."
+      heroSummary="Fathom is the strongest free offer in cloud meeting notes — unlimited recording at $0, polished summaries, CRM sync, and now a bot-free capture option (in beta). Minutes draws the line somewhere Fathom doesn't: recording, transcription, and storage all happen on your own machine, and your audio is never uploaded. Fathom processes and stores every meeting in its US cloud, with AI running through Anthropic, OpenAI, and Google; Minutes transcribes on-device and writes markdown to your own disk. Which trade you should make depends on whether 'free and polished' or 'never uploaded' is your constraint."
       quickVerdictCompetitor="you want excellent free meeting summaries with CRM workflows and you're comfortable with your recordings living in a US cloud, processed by major AI providers under no-training contracts."
       quickVerdictMinutes="your conversations must never leave your machine — for compliance, confidentiality, or principle — and you want inspectable markdown your own agents query locally, not another cloud account."
       architecture={architecture as any}
@@ -141,10 +142,10 @@ export default function FathomVsMinutesPage() {
       competitorWins={[
         "The free tier is genuinely exceptional: unlimited recordings, transcription, and storage at $0 — nobody else in the category, including us, matches that offer.",
         "Sales and CRM workflows are real product depth: HubSpot/Salesforce field sync, coaching metrics, AI scorecards, deal views.",
-        "Good agent-ecosystem citizenship: a public API and a first-party MCP server, plus bot-free capture that addresses the most-hated part of cloud notetakers.",
+        "Good agent-ecosystem citizenship: a public API and a first-party MCP server, plus bot-free capture (beta) that addresses the most-hated part of cloud notetakers.",
       ]}
       minutesWins={[
-        "Nothing leaves your machine — Fathom's bot-free mode still uploads your meeting to its cloud; Minutes' botless capture never uploads anything anywhere.",
+        "Your audio never leaves your machine — Fathom's bot-free mode still uploads your meeting to its cloud; Minutes' capture-to-storage pipeline has no upload step at all (see our security page for the complete list of what does touch the network).",
         "No indefinite vendor retention: Fathom keeps recordings by default until deleted, with auto-delete rules gated to Business+. Minutes' only copy is the one on your disk.",
         "Open source (MIT) and free forever — the privacy claims are verifiable Rust, not a trust page; and it captures in-person conversations and voice memos, not just video calls.",
       ]}

--- a/site/app/compare/krisp-vs-minutes/page.tsx
+++ b/site/app/compare/krisp-vs-minutes/page.tsx
@@ -4,7 +4,7 @@ import { ComparePage } from "@/components/compare-page";
 export const metadata: Metadata = {
   title: "Minutes vs Krisp",
   description:
-    "Minutes vs Krisp: Krisp's noise cancellation is genuinely on-device, but its meeting notes run through the cloud and transcripts live in Krisp Cloud by default. Minutes keeps the entire pipeline on your machine. A sourced, fit-based comparison.",
+    "Minutes vs Krisp: Krisp's noise cancellation is genuinely on-device, but its meeting notes run through the cloud and transcripts are stored in Krisp Cloud once notes are enabled. Minutes keeps the entire pipeline on your machine. A sourced, fit-based comparison.",
   alternates: {
     canonical: "/compare/krisp-vs-minutes",
   },
@@ -38,12 +38,12 @@ const comparisonRows = [
   },
   {
     label: "Where transcripts live",
-    competitor: "Krisp Cloud by default (US servers); on-device storage is Enterprise-gated and English-only",
+    competitor: "Krisp Cloud (US servers) once meeting notes are enabled — the only non-Enterprise option; on-device storage is Enterprise-gated",
     minutes: "Your own disk, as markdown — for everyone, not a plan tier",
   },
   {
     label: "Compliance posture",
-    competitor: "SOC 2 Type II, HIPAA with BAA on business/enterprise tiers, published DPA",
+    competitor: "SOC 2 Type II, HIPAA BAA available per its security page (which references a legacy 'Business tier'; pricing lists BAA under Enterprise), published DPA",
     minutes: "No vendor in the loop to trust, breach, or subpoena",
   },
   {
@@ -58,14 +58,14 @@ const comparisonRows = [
   },
   {
     label: "Pricing",
-    competitor: "Free (2 AI notes/day); Core $16/mo ($8 annual); Advanced $30/mo ($15 annual); Enterprise custom",
+    competitor: "Free plan per its help center (2 AI notes/day; the pricing page currently shows a 7-day trial); Core $16/mo ($8 annual); Advanced $30/mo ($15 annual); Enterprise custom",
     minutes: "Open source and free to run yourself",
   },
 ] as const;
 
 const architecture = {
   caption:
-    "Krisp earned its reputation honestly: noise cancellation runs on your device and that audio path never touches its servers. The notes product is a different pipeline — summaries are generated in the cloud and transcripts live in Krisp Cloud by default, with fully on-device storage reserved for Enterprise.",
+    "Krisp earned its reputation honestly: noise cancellation runs on your device and that audio path never touches its servers. The notes product is a different pipeline — summaries are generated in the cloud, and once you enable meeting notes, transcripts are stored in Krisp Cloud (per Krisp's security page, an explicit opt-in — but the only storage option outside Enterprise).",
   competitor: {
     name: "Krisp",
     leavesDevice: true,
@@ -87,7 +87,7 @@ const architecture = {
       },
       {
         label: "Store transcripts + recordings",
-        detail: "Krisp Cloud, US servers (on-device option: Enterprise, English-only)",
+        detail: "Krisp Cloud, US servers, once notes are enabled (on-device option: Enterprise)",
         offDevice: true,
       },
     ],
@@ -139,7 +139,7 @@ export default function KrispVsMinutesPage() {
       competitorLabel="Krisp"
       markdownHref="/compare/krisp-vs-minutes.md"
       lastReviewed="2026-07-11"
-      heroSummary="Krisp is the rare cloud-era company with real on-device credentials: its noise cancellation processes audio locally and never sends it anywhere, which is why it became the default answer to 'my calls sound bad.' But Krisp's meeting-notes product is a different pipeline — summaries are generated through Microsoft Azure, transcripts and recordings live in Krisp Cloud by default, and the fully on-device configuration is gated to Enterprise. Minutes runs the entire pipeline on your machine for everyone. If you need better-sounding calls, buy Krisp. If you need a private record of your conversations, the architectures diverge exactly where it matters."
+      heroSummary="Krisp is the rare cloud-era company with real on-device credentials: its noise cancellation processes audio locally and never sends it anywhere, which is why it became the default answer to 'my calls sound bad.' But Krisp's meeting-notes product is a different pipeline — summaries are generated through Microsoft Azure, transcripts and recordings are stored in Krisp Cloud once you enable notes, and the fully on-device storage configuration is gated to Enterprise. Minutes runs the entire pipeline on your machine for everyone. If you need better-sounding calls, buy Krisp. If you need a private record of your conversations, the architectures diverge exactly where it matters."
       quickVerdictCompetitor="your primary problem is call audio quality — noise, echo, accents — and AI notes are a convenient add-on you're comfortable having processed and stored in Krisp's cloud."
       quickVerdictMinutes="your primary problem is owning a private record of your conversations — transcripts that never leave your machine, structured notes, and agent access — and you want that as the default, not an Enterprise upgrade."
       architecture={architecture as any}
@@ -150,7 +150,7 @@ export default function KrispVsMinutesPage() {
         "Windows support today, plus an enterprise trust stack: SOC 2 Type II, HIPAA BAAs, PCI-DSS, published DPA.",
       ]}
       minutesWins={[
-        "The private configuration is the only configuration: on-device transcription and local storage for every user, free — where Krisp gates on-device transcripts/recordings to Enterprise and English-only.",
+        "The private configuration is the only configuration: on-device transcription and local storage for every user, free — where Krisp gates on-device transcript/recording storage to Enterprise (and its on-device transcription itself covers English only).",
         "It's a real memory layer: diarized speakers, action items and decisions in YAML, months of meetings greppable and queryable by your agents via MCP, CLI, SDK, and the Claude Code plugin.",
         "Open source (MIT): the claim that audio has no network path is verifiable in the Rust source, not a security-page promise.",
       ]}
@@ -161,7 +161,7 @@ export default function KrispVsMinutesPage() {
       chooseSection={[
         "Pick Krisp if the pain is acoustic: noisy environments, echo, accent friction on calls. That's its core competency and it is genuinely excellent at it.",
         "Pick Minutes if the pain is memory and privacy: you want every conversation transcribed, structured, and owned — with nothing in any vendor's cloud, on any plan.",
-        "If you're evaluating Krisp specifically for its AI notes, apply the architecture test: ask where the transcript lives and what plan tier makes it private. Then compare that answer to a tool where the private answer is the only answer.",
+        "If you're evaluating Krisp specifically for its AI notes, apply the architecture test: ask where the transcript is stored once notes are on, and what plan tier makes that storage private. Then compare that answer to a tool where the private answer is the only answer.",
       ]}
       notRightFitSection={[
         "Minutes is not the right first choice if your actual problem is call audio quality — Minutes doesn't make you sound better on calls; Krisp does, brilliantly.",

--- a/site/app/compare/macwhisper-vs-minutes/page.tsx
+++ b/site/app/compare/macwhisper-vs-minutes/page.tsx
@@ -18,7 +18,7 @@ const comparisonRows = [
   },
   {
     label: "Core job",
-    competitor: "File in, transcript out — batch jobs, subtitles, podcasts, YouTube URLs",
+    competitor: "File in, transcript out — batch jobs, subtitles, YouTube and media-file URLs",
     minutes: "Capture conversations, diarize them, keep a searchable structured record",
   },
   {
@@ -29,7 +29,7 @@ const comparisonRows = [
   {
     label: "Optional cloud AI",
     competitor: "BYO API keys for summaries/chat (OpenAI, Anthropic, others) — or fully local via Ollama/LM Studio",
-    minutes: "Optional and explicit: Claude via MCP or a local LLM you configure",
+    minutes: "Optional and explicit: Claude via MCP, a local LLM (Ollama), or BYO-key cloud providers — off by default",
   },
   {
     label: "Durable output",
@@ -53,12 +53,12 @@ const comparisonRows = [
   },
   {
     label: "Platforms",
-    competitor: "macOS (14+) and iOS; no Windows or Linux",
+    competitor: "macOS (14+ for the App Store build) and iOS; no Windows or Linux",
     minutes: "macOS menu bar app + CLI (open source, builds from source elsewhere)",
   },
   {
     label: "Pricing",
-    competitor: "Free tier; Pro €64 one-time direct (App Store channel is subscription-based)",
+    competitor: "Free tier; Pro €64 one-time direct (App Store channel sells subscriptions plus a pricier one-time lifetime unlock)",
     minutes: "Open source and free to run yourself",
   },
 ] as const;
@@ -90,7 +90,7 @@ export default function MacwhisperVsMinutesPage() {
       quickVerdictMinutes="your job is remembering conversations — recording meetings and memos into a private, diarized, searchable archive that Claude and other agents can use — and you want it open source and free."
       comparisonRows={comparisonRows as any}
       competitorWins={[
-        "File-transcription ergonomics are unmatched: drag-and-drop batches, YouTube and podcast URLs, per-speaker files, filler-word removal, and a real subtitle workflow (.srt/.vtt with inline video preview and auto-translation).",
+        "File-transcription ergonomics are unmatched: drag-and-drop batches, YouTube and media-file URLs, podcast transcription with per-speaker files, filler-word removal, and a real subtitle workflow (.srt/.vtt with inline video preview and auto-translation).",
         "One-time pricing (€64 direct, lifetime updates) is a genuinely fair deal, and the free tier already covers basic recording and file transcription in 100 languages.",
         "An iOS companion app exists; Minutes is desktop-first today.",
       ]}
@@ -105,7 +105,7 @@ export default function MacwhisperVsMinutesPage() {
       ]}
       chooseSection={[
         "Pick MacWhisper for file work: interviews, podcast episodes, subtitle jobs, transcribing someone else's videos. It is the best tool on macOS for exactly that, and the one-time price is honest.",
-        "Pick Minutes for conversation memory: your own meetings and ideas, captured continuously, structured automatically, and readable by your agents without anything leaving the machine.",
+        "Pick Minutes for conversation memory: your own meetings and ideas, captured continuously into structured local files your agents read straight from disk — no vendor sync, no account.",
         "Plenty of people should own both — they're neighbors, not rivals: one optimizes the transcript, the other optimizes the archive.",
       ]}
       notRightFitSection={[
@@ -113,7 +113,7 @@ export default function MacwhisperVsMinutesPage() {
         "It's also not the fit if you want an iOS-first experience or a polished GUI for one-off transcription jobs; MacWhisper is simply better at those today.",
       ]}
       evaluatedSection={[
-        "This is a fit-based comparison between two local-first tools, reviewed on 2026-07-11 against MacWhisper's official site and App Store listing, linked below. MacWhisper's local-by-default transcription, Whisper/Parakeet engine support, Pro feature list, and €64 one-time direct pricing (with a separate subscription-based App Store channel) are drawn from its own pages.",
+        "This is a fit-based comparison between two local-first tools, reviewed on 2026-07-11 against MacWhisper's official site and App Store listing, linked below. MacWhisper's local-by-default transcription, Whisper/Parakeet engine support, Pro feature list, and €64 one-time direct pricing (with a separate App Store channel selling subscriptions and a one-time lifetime unlock) are drawn from its own pages.",
         "The Minutes side is grounded in its public docs and open-source repository. Both tools' privacy claims are architecture-level and, in Minutes' case, verifiable in source.",
       ]}
       sources={sources as any}

--- a/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
+++ b/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
@@ -1,0 +1,299 @@
+import type { Metadata } from "next";
+import { PublicFooter } from "@/components/public-footer";
+
+export const metadata: Metadata = {
+  title: "HIPAA-compliant AI note takers: the actual state of play",
+  description:
+    "Which AI note takers can be used with PHI, under exactly what conditions — Otter, Fireflies, Fathom, Krisp, Granola — plus the on-device architecture that removes the BAA question entirely. Every claim sourced to the vendor's own documentation.",
+  alternates: {
+    canonical: "/resources/hipaa-compliant-ai-note-taker",
+  },
+};
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Which AI note takers are HIPAA compliant?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "As of July 2026, per each vendor's own documentation: Otter (Enterprise plan + signed BAA only), Fireflies (Enterprise + Private Storage + signed BAA, all three simultaneously), Fathom (publishes a blanket BAA; pricing lists HIPAA BAA under Enterprise), and Krisp (BAA on business/enterprise tiers). Granola states it is not HIPAA compliant and cannot sign BAAs. On-device tools like Minutes sit outside the BAA framework entirely because no vendor ever receives the audio.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is any AI note taker 'HIPAA certified'?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. HHS certifies no product. 'HIPAA compliant' is a vendor self-attestation that its safeguards meet HIPAA requirements when used under a signed BAA. Any tool marketing itself as 'HIPAA certified' is being imprecise.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does using a free or Pro plan of these tools violate HIPAA?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Recording PHI on a plan tier with no BAA in effect is an impermissible disclosure to a vendor, regardless of the vendor's general security quality. Every cloud vendor on this page gates its BAA to its top tier — free and mid-tier plans are not covered.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Why don't on-device note takers need a BAA?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "A BAA governs a vendor's handling of PHI it receives on your behalf. Software that captures, transcribes, and stores entirely on your own machine never gives the vendor the data — no business associate relationship is created, so there is nothing for a BAA to govern. Your own obligations (device encryption, access controls, patient consent) remain.",
+      },
+    },
+  ],
+} as const;
+
+const vendors = [
+  {
+    name: "Otter.ai",
+    verdict: "Conditional",
+    condition: "Enterprise plan + signed BAA (announced July 2025)",
+    architecture: "Cloud — audio processed and stored on Otter's servers",
+    detail:
+      "Basic, Pro, and Business tiers cannot obtain a BAA. Compliance is a plan-tier purchase, and the PHI still lives in Otter's cloud under contract.",
+    href: "/resources/is-otter-ai-hipaa-compliant",
+  },
+  {
+    name: "Fireflies.ai",
+    verdict: "Conditional",
+    condition: "Enterprise ($39/user/mo annual) + Private Storage + signed BAA — all three at once",
+    architecture: "Cloud — US AWS/GCP by default; AI via OpenAI and ASR vendors under zero-retention BAAs",
+    detail:
+      "Documented unusually precisely by Fireflies itself: if any one condition lapses, compliance is disabled. Free, Pro, and Business are not covered.",
+    href: "/resources/is-fireflies-ai-hipaa-compliant",
+  },
+  {
+    name: "Fathom",
+    verdict: "Conditional",
+    condition: "Publishes a blanket BAA; pricing lists 'HIPAA BAA' under Enterprise",
+    architecture: "Cloud — US-only storage, indefinite default retention; AI via Anthropic/OpenAI/Google",
+    detail:
+      "The published blanket BAA is unusually accessible. The plan gating is stated ambiguously across Fathom's own pages — confirm in writing which tier your BAA covers before recording PHI.",
+    href: "/compare/fathom-vs-minutes",
+  },
+  {
+    name: "Krisp",
+    verdict: "Conditional",
+    condition: "BAA available per its security page (which references a legacy 'Business tier'; pricing lists BAA under Enterprise)",
+    architecture: "Hybrid — noise cancellation on-device; AI notes via Azure; transcripts in Krisp Cloud once notes are enabled",
+    detail:
+      "The famous on-device processing applies to the audio-cleanup path, not the notes pipeline. On-device transcript storage is an Enterprise feature.",
+    href: "/compare/krisp-vs-minutes",
+  },
+  {
+    name: "Granola",
+    verdict: "No",
+    condition: "None — Granola states it cannot sign BAAs on any plan",
+    architecture: "Cloud — transcription via Deepgram/AssemblyAI, notes via OpenAI/Anthropic, storage on US AWS",
+    detail:
+      "Granola says it plainly in its own docs: not HIPAA compliant, don't use it for PHI. Respect the candor; ignore third-party posts claiming otherwise.",
+    href: "/resources/is-granola-hipaa-compliant",
+  },
+  {
+    name: "Minutes (ours)",
+    verdict: "No BAA needed",
+    condition: "Open source, free — the vendor never receives the data",
+    architecture: "On-device — capture, transcription, diarization, and storage all on your own machine",
+    detail:
+      "Not 'HIPAA certified' (nothing is). On-device processing means no business associate exists; the compliance surface reduces to your own device controls and consent workflow.",
+    href: "/security",
+  },
+] as const;
+
+const sources = [
+  { label: "Otter Help Center: HIPAA", href: "https://help.otter.ai/hc/en-us/articles/33975072019991-HIPAA-Otter-ai" },
+  { label: "Fireflies: set up HIPAA compliance", href: "https://guide.fireflies.ai/articles/3704059205-set-up-hipaa-compliance-for-your-workspace" },
+  { label: "Fathom blanket BAA", href: "https://www.fathom.ai/baa" },
+  { label: "Fathom HIPAA help article", href: "https://help.fathom.video/en/articles/5291265" },
+  { label: "Krisp security for AI Meeting Assistant", href: "https://krisp.ai/security-for-ai-meeting-assistant/" },
+  { label: "Granola docs: Is Granola HIPAA compliant?", href: "https://docs.granola.ai/help-center/consent-security-privacy/is-granola-hipaa-compliant" },
+  { label: "HHS: Business Associate Contracts", href: "https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html" },
+  { label: "Minutes security & privacy architecture", href: "/security" },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function HipaaCompliantAiNoteTakerPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a href="/resources/hipaa-compliant-ai-note-taker.md" className="hover:text-[var(--accent)]">
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          HIPAA-compliant AI note takers: the actual state of play
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          Every vendor in this category now says something about HIPAA, and almost every summary
+          you&rsquo;ll find flattens the conditions that make the claims true or false. Here is
+          the July 2026 state of play, one vendor at a time, each sourced to that vendor&rsquo;s
+          own documentation — including ours.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-07-11
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            Sourced answer
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-12 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Two rules before the list
+        </p>
+        <div className="mt-4 space-y-3 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">Nothing is &ldquo;HIPAA certified.&rdquo;</span>{" "}
+            HHS certifies no product, ever. &ldquo;Compliant&rdquo; means the vendor attests its
+            safeguards meet HIPAA&rsquo;s requirements when used under a signed BAA — it is a
+            self-attestation plus a contract, not a government stamp.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">The plan tier is the whole ballgame.</span>{" "}
+            Every cloud vendor below gates its BAA to a top tier. A clinician on a free or Pro
+            plan of any of them is making impermissible disclosures, no matter how good the
+            vendor&rsquo;s security page looks.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Vendor By Vendor" />
+        <div className="grid gap-4">
+          {vendors.map((v) => (
+            <div
+              key={v.name}
+              className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="font-serif text-[22px] text-[var(--text)]">{v.name}</h2>
+                <span
+                  className={`rounded-full px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${
+                    v.verdict === "No"
+                      ? "bg-[var(--bg-hover)] text-[var(--text-secondary)]"
+                      : v.verdict === "No BAA needed"
+                        ? "bg-[var(--accent-soft)] text-[var(--accent)]"
+                        : "bg-[var(--bg-hover)] text-[var(--text-secondary)]"
+                  }`}
+                >
+                  {v.verdict}
+                </span>
+              </div>
+              <p className="mt-3 text-[15px] leading-8 text-[var(--text)]">{v.condition}</p>
+              <p className="mt-1 font-mono text-[12px] leading-6 text-[var(--text-secondary)]">
+                {v.architecture}
+              </p>
+              <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">
+                {v.detail}{" "}
+                <a href={v.href} className="text-[var(--accent)] hover:underline">
+                  Full analysis →
+                </a>
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="How To Read This As A Buyer" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Notice the pattern: for every cloud vendor, HIPAA is a <em>pricing tier</em>. That
+            isn&rsquo;t cynicism — BAAs carry real legal exposure, and vendors charge for it. But
+            it means the compliance question and the procurement question are the same question,
+            and downgrades, lapsed contracts, or a clinician&rsquo;s personal account silently
+            break compliance. If you go cloud, put the BAA condition in your renewal checklist.
+          </p>
+          <p>
+            The alternative is to change the architecture instead of buying the contract: with
+            on-device processing, the vendor never receives PHI, so there is no business
+            associate and nothing to lapse. That&rsquo;s what{" "}
+            <span className="font-medium text-[var(--text)]">Minutes</span> is — open source,
+            free, capture-to-storage on your own machine. The trade-offs are real (no hosted team
+            features, macOS-first) and the remaining duties are yours (encrypted disk, access
+            control, patient consent). But the vendor-risk column of your HIPAA analysis goes to
+            zero, permanently, on every &ldquo;plan.&rdquo;
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            See the on-device architecture
+          </a>
+          <a
+            href="/resources/is-otter-ai-hipaa-compliant"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Start with the Otter analysis
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-6 text-[13px] leading-6 text-[var(--text-tertiary)]">
+          Informational, not legal advice. Vendor policies and plan gating change — verify
+          against each vendor&rsquo;s current documentation and your compliance counsel before
+          recording PHI with any tool.
+        </p>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
+++ b/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
@@ -1,0 +1,263 @@
+import type { Metadata } from "next";
+import { PublicFooter } from "@/components/public-footer";
+
+export const metadata: Metadata = {
+  title: "Is it legal to record a meeting? Consent law, explained",
+  description:
+    "One-party vs all-party consent states, what changes when an AI notetaker does the recording, workplace and cross-state rules, and the consent script that keeps you clear everywhere. Sourced, with a state-law reference.",
+  alternates: {
+    canonical: "/resources/is-it-legal-to-record-a-meeting",
+  },
+};
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Is it legal to record a meeting you're part of?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "In most US states, yes — federal law and roughly three dozen states require only one party's consent, and as a participant you are that party. But eleven-plus states, including California, Florida, Illinois, Massachusetts, Pennsylvania, and Washington, require all parties' consent for confidential communications. Cross-state calls should follow the strictest applicable rule.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does using an AI notetaker change recording-consent law?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The consent rules are the same — a recording is a recording whether a human presses the button or software does. What changes is disclosure mechanics: bot notetakers announce themselves as visible participants, while device-side capture tools are silent, so the duty to inform participants falls entirely on you. Some vendors also display recording notices; that supplements but does not replace your consent obligation in all-party states.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is the safest practice for recording meetings?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Announce and get affirmative acknowledgment at the start of every recorded meeting, regardless of state: 'I'd like to record this for notes — everyone okay with that?' It satisfies all-party states, is professionally courteous everywhere, and creates a consent record on the recording itself.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can my employer record meetings without telling me?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Workplace rules layer on top of state law: one-party states give employers more room, all-party states don't. Many employers handle consent through policy and meeting-platform notices. Union agreements, sector rules, and jurisdictions like the EU (GDPR) add further constraints. Check policy and local law rather than assuming.",
+      },
+    },
+  ],
+} as const;
+
+const sources = [
+  {
+    label: "RCFP Reporter's Recording Guide — state-by-state consent law",
+    href: "https://www.rcfp.org/reporters-recording-guide/",
+  },
+  {
+    label: "Justia: Recording Phone Calls and Conversations — 50-state survey",
+    href: "https://www.justia.com/50-state-surveys/recording-phone-calls-and-conversations/",
+  },
+  {
+    label: "18 U.S.C. § 2511(2)(d) — federal one-party consent",
+    href: "https://www.law.cornell.edu/uscode/text/18/2511",
+  },
+  {
+    label: "AI notetakers and attorney–client privilege — our analysis",
+    href: "/resources/ai-notetakers-attorney-client-privilege",
+  },
+  {
+    label: "How to remove AI notetaker bots from meetings",
+    href: "/resources/remove-ai-notetaker-bots-from-meetings",
+  },
+  { label: "Minutes consent-in-frontmatter design", href: "/writing/governance-built-in-not-retrofitted" },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function IsItLegalToRecordAMeetingPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a
+            href="/resources/is-it-legal-to-record-a-meeting.md"
+            className="hover:text-[var(--accent)]"
+          >
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          Is it legal to record a meeting?
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          Usually yes, if you&rsquo;re in it — but the exceptions are exactly the states where a
+          lot of business happens, and AI notetakers have made the question urgent for people
+          who never thought about wiretap law before. Here&rsquo;s the map, what changes when
+          software does the recording, and the one habit that keeps you clear everywhere.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-07-11
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            Not legal advice
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-12 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Quick answer
+        </p>
+        <div className="mt-4 space-y-3 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              Federal law and most states: one-party consent.
+            </span>{" "}
+            If you&rsquo;re a participant, you are the one party — you can record without asking
+            (18 U.S.C. § 2511(2)(d), absent criminal or tortious purpose).
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              Eleven-plus states: all-party consent
+            </span>{" "}
+            for confidential communications — including California, Florida, Illinois, Maryland,
+            Massachusetts, Montana, Nevada (as interpreted), New Hampshire, Pennsylvania, and
+            Washington. On a call spanning states, follow the strictest rule in the room. The
+            RCFP guide linked below is the current state-by-state reference.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="What AI Notetakers Change — And Don't" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            The law doesn&rsquo;t care whether a human or software presses record. What changes
+            is the <em>disclosure mechanics</em>. A bot notetaker announces itself — it sits in
+            the participant list as &ldquo;Otter Notetaker&rdquo; or &ldquo;Fireflies.ai
+            Notetaker,&rdquo; which is a form of notice (though silence is not consent in
+            all-party states). Device-side tools — Granola, Krisp&rsquo;s botless mode, and our
+            own Minutes — record without any visible artifact in the meeting. That&rsquo;s
+            better product design and worse automatic disclosure: the duty to inform lands
+            entirely on you.
+          </p>
+          <p>
+            We build a botless tool, so let&rsquo;s be unambiguous about our own product:
+            botless capture is not a mechanism for recording people without their knowledge,
+            and using it that way in an all-party state is illegal. It&rsquo;s why Minutes&rsquo;
+            recording frontmatter carries a consent field — so the record itself can document
+            how consent was obtained.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Habit That Solves It Everywhere" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Open every recorded meeting with one sentence and a pause:{" "}
+            <span className="font-medium text-[var(--text)]">
+              &ldquo;I&rsquo;d like to record this for notes — everyone okay with that?&rdquo;
+            </span>{" "}
+            Affirmative answers satisfy the strictest all-party state, the acknowledgment lives
+            on the recording itself, and — the underrated part — it&rsquo;s just good manners.
+            Most consent-law trouble in business contexts starts as a courtesy failure before it
+            becomes a legal one.
+          </p>
+          <p>
+            Layered on top: workplace policy (employers often standardize notice via meeting
+            platforms), sector rules (health, finance, education), and non-US law — the EU
+            treats recordings as personal-data processing under GDPR, which is a consent-or-
+            legal-basis analysis, not a one-party/all-party one. When in doubt, announce and
+            ask; when the stakes are real, ask counsel.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="One More Distinction Worth Having" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Consent to record and consent to <em>upload</em> are different things, and
+            participants increasingly know it. &ldquo;Okay if I record?&rdquo; quietly became
+            &ldquo;okay if this conversation goes to a transcription vendor, an LLM provider,
+            and a US cloud?&rdquo; when cloud notetakers took over. With on-device tools the two
+            questions collapse back into one — the recording exists only on the machine of the
+            person who asked. Several people have told us that&rsquo;s made the consent
+            conversation itself easier: &ldquo;it stays on my laptop&rdquo; is a sentence
+            everyone in the room can evaluate.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/writing/governance-built-in-not-retrofitted"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            How Minutes records consent
+          </a>
+          <a
+            href="/resources/ai-notetakers-attorney-client-privilege"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            The privilege analysis
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-6 text-[13px] leading-6 text-[var(--text-tertiary)]">
+          Informational, not legal advice. Consent law is state- and fact-specific and changes;
+          the RCFP guide is the reference to check, and counsel is the answer when it matters.
+        </p>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/legal-transcription-software/page.tsx
+++ b/site/app/resources/legal-transcription-software/page.tsx
@@ -175,11 +175,11 @@ export default function LegalTranscriptionSoftwarePage() {
           <p>
             <span className="font-medium text-[var(--text)]">Minutes</span> is built for job #2.
             It records and transcribes on your own machine (whisper.cpp — the audio has no
-            network path), labels speakers, extracts action items, and stores everything as
-            markdown files on your disk with owner-only permissions — organized, greppable, and
-            queryable by your AI assistant without any of it leaving your control. It&rsquo;s
-            open source (MIT), so your security review can read the code instead of a vendor
-            questionnaire.
+            network path), labels speakers, and stores everything as markdown files on your disk
+            with owner-only permissions — organized, greppable, and readable by your AI
+            assistant straight from local files, with structured action items filled in once you
+            connect one. It&rsquo;s open source (MIT), so your security review can read the code
+            instead of a vendor questionnaire.
           </p>
           <p>
             Where it is <em>not</em> the tool: certified transcripts (job #1 — hire a human),

--- a/site/app/resources/local-dictation-macos/page.tsx
+++ b/site/app/resources/local-dictation-macos/page.tsx
@@ -15,7 +15,7 @@ const options = [
     name: "Built-in macOS dictation",
     bestFor: "Zero-install, occasional use",
     detail:
-      "Press the shortcut, talk, done. Apple processes many languages on-device on Apple Silicon Macs. No punctuation intelligence to speak of, no custom vocabulary, and no formatting modes — but it's free, already installed, and fine for a quick sentence.",
+      "Press the shortcut, talk, done. Apple processes many languages on-device on Apple Silicon Macs, with automatic punctuation. No custom vocabulary and no formatting modes — but it's free, already installed, and fine for a quick sentence.",
   },
   {
     name: "superwhisper",
@@ -27,13 +27,13 @@ const options = [
     name: "MacWhisper",
     bestFor: "File transcription first, dictation included",
     detail:
-      "Primarily the best drag-and-drop file transcriber on macOS, with a menu-bar dictation feature included. If you mostly transcribe recordings and only sometimes dictate, one purchase covers both. Closed source; free tier, one-time Pro purchase.",
+      "Primarily the best drag-and-drop file transcriber on macOS, with a system-wide dictation feature included in the direct-download version (the App Store build lacks dictation). If you mostly transcribe recordings and only sometimes dictate, the direct version covers both. Closed source; free tier, one-time Pro purchase.",
   },
   {
     name: "Minutes",
     bestFor: "Dictation as part of a conversation-memory system",
     detail:
-      "Open source (MIT) and free. Dictation is one of four capture modes: speak, and text lands in your clipboard and a timestamped daily note — alongside meeting recording, voice memos, and live transcription, all on-device, all searchable by your AI agents via MCP. Full disclosure: Minutes is our tool.",
+      "Open source (MIT) and free. Dictation is one of four capture modes: speak, and the text is typed at your cursor (or lands in your clipboard via the CLI), with a timestamped copy in your daily note — alongside meeting recording, voice memos, and live transcription, all on-device, all searchable by your AI agents via MCP. Full disclosure: Minutes is our tool.",
   },
 ] as const;
 
@@ -153,14 +153,14 @@ export default function LocalDictationMacosPage() {
               minutes setup --model tiny
             </code>{" "}
             once to download a local Whisper model, and bind the dictation hotkey in the menu bar
-            app. Speak; the transcribed text lands in your clipboard for pasting anywhere, and a
-            timestamped copy is appended to your daily note in{" "}
+            app. Speak; the text is inserted where your cursor is (the CLI mode lands it in your
+            clipboard instead), and a timestamped copy is appended to your daily note in{" "}
             <code className="rounded-[3px] bg-[var(--bg-hover)] px-1.5 py-0.5 font-mono text-[13px]">
               ~/meetings
             </code>{" "}
             — which means every idea you&rsquo;ve ever dictated is greppable, and your agents can
             answer &ldquo;what was that idea I had last Tuesday?&rdquo; That daily-note trail is
-            the practical difference from pure dictation tools: text you paste into other apps
+            the practical difference from pure dictation tools: text you dictate into other apps
             vanishes into those apps; text that also lands in your own files compounds.
           </p>
         </div>

--- a/site/app/resources/meeting-minutes-template/page.tsx
+++ b/site/app/resources/meeting-minutes-template/page.tsx
@@ -202,11 +202,12 @@ export default function MeetingMinutesTemplatePage() {
           <p>
             Full disclosure: we publish this page and we also build the tool that makes it
             partly obsolete. <span className="font-medium text-[var(--text)]">Minutes</span>{" "}
-            (open source, free) records the meeting, transcribes it on your device, and writes
-            exactly the structure above automatically — attendees, decisions, and action items
-            as structured YAML in a markdown file on your own disk. The template becomes the
-            output format, not homework. Templates still win for meetings you don&rsquo;t
-            record, and formal board minutes where a human secretary is the point.
+            (open source, free) records the meeting, transcribes it on your device, and — once
+            you connect an assistant (Claude via MCP, or a local LLM) — fills in the structure
+            above automatically: attendees, decisions, and action items as structured YAML in a
+            markdown file on your own disk. The template becomes the output format, not
+            homework. Templates still win for meetings you don&rsquo;t record, and formal board
+            minutes where a human secretary is the point.
           </p>
         </div>
       </section>

--- a/site/app/security/page.tsx
+++ b/site/app/security/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 const pipeline = [
   {
     step: "Capture",
-    detail: "Mic and system audio, recorded on your machine (cpal)",
+    detail: "Mic (cpal) and system audio (native macOS capture in the desktop app, or a loopback device), recorded on your machine",
   },
   {
     step: "Transcribe",
@@ -163,17 +163,19 @@ export default function SecurityPage() {
           <p>
             A security page you can trust has to be honest about the exceptions, so here is the
             complete list. Minutes downloads transcription and diarization models once, at setup.
-            If you install updates, those come over the network too. And if you explicitly
-            configure an LLM for automated summarization, your transcript text goes wherever you
-            pointed it — at a local model via Ollama (the private default posture), or at a cloud
-            provider if you choose one and supply a key.
+            If you install updates, those come over the network too. And if you enable automated
+            summarization — it is off by default — your transcript text goes wherever you point
+            it: a local model via Ollama, an agent CLI you&rsquo;ve signed into (claude, codex,
+            gemini — which round-trips through that provider&rsquo;s cloud), or a cloud API if
+            you supply a key.
           </p>
           <p>
             What is never in that traffic: your audio and your transcripts, unless you yourself
             configured a summarizer to receive them. Out of the box, Minutes needs no API key and
             sends conversation content nowhere. When Claude summarizes a meeting through MCP, it
             reads local files through tools you granted — visible in your agent&rsquo;s tool log,
-            not a background sync.
+            not a background sync — and what it reads travels to your agent&rsquo;s model
+            provider as conversation context, like anything else you show your agent.
           </p>
         </div>
       </section>

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -23,6 +23,8 @@ const routes = [
   "/proof",
   "/resources/ai-notetakers-attorney-client-privilege",
   "/resources/best-local-speech-to-text",
+  "/resources/hipaa-compliant-ai-note-taker",
+  "/resources/is-it-legal-to-record-a-meeting",
   "/resources/best-mcp-meeting-memory-tools",
   "/resources/best-meeting-tools-for-claude-code-and-codex",
   "/resources/is-fireflies-ai-hipaa-compliant",

--- a/site/public/compare/fathom-vs-minutes.md
+++ b/site/public/compare/fathom-vs-minutes.md
@@ -2,7 +2,7 @@
 
 Last reviewed: 2026-07-11
 
-Fathom is the strongest free offer in cloud meeting notes — unlimited recording at $0, polished summaries, CRM sync, and now a bot-free capture option. Minutes draws the line somewhere Fathom doesn't: your conversation never leaves your machine at all.
+Fathom is the strongest free offer in cloud meeting notes — unlimited recording at $0, polished summaries, CRM sync, and now a bot-free capture option (in beta). Minutes draws the line somewhere Fathom doesn't: recording, transcription, and storage all happen on your own machine, and your audio is never uploaded.
 
 ## Quick verdict
 
@@ -11,31 +11,31 @@ Fathom is the strongest free offer in cloud meeting notes — unlimited recordin
 
 ## Where your conversation goes
 
-**Fathom** (leaves your device): capture (bot in the call, or bot-free via desktop app) → transcribe + summarize in Fathom's cloud (AI via Anthropic/OpenAI/Google) → store on Fathom's US servers, indefinitely by default (auto-delete rules are Business+). SOC 2 Type II, published blanket HIPAA BAA, no-training contracts with LLM subprocessors — a serious cloud posture, but a cloud posture. Fathom improves its own models on de-identified customer data unless you opt out.
+**Fathom** (leaves your device): capture (bot in the call, or bot-free via desktop app, beta) → transcribe + summarize in Fathom's cloud (AI via Anthropic/OpenAI/Google) → store on Fathom's US servers, indefinitely by default (auto-delete rules are Business+). SOC 2 Type II, published blanket HIPAA BAA, no-training contracts with LLM subprocessors — a serious cloud posture, but a cloud posture. Fathom improves its own models on de-identified customer data unless you opt out.
 
-**Minutes** (stays on device): capture device audio (no bot, works offline/in person) → transcribe + diarize on-device (whisper.cpp/parakeet.cpp + pyannote) → store markdown on your disk (0600 permissions). Nothing is uploaded; the only copy is yours.
+**Minutes** (stays on device): capture device audio (no bot, works offline/in person) → transcribe + diarize on-device (whisper.cpp/parakeet.cpp + pyannote) → store markdown on your disk (0600 permissions). Nothing is uploaded by default — the only network traffic is one-time model downloads, plus transcript text if you explicitly configure an LLM summarizer (local via Ollama, or a provider you choose). See https://useminutes.app/security for the complete list.
 
 ## At a glance
 
-- Capture — Fathom: bot or bot-free, Zoom/Meet/Teams/Slack Huddles; Minutes: always botless, in-person too
-- Processing — Fathom: cloud, post-meeting; Minutes: on-device
+- Capture — Fathom: bot, or bot-free via desktop app (beta), Zoom/Meet/Teams/Slack Huddles; Minutes: always botless, in-person too
+- Processing — Fathom: cloud; Minutes: on-device (audio never uploaded)
 - Storage — Fathom: US servers, indefinite default retention; Minutes: your disk
 - Data residency — Fathom: US only; Minutes: moot
 - Model training — Fathom: subprocessors barred, internal de-identified training with opt-out; Minutes: no vendor exists
 - Compliance — Fathom: SOC 2 Type II, published blanket BAA (pricing lists HIPAA BAA under Enterprise); Minutes: no vendor in the loop
 - Open source — Fathom: no; Minutes: MIT
 - API/MCP — Fathom: public API + first-party MCP over its cloud; Minutes: MCP (31 tools) + CLI + SDK over local files
-- Pricing — Fathom: Free (unlimited recording), Premium $20, Team $19, Business $34/user/mo, Enterprise custom; Minutes: free, open source
+- Pricing — Fathom: Free (unlimited recording), Premium $20, Team $19, Business $34/user/mo billed monthly ($16/$15/$25 annually), Enterprise custom; Minutes: free, open source
 
 ## Where Fathom wins
 
 - Genuinely exceptional free tier: unlimited recordings, transcription, storage at $0 — nobody matches it, including us
 - Real sales/CRM depth: HubSpot/Salesforce sync, coaching metrics, scorecards
-- Good agent citizenship: public API + first-party MCP; bot-free capture option
+- Good agent citizenship: public API + first-party MCP; bot-free capture option (beta)
 
 ## Where Minutes wins
 
-- Nothing leaves your machine — Fathom's bot-free mode still uploads to its cloud; Minutes never uploads anything
+- Your audio never leaves your machine — Fathom's bot-free mode still uploads to its cloud; Minutes' capture-to-storage pipeline has no upload step
 - No vendor retention to audit: Fathom keeps recordings by default until deleted; Minutes' only copy is yours
 - Open source, free forever, and captures in-person conversations and voice memos — no meeting link required
 
@@ -49,4 +49,4 @@ Fathom is the strongest free offer in cloud meeting notes — unlimited recordin
 - https://fathom.ai/ · https://fathom.ai/pricing · https://www.fathom.ai/baa
 - https://help.fathom.video/en/articles/296512 (security) · /5291265 (HIPAA) · /296448 (retention)
 - https://developers.fathom.ai/mcp-docs
-- https://useminutes.app/for-agents · https://useminutes.app/docs/mcp/tools
+- https://useminutes.app/for-agents · https://useminutes.app/docs/mcp/tools · https://useminutes.app/security

--- a/site/public/compare/krisp-vs-minutes.md
+++ b/site/public/compare/krisp-vs-minutes.md
@@ -2,7 +2,7 @@
 
 Last reviewed: 2026-07-11
 
-Krisp has real on-device credentials: its noise cancellation processes audio locally and never sends it anywhere. But its meeting-notes product is a different pipeline — summaries via Microsoft Azure, transcripts and recordings in Krisp Cloud by default, fully on-device configuration gated to Enterprise (and English-only). Minutes runs the entire pipeline on your machine for everyone.
+Krisp has real on-device credentials: its noise cancellation processes audio locally and never sends it anywhere. But its meeting-notes product is a different pipeline — summaries via Microsoft Azure, transcripts and recordings stored in Krisp Cloud once you enable notes (an explicit opt-in per Krisp's security page, but the only storage option outside Enterprise), and fully on-device storage gated to Enterprise. Minutes runs the entire pipeline on your machine for everyone.
 
 ## Quick verdict
 
@@ -11,7 +11,7 @@ Krisp has real on-device credentials: its noise cancellation processes audio loc
 
 ## Where your conversation goes
 
-**Krisp** (hybrid): capture + denoise on-device (genuinely local) → transcribe on-device for English, Krisp servers for 15 other languages → AI notes in the cloud (Microsoft Azure) → transcripts/recordings stored in Krisp Cloud, US servers (on-device storage: Enterprise, English-only). SOC 2 Type II, HIPAA BAAs on business tiers, published DPA.
+**Krisp** (hybrid): capture + denoise on-device (genuinely local) → transcribe on-device for English, Krisp servers for 15 other languages → AI notes in the cloud (Microsoft Azure) → transcripts/recordings stored in Krisp Cloud (US servers) once notes are enabled; on-device storage is an Enterprise feature. SOC 2 Type II, HIPAA BAA available (its security page references a legacy "Business tier"; pricing lists BAA under Enterprise), published DPA.
 
 **Minutes** (all local): capture device audio → transcribe + diarize on-device (whisper.cpp/parakeet.cpp + pyannote) → markdown on your disk, 0600 permissions. The private configuration is the only configuration.
 
@@ -21,10 +21,10 @@ Krisp has real on-device credentials: its noise cancellation processes audio loc
 - Noise cancellation — Krisp: best in category, on-device; Minutes: optional local RNNoise denoising, not the headline
 - Transcription — Krisp: on-device English, server-side for 15 languages; Minutes: on-device always, ~99 languages
 - AI notes — Krisp: cloud (Azure); Minutes: local structure; LLM only if you configure one
-- Transcript storage — Krisp: Krisp Cloud default, US; Minutes: your disk, everyone
+- Transcript storage — Krisp: Krisp Cloud (US) once notes are enabled, Enterprise for on-device; Minutes: your disk, everyone
 - Open source — Krisp: no; Minutes: MIT
 - Platforms — Krisp: macOS + Windows; Minutes: macOS app + CLI (open source)
-- Pricing — Krisp: Free (2 AI notes/day), Core $16/$8, Advanced $30/$15, Enterprise custom; Minutes: free
+- Pricing — Krisp: free plan per its help center (2 AI notes/day; pricing page currently shows a 7-day trial), Core $16/$8, Advanced $30/$15, Enterprise custom; Minutes: free
 
 ## Where Krisp wins
 
@@ -34,7 +34,7 @@ Krisp has real on-device credentials: its noise cancellation processes audio loc
 
 ## Where Minutes wins
 
-- Private-by-architecture for every user, free — Krisp gates on-device transcripts to Enterprise, English-only
+- Private-by-architecture for every user, free — Krisp gates on-device transcript storage to Enterprise (and its on-device transcription covers English only)
 - Real memory layer: diarized speakers, YAML action items/decisions, months of meetings queryable via MCP/CLI/SDK
 - Open source: "audio has no network path" is verifiable in source
 

--- a/site/public/compare/macwhisper-vs-minutes.md
+++ b/site/public/compare/macwhisper-vs-minutes.md
@@ -6,24 +6,24 @@ Both transcribe locally on your Mac, and both can run Whisper or Parakeet models
 
 ## Quick verdict
 
-- Choose **MacWhisper** if your job is transcribing files — interviews, podcasts, videos, YouTube links — with the most polished Mac GUI, subtitle export, and a one-time price (€64 direct; the App Store channel is subscription-based).
+- Choose **MacWhisper** if your job is transcribing files — interviews, podcasts, videos, YouTube links — with the most polished Mac GUI, subtitle export, and a one-time price (€64 direct; the App Store channel sells subscriptions plus a pricier one-time lifetime unlock).
 - Choose **Minutes** if your job is remembering conversations — meetings and memos into a private, diarized, searchable archive for Claude and other agents — open source and free.
 
 ## At a glance
 
-- Core job — MacWhisper: file in, transcript out (batch, subtitles, podcasts, YouTube); Minutes: capture conversations, diarize, keep a structured archive
+- Core job — MacWhisper: file in, transcript out (batch, subtitles, YouTube and media-file URLs); Minutes: capture conversations, diarize, keep a structured archive
 - Transcription — both on-device; both support Whisper and Parakeet engines
-- Optional cloud AI — MacWhisper: BYO API keys (or fully local via Ollama/LM Studio); Minutes: explicit opt-in only (Claude via MCP or local LLM)
+- Optional cloud AI — MacWhisper: BYO API keys (or fully local via Ollama/LM Studio); Minutes: explicit opt-in only (Claude via MCP, local LLM, or BYO-key cloud — off by default)
 - Output — MacWhisper: per-file exports (txt/srt/vtt/md/pdf/docx); Minutes: markdown corpus with YAML frontmatter, action items, decisions
 - Speakers — MacWhisper: automatic speaker recognition (Pro); Minutes: diarization + confidence-aware attribution that learns names
 - Agent surface — MacWhisper: CLI + workflow automations, no MCP we could find; Minutes: MCP (31 tools), CLI, SDK, Claude Code plugin
 - Open source — MacWhisper: no; Minutes: MIT
-- Platforms — MacWhisper: macOS 14+ and iOS; Minutes: macOS menu bar app + CLI (open source)
+- Platforms — MacWhisper: macOS (14+ for the App Store build) and iOS; Minutes: macOS menu bar app + CLI (open source)
 - Pricing — MacWhisper: free tier, Pro €64 one-time direct; Minutes: free
 
 ## Where MacWhisper wins
 
-- Unmatched file-transcription ergonomics: batches, YouTube/podcast URLs, per-speaker files, filler-word removal, real subtitle workflow with auto-translation
+- Unmatched file-transcription ergonomics: batches, YouTube/media-file URLs, podcast transcription with per-speaker files, filler-word removal, real subtitle workflow with auto-translation
 - Honest one-time pricing with lifetime updates; capable free tier (100 languages)
 - iOS companion app
 

--- a/site/public/resources/hipaa-compliant-ai-note-taker.md
+++ b/site/public/resources/hipaa-compliant-ai-note-taker.md
@@ -1,0 +1,39 @@
+# HIPAA-compliant AI note takers: the actual state of play
+
+Last reviewed: 2026-07-11 · Not legal advice
+
+Every vendor now says something about HIPAA; almost every summary flattens the conditions that make the claims true or false. The July 2026 state of play, each sourced to the vendor's own documentation.
+
+## Two rules before the list
+
+1. **Nothing is "HIPAA certified."** HHS certifies no product. "Compliant" = vendor self-attestation + a signed BAA.
+2. **The plan tier is the whole ballgame.** Every cloud vendor gates its BAA to a top tier. Free/Pro usage with PHI is an impermissible disclosure regardless of security quality.
+
+## Vendor by vendor
+
+| Vendor | Verdict | Condition | Architecture |
+|---|---|---|---|
+| Otter.ai | Conditional | Enterprise + signed BAA (since July 2025) | Cloud — Otter's servers |
+| Fireflies.ai | Conditional | Enterprise ($39/u/mo annual) + Private Storage + BAA, all three at once | Cloud — US AWS/GCP; OpenAI + ASR vendors under zero-retention BAAs |
+| Fathom | Conditional | Published blanket BAA; pricing lists HIPAA BAA under Enterprise — plan gating ambiguous, confirm in writing | Cloud — US-only, indefinite default retention; Anthropic/OpenAI/Google |
+| Krisp | Conditional | BAA available per its security page (which references a legacy "Business tier"; pricing lists BAA under Enterprise) | Hybrid — on-device noise cancellation, cloud notes (Azure), Krisp Cloud storage once notes are enabled |
+| Granola | **No** | None — "cannot sign BAAs," per Granola's own docs | Cloud — Deepgram/AssemblyAI, OpenAI/Anthropic, US AWS |
+| Minutes (ours) | **No BAA needed** | Open source, free — vendor never receives the data | On-device — capture to storage on your machine |
+
+Full analyses: /resources/is-otter-ai-hipaa-compliant · /resources/is-fireflies-ai-hipaa-compliant · /resources/is-granola-hipaa-compliant · /compare/fathom-vs-minutes · /compare/krisp-vs-minutes
+
+## How to read this as a buyer
+
+For every cloud vendor, HIPAA is a pricing tier. BAAs carry real legal exposure and vendors charge for it — but it means compliance and procurement are the same question, and downgrades, lapsed contracts, or a clinician's personal account silently break compliance. If you go cloud, put the BAA condition in your renewal checklist.
+
+The alternative is changing the architecture instead of buying the contract: on-device processing means the vendor never receives PHI — no business associate, nothing to lapse. That's Minutes: open source, free, capture-to-storage local. Trade-offs are real (no hosted team features, macOS-first) and the remaining duties are yours (encrypted disk, access control, consent). But the vendor-risk column goes to zero on every "plan."
+
+## Sources
+
+- https://help.otter.ai/hc/en-us/articles/33975072019991-HIPAA-Otter-ai
+- https://guide.fireflies.ai/articles/3704059205-set-up-hipaa-compliance-for-your-workspace
+- https://www.fathom.ai/baa · https://help.fathom.video/en/articles/5291265
+- https://krisp.ai/security-for-ai-meeting-assistant/
+- https://docs.granola.ai/help-center/consent-security-privacy/is-granola-hipaa-compliant
+- https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html
+- https://useminutes.app/security

--- a/site/public/resources/is-it-legal-to-record-a-meeting.md
+++ b/site/public/resources/is-it-legal-to-record-a-meeting.md
@@ -1,0 +1,33 @@
+# Is it legal to record a meeting?
+
+Last reviewed: 2026-07-11 · Not legal advice
+
+Usually yes, if you're in it — but the exceptions are exactly the states where a lot of business happens.
+
+## Quick answer
+
+- **Federal law and most states: one-party consent.** As a participant you are the one party — you can record without asking (18 U.S.C. § 2511(2)(d), absent criminal or tortious purpose).
+- **Eleven-plus states: all-party consent** for confidential communications — including California, Florida, Illinois, Maryland, Massachusetts, Montana, New Hampshire, Pennsylvania, and Washington. On cross-state calls, follow the strictest rule in the room. State-by-state reference: RCFP Reporter's Recording Guide.
+
+## What AI notetakers change — and don't
+
+The law doesn't care whether a human or software presses record. What changes is disclosure mechanics: a bot notetaker announces itself in the participant list (a form of notice, though silence ≠ consent in all-party states). Device-side tools — Granola, Krisp's botless mode, and our own Minutes — record with no visible artifact in the meeting. Better product design, worse automatic disclosure: the duty to inform lands entirely on you.
+
+We build a botless tool, so plainly: botless capture is not a mechanism for recording people without their knowledge, and using it that way in an all-party state is illegal. Minutes' recording frontmatter carries a consent field — so the record itself can document how consent was obtained.
+
+## The habit that solves it everywhere
+
+Open every recorded meeting with: **"I'd like to record this for notes — everyone okay with that?"** Affirmative answers satisfy the strictest state, the acknowledgment lives on the recording, and it's good manners. Layered on top: workplace policy, sector rules, and non-US law (the EU treats recordings as personal-data processing under GDPR — a legal-basis analysis, not one-party/all-party).
+
+## Consent to record ≠ consent to upload
+
+"Okay if I record?" quietly became "okay if this goes to a transcription vendor, an LLM provider, and a US cloud?" when cloud notetakers took over. With on-device tools the questions collapse back into one — the recording exists only on the machine of the person who asked. "It stays on my laptop" is a sentence everyone in the room can evaluate.
+
+## Sources
+
+- https://www.rcfp.org/reporters-recording-guide/
+- https://www.justia.com/50-state-surveys/recording-phone-calls-and-conversations/
+- https://www.law.cornell.edu/uscode/text/18/2511
+- https://useminutes.app/resources/ai-notetakers-attorney-client-privilege
+- https://useminutes.app/resources/remove-ai-notetaker-bots-from-meetings
+- https://useminutes.app/writing/governance-built-in-not-retrofitted

--- a/site/public/resources/legal-transcription-software.md
+++ b/site/public/resources/legal-transcription-software.md
@@ -17,7 +17,7 @@ Most "legal transcription software" roundups compare turnaround times and per-mi
 
 ## Where Minutes fits — and doesn't
 
-Minutes is built for job #2: records and transcribes on your own machine (whisper.cpp — the audio has no network path), labels speakers, extracts action items, stores markdown on your disk with owner-only permissions — greppable and queryable by your AI assistant without leaving your control. Open source (MIT): your security review can read the code.
+Minutes is built for job #2: records and transcribes on your own machine (whisper.cpp — the audio has no network path), labels speakers, stores markdown on your disk with owner-only permissions — greppable, readable by your AI assistant straight from local files, with structured action items filled in once you connect one. Open source (MIT): your security review can read the code.
 
 Not the tool for: certified transcripts (hire a human), jurisdiction-formatted verbatim output, medical-legal templating. Your own obligations — consent, device encryption, matter-based access — stay with you.
 

--- a/site/public/resources/local-dictation-macos.md
+++ b/site/public/resources/local-dictation-macos.md
@@ -6,16 +6,16 @@ Dictation is the most personal audio there is, and it's where cloud processing i
 
 ## Quick answer
 
-- Occasional sentence → **built-in macOS dictation** (already installed; Apple processes many languages on-device on Apple Silicon)
+- Occasional sentence → **built-in macOS dictation** (already installed; Apple processes many languages on-device on Apple Silicon, with auto-punctuation)
 - Heavy daily dictation with per-app formatting → **superwhisper** (local models by default, closed source, subscription)
-- File transcription first, dictation included → **MacWhisper** (one-time Pro purchase)
-- Dictation as part of a conversation-memory system → **Minutes** (open source, free; clipboard + timestamped daily note, plus meetings/memos/live transcription, all agent-searchable)
+- File transcription first, dictation included → **MacWhisper** (one-time Pro purchase; dictation is in the direct-download version only, not the App Store build)
+- Dictation as part of a conversation-memory system → **Minutes** (open source, free; text typed at your cursor — or clipboard via CLI — plus a timestamped daily note, alongside meetings/memos/live transcription, all agent-searchable)
 
 Careful if "local" is your requirement: several popular dictation apps (Wispr Flow best known) process speech in the cloud — a different privacy contract.
 
 ## Setting up Minutes dictation
 
-Install, run `minutes setup --model tiny` once, bind the hotkey in the menu bar app. Speak: text lands in your clipboard AND a timestamped daily note in ~/meetings. Text you paste into other apps vanishes into those apps; text that also lands in your own files compounds — your agents can answer "what was that idea I had last Tuesday?"
+Install, run `minutes setup --model tiny` once, bind the hotkey in the menu bar app. Speak: text is inserted at your cursor (CLI mode uses the clipboard), and a timestamped copy is appended to your daily note in ~/meetings. Text you dictate into other apps vanishes into those apps; text that also lands in your own files compounds — your agents can answer "what was that idea I had last Tuesday?"
 
 ## How to choose
 

--- a/site/public/resources/meeting-minutes-template.md
+++ b/site/public/resources/meeting-minutes-template.md
@@ -96,6 +96,6 @@ Minutes are not a transcript. They answer three future questions: what did we de
 
 ## Or stop filling in templates
 
-Full disclosure: we build the tool that makes this page partly obsolete. Minutes (open source, free) records the meeting, transcribes on your device, and writes exactly this structure automatically — attendees, decisions, action items as structured YAML in markdown on your own disk. Templates still win for meetings you don't record and formal board minutes where a human secretary is the point.
+Full disclosure: we build the tool that makes this page partly obsolete. Minutes (open source, free) records the meeting, transcribes on your device, and — once you connect an assistant (Claude via MCP, or a local LLM) — fills in this structure automatically: attendees, decisions, action items as structured YAML in markdown on your own disk. Templates still win for meetings you don't record and formal board minutes where a human secretary is the point.
 
 https://github.com/silverstein/minutes

--- a/site/public/security.md
+++ b/site/public/security.md
@@ -6,7 +6,7 @@ Cloud notetakers answer the security question with policies: encryption in trans
 
 ## The pipeline — every step on your device
 
-1. **Capture** — mic and system audio, recorded on your machine (cpal)
+1. **Capture** — mic (cpal) and system audio (native macOS capture in the desktop app, or a loopback device), recorded on your machine
 2. **Transcribe** — whisper.cpp or parakeet.cpp, running on your CPU/GPU
 3. **Diarize** — pyannote ONNX models, local; speaker labels never computed in a cloud
 4. **Store** — markdown + YAML frontmatter on your own disk, 0600 owner-only permissions
@@ -22,9 +22,9 @@ Cloud notetakers answer the security question with policies: encryption in trans
 
 - Transcription and diarization models are downloaded once, at setup
 - Updates, if you install them
-- If you explicitly configure an LLM for automated summarization, transcript text goes where you pointed it — a local model via Ollama (the private default posture), or a cloud provider if you choose one and supply a key
+- If you enable automated summarization (off by default), transcript text goes where you point it — a local model via Ollama, an agent CLI you've signed into (claude/codex/gemini — which round-trips through that provider's cloud), or a cloud API if you supply a key
 
-What is never in that traffic: your audio and transcripts, unless you yourself configured a summarizer to receive them. Out of the box, Minutes needs no API key and sends conversation content nowhere. When Claude summarizes a meeting through MCP, it reads local files through tools you granted — visible in your agent's tool log, not a background sync.
+What is never in that traffic: your audio and transcripts, unless you yourself configured a summarizer to receive them. Out of the box, Minutes needs no API key and sends conversation content nowhere. When Claude summarizes a meeting through MCP, it reads local files through tools you granted — visible in your agent's tool log, not a background sync — and what it reads travels to your agent's model provider as conversation context, like anything else you show your agent.
 
 ## For regulated work
 


### PR DESCRIPTION
## What

**Two new pages (cluster capstones):**
- `/resources/hipaa-compliant-ai-note-taker` — targets the head query of the compliance cluster ("hipaa compliant ai note taker", 200/mo). Vendor matrix sourced to each vendor's own docs: Otter/Fireflies/Fathom/Krisp conditional (with exact conditions), Granola no (their own words), Minutes outside the BAA framework by architecture. Internally links every per-vendor analysis.
- `/resources/is-it-legal-to-record-a-meeting` — the Otter-proven legality topic (their version ranks for 132 keywords). One-party vs all-party states (18 U.S.C. § 2511, RCFP), what AI notetakers change about disclosure, an explicit "botless capture is not a stealth-recording mechanism" stance, and the consent-to-record vs consent-to-upload distinction only an on-device vendor can make.

**19 fixes from the full adversarial review** (two agents, 52 + 46 claims verified):
- Competitor corrections: Fathom bot-free is beta + billing qualifiers on prices; MacWhisper's App Store channel has a one-time lifetime unlock and its dictation is direct-download-only; Krisp's cloud storage is opt-in-once-notes-are-enabled per their own security page (not "by default"), BAA tier language is legacy; Apple dictation has auto-punctuation.
- Honesty corrections vs our own codebase: absolute "nothing is uploaded" claims now carry carve-outs everywhere they appear; the MCP paragraph now says agent-read content travels to the agent's model provider; summarization documented as **off by default** including the signed-in agent-CLI path; "writes structure automatically" now says "once you connect an assistant" (default engine is `none`); dictation flow corrected to insert-at-cursor (desktop) vs clipboard (CLI); system-audio capture mechanism stated precisely; consent-frontmatter claim matched to `Option<ConsentBasis>`.

## Verification

- Both review reports were produced by agents instructed to refute, not confirm; every finding applied, none skipped
- `npm run build` green — 40 routes
- Both new pages carry FAQPage JSON-LD + not-legal-advice notes; sitemap updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)