### PR TITLE
feat(consent): Phase 2 Wave 2 — agent-layer sensitivity enforcement

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -594,6 +594,11 @@ enum Commands {
         /// every millisecond counts.
         #[arg(long, conflicts_with = "sync")]
         no_sync: bool,
+
+        /// Include meetings designated `sensitivity: restricted` (excluded
+        /// by default). The override is recorded on the event bus.
+        #[arg(long)]
+        include_restricted: bool,
     },
 
     /// Show open action items across all meetings
@@ -601,6 +606,11 @@ enum Commands {
         /// Filter by assignee name
         #[arg(short, long)]
         assignee: Option<String>,
+
+        /// Include meetings designated `sensitivity: restricted` (excluded
+        /// by default). The override is recorded on the event bus.
+        #[arg(long)]
+        include_restricted: bool,
     },
 
     /// Flag conflicting decisions and stale commitments across meetings
@@ -672,6 +682,11 @@ enum Commands {
         /// Filter by attendee / person
         #[arg(short, long)]
         attendee: Option<String>,
+
+        /// Include meetings designated `sensitivity: restricted` (excluded
+        /// by default). The override is recorded on the event bus.
+        #[arg(long)]
+        include_restricted: bool,
     },
 
     /// List recent meetings and voice memos
@@ -691,6 +706,11 @@ enum Commands {
         /// Skip filesystem sync entirely; query the index as-is.
         #[arg(long, conflicts_with = "sync")]
         no_sync: bool,
+
+        /// Include meetings designated `sensitivity: restricted` (excluded
+        /// by default). The override is recorded on the event bus.
+        #[arg(long)]
+        include_restricted: bool,
     },
 
     /// Export meetings as CSV (to stdout or file)
@@ -1661,6 +1681,7 @@ fn main() -> Result<()> {
             format,
             sync,
             no_sync,
+            include_restricted,
         } => cmd_search(
             &query,
             content_type,
@@ -1671,9 +1692,13 @@ fn main() -> Result<()> {
             owner,
             &format,
             resolve_sync_mode(sync, no_sync),
+            include_restricted,
             &config,
         ),
-        Commands::Actions { assignee } => cmd_actions(assignee.as_deref(), &config),
+        Commands::Actions {
+            assignee,
+            include_restricted,
+        } => cmd_actions(assignee.as_deref(), include_restricted, &config),
         Commands::Consistency {
             owner,
             stale_after_days,
@@ -1708,16 +1733,26 @@ fn main() -> Result<()> {
             content_type,
             since,
             attendee,
-        } => cmd_research(&query, content_type, since, attendee, &config),
+            include_restricted,
+        } => cmd_research(
+            &query,
+            content_type,
+            since,
+            attendee,
+            include_restricted,
+            &config,
+        ),
         Commands::List {
             limit,
             content_type,
             sync,
             no_sync,
+            include_restricted,
         } => cmd_list(
             limit,
             content_type,
             resolve_sync_mode(sync, no_sync),
+            include_restricted,
             &config,
         ),
         Commands::Export {
@@ -2807,11 +2842,12 @@ fn build_weekly_summary_markdown(config: &Config) -> Result<String> {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: false,
     };
 
     let meetings = minutes_core::search::search("", config, &filters)?;
     let consistency = minutes_core::search::consistency_report(config, None, 7)?;
-    let open_actions = minutes_core::search::find_open_actions(config, None)?;
+    let open_actions = minutes_core::search::find_open_actions(config, None, false)?;
 
     let recent_titles = if meetings.is_empty() {
         "- No meetings or memos in the last 7 days.".to_string()
@@ -2895,6 +2931,7 @@ fn build_proactive_context_markdown(config: &Config) -> Result<String> {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: false,
     };
     let recent_results = minutes_core::search::search("", config, &filters)?;
     let recent_meetings = recent_results
@@ -3223,6 +3260,24 @@ fn resolve_sync_mode(sync: bool, no_sync: bool) -> minutes_core::search_index::S
     }
 }
 
+/// Record an explicit `--include-restricted` override on the event bus
+/// before any results are returned, so the bypass is never silent (consent
+/// layer Wave 2). Best-effort by design: a failed append warns on stderr but
+/// never blocks the caller (headless/hook discipline).
+fn record_sensitivity_override(surface: &str, query: Option<&str>) {
+    if let Err(error) = minutes_core::events::append_event_strict(
+        minutes_core::events::MinutesEvent::SensitivityOverride {
+            surface: surface.to_string(),
+            query: query.map(|q| q.to_string()),
+        },
+    ) {
+        eprintln!(
+            "WARN: could not record sensitivity.override event: {}",
+            error
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn cmd_search(
     query: &str,
@@ -3234,9 +3289,13 @@ fn cmd_search(
     owner: Option<String>,
     format: &str,
     sync_mode: minutes_core::search_index::SyncMode,
+    include_restricted: bool,
     config: &Config,
 ) -> Result<()> {
     let json_mode = format == "json";
+    if include_restricted {
+        record_sensitivity_override("cli.search", Some(query));
+    }
     let filters = minutes_core::search::SearchFilters {
         content_type,
         since,
@@ -3244,6 +3303,7 @@ fn cmd_search(
         intent_kind: intent_kind.as_deref().map(parse_intent_kind).transpose()?,
         owner,
         recorded_by: None,
+        include_restricted,
     };
 
     if intents_only {
@@ -3328,8 +3388,11 @@ fn cmd_search(
     Ok(())
 }
 
-fn cmd_actions(assignee: Option<&str>, config: &Config) -> Result<()> {
-    let results = minutes_core::search::find_open_actions(config, assignee)
+fn cmd_actions(assignee: Option<&str>, include_restricted: bool, config: &Config) -> Result<()> {
+    if include_restricted {
+        record_sensitivity_override("cli.actions", assignee);
+    }
+    let results = minutes_core::search::find_open_actions(config, assignee, include_restricted)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     if results.is_empty() {
@@ -3354,6 +3417,7 @@ fn cmd_list(
     limit: usize,
     content_type: Option<String>,
     sync_mode: minutes_core::search_index::SyncMode,
+    include_restricted: bool,
     config: &Config,
 ) -> Result<()> {
     // List delegates to search with an empty query — DRY, no duplicated file walking
@@ -3367,6 +3431,7 @@ fn cmd_list(
         None,
         "text",
         sync_mode,
+        include_restricted,
         config,
     )
 }
@@ -3383,6 +3448,7 @@ fn cmd_export(
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: true,
     };
 
     // Reuse search with empty query to get all meetings
@@ -4312,8 +4378,12 @@ fn cmd_research(
     content_type: Option<String>,
     since: Option<String>,
     attendee: Option<String>,
+    include_restricted: bool,
     config: &Config,
 ) -> Result<()> {
+    if include_restricted {
+        record_sensitivity_override("cli.research", Some(query));
+    }
     let filters = minutes_core::search::SearchFilters {
         content_type,
         since,
@@ -4321,6 +4391,7 @@ fn cmd_research(
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted,
     };
 
     let report = minutes_core::search::cross_meeting_research(query, config, &filters)
@@ -4392,6 +4463,17 @@ fn parse_intent_kind(kind: &str) -> Result<minutes_core::markdown::IntentKind> {
     }
 }
 
+/// True when the meeting file at `path` carries `sensitivity: restricted`
+/// frontmatter (consent layer Wave 2). Unreadable files are treated as not
+/// restricted; downstream ingest surfaces its own read errors.
+fn meeting_is_restricted(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let (fm_str, _) = minutes_core::markdown::split_frontmatter(&content);
+    minutes_core::markdown::extract_field(fm_str, "sensitivity").as_deref() == Some("restricted")
+}
+
 fn cmd_ingest(path: Option<PathBuf>, all: bool, dry_run: bool, config: &Config) -> Result<()> {
     if !config.knowledge.enabled || config.knowledge.path.as_os_str().is_empty() {
         eprintln!("Knowledge base is not configured.");
@@ -4424,10 +4506,28 @@ fn cmd_ingest(path: Option<PathBuf>, all: bool, dry_run: bool, config: &Config) 
             }
         }
         found.sort();
+        // Sensitivity enforcement (consent layer Wave 2): restricted meetings
+        // never enter the knowledge base via batch ingest. There is no
+        // override for knowledge ingest in this wave.
+        let before = found.len();
+        found.retain(|p| !meeting_is_restricted(p));
+        let skipped_restricted = before - found.len();
+        if skipped_restricted > 0 {
+            eprintln!(
+                "  skipping {} meeting(s) designated `sensitivity: restricted` (excluded from knowledge ingest)",
+                skipped_restricted
+            );
+        }
         found
     } else if let Some(ref p) = path {
         if !p.exists() {
             anyhow::bail!("File not found: {}", p.display());
+        }
+        if meeting_is_restricted(p) {
+            anyhow::bail!(
+                "{} is designated `sensitivity: restricted`; it is excluded from knowledge ingest by default and was not written to the knowledge base",
+                p.display()
+            );
         }
         vec![p.clone()]
     } else {
@@ -4561,6 +4661,7 @@ fn resolve_single_meeting(meeting: &str, config: &Config) -> Result<std::path::P
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: true,
     };
     let results = minutes_core::search::search(meeting, config, &filters)?;
     if results.is_empty() {
@@ -4920,6 +5021,7 @@ fn cmd_clean(meeting: &str, apply: bool, config: &Config) -> Result<()> {
                 intent_kind: None,
                 owner: None,
                 recorded_by: None,
+                include_restricted: true,
             };
             let results = minutes_core::search::search(meeting, config, &filters)?;
             if results.is_empty() {

--- a/crates/core/src/calendar.rs
+++ b/crates/core/src/calendar.rs
@@ -261,6 +261,8 @@ pub fn calendar_access_status() -> CalendarAccess {
 }
 
 /// Parse the helper's `--status` JSON line into a [`CalendarAccess`].
+/// Only reachable from the macOS helper path in non-test builds.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn parse_calendar_access(raw: &str) -> CalendarAccess {
     let value: serde_json::Value = match serde_json::from_str(raw.trim()) {
         Ok(value) => value,

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -361,6 +361,19 @@ pub enum MinutesEvent {
         reason: String,
         message: String,
     },
+    /// Explicit override that surfaced `sensitivity: restricted` meetings on
+    /// an agent-facing read surface. Restricted meetings are excluded from
+    /// those surfaces by default; when a caller opts in, the override is
+    /// recorded here so it is never silent (consent layer Wave 2).
+    #[serde(rename = "sensitivity.override")]
+    SensitivityOverride {
+        /// Read surface that honored the override (e.g. "cli.search",
+        /// "cli.actions", "cli.research").
+        surface: String,
+        /// Query or filter context supplied by the caller, if any.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        query: Option<String>,
+    },
     /// Append-only agent commentary. This never mutates human-authored notes.
     #[serde(rename = "agent.annotation")]
     AgentAnnotation {
@@ -1688,6 +1701,46 @@ mod tests {
             }
             other => panic!("unexpected event: {:?}", other),
         }
+    }
+
+    #[test]
+    fn sensitivity_override_serializes_dotted_name() {
+        let envelope = EventEnvelope {
+            v: EVENT_SCHEMA_VERSION,
+            seq: 9,
+            timestamp: Local::now(),
+            event: MinutesEvent::SensitivityOverride {
+                surface: "cli.search".into(),
+                query: Some("pricing".into()),
+            },
+        };
+
+        let value = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(value["event_type"], "sensitivity.override");
+        assert_eq!(value["surface"], "cli.search");
+        assert_eq!(value["query"], "pricing");
+
+        let parsed: EventEnvelope =
+            serde_json::from_str(&serde_json::to_string(&envelope).unwrap()).unwrap();
+        match parsed.event {
+            MinutesEvent::SensitivityOverride { surface, query } => {
+                assert_eq!(surface, "cli.search");
+                assert_eq!(query.as_deref(), Some("pricing"));
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sensitivity_override_omits_absent_query() {
+        let envelope = EventEnvelope::new(MinutesEvent::SensitivityOverride {
+            surface: "cli.actions".into(),
+            query: None,
+        });
+
+        let json = serde_json::to_string(&envelope).unwrap();
+        assert!(json.contains("\"event_type\":\"sensitivity.override\""));
+        assert!(!json.contains("\"query\""));
     }
 
     #[test]

--- a/crates/core/src/knowledge.rs
+++ b/crates/core/src/knowledge.rs
@@ -6,7 +6,7 @@
 //! hallucination propagation.
 
 use crate::config::{Config, KnowledgeConfig};
-use crate::markdown::Frontmatter;
+use crate::markdown::{Frontmatter, Sensitivity};
 use chrono::{DateTime, Local};
 use std::collections::HashMap;
 use std::fs;
@@ -107,6 +107,21 @@ pub fn update_from_meeting(
     _transcript: &str,
     config: &Config,
 ) -> Result<UpdateResult, Box<dyn std::error::Error>> {
+    // Sensitivity enforcement (consent layer Wave 2): a restricted meeting
+    // contributes no facts to the knowledge base. Batch and pipeline callers
+    // skip silently; the explicit `ingest_file` path refuses with a message.
+    if matches!(frontmatter.sensitivity, Some(Sensitivity::Restricted)) {
+        tracing::debug!(
+            path = %result.path.display(),
+            "skipping restricted meeting during knowledge update (sensitivity enforcement)"
+        );
+        return Ok(UpdateResult {
+            facts_written: 0,
+            facts_skipped: 0,
+            people_updated: vec![],
+        });
+    }
+
     if !config.knowledge.enabled || config.knowledge.path.as_os_str().is_empty() {
         return Ok(UpdateResult {
             facts_written: 0,
@@ -190,6 +205,18 @@ pub fn ingest_file(
         return Err("no frontmatter found".into());
     }
     let frontmatter: Frontmatter = serde_yaml::from_str(fm_str)?;
+
+    // Sensitivity enforcement (consent layer Wave 2): refusing an explicitly
+    // named restricted meeting must be loud, not a silent zero-fact result.
+    // There is no override for knowledge ingest in this wave.
+    if matches!(frontmatter.sensitivity, Some(Sensitivity::Restricted)) {
+        return Err(format!(
+            "{} is designated `sensitivity: restricted`; it is excluded from knowledge ingest by default and was not written to the knowledge base",
+            meeting_path.display()
+        )
+        .into());
+    }
+
     let result = crate::WriteResult {
         path: meeting_path.to_path_buf(),
         title: frontmatter.title.clone(),
@@ -609,6 +636,63 @@ mod tests {
         assert_eq!(slugify("Dan Benamoz"), "dan-benamoz");
         assert_eq!(slugify("  Mat  "), "mat");
         assert_eq!(slugify("Sarah O'Brien"), "sarah-o-brien");
+    }
+
+    #[test]
+    fn update_from_meeting_skips_restricted_meetings() {
+        let dir = TempDir::new().unwrap();
+        let config = Config {
+            knowledge: KnowledgeConfig {
+                enabled: true,
+                path: dir.path().to_path_buf(),
+                adapter: "wiki".into(),
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+
+        let frontmatter: Frontmatter = serde_yaml::from_str(
+            "title: Board Sync\ntype: meeting\ndate: 2026-06-10T12:00:00-07:00\nduration: 30m\nsensitivity: restricted\nattendees: [Alex Kim]\naction_items:\n  - assignee: Alex Kim\n    task: Draft board memo\n    status: open\ndecisions: []\nintents: []",
+        )
+        .unwrap();
+        let result = crate::WriteResult {
+            path: dir.path().join("2026-06-10-board.md"),
+            title: "Board Sync".into(),
+            word_count: 10,
+            content_type: crate::ContentType::Meeting,
+        };
+
+        let update = update_from_meeting(&result, &frontmatter, "notes", &config).unwrap();
+        assert_eq!(update.facts_written, 0);
+        assert_eq!(update.facts_skipped, 0);
+        assert!(update.people_updated.is_empty());
+        // Nothing was written to the knowledge base — not even the log.
+        assert!(fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn ingest_file_refuses_restricted_meetings() {
+        let kb = TempDir::new().unwrap();
+        let meetings = TempDir::new().unwrap();
+        let meeting_path = meetings.path().join("2026-06-10-board.md");
+        fs::write(
+            &meeting_path,
+            "---\ntitle: Board Sync\ntype: meeting\ndate: 2026-06-10T12:00:00-07:00\nduration: 30m\nsensitivity: restricted\nattendees: [Alex Kim]\naction_items: []\ndecisions: []\nintents: []\n---\n\nnotes\n",
+        )
+        .unwrap();
+        let config = Config {
+            knowledge: KnowledgeConfig {
+                enabled: true,
+                path: kb.path().to_path_buf(),
+                adapter: "wiki".into(),
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+
+        let error = ingest_file(&meeting_path, &config).unwrap_err();
+        assert!(error.to_string().contains("sensitivity: restricted"));
+        assert!(fs::read_dir(kb.path()).unwrap().next().is_none());
     }
 
     #[test]

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::error::SearchError;
-use crate::markdown::{extract_field, split_frontmatter, Frontmatter, IntentKind};
+use crate::markdown::{extract_field, split_frontmatter, Frontmatter, IntentKind, Sensitivity};
 use crate::overlays;
 use chrono::Local;
 use serde::Serialize;
@@ -27,6 +27,28 @@ fn walk_meeting_files(dir: &Path) -> impl Iterator<Item = walkdir::DirEntry> {
         })
         .filter_map(|e| e.ok())
         .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+}
+
+/// True when the file at `path` carries `sensitivity: restricted` frontmatter.
+///
+/// Reads only the frontmatter via the line-based `extract_field` helper, so
+/// the check stays cheap enough to post-filter index results. Unreadable
+/// files are treated as not restricted — every consumer skips them anyway.
+fn is_restricted_path(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let (frontmatter, _) = split_frontmatter(&content);
+    extract_field(frontmatter, "sensitivity").as_deref() == Some("restricted")
+}
+
+/// Drop results whose source meeting is `sensitivity: restricted` unless the
+/// caller opted in via `filters.include_restricted` (consent layer Wave 2).
+fn exclude_restricted_results(results: &mut Vec<SearchResult>, filters: &SearchFilters) {
+    if filters.include_restricted {
+        return;
+    }
+    results.retain(|result| !is_restricted_path(&result.path));
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -312,6 +334,12 @@ pub struct SearchFilters {
     pub intent_kind: Option<IntentKind>,
     pub owner: Option<String>,
     pub recorded_by: Option<String>,
+    /// Include meetings designated `sensitivity: restricted`. Default false:
+    /// restricted meetings are excluded from search and intent results unless
+    /// the caller opts in explicitly (consent layer Wave 2). Callers that set
+    /// this on an agent-facing surface must record the override on the event
+    /// bus (`sensitivity.override`).
+    pub include_restricted: bool,
 }
 
 /// Resolve a meeting file by slug prefix (date-title pattern).
@@ -380,6 +408,14 @@ pub fn cross_meeting_research(
                 continue;
             }
         };
+
+        // Sensitivity enforcement (consent layer Wave 2): restricted meetings
+        // stay out of cross-meeting research unless explicitly overridden.
+        if !filters.include_restricted
+            && matches!(frontmatter.sensitivity, Some(Sensitivity::Restricted))
+        {
+            continue;
+        }
 
         let content_type = match frontmatter.r#type {
             crate::markdown::ContentType::Meeting => "meeting".to_string(),
@@ -573,7 +609,9 @@ fn search_with_mode_and_vocabulary(
 
     let expansions = vocabulary_search_expansions(query, vocabulary_override);
     if expansions.len() <= 1 {
-        return Ok(index.search(query, filters, None)?);
+        let mut results = index.search(query, filters, None)?;
+        exclude_restricted_results(&mut results, filters);
+        return Ok(results);
     }
 
     let original_key = search_expansion_key(query);
@@ -593,6 +631,7 @@ fn search_with_mode_and_vocabulary(
         }
     }
 
+    exclude_restricted_results(&mut merged, filters);
     Ok(merged)
 }
 
@@ -730,6 +769,12 @@ fn consistency_report_at(
         }
 
         match serde_yaml::from_str::<Frontmatter>(frontmatter_str) {
+            // Sensitivity enforcement (consent layer Wave 2): restricted
+            // meetings never feed the consistency report. No override on this
+            // surface in this wave — like the graph, exclusion is complete.
+            Ok(frontmatter) if matches!(frontmatter.sensitivity, Some(Sensitivity::Restricted)) => {
+                tracing::debug!(path = %path.display(), "skipping restricted meeting in consistency report (sensitivity enforcement)");
+            }
             Ok(frontmatter) => parsed_frontmatters.push((path.to_path_buf(), frontmatter)),
             Err(e) => {
                 tracing::warn!(path = %path.display(), error = %e, "skipping malformed frontmatter in consistency report");
@@ -914,6 +959,12 @@ pub fn person_profile(config: &Config, person: &str) -> Result<PersonProfile, Se
         }
 
         match serde_yaml::from_str::<Frontmatter>(frontmatter_str) {
+            // Sensitivity enforcement (consent layer Wave 2): restricted
+            // meetings never feed person profiles. No override on this
+            // surface in this wave — like the graph, exclusion is complete.
+            Ok(frontmatter) if matches!(frontmatter.sensitivity, Some(Sensitivity::Restricted)) => {
+                tracing::debug!(path = %path.display(), "skipping restricted meeting in person profile (sensitivity enforcement)");
+            }
             Ok(frontmatter) => parsed_frontmatters.push((path.to_path_buf(), frontmatter)),
             Err(e) => {
                 tracing::warn!(path = %path.display(), error = %e, "skipping malformed frontmatter in person profile");
@@ -1125,6 +1176,14 @@ fn process_intent_file(
     let frontmatter: Frontmatter = serde_yaml::from_str(frontmatter_str)
         .map_err(|e| SearchError::Io(std::io::Error::other(e.to_string())))?;
 
+    // Sensitivity enforcement (consent layer Wave 2): restricted meetings
+    // contribute no intent records unless explicitly overridden.
+    if !filters.include_restricted
+        && matches!(frontmatter.sensitivity, Some(Sensitivity::Restricted))
+    {
+        return Ok(vec![]);
+    }
+
     let date = frontmatter.date.to_rfc3339();
     let content_type = match frontmatter.r#type {
         crate::markdown::ContentType::Meeting => "meeting".to_string(),
@@ -1216,9 +1275,14 @@ fn process_intent_file(
 
 /// Find meetings with open action items, optionally filtered by assignee.
 /// Parses YAML frontmatter for the structured action_items field.
+///
+/// Meetings designated `sensitivity: restricted` are excluded unless
+/// `include_restricted` is true; callers that set it on an agent-facing
+/// surface must record the override on the event bus (consent layer Wave 2).
 pub fn find_open_actions(
     config: &Config,
     assignee: Option<&str>,
+    include_restricted: bool,
 ) -> Result<Vec<ActionResult>, SearchError> {
     let dir = &config.output_dir;
     if !dir.exists() {
@@ -1235,6 +1299,15 @@ pub fn find_open_actions(
         };
 
         let (fm_str, _) = split_frontmatter(&content);
+
+        // Sensitivity enforcement (consent layer Wave 2): restricted meetings
+        // contribute no action items unless explicitly overridden.
+        if !include_restricted
+            && extract_field(fm_str, "sensitivity").as_deref() == Some("restricted")
+        {
+            continue;
+        }
+
         let title = extract_field(fm_str, "title").unwrap_or_default();
         let date = extract_field(fm_str, "date").unwrap_or_default();
 
@@ -1402,6 +1475,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: None,
+            include_restricted: false,
         };
 
         let results = search("pricing", &config, &filters).unwrap();
@@ -1430,6 +1504,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: None,
+            include_restricted: false,
         };
 
         let results = search("nonexistent", &config, &filters).unwrap();
@@ -1457,6 +1532,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: None,
+            include_restricted: false,
         };
 
         let results = search("pricing", &config, &filters).unwrap();
@@ -1533,6 +1609,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: Some("mat".into()),
+            include_restricted: false,
         };
         let non_matching_filters = SearchFilters {
             content_type: None,
@@ -1541,6 +1618,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: Some("sarah".into()),
+            include_restricted: false,
         };
 
         let matching_results = search("pricing", &config, &matching_filters).unwrap();
@@ -1565,6 +1643,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: None,
+            include_restricted: false,
         };
 
         let results = search("anything", &config, &filters).unwrap();
@@ -1606,6 +1685,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: None,
+            include_restricted: false,
         };
 
         let overlay_db = dir.path().join("overlays.db");
@@ -1643,6 +1723,7 @@ mod tests {
             intent_kind: Some(IntentKind::Commitment),
             owner: Some("sarah".into()),
             recorded_by: None,
+            include_restricted: false,
         };
 
         let overlay_db = dir.path().join("overlays.db");
@@ -1691,6 +1772,7 @@ mod tests {
             intent_kind: Some(IntentKind::ActionItem),
             owner: Some("alex".into()),
             recorded_by: None,
+            include_restricted: false,
         };
 
         let results = search_intents_at("", &config, &filters, &overlay_db).unwrap();
@@ -1720,6 +1802,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: Some("mat".into()),
+            include_restricted: false,
         };
         let non_matching_filters = SearchFilters {
             content_type: None,
@@ -1728,6 +1811,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: Some("sarah".into()),
+            include_restricted: false,
         };
 
         let matching_results = process_intent_file(
@@ -2060,6 +2144,7 @@ mod tests {
             intent_kind: None,
             owner: None,
             recorded_by: None,
+            include_restricted: false,
         };
         let report = cross_meeting_research("pricing", &config, &filters).unwrap();
 
@@ -2088,13 +2173,168 @@ mod tests {
             ..Config::default()
         };
 
-        let results = find_open_actions(&config, None).unwrap();
+        let results = find_open_actions(&config, None, false).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].assignee, "mat");
         assert_eq!(results[0].task, "Send doc");
 
         // Filter by assignee
-        let filtered = find_open_actions(&config, Some("nobody")).unwrap();
+        let filtered = find_open_actions(&config, Some("nobody"), false).unwrap();
         assert!(filtered.is_empty());
+    }
+
+    // ── Sensitivity enforcement (consent layer Wave 2) ──────────
+
+    const RESTRICTED_MEETING: &str = "---\ntitle: Board Pricing Strategy\ntype: meeting\ndate: 2026-06-11T12:00:00-07:00\nduration: 30m\nstatus: complete\nsensitivity: restricted\nattendees: [Alex Kim]\npeople: [Alex Kim]\naction_items:\n  - assignee: Alex Kim\n    task: Draft board pricing memo\n    status: open\ndecisions:\n  - text: Hold the pricing floor at current levels\n    topic: pricing\nintents:\n  - kind: commitment\n    what: Draft board pricing memo\n    who: Alex Kim\n    status: open\n---\n\n## Transcript\n\nRestricted pricing discussion.\n";
+
+    const NORMAL_MEETING: &str = "---\ntitle: Pricing Sync\ntype: meeting\ndate: 2026-06-10T12:00:00-07:00\nduration: 30m\nstatus: complete\nattendees: [Sam Lee]\npeople: [Sam Lee]\naction_items:\n  - assignee: Sam Lee\n    task: Share pricing deck\n    status: open\ndecisions:\n  - text: Ship monthly pricing page\n    topic: pricing\nintents:\n  - kind: commitment\n    what: Share pricing deck\n    who: Sam Lee\n    status: open\n---\n\n## Transcript\n\nWe discussed pricing.\n";
+
+    fn restricted_test_dir() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        create_test_file(dir.path(), "2026-06-10-pricing-sync.md", NORMAL_MEETING);
+        create_test_file(dir.path(), "2026-06-11-board.md", RESTRICTED_MEETING);
+        dir
+    }
+
+    #[test]
+    fn search_excludes_restricted_meetings_by_default() {
+        let _guard = crate::test_home_env_lock();
+        let dir = restricted_test_dir();
+        let config = Config {
+            output_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
+
+        let default_results = search("pricing", &config, &SearchFilters::default()).unwrap();
+        assert_eq!(default_results.len(), 1);
+        assert_eq!(default_results[0].title, "Pricing Sync");
+
+        let overridden = search(
+            "pricing",
+            &config,
+            &SearchFilters {
+                include_restricted: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(overridden.len(), 2);
+        assert!(overridden
+            .iter()
+            .any(|result| result.title == "Board Pricing Strategy"));
+    }
+
+    #[test]
+    fn search_intents_excludes_restricted_meetings_by_default() {
+        let _guard = crate::test_home_env_lock();
+        let dir = restricted_test_dir();
+        let config = Config {
+            output_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
+
+        let default_results =
+            search_intents("pricing", &config, &SearchFilters::default()).unwrap();
+        assert_eq!(default_results.len(), 1);
+        assert_eq!(default_results[0].what, "Share pricing deck");
+
+        let overridden = search_intents(
+            "pricing",
+            &config,
+            &SearchFilters {
+                include_restricted: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(overridden.len(), 2);
+    }
+
+    #[test]
+    fn find_open_actions_excludes_restricted_meetings_by_default() {
+        let _guard = crate::test_home_env_lock();
+        let dir = restricted_test_dir();
+        let config = Config {
+            output_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
+
+        let default_results = find_open_actions(&config, None, false).unwrap();
+        assert_eq!(default_results.len(), 1);
+        assert_eq!(default_results[0].task, "Share pricing deck");
+
+        let overridden = find_open_actions(&config, None, true).unwrap();
+        assert_eq!(overridden.len(), 2);
+        assert!(overridden
+            .iter()
+            .any(|action| action.task == "Draft board pricing memo"));
+    }
+
+    #[test]
+    fn cross_meeting_research_excludes_restricted_meetings_by_default() {
+        let _guard = crate::test_home_env_lock();
+        let dir = restricted_test_dir();
+        let config = Config {
+            output_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
+
+        let report = cross_meeting_research("pricing", &config, &SearchFilters::default()).unwrap();
+        assert!(report
+            .recent_meetings
+            .iter()
+            .all(|meeting| meeting.title != "Board Pricing Strategy"));
+        assert!(report
+            .related_decisions
+            .iter()
+            .all(|decision| !decision.what.contains("pricing floor")));
+
+        let overridden = cross_meeting_research(
+            "pricing",
+            &config,
+            &SearchFilters {
+                include_restricted: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(overridden
+            .recent_meetings
+            .iter()
+            .any(|meeting| meeting.title == "Board Pricing Strategy"));
+    }
+
+    #[test]
+    fn person_profile_always_excludes_restricted_meetings() {
+        let _guard = crate::test_home_env_lock();
+        let dir = restricted_test_dir();
+        let config = Config {
+            output_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
+
+        // Alex Kim only appears in the restricted meeting, so the profile
+        // must come back empty — no override exists on this surface.
+        let profile = person_profile(&config, "Alex Kim").unwrap();
+        assert!(profile.recent_meetings.is_empty());
+        assert!(profile.open_intents.is_empty());
+        assert!(profile.recent_decisions.is_empty());
+    }
+
+    #[test]
+    fn consistency_report_always_excludes_restricted_meetings() {
+        let _guard = crate::test_home_env_lock();
+        let dir = restricted_test_dir();
+        let config = Config {
+            output_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
+
+        let overlay_db = TempDir::new().unwrap().path().join("overlays.db");
+        let report = consistency_report_at(&config, None, 0, &overlay_db).unwrap();
+        assert!(report
+            .stale_commitments
+            .iter()
+            .all(|stale| stale.entry.what != "Draft board pricing memo"));
     }
 }

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -697,8 +697,10 @@ fn transcribe_whisper_dispatch(
 
     #[cfg(not(feature = "whisper"))]
     {
-        let mut stats = FilterStats::default();
-        stats.audio_duration_secs = samples.len() as f64 / 16000.0;
+        let stats = FilterStats {
+            audio_duration_secs: samples.len() as f64 / 16000.0,
+            ..Default::default()
+        };
         let _ = config; // suppress unused warning
         let _ = hints; // only used when the whisper feature is enabled
         let duration_secs = samples.len() as f64 / 16000.0;

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -326,6 +326,57 @@ function registerDocsAppTool(
 
 const execFileAsync = promisify(execFile);
 
+// ── Sensitivity enforcement shims (consent layer Wave 2) ────
+// The published minutes-sdk typings can lag the in-repo reader: the
+// `sensitivity` frontmatter field, the ReadOptions `includeRestricted`
+// parameter, and the restricted `getMeeting` stub ship with sdk >= 0.20.
+// These wrappers keep the server compiling against older typings while
+// passing the option through. With an older sdk at runtime the extra
+// argument is ignored (no exclusion in the pure-TS fallback yet) and the
+// CLI path still enforces the exclusion + records the override event.
+
+type SensitivityReadOptions = { includeRestricted?: boolean };
+
+/** `frontmatter.sensitivity`, tolerant of older sdk typings. */
+function meetingSensitivity(meeting: unknown): string | undefined {
+  return (meeting as any)?.frontmatter?.sensitivity;
+}
+
+/** True for the minimal restricted stub returned by sdk >= 0.20 getMeeting. */
+function isRestrictedStubMeeting(meeting: unknown): boolean {
+  return Boolean((meeting as any)?.restricted_stub);
+}
+
+const listMeetingsWithOpts = reader.listMeetings as unknown as (
+  dir: string,
+  limit?: number,
+  opts?: SensitivityReadOptions
+) => ReturnType<typeof reader.listMeetings>;
+
+const searchMeetingsWithOpts = reader.searchMeetings as unknown as (
+  dir: string,
+  query: string,
+  limit?: number,
+  opts?: SensitivityReadOptions
+) => ReturnType<typeof reader.searchMeetings>;
+
+const findOpenActionsWithOpts = reader.findOpenActions as unknown as (
+  dir: string,
+  assignee?: string,
+  opts?: SensitivityReadOptions
+) => ReturnType<typeof reader.findOpenActions>;
+
+const getPersonProfileWithOpts = reader.getPersonProfile as unknown as (
+  dir: string,
+  name: string,
+  opts?: SensitivityReadOptions
+) => ReturnType<typeof reader.getPersonProfile>;
+
+const getMeetingWithOpts = reader.getMeeting as unknown as (
+  filePath: string,
+  opts?: SensitivityReadOptions
+) => ReturnType<typeof reader.getMeeting>;
+
 // ── QMD semantic search (optional — falls back to CLI) ──────
 
 let qmdAvailable: boolean | null = null;
@@ -355,12 +406,29 @@ async function isQmdAvailable(): Promise<boolean> {
   return qmdAvailable;
 }
 
-async function enrichWithFrontmatter(qmdResults: any[]): Promise<any[]> {
-  return Promise.all(
+async function enrichWithFrontmatter(
+  qmdResults: any[],
+  includeRestricted: boolean
+): Promise<any[]> {
+  const enriched = await Promise.all(
     qmdResults.map(async (r: any) => {
       const filePath = r.source_path || r.path;
       try {
-        const meeting = await reader.getMeeting(filePath);
+        const meeting = await getMeetingWithOpts(filePath, {
+          includeRestricted,
+        });
+        // Sensitivity enforcement: without the override, drop restricted (or
+        // unreadable) hits entirely so a semantic index match cannot leak a
+        // restricted meeting into search results. Older sdks return null for
+        // restricted meetings; sdk >= 0.20 returns a stub — both are dropped.
+        if (
+          !includeRestricted &&
+          (!meeting ||
+            isRestrictedStubMeeting(meeting) ||
+            meetingSensitivity(meeting) === "restricted")
+        ) {
+          return null;
+        }
         return {
           date: meeting?.frontmatter.date || "",
           title: meeting?.frontmatter.title || "",
@@ -379,12 +447,14 @@ async function enrichWithFrontmatter(qmdResults: any[]): Promise<any[]> {
       }
     })
   );
+  return enriched.filter((r): r is any => r !== null);
 }
 
 async function searchViaQmd(
   query: string,
   limit: number,
-  contentType?: string
+  contentType?: string,
+  includeRestricted: boolean = false
 ): Promise<any[] | null> {
   if (!(await isQmdAvailable())) return null;
 
@@ -397,7 +467,7 @@ async function searchViaQmd(
     const results = Array.isArray(parsed) ? parsed : parsed.results || [];
     if (results.length === 0) return null;
 
-    const enriched = await enrichWithFrontmatter(results);
+    const enriched = await enrichWithFrontmatter(results, includeRestricted);
 
     // Apply content type filter if specified
     if (contentType) {
@@ -1699,22 +1769,28 @@ registerDocsAppTool(
   server,
   "list_meetings",
   {
-    description: "List recent meetings and voice memos.",
+    description: "List recent meetings and voice memos. Meetings designated `sensitivity: restricted` are excluded unless include_restricted is set; the override is logged.",
     inputSchema: {
       limit: z.number().optional().default(10).describe("Maximum results"),
       type: z.enum(["meeting", "memo"]).optional().describe("Filter by type"),
+      include_restricted: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Include meetings designated `sensitivity: restricted` (excluded by default; the override is logged)"),
     },
     annotations: { title: "List Meetings", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _meta: { ui: { resourceUri: UI_RESOURCE_URI } },
   },
-  async ({ limit, type: contentType }) => {
+  async ({ limit, type: contentType, include_restricted }) => {
     // Pure-TS fallback when CLI is not available
     if (!(await isCliAvailable())) {
-      const meetings = await reader.listMeetings(MEETINGS_DIR, limit);
+      const opts = { includeRestricted: include_restricted };
+      const meetings = await listMeetingsWithOpts(MEETINGS_DIR, limit, opts);
       const filtered = contentType
         ? meetings.filter((m) => m.frontmatter.type === contentType)
         : meetings;
-      const openActions = await reader.findOpenActions(MEETINGS_DIR);
+      const openActions = await findOpenActionsWithOpts(MEETINGS_DIR, undefined, opts);
 
       if (filtered.length === 0) {
         return {
@@ -1739,11 +1815,16 @@ registerDocsAppTool(
 
     const args = ["list", "--limit", String(limit)];
     if (contentType) args.push("-t", contentType);
+    // The CLI records the sensitivity.override event when this flag is set.
+    if (include_restricted) args.push("--include-restricted");
+
+    const actionArgs = ["search", "", "--intents-only", "--intent-kind", "action-item", "--limit", "20"];
+    if (include_restricted) actionArgs.push("--include-restricted");
 
     // Fetch meetings and action items in parallel
     const [meetingsResult, actionsResult] = await Promise.all([
       runMinutes(args),
-      runMinutes(["search", "", "--intents-only", "--intent-kind", "action-item", "--limit", "20"]).catch(() => ({ stdout: "[]", stderr: "" })),
+      runMinutes(actionArgs).catch(() => ({ stdout: "[]", stderr: "" })),
     ]);
 
     const meetings = parseJsonOutput(meetingsResult.stdout);
@@ -1779,7 +1860,7 @@ registerDocsAppTool(
   server,
   "search_meetings",
   {
-    description: "Search meeting transcripts and voice memos.",
+    description: "Search meeting transcripts and voice memos. Meetings designated `sensitivity: restricted` are excluded unless include_restricted is set; the override is logged.",
     inputSchema: {
       query: z.string().describe("Text to search for"),
       type: z.enum(["meeting", "memo"]).optional().describe("Filter by type"),
@@ -1795,11 +1876,16 @@ registerDocsAppTool(
         .optional()
         .default(false)
         .describe("Return structured intent records instead of transcript snippets"),
+      include_restricted: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Include meetings designated `sensitivity: restricted` (excluded by default; the override is logged)"),
     },
     annotations: { title: "Search Meetings", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _meta: { ui: { resourceUri: UI_RESOURCE_URI } },
   },
-  async ({ query, type: contentType, since, limit, intent_kind, owner, intents_only }) => {
+  async ({ query, type: contentType, since, limit, intent_kind, owner, intents_only, include_restricted }) => {
     // Pure-TS fallback when CLI is not available
     if (!(await isCliAvailable())) {
       const droppedFilters = [since && "since", intent_kind && "intent_kind", owner && "owner", intents_only && "intents_only"].filter(Boolean);
@@ -1807,7 +1893,9 @@ registerDocsAppTool(
         ? `\n\n(Note: ${droppedFilters.join(", ")} filters require the CLI. Install: brew install minutes)`
         : "";
 
-      const results = await reader.searchMeetings(MEETINGS_DIR, query, limit);
+      const results = await searchMeetingsWithOpts(MEETINGS_DIR, query, limit, {
+        includeRestricted: include_restricted,
+      });
       const filtered = contentType
         ? results.filter((m) => m.frontmatter.type === contentType)
         : results;
@@ -1834,15 +1922,17 @@ registerDocsAppTool(
       };
     }
 
-    // Intent/metadata queries always use CLI (QMD doesn't index YAML frontmatter fields)
-    const useCliOnly = intents_only || intent_kind || owner || since;
+    // Intent/metadata queries always use CLI (QMD doesn't index YAML frontmatter fields).
+    // include_restricted also routes through the CLI so the override is
+    // recorded on the event bus, not just applied.
+    const useCliOnly = intents_only || intent_kind || owner || since || include_restricted;
 
     // Try QMD semantic search for text queries
     let results: any[] | null = null;
     let usedQmd = false;
 
     if (!useCliOnly) {
-      results = await searchViaQmd(query, limit, contentType);
+      results = await searchViaQmd(query, limit, contentType, include_restricted);
       if (results) usedQmd = true;
     }
 
@@ -1854,6 +1944,8 @@ registerDocsAppTool(
       if (intent_kind) args.push("--intent-kind", intent_kind);
       if (owner) args.push("--owner", owner);
       if (intents_only) args.push("--intents-only");
+      // The CLI records the sensitivity.override event when this flag is set.
+      if (include_restricted) args.push("--include-restricted");
 
       const { stdout, stderr } = await runMinutes(args);
       const parsed = parseJsonOutput(stdout);
@@ -2058,7 +2150,7 @@ registerDocsAppTool(
   server,
   "consistency_report",
   {
-    description: "Flag conflicting decisions and stale commitments across meetings using structured intent data.",
+    description: "Flag conflicting decisions and stale commitments across meetings using structured intent data. Meetings designated `sensitivity: restricted` are always excluded from this report.",
     inputSchema: {
       owner: z.string().optional().describe("Filter stale commitments by owner / person"),
       stale_after_days: z
@@ -2137,14 +2229,19 @@ registerDocsAppTool(
   server,
   "get_person_profile",
   {
-    description: "Get a rich relationship profile for a person: meetings, commitments, topics, relationship score, and trend. Uses the conversation graph index for instant results.",
+    description: "Get a rich relationship profile for a person: meetings, commitments, topics, relationship score, and trend. Uses the conversation graph index for instant results. Meetings designated `sensitivity: restricted` never enter the graph; include_restricted only affects the file-reader fallback and is logged.",
     inputSchema: {
       name: z.string().describe("Person / attendee name to profile"),
+      include_restricted: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Include meetings designated `sensitivity: restricted` in the file-reader fallback (graph-backed results always exclude them; the override is logged)"),
     },
     annotations: { title: "Person Profile", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _meta: { ui: { resourceUri: UI_RESOURCE_URI } },
   },
-  async ({ name }) => {
+  async ({ name, include_restricted }) => {
     // Try graph index first (via CLI `minutes people --json`)
     if (await isCliAvailable()) {
       const { stdout } = await runMinutes(["people", "--json"]);
@@ -2217,7 +2314,9 @@ registerDocsAppTool(
     }
 
     // Pure-TS fallback when CLI is not available
-    const profile = await reader.getPersonProfile(MEETINGS_DIR, name);
+    const profile = await getPersonProfileWithOpts(MEETINGS_DIR, name, {
+      includeRestricted: include_restricted,
+    });
     const sections = [];
     if (profile.topics.length > 0) sections.push("Topics: " + profile.topics.join(", "));
     if (profile.meetings.length > 0) sections.push("Meetings:\n" + profile.meetings.map((m) => `- ${m.date} — ${m.title}`).join("\n"));
@@ -2235,18 +2334,25 @@ registerDocsAppTool(
 
 registerTool(
   "research_topic",
-  "Research a topic across meetings, decisions, and open follow-ups.",
+  "Research a topic across meetings, decisions, and open follow-ups. Meetings designated `sensitivity: restricted` are excluded unless include_restricted is set; the override is logged.",
   {
     query: z.string().describe("Topic or question to investigate across meetings"),
     type: z.enum(["meeting", "memo"]).optional().describe("Filter by type"),
     since: z.string().optional().describe("Only results after this date (ISO)"),
     attendee: z.string().optional().describe("Filter by attendee / person"),
+    include_restricted: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("Include meetings designated `sensitivity: restricted` (excluded by default; the override is logged)"),
   },
   { title: "Research Topic", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-  async ({ query, type: contentType, since, attendee }) => {
+  async ({ query, type: contentType, since, attendee, include_restricted }) => {
     if (!(await isCliAvailable())) {
       // Fallback: basic search when CLI is not available
-      const results = await reader.searchMeetings(MEETINGS_DIR, query, 20);
+      const results = await searchMeetingsWithOpts(MEETINGS_DIR, query, 20, {
+        includeRestricted: include_restricted,
+      });
       const filtered = contentType ? results.filter((m) => m.frontmatter.type === contentType) : results;
       const text = filtered.length > 0
         ? filtered.map((m) => `${m.frontmatter.date} — ${m.frontmatter.title}\n  ${m.path}`).join("\n\n")
@@ -2258,6 +2364,8 @@ registerTool(
     if (contentType) args.push("-t", contentType);
     if (since) args.push("--since", since);
     if (attendee) args.push("--attendee", attendee);
+    // The CLI records the sensitivity.override event when this flag is set.
+    if (include_restricted) args.push("--include-restricted");
 
     const { stdout, stderr } = await runMinutes(args);
     const report = parseJsonOutput(stdout);
@@ -2338,17 +2446,56 @@ registerDocsAppTool(
   server,
   "get_meeting",
   {
-    description: "Get the full transcript and details of a specific meeting or memo. Speaker attributions reflect sidecar overlay confirmations.",
+    description: "Get the full transcript and details of a specific meeting or memo. Speaker attributions reflect sidecar overlay confirmations. A meeting designated `sensitivity: restricted` returns a minimal stub unless include_restricted is set; the override is logged.",
     inputSchema: {
       path: z.string().describe("Path to the meeting markdown file"),
+      include_restricted: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Return the full content of a meeting designated `sensitivity: restricted` (a stub is returned by default; the override is logged)"),
     },
     annotations: { title: "View Meeting", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _meta: { ui: { resourceUri: UI_RESOURCE_URI } },
   },
-  async ({ path: filePath }) => {
+  async ({ path: filePath, include_restricted }) => {
     try {
       const resolved = validatePathInDirectory(filePath, await getEffectiveMeetingsDir(), [".md"]);
       const rawContent = await readFile(resolved, "utf-8");
+
+      // Sensitivity enforcement (consent layer Wave 2): a restricted meeting
+      // fetched by exact path returns a minimal stub — title, date, and the
+      // designation — never the transcript, unless the caller overrides.
+      const sensitivityParsed = reader.parseFrontmatter(rawContent, resolved);
+      if (sensitivityParsed && meetingSensitivity(sensitivityParsed) === "restricted") {
+        if (!include_restricted) {
+          const stubText = [
+            `${sensitivityParsed.frontmatter.title}`,
+            `date: ${sensitivityParsed.frontmatter.date}`,
+            "sensitivity: restricted",
+            "",
+            "Content excluded by default: this meeting is designated `sensitivity: restricted`.",
+            "Pass include_restricted: true for an explicit, logged override.",
+          ].join("\n");
+          return {
+            content: [{ type: "text" as const, text: stubText }],
+            structuredContent: {
+              path: resolved,
+              title: sensitivityParsed.frontmatter.title,
+              date: sensitivityParsed.frontmatter.date,
+              sensitivity: "restricted",
+              restricted_stub: true,
+              view: "detail",
+            },
+            _meta: { ui: { resourceUri: UI_RESOURCE_URI }, view: "detail", path: resolved },
+          };
+        }
+        // The MCP server has no direct event-bus writer; the override is
+        // recorded in the server log and flagged in the response instead.
+        console.error(
+          `[Minutes] include_restricted override: returning restricted meeting ${resolved} via get_meeting`
+        );
+      }
 
       // Ask the CLI for an overlay-applied structured view. Raw markdown on
       // disk is never mutated — the CLI just layers ~/.minutes/overlays.db on
@@ -2403,9 +2550,18 @@ registerDocsAppTool(
         }
       }
 
+      let structuredOut: Record<string, unknown> = structured;
+      if (include_restricted && meetingSensitivity(sensitivityParsed) === "restricted") {
+        structuredOut = {
+          ...structured,
+          sensitivity: "restricted",
+          sensitivity_override: { applied: true, logged: "server-log" },
+        };
+      }
+
       return {
         content: [{ type: "text" as const, text: rawContent }],
-        structuredContent: structured,
+        structuredContent: structuredOut,
         _meta: { ui: { resourceUri: UI_RESOURCE_URI }, view: "detail", path: resolved },
       };
     } catch (error: any) {
@@ -2625,7 +2781,7 @@ registerDocsAppTool(
   server,
   "track_commitments",
   {
-    description: "List open and stale commitments (action items, intents, decisions) across all meetings. Optionally filter by person. Answers: 'What did I promise Sarah?' or 'What's overdue?'",
+    description: "List open and stale commitments (action items, intents, decisions) across all meetings. Optionally filter by person. Answers: 'What did I promise Sarah?' or 'What's overdue?' Meetings designated `sensitivity: restricted` never enter the underlying graph.",
     inputSchema: {
       person: z.string().optional().describe("Filter by person name or slug (optional — omit for all commitments)"),
     },
@@ -2690,7 +2846,7 @@ registerDocsAppTool(
   server,
   "relationship_map",
   {
-    description: "Show all contacts with relationship scores, meeting frequency, and 'losing touch' alerts. Overview of your entire conversation network.",
+    description: "Show all contacts with relationship scores, meeting frequency, and 'losing touch' alerts. Overview of your entire conversation network. Meetings designated `sensitivity: restricted` never enter the underlying graph.",
     inputSchema: {
       limit: z.number().optional().describe("Max people to return (default: 15)"),
     },

--- a/crates/sdk/src/reader.test.ts
+++ b/crates/sdk/src/reader.test.ts
@@ -768,18 +768,40 @@ describe("sensitivity enforcement", () => {
     );
   });
 
-  it("getMeeting returns null for a restricted meeting even when given its path", async () => {
+  it("getMeeting returns a minimal stub for a restricted meeting fetched by path", async () => {
     const path = writeMeeting("restricted.md", RESTRICTED_MEETING);
-    expect(await getMeeting(path)).toBeNull();
-    const overridden = await getMeeting(path, { includeRestricted: true });
-    expect(overridden?.frontmatter.title).toBe("Board Pricing Strategy");
+    const stub = await getMeeting(path);
+    expect(stub).not.toBeNull();
+    expect(stub!.restricted_stub).toBe(true);
+    // The stub keeps only title/date/type/sensitivity...
+    expect(stub!.frontmatter.title).toBe("Board Pricing Strategy");
+    expect(stub!.frontmatter.sensitivity).toBe("restricted");
+    expect(stub!.frontmatter.date).not.toBe("");
+    // ...and points at the override, never the content.
+    expect(stub!.body).toContain("excluded by default");
+    expect(stub!.body).toContain("include_restricted");
+    expect(stub!.body).not.toContain("Confidential board pricing discussion");
+    expect(stub!.frontmatter.action_items).toEqual([]);
+    expect(stub!.frontmatter.decisions).toEqual([]);
+    expect(stub!.frontmatter.attendees).toEqual([]);
   });
 
-  it("getMeetingWithOverlays inherits the restricted exclusion", async () => {
+  it("getMeeting returns the full restricted meeting with the explicit override", async () => {
     const path = writeMeeting("restricted.md", RESTRICTED_MEETING);
-    // minutesBin points nowhere, so it falls back to getMeeting(), which excludes.
+    const overridden = await getMeeting(path, { includeRestricted: true });
+    expect(overridden?.restricted_stub).toBeUndefined();
+    expect(overridden?.frontmatter.title).toBe("Board Pricing Strategy");
+    expect(overridden?.frontmatter.action_items.length).toBeGreaterThan(0);
+    expect(overridden?.body).toContain("Confidential board pricing discussion");
+  });
+
+  it("getMeetingWithOverlays inherits the restricted stub without calling the CLI", async () => {
+    const path = writeMeeting("restricted.md", RESTRICTED_MEETING);
+    // minutesBin points nowhere, so any CLI attempt would fail; the stub is
+    // returned before the overlay path runs at all.
     const out = await getMeetingWithOverlays(path, { minutesBin: "/nonexistent" });
-    expect(out).toBeNull();
+    expect(out?.restricted_stub).toBe(true);
+    expect(out?.body).toContain("excluded by default");
   });
 
   it("findOpenActions skips actions from restricted meetings by default", async () => {

--- a/crates/sdk/src/reader.ts
+++ b/crates/sdk/src/reader.ts
@@ -131,6 +131,14 @@ export interface MeetingFile {
   frontmatter: Frontmatter;
   body: string;
   path: string;
+  /**
+   * True when this object is a minimal placeholder for a meeting designated
+   * `sensitivity: restricted`, returned by `getMeeting` without the
+   * `includeRestricted` override. A stub carries only title, date, type, and
+   * the sensitivity designation — never the transcript body, action items,
+   * decisions, or attendees.
+   */
+  restricted_stub?: boolean;
 }
 
 function parseRawAttendees(raw?: string): string[] {
@@ -522,12 +530,49 @@ export async function searchMeetings(
 }
 
 /**
+ * Body text carried by a restricted-meeting stub instead of the transcript.
+ */
+const RESTRICTED_STUB_NOTE =
+  "Content excluded by default: this meeting is designated `sensitivity: restricted`. " +
+  "Pass the include_restricted parameter for an explicit, logged override.";
+
+/**
+ * Build the minimal placeholder returned for a restricted meeting fetched by
+ * exact path without the override: title, date, type, and the sensitivity
+ * designation only. The transcript body, action items, decisions, and
+ * attendees are never included.
+ */
+function restrictedStub(meeting: MeetingFile): MeetingFile {
+  return {
+    path: meeting.path,
+    restricted_stub: true,
+    body: RESTRICTED_STUB_NOTE,
+    frontmatter: {
+      title: meeting.frontmatter.title,
+      type: meeting.frontmatter.type,
+      date: meeting.frontmatter.date,
+      duration: "",
+      capture: meeting.frontmatter.capture,
+      sensitivity: "restricted",
+      tags: [],
+      attendees: [],
+      people: [],
+      action_items: [],
+      decisions: [],
+      intents: [],
+    },
+  };
+}
+
+/**
  * Get a single meeting by file path.
  *
- * A restricted meeting is excluded by default (returns null with a logged
- * note), even when the caller already knows the path, so a stored path cannot
- * be used to bypass the policy. Pass `{ includeRestricted: true }` for an
- * explicit, logged override.
+ * A restricted meeting is reduced to a minimal stub by default — title, date,
+ * `sensitivity: restricted`, and a note that content is excluded until the
+ * `includeRestricted` override is passed — even when the caller already knows
+ * the path, so a stored path cannot be used to bypass the policy. Pass
+ * `{ includeRestricted: true }` for an explicit, logged override; check
+ * `restricted_stub` on the result to tell the two apart.
  */
 export async function getMeeting(
   filePath: string,
@@ -538,9 +583,9 @@ export async function getMeeting(
   if (isRestricted(meeting)) {
     if (!opts.includeRestricted) {
       console.warn(
-        `[minutes] get_meeting: ${filePath} is restricted; excluded by default`
+        `[minutes] get_meeting: ${filePath} is restricted; returning stub (content excluded by default)`
       );
-      return null;
+      return restrictedStub(meeting);
     }
     console.warn(
       `[minutes] include_restricted override: returning restricted meeting ${filePath}`
@@ -683,6 +728,9 @@ export async function getMeetingWithOverlays(
     includeRestricted: options.includeRestricted,
   });
   if (!fallback) return null;
+  // A restricted stub never goes through the CLI overlay path: overlays would
+  // add speaker names to a meeting whose content is excluded by default.
+  if (fallback.restricted_stub) return fallback;
 
   // Dynamically import child_process so this module still loads in
   // environments without it (browsers, Edge runtimes). The function

--- a/docs/architecture/consent-enforcement.md
+++ b/docs/architecture/consent-enforcement.md
@@ -1,0 +1,93 @@
+# Consent Enforcement — Restricted Meetings at the Agent Layer
+
+Wave 2 of the consent layer (bead `minutes-3yub.4`). Wave 1 introduced the
+designation — meetings can carry `capture: none` and `sensitivity: restricted`
+frontmatter (see [frontmatter-schema.md](frontmatter-schema.md)). Wave 2 makes
+the designation an enforcement contract: a restricted meeting is **excluded by
+default from every agent surface**, with an explicit, logged override where an
+override exists at all. The human-readable markdown on disk is never touched —
+the operator's own files stay fully readable.
+
+## The contract
+
+| Surface | Default | Override | Override logging |
+|---|---|---|---|
+| Core text search (`search`, `search_with_mode`) | excluded | `SearchFilters::include_restricted` | caller's responsibility (CLI does it) |
+| Core intent search (`search_intents`) | excluded | `SearchFilters::include_restricted` | caller's responsibility (CLI does it) |
+| Core open actions (`find_open_actions`) | excluded | `include_restricted` parameter | caller's responsibility (CLI does it) |
+| Core cross-meeting research (`cross_meeting_research`) | excluded | `SearchFilters::include_restricted` | caller's responsibility (CLI does it) |
+| Core consistency report (`consistency_report`) | excluded | none this wave | n/a |
+| Core person profile (`person_profile`) | excluded | none this wave | n/a |
+| Knowledge graph rebuild (`graph.rs`) | excluded | none this wave | n/a — graph.db wipes on rebuild, so exclusion at build time is complete |
+| Knowledge ingest (`knowledge.rs`, `minutes ingest`) | skipped in batch; explicit ingest of a restricted meeting is refused with a message | none this wave | n/a |
+| CLI `search` / `list` / `actions` / `research` | excluded | `--include-restricted` | `sensitivity.override` event appended before results are returned |
+| SDK reader (`crates/sdk/src/reader.ts`: list, search, actions, decisions, person profiles, voice memos) | excluded | `includeRestricted` option | stderr warning naming count + surface |
+| SDK reader `getMeeting` by exact path | minimal stub (title, date, `sensitivity: restricted`, note) — never the body | `includeRestricted` option | stderr warning |
+| MCP tools (`list_meetings`, `search_meetings`, `get_meeting`, `research_topic`, `get_person_profile`) | excluded / stub | `include_restricted` parameter | via the CLI's `sensitivity.override` event on CLI-backed paths; server log + `sensitivity_override` response note where the server cannot write events |
+| MCP graph-backed tools (`track_commitments`, `relationship_map`, `get_person_profile` graph path) | excluded | none this wave (restricted facts never enter the graph) | n/a |
+
+Desktop app search, list, palette actions, and other in-app navigation are the
+**operator's own surface**, not an agent surface: restricted meetings stay
+visible to the human in their own app. Assistant-facing context builders in
+the desktop app (assistant workspace context, proactive context bundle, the
+automation weekly summary) follow the agent-surface default and exclude
+restricted meetings.
+
+## Override logging
+
+The override is never silent. When `--include-restricted` is passed to a CLI
+read command, the CLI appends a `sensitivity.override` event to the
+append-only event log (`~/.minutes/events.jsonl`) **before returning
+results**:
+
+```json
+{"v":1,"seq":42,"timestamp":"...","event_type":"sensitivity.override","surface":"cli.search","query":"pricing"}
+```
+
+- `surface` — the read surface that honored the override (`cli.search`,
+  `cli.actions`, `cli.research`; `cli.list` routes through `cli.search` with
+  an empty query).
+- `query` — the query or filter context supplied by the caller, omitted when
+  there is none.
+
+The append is best-effort by design: a failed append warns on stderr but
+never blocks the caller (the never-block-non-interactive-callers rule from
+v1). MCP tools that route through the CLI inherit this event. The MCP server
+itself has no event-bus writer; where a tool serves an override without a CLI
+round-trip (`get_meeting`), it records the override in the server log and
+flags it in the structured response (`sensitivity_override`).
+
+## Restricted stub (get-by-path)
+
+Knowing a restricted meeting's path is not a bypass. `getMeeting` in the SDK
+reader and the MCP `get_meeting` tool return a minimal stub without the
+override:
+
+- title, date, `sensitivity: restricted`
+- a note that content is excluded by default and the `include_restricted`
+  parameter is required
+- never the transcript body, action items, decisions, or attendees
+
+The SDK stub is marked with `restricted_stub: true` so callers can tell it
+apart from a full meeting.
+
+## No override surfaces (this wave)
+
+The knowledge graph, knowledge ingest, consistency reports, and person
+profiles have **no override**: restricted facts simply do not enter those
+derived stores or reports. `graph.db` wipes on rebuild, so graph exclusion at
+build time is complete. An explicitly named restricted meeting passed to
+`minutes ingest` is refused with a message naming the designation; batch
+ingest (`--all`) skips restricted meetings and reports the skipped count.
+
+## Compatibility notes
+
+- All changes are additive: `sensitivity` absent means normal behavior
+  everywhere, and existing corpora are unaffected.
+- Agents never write `sensitivity` (RFC #194 discipline) — the designation is
+  set by the human-initiated flows from Wave 1.
+- The MCP server compiles against the published `minutes-sdk` typings, which
+  may lag the in-repo reader. Until an SDK release that includes the
+  `includeRestricted` option is published and bundled, the pure-TS fallback
+  paths pass the option through shims (older SDKs ignore it) and the
+  CLI-backed paths carry the enforcement.

--- a/docs/architecture/frontmatter-schema.md
+++ b/docs/architecture/frontmatter-schema.md
@@ -367,6 +367,11 @@ while leaving the operator's own files fully readable on disk. Agents never
 mutate the `sensitivity` field; it is set by Minutes when the meeting is
 designated.
 
+The full per-surface contract — core search/actions/research, CLI
+`--include-restricted` with `sensitivity.override` event logging, knowledge
+ingest refusal, the get-by-path stub, and MCP tool parameters — is documented
+in [consent-enforcement.md](consent-enforcement.md).
+
 ---
 
 ## Consuming Minutes

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1392;
+export const MINUTES_TEST_COUNT = 1403;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 31;
 export const MINUTES_CLI_COMMAND_COUNT = 55;
-export const MINUTES_TEST_COUNT = 1403;
+export const MINUTES_TEST_COUNT = 1405;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1908,6 +1908,7 @@ fn latest_saved_artifact_from_search(config: &Config) -> Option<PathBuf> {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: true,
     };
     minutes_core::search::search("", config, &filters)
         .ok()?
@@ -2105,6 +2106,7 @@ fn build_related_context(
             intent_kind: None,
             owner: None,
             recorded_by: None,
+            include_restricted: true,
         };
         if let Ok(report) = minutes_core::search::cross_meeting_research(topic, config, &filters) {
             for meeting in report.recent_meetings.into_iter().take(3) {
@@ -4356,6 +4358,7 @@ fn latest_saved_artifact_path(
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: true,
     };
     let latest = minutes_core::search::search("", &config, &filters)
         .map_err(|e| e.to_string())?
@@ -6595,6 +6598,7 @@ pub fn cmd_weekly_summary() -> Result<WeeklySummaryView, String> {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: true,
     };
 
     let meetings =
@@ -6602,7 +6606,7 @@ pub fn cmd_weekly_summary() -> Result<WeeklySummaryView, String> {
     let consistency =
         minutes_core::search::consistency_report(&config, None, 7).map_err(|e| e.to_string())?;
     let open_actions =
-        minutes_core::search::find_open_actions(&config, None).map_err(|e| e.to_string())?;
+        minutes_core::search::find_open_actions(&config, None, true).map_err(|e| e.to_string())?;
 
     let meetings_count = meetings.len();
     let recent_titles = if meetings.is_empty() {
@@ -6693,6 +6697,7 @@ pub fn cmd_proactive_context_bundle() -> Result<ProactiveContextBundleView, Stri
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: false,
     };
 
     let recent_results =
@@ -6811,6 +6816,7 @@ pub fn cmd_list_meetings(limit: Option<usize>) -> serde_json::Value {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: true,
     };
     match minutes_core::search::search("", &config, &filters) {
         Ok(results) => {
@@ -6873,7 +6879,12 @@ fn compute_lifecycle_badges(
 #[tauri::command]
 pub fn cmd_search(query: String) -> Result<Vec<minutes_core::search::SearchResult>, String> {
     let config = Config::load();
-    let filters = minutes_core::search::SearchFilters::default();
+    // Desktop search is the operator's own surface, not an agent surface:
+    // restricted meetings stay visible to the human in their own app.
+    let filters = minutes_core::search::SearchFilters {
+        include_restricted: true,
+        ..Default::default()
+    };
     minutes_core::search::search(&query, &config, &filters).map_err(|e| e.to_string())
 }
 

--- a/tauri/src-tauri/src/context.rs
+++ b/tauri/src-tauri/src/context.rs
@@ -346,6 +346,7 @@ pub fn generate_assistant_context(config: &Config) -> Result<String, String> {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: false,
     };
 
     if let Ok(results) = search::search("", config, &filters) {
@@ -373,6 +374,7 @@ pub fn generate_assistant_context(config: &Config) -> Result<String, String> {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: false,
     };
     if let Ok(intents) = search::search_intents("", config, &intent_filters) {
         let open: Vec<_> = intents

--- a/tauri/src-tauri/src/palette_dispatch.rs
+++ b/tauri/src-tauri/src/palette_dispatch.rs
@@ -532,6 +532,7 @@ fn dispatch_action(
                 intent_kind: None,
                 owner: None,
                 recorded_by: None,
+                include_restricted: true,
             };
             let results = minutes_core::search::search("", &config, &filters)
                 .map_err(|e| format!("list meetings: {}", e))?;
@@ -563,6 +564,7 @@ fn dispatch_action(
                 intent_kind: None,
                 owner: None,
                 recorded_by: None,
+                include_restricted: true,
             };
             let results = minutes_core::search::search("", &config, &filters)
                 .map_err(|e| format!("list today's meetings: {}", e))?;
@@ -627,6 +629,7 @@ fn dispatch_action(
                 intent_kind: None,
                 owner: None,
                 recorded_by: None,
+                include_restricted: true,
             };
             let research = minutes_core::search::cross_meeting_research(&q, &config, &filters)
                 .map_err(|e| format!("research: {}", e))?;
@@ -636,7 +639,7 @@ fn dispatch_action(
         }
         ActionId::FindOpenActionItems => {
             let config = Config::load();
-            let actions = minutes_core::search::find_open_actions(&config, None)
+            let actions = minutes_core::search::find_open_actions(&config, None, true)
                 .map_err(|e| format!("find open actions: {}", e))?;
             let actions =
                 serde_json::to_value(&actions).map_err(|e| format!("serialize actions: {}", e))?;
@@ -651,6 +654,7 @@ fn dispatch_action(
                 intent_kind: Some(minutes_core::markdown::IntentKind::Decision),
                 owner: None,
                 recorded_by: None,
+                include_restricted: true,
             };
             let decisions = minutes_core::search::search_intents("", &config, &filters)
                 .map_err(|e| format!("search decisions: {}", e))?;


### PR DESCRIPTION
## What

Completes bead `minutes-3yub.4` — the enforcement half of the consent layer, per `docs/plans/consent-layer-phase2-2026-06-10.md`. Meetings designated `sensitivity: restricted` are now **invisible by default to every agent surface**, with an explicit, logged override:

- **Core search**: `include_restricted` filter (default off) across text search, cross-meeting research, and open-action queries; `consistency_report` and `person_profile` exclude unconditionally, mirroring the graph.
- **CLI**: `--include-restricted` on `search`/`actions`/`research`/`list`; using it appends a `sensitivity.override` event (surface + query) to the append-only event bus before results are returned. `ingest` refuses explicitly named restricted meetings and pre-filters `--all`.
- **SDK reader**: `getMeeting` on a restricted file returns a minimal stub (title/date/designation + excluded-by-default note) — never transcript, actions, decisions, or attendees.
- **MCP**: `include_restricted` param on the five meeting-reading tools; CLI-backed paths write the override event; QMD semantic-index snippets can no longer leak restricted content; tool descriptions updated honestly.
- **Tauri**: the operator's own UI keeps full visibility; assistant context builders exclude.

New `docs/architecture/consent-enforcement.md` documents the per-surface contract and override event format. Builds on #306 (designation), #356 (retention), #350 (reader listing exclusion).

## Design decisions

- Override logging is best-effort (warn, never block) per the "never block non-interactive callers" hard constraint, and always precedes result delivery.
- Graph gets no override this wave (per plan): restricted facts simply never enter it.
- Published `minutes-sdk@0.19.0` predates the sensitivity field, so the MCP server uses typed shims; CLI-backed paths enforce fully today, and full SDK enforcement lands with the next sdk publish (same stance as #350's scope note).
- Copy discipline verified: no "legal"/"compliant"/"lawful" anywhere in the diff.

## Verification

957 core + 49 CLI + 62 SDK + 63 MCP tests green (13 new); `mcp_tools_test.mjs` 10/10; fmt + clippy (core+cli, pinned 1.95.0) clean; release constants synced; manual end-to-end exclusion/override/event-logging confirmed against a scratch $HOME. Includes two pre-existing Linux clippy fixes (also in #439 — whichever merges second rebases trivially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)