### PR TITLE
fix(test): restore integration build — missing include_restricted on SearchFilters

### DIFF
--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -169,6 +169,7 @@ fn search_filters_by_content_type() {
         intent_kind: None,
         owner: None,
         recorded_by: None,
+        include_restricted: false,
     };
 
     // Search for content that exists in the output (varies by whisper vs placeholder)


### PR DESCRIPTION
`cargo test -p minutes-core` currently fails to compile on `main`:

```
error[E0063]: missing field `include_restricted` in initializer of `SearchFilters`
   --> tests/integration/pipeline_test.rs:165
```

#441 (consent Phase 2 Wave 2, `3abcdd4`) added `include_restricted` to `SearchFilters` and updated the in-crate/CLI usages, but missed this integration-test struct literal — which isn't in the fast CI path, so it slipped through. Add the field with the default `false` (exclude restricted meetings, matching `SearchFilters::default()`). Integration target compiles and runs again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)