### PR TITLE
feat(core): on-device summarization via Apple Foundation Models (macOS 26+)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ node test/mcp_tools_test.mjs                        # 8 MCP integration tests
 
 - All audio processing is local (whisper.cpp or parakeet.cpp + pyannote-rs + Silero VAD). ffmpeg recommended but optional.
 - Claude summarizes via MCP when the user asks (no API key needed)
-- Optional automated summarization via Ollama (local), Mistral, or cloud LLMs
+- Optional automated summarization fully on-device via Apple Foundation Models (macOS 26+, `engine = "apple"`; preferred by `"auto"` when available — see docs/architecture/apple-foundation-models.md), via Ollama (local), Mistral, or cloud LLMs
 - Config at `~/.config/minutes/config.toml` (optional, compiled defaults work)
 - Tauri assistant uses a singleton workspace at `~/.minutes/assistant/`
 - `CLAUDE.md` and `AGENTS.md` hold matching general assistant instructions; `CURRENT_MEETING.md` is the active meeting focus for "Discuss with AI"

--- a/crates/core/resources/apple-fm-helper.swift
+++ b/crates/core/resources/apple-fm-helper.swift
@@ -1,0 +1,161 @@
+// apple-fm-helper — on-device summarization via Apple Foundation Models.
+//
+// Compiled on demand by minutes-core (see crates/core/src/apple_fm.rs), the
+// same lifecycle as apple-speech-helper.swift. Requires macOS 26+ with Apple
+// Intelligence enabled; on anything older the helper still compiles and
+// reports runtimeSupported=false instead of failing.
+//
+// Contract (JSON on stdout, one object per invocation):
+//   apple-fm-helper capabilities
+//     -> {"kind":"capabilities","schemaVersion":1,...}
+//   apple-fm-helper generate --input-file <path>
+//     input file: {"systemPrompt":"...","prompt":"..."}
+//     -> {"kind":"generation","schemaVersion":1,"text":...,"error":...}
+//
+// The prompt travels via a caller-owned 0600 temp file, never argv, so
+// transcript content cannot appear in the process list.
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+struct CapabilityReport: Codable {
+    let kind: String
+    let schemaVersion: Int
+    let osVersion: String
+    let runtimeSupported: Bool
+    let availability: String
+    let reason: String?
+}
+
+struct GenerationInput: Codable {
+    let systemPrompt: String
+    let prompt: String
+}
+
+struct GenerationResult: Codable {
+    let kind: String
+    let schemaVersion: Int
+    let text: String?
+    let error: String?
+    let elapsedMs: UInt64
+}
+
+func osVersionString() -> String {
+    let v = ProcessInfo.processInfo.operatingSystemVersion
+    return "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+}
+
+func emit<T: Codable>(_ value: T) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    if let data = try? encoder.encode(value),
+        let text = String(data: data, encoding: .utf8)
+    {
+        print(text)
+    }
+}
+
+func capabilityReport() -> CapabilityReport {
+    #if canImport(FoundationModels)
+    if #available(macOS 26.0, *) {
+        let model = SystemLanguageModel.default
+        switch model.availability {
+        case .available:
+            return CapabilityReport(
+                kind: "capabilities", schemaVersion: 1, osVersion: osVersionString(),
+                runtimeSupported: true, availability: "available", reason: nil)
+        case .unavailable(let reason):
+            return CapabilityReport(
+                kind: "capabilities", schemaVersion: 1, osVersion: osVersionString(),
+                runtimeSupported: true, availability: "unavailable",
+                reason: String(describing: reason))
+        }
+    }
+    #endif
+    return CapabilityReport(
+        kind: "capabilities", schemaVersion: 1, osVersion: osVersionString(),
+        runtimeSupported: false, availability: "unavailable",
+        reason: "FoundationModels requires macOS 26 or newer")
+}
+
+func runGenerate(inputFile: String) async {
+    let started = DispatchTime.now()
+    func elapsedMs() -> UInt64 {
+        (DispatchTime.now().uptimeNanoseconds - started.uptimeNanoseconds) / 1_000_000
+    }
+    func fail(_ message: String) {
+        emit(
+            GenerationResult(
+                kind: "generation", schemaVersion: 1, text: nil, error: message,
+                elapsedMs: elapsedMs()))
+    }
+
+    guard let data = FileManager.default.contents(atPath: inputFile),
+        let input = try? JSONDecoder().decode(GenerationInput.self, from: data)
+    else {
+        fail("could not read or parse generation input file")
+        return
+    }
+
+    #if canImport(FoundationModels)
+    if #available(macOS 26.0, *) {
+        let model = SystemLanguageModel.default
+        guard case .available = model.availability else {
+            fail("Apple Intelligence model unavailable on this system")
+            return
+        }
+        do {
+            let session = LanguageModelSession(instructions: input.systemPrompt)
+            let options = GenerationOptions(temperature: 0.3)
+            let response = try await session.respond(to: input.prompt, options: options)
+            emit(
+                GenerationResult(
+                    kind: "generation", schemaVersion: 1, text: response.content,
+                    error: nil, elapsedMs: elapsedMs()))
+        } catch {
+            fail("generation failed: \(error)")
+        }
+        return
+    }
+    #endif
+    fail("FoundationModels requires macOS 26 or newer")
+}
+
+@main
+struct AppleFmHelper {
+    static func main() async {
+        var args = Array(CommandLine.arguments.dropFirst())
+        let command = args.isEmpty ? "capabilities" : args.removeFirst()
+
+        switch command {
+        case "capabilities", "--capabilities":
+            emit(capabilityReport())
+        case "generate":
+            var inputFile: String? = nil
+            var index = 0
+            while index < args.count {
+                if args[index] == "--input-file", index + 1 < args.count {
+                    inputFile = args[index + 1]
+                    index += 2
+                } else {
+                    index += 1
+                }
+            }
+            guard let inputFile else {
+                emit(
+                    GenerationResult(
+                        kind: "generation", schemaVersion: 1, text: nil,
+                        error: "generate requires --input-file <path>", elapsedMs: 0))
+                exit(2)
+            }
+            await runGenerate(inputFile: inputFile)
+        default:
+            FileHandle.standardError.write(
+                Data("unknown command: \(command)\n".utf8))
+            exit(2)
+        }
+    }
+}

--- a/crates/core/src/apple_fm.rs
+++ b/crates/core/src/apple_fm.rs
@@ -1,0 +1,353 @@
+//! On-device summarization via Apple Foundation Models (macOS 26+).
+//!
+//! Mirrors the `apple_speech` helper lifecycle: a small Swift helper is
+//! embedded at compile time, written under `~/.minutes/lib/`, compiled once
+//! with `swiftc`, and invoked as a subprocess with a JSON contract. The
+//! prompt is passed through a 0600 temp file (never argv) so transcript
+//! content cannot appear in the process list.
+//!
+//! Everything runs on-device: the Foundation Models framework is Apple's
+//! local Apple Intelligence model. No network traffic is involved at any
+//! point in this module.
+//!
+//! `MINUTES_APPLE_FM_HELPER` overrides helper resolution on every platform,
+//! which is how the subprocess contract is unit-tested off-macOS.
+
+use serde::Deserialize;
+#[cfg(any(test, target_os = "macos"))]
+use std::path::PathBuf;
+use std::sync::OnceLock;
+#[cfg(any(test, target_os = "macos"))]
+use std::time::Duration;
+
+#[cfg(any(test, target_os = "macos"))]
+use crate::calendar::output_with_timeout;
+#[cfg(any(test, target_os = "macos"))]
+use std::process::Command;
+
+#[cfg(target_os = "macos")]
+const HELPER_SOURCE: &str = include_str!("../resources/apple-fm-helper.swift");
+/// Capability probes are near-instant; generation gets a generous local budget.
+#[cfg(any(test, target_os = "macos"))]
+const CAPABILITY_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(any(test, target_os = "macos"))]
+const GENERATION_TIMEOUT: Duration = Duration::from_secs(240);
+
+/// Foundation Models exposes a ~4k-token context window. Chunks are capped
+/// below the configured `chunk_max_tokens` so system prompt + output fit.
+pub const APPLE_FM_MAX_CHUNK_TOKENS: usize = 3000;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(not(any(test, target_os = "macos")), allow(dead_code))]
+struct CapabilityReport {
+    #[allow(dead_code)]
+    kind: String,
+    #[allow(dead_code)]
+    schema_version: u32,
+    runtime_supported: bool,
+    availability: String,
+    #[allow(dead_code)]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(not(any(test, target_os = "macos")), allow(dead_code))]
+struct GenerationResult {
+    #[allow(dead_code)]
+    kind: String,
+    #[allow(dead_code)]
+    schema_version: u32,
+    text: Option<String>,
+    error: Option<String>,
+}
+
+/// Resolve the helper binary: env override first (any platform, used by
+/// tests and power users), then the on-demand compiled helper on macOS.
+#[cfg(any(test, target_os = "macos"))]
+fn resolve_helper() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("MINUTES_APPLE_FM_HELPER") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+        tracing::warn!(?path, "MINUTES_APPLE_FM_HELPER set but does not exist");
+        return None;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        match ensure_helper_installed() {
+            Ok(path) => Some(path),
+            Err(error) => {
+                tracing::warn!(%error, "apple-fm helper unavailable");
+                None
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    None
+}
+
+/// Whether Apple Foundation Models generation is usable right now.
+///
+/// The probe result is cached per-process: availability doesn't change
+/// mid-run, and the pipeline may consult this several times per meeting.
+pub fn is_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(probe_availability)
+}
+
+fn probe_availability() -> bool {
+    #[cfg(any(test, target_os = "macos"))]
+    {
+        let Some(helper) = resolve_helper() else {
+            return false;
+        };
+        let mut command = Command::new(&helper);
+        command.arg("capabilities");
+        let Some(output) = output_with_timeout(command, CAPABILITY_TIMEOUT) else {
+            tracing::warn!("apple-fm capabilities probe timed out");
+            return false;
+        };
+        if !output.status.success() {
+            return false;
+        }
+        match serde_json::from_slice::<CapabilityReport>(&output.stdout) {
+            Ok(report) => report.runtime_supported && report.availability == "available",
+            Err(error) => {
+                tracing::warn!(%error, "apple-fm capabilities probe returned invalid JSON");
+                false
+            }
+        }
+    }
+    #[cfg(not(any(test, target_os = "macos")))]
+    false
+}
+
+/// Run one on-device generation: `system_prompt` becomes the session
+/// instructions, `prompt` the user turn. Returns the model's text.
+pub fn generate(system_prompt: &str, prompt: &str) -> Result<String, Box<dyn std::error::Error>> {
+    #[cfg(any(test, target_os = "macos"))]
+    {
+        let helper = resolve_helper().ok_or("apple-fm helper not available")?;
+
+        let payload = serde_json::json!({
+            "systemPrompt": system_prompt,
+            "prompt": prompt,
+        });
+        // 0600 temp file keeps transcript text out of argv and other users' reach.
+        let mut input_file = tempfile::Builder::new()
+            .prefix("minutes-apple-fm-")
+            .suffix(".json")
+            .tempfile()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(input_file.path(), std::fs::Permissions::from_mode(0o600))?;
+        }
+        use std::io::Write;
+        input_file.write_all(payload.to_string().as_bytes())?;
+        input_file.flush()?;
+
+        let mut command = Command::new(&helper);
+        command
+            .arg("generate")
+            .arg("--input-file")
+            .arg(input_file.path());
+        let output = output_with_timeout(command, GENERATION_TIMEOUT)
+            .ok_or("apple-fm generation timed out")?;
+
+        let parsed: GenerationResult = serde_json::from_slice(&output.stdout).map_err(|e| {
+            format!(
+                "apple-fm helper returned invalid JSON ({}): {}",
+                e,
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })?;
+        if let Some(error) = parsed.error {
+            return Err(error.into());
+        }
+        parsed
+            .text
+            .ok_or_else(|| "apple-fm helper returned neither text nor error".into())
+    }
+    #[cfg(not(any(test, target_os = "macos")))]
+    {
+        let _ = (system_prompt, prompt);
+        Err("Apple Foundation Models summarization requires macOS".into())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_helper_installed() -> crate::error::Result<PathBuf> {
+    use crate::config::Config;
+    use crate::error::MinutesError;
+    use std::fs;
+
+    let bin_path = Config::minutes_dir().join("bin").join("apple-fm-helper");
+    let source_path = Config::minutes_dir()
+        .join("lib")
+        .join("apple-fm-helper.swift");
+
+    if let Some(parent) = source_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if let Some(parent) = bin_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let needs_source_write = match fs::read_to_string(&source_path) {
+        Ok(existing) => existing != HELPER_SOURCE,
+        Err(_) => true,
+    };
+    if needs_source_write {
+        fs::write(&source_path, HELPER_SOURCE)?;
+    }
+
+    let needs_compile = match (fs::metadata(&source_path), fs::metadata(&bin_path)) {
+        (_, Err(_)) => true,
+        (Ok(source_meta), Ok(bin_meta)) => source_meta.modified().ok() > bin_meta.modified().ok(),
+        _ => true,
+    };
+    if needs_compile {
+        let output = Command::new("xcrun")
+            .arg("swiftc")
+            .arg("-parse-as-library")
+            .arg("-O")
+            .arg(&source_path)
+            .arg("-o")
+            .arg(&bin_path)
+            .output()
+            .or_else(|_| {
+                Command::new("swiftc")
+                    .arg("-parse-as-library")
+                    .arg("-O")
+                    .arg(&source_path)
+                    .arg("-o")
+                    .arg(&bin_path)
+                    .output()
+            })?;
+        if !output.status.success() {
+            return Err(MinutesError::Io(std::io::Error::other(format!(
+                "failed to compile apple-fm helper: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))));
+        }
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o700))?;
+    }
+
+    Ok(bin_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Write an executable stub script that plays the helper's role.
+    fn write_stub(dir: &std::path::Path, body: &str) -> PathBuf {
+        let path = dir.join("fake-apple-fm-helper");
+        let mut file = std::fs::File::create(&path).unwrap();
+        writeln!(file, "#!/bin/sh").unwrap();
+        writeln!(file, "{}", body).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        path
+    }
+
+    // Env-var tests share a process; serialize them.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard;
+    impl EnvGuard {
+        fn set(path: &std::path::Path) -> Self {
+            std::env::set_var("MINUTES_APPLE_FM_HELPER", path);
+            EnvGuard
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("MINUTES_APPLE_FM_HELPER");
+        }
+    }
+
+    #[test]
+    fn generate_returns_text_from_helper() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let stub = write_stub(
+            dir.path(),
+            r#"echo '{"kind":"generation","schemaVersion":1,"text":"SUMMARY: a short recap","error":null,"elapsedMs":5}'"#,
+        );
+        let _guard = EnvGuard::set(&stub);
+        let text = generate("system", "prompt").unwrap();
+        assert!(text.contains("SUMMARY"));
+    }
+
+    #[test]
+    fn generate_surfaces_helper_error() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let stub = write_stub(
+            dir.path(),
+            r#"echo '{"kind":"generation","schemaVersion":1,"text":null,"error":"Apple Intelligence model unavailable on this system","elapsedMs":1}'"#,
+        );
+        let _guard = EnvGuard::set(&stub);
+        let error = generate("system", "prompt").unwrap_err().to_string();
+        assert!(error.contains("unavailable"));
+    }
+
+    #[test]
+    fn generate_receives_prompt_via_input_file_not_argv() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        // Stub asserts $1/$2 shape, then echoes the input file's contents back
+        // as the generated text so the test can confirm file-based transport.
+        let stub = write_stub(
+            dir.path(),
+            r#"[ "$1" = "generate" ] || exit 2
+[ "$2" = "--input-file" ] || exit 2
+grep -q "the secret transcript" "$3" || exit 3
+echo '{"kind":"generation","schemaVersion":1,"text":"file transport confirmed","error":null,"elapsedMs":1}'"#,
+        );
+        let _guard = EnvGuard::set(&stub);
+        let text = generate("SYS", "the secret transcript").unwrap();
+        assert_eq!(text, "file transport confirmed");
+    }
+
+    #[test]
+    fn probe_availability_true_when_helper_reports_available() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let stub = write_stub(
+            dir.path(),
+            r#"echo '{"kind":"capabilities","schemaVersion":1,"osVersion":"26.0.0","runtimeSupported":true,"availability":"available","reason":null}'"#,
+        );
+        let _guard = EnvGuard::set(&stub);
+        assert!(probe_availability());
+    }
+
+    #[test]
+    fn probe_availability_false_when_model_unavailable() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let stub = write_stub(
+            dir.path(),
+            r#"echo '{"kind":"capabilities","schemaVersion":1,"osVersion":"15.5.0","runtimeSupported":false,"availability":"unavailable","reason":"needs macOS 26"}'"#,
+        );
+        let _guard = EnvGuard::set(&stub);
+        assert!(!probe_availability());
+    }
+
+    #[test]
+    fn probe_availability_false_without_helper() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Point the override at a nonexistent path: resolution must fail closed.
+        std::env::set_var("MINUTES_APPLE_FM_HELPER", "/nonexistent/apple-fm-helper");
+        let result = probe_availability();
+        std::env::remove_var("MINUTES_APPLE_FM_HELPER");
+        assert!(!result);
+    }
+}

--- a/crates/core/src/apple_fm.rs
+++ b/crates/core/src/apple_fm.rs
@@ -241,7 +241,8 @@ fn ensure_helper_installed() -> crate::error::Result<PathBuf> {
     Ok(bin_path)
 }
 
-#[cfg(test)]
+// Stub-script-based tests are unix-only: the fake helper is a /bin/sh script.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod apple_fm;
 pub mod apple_speech;
 pub mod autoresearch;
 pub mod calendar;

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -8,8 +8,10 @@ use std::time::Instant;
 // LLM summarization module (pluggable).
 //
 // Supported engines:
-//   "auto"    → Detect installed AI CLI (claude > codex > gemini > opencode), skip if none found (default)
+//   "auto"    → Prefer on-device Apple Foundation Models when available, else detect an
+//               installed AI CLI (claude > codex > gemini > opencode), skip if none found (default)
 //   "none"    → Skip summarization — Claude summarizes via MCP when asked
+//   "apple"   → Apple Foundation Models, fully on-device (macOS 26+ with Apple Intelligence)
 //   "agent"   → Agent CLI (claude -p, codex exec, gemini -p, opencode run, pi -p) — uses existing subscription, no API key
 //   "ollama"  → Local Ollama server (no API key needed)
 //   "claude"  → Anthropic Claude API (ANTHROPIC_API_KEY env var, legacy)
@@ -124,7 +126,14 @@ pub fn summarize_with_template(
 
     let result = match engine.as_str() {
         "auto" => {
-            if let Some(agent) = detect_agent_cli() {
+            // Privacy-first ordering: a working on-device model beats any path
+            // that round-trips through a provider's cloud.
+            if crate::apple_fm::is_available() {
+                tracing::info!(
+                    "auto-selected Apple Foundation Models (on-device) for summarization"
+                );
+                summarize_with_apple_fm(&combined, config, template)
+            } else if let Some(agent) = detect_agent_cli() {
                 tracing::info!(agent = %agent, "auto-detected AI CLI for summarization");
                 summarize_with_agent_cmd(
                     transcript,
@@ -156,6 +165,7 @@ pub fn summarize_with_template(
             }
         }
         "agent" => summarize_with_agent(transcript, user_notes, screen_files, config, template),
+        "apple" | "apple-fm" => summarize_with_apple_fm(&combined, config, template),
         "claude" => summarize_with_claude(&combined, screen_files, config, template),
         "openai" => summarize_with_openai(&combined, screen_files, config, template),
         "mistral" => summarize_with_mistral(&combined, screen_files, config, template),
@@ -334,7 +344,14 @@ pub fn title_refinement_input_chars(
 
 pub fn title_refinement_model(config: &Config) -> Option<String> {
     match config.summarization.engine.as_str() {
-        "auto" => detect_agent_cli().map(|agent| format!("agent:{}", agent_label(&agent))),
+        "auto" => {
+            if crate::apple_fm::is_available() {
+                Some("apple:foundation-models".into())
+            } else {
+                detect_agent_cli().map(|agent| format!("agent:{}", agent_label(&agent)))
+            }
+        }
+        "apple" | "apple-fm" => Some("apple:foundation-models".into()),
         "agent" => {
             let agent_cmd = if config.summarization.agent_command.is_empty() {
                 "claude".to_string()
@@ -730,6 +747,7 @@ pub(crate) fn summarization_model_hint(config: &Config, has_screen_context: bool
     match config.summarization.engine.as_str() {
         "auto" => "agent:auto".into(),
         "agent" => configured_agent_hint(config),
+        "apple" | "apple-fm" => "apple:foundation-models".into(),
         "claude" => "anthropic:claude-sonnet-4-20250514".into(),
         "openai" => {
             if has_screen_context {
@@ -751,6 +769,7 @@ pub(crate) fn summarization_model_hint(config: &Config, has_screen_context: bool
 pub fn speaker_mapping_model_hint(config: &Config) -> String {
     match config.summarization.engine.as_str() {
         "none" | "auto" | "agent" => configured_agent_hint(config),
+        "apple" | "apple-fm" => "apple:foundation-models".into(),
         "claude" => "anthropic:claude-sonnet-4-20250514".into(),
         "openai" => "openai:gpt-4o-mini".into(),
         "mistral" => format!("mistral:{}", config.summarization.mistral_model),
@@ -2108,6 +2127,37 @@ fn summarize_with_openai_compatible(
 
 // ── Ollama (local) ───────────────────────────────────────────
 
+/// Summarize fully on-device via Apple Foundation Models (macOS 26+).
+///
+/// Same map-reduce chunking as the other engines, but capped at the FM
+/// context window (`APPLE_FM_MAX_CHUNK_TOKENS`) regardless of the configured
+/// `chunk_max_tokens`. No network traffic at any point.
+fn summarize_with_apple_fm(
+    transcript: &str,
+    config: &Config,
+    template: Option<&Template>,
+) -> Result<Summary, Box<dyn std::error::Error>> {
+    let chunk_tokens = config
+        .summarization
+        .chunk_max_tokens
+        .min(crate::apple_fm::APPLE_FM_MAX_CHUNK_TOKENS);
+    let chunks = build_prompt(transcript, chunk_tokens);
+    let system_prompt = build_system_prompt(get_effective_summary_language(config), template);
+    let mut all_text = String::new();
+
+    for chunk in &chunks {
+        let prompt = format!(
+            "Summarize this transcript:\n\n<transcript>\n{}\n</transcript>",
+            chunk
+        );
+        let text = crate::apple_fm::generate(&system_prompt, &prompt)?;
+        all_text.push_str(&text);
+        all_text.push('\n');
+    }
+
+    Ok(parse_summary_response(&all_text))
+}
+
 fn summarize_with_ollama(
     transcript: &str,
     config: &Config,
@@ -2265,11 +2315,16 @@ fn run_title_refinement_prompt(
 ) -> Result<String, Box<dyn std::error::Error>> {
     match config.summarization.engine.as_str() {
         "auto" => {
-            if let Some(agent) = detect_agent_cli() {
+            if crate::apple_fm::is_available() {
+                crate::apple_fm::generate("You generate concise meeting titles.", prompt)
+            } else if let Some(agent) = detect_agent_cli() {
                 run_title_refinement_via_agent(prompt, &agent)
             } else {
                 Err("no AI CLI found (claude, codex, gemini, opencode)".into())
             }
+        }
+        "apple" | "apple-fm" => {
+            crate::apple_fm::generate("You generate concise meeting titles.", prompt)
         }
         "agent" => {
             let agent_cmd = if config.summarization.agent_command.is_empty() {

--- a/docs/architecture/apple-foundation-models.md
+++ b/docs/architecture/apple-foundation-models.md
@@ -1,0 +1,77 @@
+# Apple Foundation Models Summarization
+
+Minutes can summarize meetings fully on-device using Apple's Foundation
+Models framework (the local Apple Intelligence model) on macOS 26+. This is
+the first summarization engine that fills in summaries, action items, and
+decisions with **zero setup, zero API keys, and zero network traffic**.
+
+## Requirements
+
+- macOS 26 (Tahoe) or newer
+- Apple Intelligence enabled in System Settings
+- Apple Silicon
+- Xcode Command Line Tools (for the one-time `swiftc` helper compile)
+
+## How it works
+
+The implementation mirrors the `apple-speech` helper pattern:
+
+1. `crates/core/resources/apple-fm-helper.swift` is embedded in the binary
+   at compile time (`include_str!`).
+2. On first use, minutes-core writes it to `~/.minutes/lib/` and compiles it
+   once with `swiftc` into `~/.minutes/bin/apple-fm-helper` (0700).
+3. The helper exposes two commands with a JSON-on-stdout contract:
+   - `capabilities` → availability report (schemaVersion 1)
+   - `generate --input-file <path>` → generation result
+4. Prompts travel via a 0600 temp file, never argv, so transcript content
+   cannot appear in the process list.
+5. `crates/core/src/apple_fm.rs` wraps this with a cached availability probe
+   (`is_available()`) and a `generate()` call with a 240s timeout.
+
+On macOS versions older than 26 (or with Apple Intelligence disabled) the
+helper still compiles and reports unavailability cleanly; Minutes falls back
+per the engine rules below. There is no network path anywhere in this module.
+
+## Engine selection
+
+```toml
+[summarization]
+engine = "apple"     # explicit: Apple Foundation Models only
+# or
+engine = "auto"      # prefers Apple FM when available, else agent CLI, else none
+```
+
+- `engine = "apple"` (alias `"apple-fm"`): use Foundation Models; errors
+  surface as processing warnings if unavailable.
+- `engine = "auto"`: privacy-first ordering — **Apple FM first** (on-device),
+  then an installed agent CLI (claude/codex/gemini/opencode, which round-trips
+  through that provider's cloud), then skip.
+- The compiled default remains `engine = "none"` (no summarization).
+
+Title refinement and the summarize path both honor the engine; model hints
+report as `apple:foundation-models` in processing logs and frontmatter.
+
+## Context window
+
+Foundation Models exposes a ~4k-token context window. Chunking caps at
+`APPLE_FM_MAX_CHUNK_TOKENS` (3000) regardless of `chunk_max_tokens`, using
+the same map-reduce flow as the other engines.
+
+## Testing
+
+The subprocess contract is unit-tested on every platform via the
+`MINUTES_APPLE_FM_HELPER` env override, which points resolution at a stub
+script (see `apple_fm.rs` tests). Real end-to-end generation requires
+hardware with Apple Intelligence — see the dogfood checklist below.
+
+## Dogfood checklist (macOS 26 hardware)
+
+1. `cargo build --release -p minutes-cli` and install per CLAUDE.md.
+2. Set `engine = "apple"` in `~/.config/minutes/config.toml`.
+3. `minutes process <some .wav>` — first run compiles the helper (a few
+   seconds), then summarization runs locally. Verify `summary`,
+   `action_items`, and `decisions` frontmatter are populated.
+4. Check `~/.minutes/logs/minutes.log` for `apple:foundation-models` model
+   hints and no network egress.
+5. Try `engine = "auto"` with no agent CLI on PATH and confirm Apple FM is
+   selected.

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1405;
+export const MINUTES_TEST_COUNT = 1411;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What

A new `"apple"` summarization engine that runs Apple's Foundation Models (local Apple Intelligence) fully on-device — the first engine that fills in summaries, action items, and decisions with **zero setup, zero API keys, and zero network traffic**. `"auto"` now prefers it over agent CLIs, making the auto path privacy-first. The compiled default remains `"none"`.

Implementation mirrors the proven `apple_speech` helper pattern (embedded Swift source, one-time `swiftc` compile, JSON contract, timeouts). Prompts travel via a 0600 temp file, never argv. Full design in `docs/architecture/apple-foundation-models.md`.

## Verification

- 953/953 minutes-core lib tests pass (CI-style, `--test-threads=1`), including 6 new tests that exercise the subprocess contract via the `MINUTES_APPLE_FM_HELPER` stub override
- `cargo fmt --check` clean; clippy clean for all touched files on the pinned 1.95.0 toolchain
- Includes two small pre-existing clippy fixes (cfg-gating `parse_calendar_access`, struct-literal `FilterStats` init) — correct regardless of the macOS-only CI clippy job

## ⚠️ Needs Mac dogfood before merge

I built this from a Linux box: **the Swift helper compiles only at runtime on macOS and has never been compiled.** Do not merge until the dogfood checklist in `docs/architecture/apple-foundation-models.md` passes on macOS 26 hardware — ~5 minutes: set `engine = "apple"`, process a wav, confirm frontmatter populates and the helper compiles. Syntax fixes to the Swift file, if needed, are expected to be minor.

Also note: `"auto"` behavior changes on Apple-Intelligence Macs (FM will be silently preferred over claude/codex CLIs). That's the intent — on-device beats cloud round-trip — but it's a behavior change worth a conscious nod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)