### PR TITLE
fix(graph): split multi-person strings into separate entities (#385 class 2)

### DIFF
--- a/crates/core/src/person_identity.rs
+++ b/crates/core/src/person_identity.rs
@@ -504,6 +504,55 @@ pub(crate) fn strip_contamination(name: &str) -> &str {
     }
 }
 
+/// Split a raw people string into individual person references on explicit
+/// conjunctions, so multi-person strings ("Gert and Liam", "Liam & Joe") don't
+/// fuse into one entity (#385 class 2).
+///
+/// Separators: the word `and` (case-insensitive), `&`, `+`, `;`. Commas are
+/// treated as separators ONLY when one of those conjunctions is also present
+/// (an "A, B, and C" list) — a lone comma is often "Last, First" for a single
+/// person, so `"Chen, Sarah"` is deliberately left intact. A name with no
+/// separator ("Sarah Chen", "Anne Marie") passes through unchanged.
+pub(crate) fn split_person_references(raw: &str) -> Vec<String> {
+    let has_conjunction = raw
+        .split_whitespace()
+        .any(|t| t.eq_ignore_ascii_case("and"))
+        || raw.contains('&')
+        || raw.contains('+');
+    let split_char = |c: char| c == '&' || c == '+' || c == ';' || (has_conjunction && c == ',');
+
+    let mut out: Vec<String> = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+    let flush = |current: &mut Vec<String>, out: &mut Vec<String>| {
+        if !current.is_empty() {
+            out.push(current.join(" "));
+            current.clear();
+        }
+    };
+
+    for token in raw.split_whitespace() {
+        if token.eq_ignore_ascii_case("and") {
+            flush(&mut current, &mut out);
+            continue;
+        }
+        for (i, piece) in token.split(split_char).enumerate() {
+            if i > 0 {
+                flush(&mut current, &mut out);
+            }
+            let piece = piece.trim();
+            if !piece.is_empty() {
+                current.push(piece.to_string());
+            }
+        }
+    }
+    flush(&mut current, &mut out);
+
+    if out.is_empty() {
+        out.push(raw.trim().to_string());
+    }
+    out
+}
+
 fn normalize_entity_identity(entity: &EntityRef) -> Option<PersonIdentity> {
     // Role/title descriptors ("tech lead"), diarization speaker labels
     // ("speaker 0"), and generic/group tokens ("team", "qa engineer") must not
@@ -952,6 +1001,35 @@ mod tests {
             let once = strip_contamination(s);
             assert_eq!(strip_contamination(once), once, "not idempotent for {s:?}");
         }
+    }
+
+    #[test]
+    fn split_person_references_splits_on_conjunctions() {
+        // #385 class 2: multi-person strings become separate references.
+        assert_eq!(split_person_references("Gert and Liam"), ["Gert", "Liam"]);
+        assert_eq!(split_person_references("Liam & Joe"), ["Liam", "Joe"]);
+        assert_eq!(split_person_references("Liam+Joe"), ["Liam", "Joe"]);
+        assert_eq!(
+            split_person_references("Gert and Liam and Junrei"),
+            ["Gert", "Liam", "Junrei"]
+        );
+        // Comma splits only because a conjunction is present (an "A, B, and C" list).
+        assert_eq!(
+            split_person_references("Gert, Liam, and Junrei"),
+            ["Gert", "Liam", "Junrei"]
+        );
+    }
+
+    #[test]
+    fn split_person_references_preserves_single_names() {
+        // Real names must never be split.
+        assert_eq!(split_person_references("Sarah Chen"), ["Sarah Chen"]);
+        assert_eq!(split_person_references("Anne Marie"), ["Anne Marie"]);
+        assert_eq!(split_person_references("Mat"), ["Mat"]);
+        // "Andrew" contains "and" but not as a standalone token — must not split.
+        assert_eq!(split_person_references("Andrew"), ["Andrew"]);
+        // Lone comma with no conjunction = "Last, First", left intact.
+        assert_eq!(split_person_references("Chen, Sarah"), ["Chen, Sarah"]);
     }
 
     #[test]

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -4631,6 +4631,17 @@ fn derive_structured_tags(
 }
 
 fn add_person_entity(entities: &mut BTreeMap<String, (String, BTreeSet<String>)>, raw: &str) {
+    // #385 class 2: split multi-person strings ("Gert and Liam") into separate
+    // references before each is stripped, gated, and slugged individually.
+    for reference in crate::person_identity::split_person_references(raw) {
+        add_single_person_entity(entities, &reference);
+    }
+}
+
+fn add_single_person_entity(
+    entities: &mut BTreeMap<String, (String, BTreeSet<String>)>,
+    raw: &str,
+) {
     let Some(trimmed) = (match resolve_speaker_reference(raw, &[], false) {
         Some(name) => Some(name),
         None => {
@@ -6565,6 +6576,46 @@ mod tests {
         assert!(
             !slugs.contains(&"sam-engineering-lead"),
             "role suffix must not appear in slug: {:?}",
+            slugs
+        );
+    }
+
+    #[test]
+    fn add_person_entity_splits_multi_person_strings() {
+        // #385 class 2: "Gert and Liam" must become two entities, not "gert-liam".
+        let entities = build_entity_links(
+            "meeting",
+            None,
+            &[
+                "Gert and Liam".into(),
+                "Liam & Joe".into(),
+                "Sarah Chen".into(),
+            ],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+        );
+
+        let slugs: Vec<&str> = entities.people.iter().map(|e| e.slug.as_str()).collect();
+        assert!(slugs.contains(&"gert"), "gert present: {:?}", slugs);
+        assert!(slugs.contains(&"liam"), "liam present: {:?}", slugs);
+        assert!(slugs.contains(&"joe"), "joe present: {:?}", slugs);
+        assert!(
+            !slugs.contains(&"gert-liam"),
+            "must not fuse multi-person: {:?}",
+            slugs
+        );
+        assert!(
+            !slugs.contains(&"liam-joe"),
+            "must not fuse multi-person: {:?}",
+            slugs
+        );
+        // A genuine two-word name must NOT be split (would appear as sarah + chen).
+        assert!(
+            slugs.contains(&"sarah-chen"),
+            "real two-word name must stay intact: {:?}",
             slugs
         );
     }


### PR DESCRIPTION
Addresses **class 2** of #385 (multi-person concatenation). Classes 1 & 4 shipped in #386; class 3 (name-variant fragmentation) remains the #371 resolution work, so this doesn't close the umbrella.

**Bug:** the extractor sometimes returns several names as one string ("Gert and Liam"), which fused into a single person entity — real-vault evidence: `gert-liam`, `liam-joe`, `gert-liam-junrei-an`.

**Fix:** `split_person_references()` splits a raw people string on unambiguous separators before each part is stripped/gated/slugged individually:
- Splits on `and` (case-insensitive word), `&`, `+`, `;`
- Splits on commas **only** when a conjunction is also present (an "A, B, and C" list)
- A lone comma is left intact — `"Chen, Sarah"` is "Last, First" for one person
- Separator-free names never split — `"Sarah Chen"`, `"Anne Marie"`, `"Andrew"` (contains "and" but not as a token) all pass through

Deliberately conservative to avoid ever splitting a real name.

**Tests:** splitter unit coverage (conjunctions split; real names / lone-comma preserved) + an end-to-end `build_entity_links` check that "Gert and Liam" yields distinct `gert`/`liam` entities while "Sarah Chen" stays `sarah-chen`. fmt + clippy clean.

**Note:** existing contaminated vaults collapse on the next `minutes people --rebuild` (extraction + normalize both run there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)