### PR TITLE
feat(recall): token-level streaming in the chat panel

### DIFF
--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -949,7 +949,13 @@ pub fn build_chat_invocation(
         if let Some(pos) = args.iter().position(|a| a == "--output-format") {
             if args.get(pos + 1).map(String::as_str) == Some("text") {
                 args[pos + 1] = "stream-json".to_string();
+                // `--verbose` is required by claude's `--print` mode for
+                // stream-json; `--include-partial-messages` upgrades it from
+                // one complete assistant message at the end to token-level
+                // `content_block_delta` events, so the panel renders the reply
+                // as it generates instead of dumping it all at once.
                 args.insert(pos + 2, "--verbose".to_string());
+                args.insert(pos + 3, "--include-partial-messages".to_string());
             }
         }
     }
@@ -3586,6 +3592,8 @@ PARTICIPANTS:
             .windows(2)
             .any(|w| w[0] == "--output-format" && w[1] == "stream-json"));
         assert!(inv.args.iter().any(|a| a == "--verbose"));
+        // Token-level streaming so the panel renders as the reply generates.
+        assert!(inv.args.iter().any(|a| a == "--include-partial-messages"));
         assert!(!inv.args.iter().any(|a| a == "text"));
         // No bogus / removed flags, prompt travels on stdin not argv.
         assert!(!inv.args.iter().any(|a| a == "--no-interactive"));

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -11538,6 +11538,9 @@
     const recallChatSendBtn = document.getElementById('recall-chat-send');
     let currentAssistantBubble = null;
     let currentAssistantRaw = '';
+    // True once token-level deltas have rendered for the current turn, so the
+    // trailing complete `assistant` message isn't appended as a duplicate.
+    let currentAssistantStreamed = false;
     let chatListenersRegistered = false;
     let recallChatStreaming = false;
 
@@ -11871,6 +11874,7 @@
       if (recallChatMessages) recallChatMessages.replaceChildren();
       currentAssistantBubble = null;
       currentAssistantRaw = '';
+      currentAssistantStreamed = false;
       const jumpPill = document.getElementById('recall-chat-jump');
       if (jumpPill) jumpPill.style.display = 'none';
       try {
@@ -12006,10 +12010,25 @@
         const chunk = event.payload;
         updateRecallChatStatus(chunk);
         let text = '';
-        if (chunk && chunk.type === 'assistant' && chunk.message && chunk.message.content) {
-          // Streaming assistant turn: { type:"assistant", message:{ content:[{type:"text",text:"..."}] } }
-          for (const part of chunk.message.content) {
-            if (part.type === 'text') text += part.text;
+        if (chunk && chunk.type === 'stream_event' && chunk.event) {
+          // Token-level streaming (claude --include-partial-messages): render
+          // text as it generates instead of waiting for the whole reply. The
+          // complete `assistant` event that follows is then a duplicate and is
+          // skipped below (currentAssistantStreamed).
+          const ev = chunk.event;
+          if (ev.type === 'content_block_delta' && ev.delta && ev.delta.type === 'text_delta') {
+            text = ev.delta.text || '';
+            if (text) currentAssistantStreamed = true;
+          }
+        } else if (chunk && chunk.type === 'assistant' && chunk.message && chunk.message.content) {
+          // Complete assistant turn. When token deltas already streamed it in,
+          // its text is a duplicate — skip it (updateRecallChatStatus above
+          // still read any tool_use blocks for the grounding narration). Only
+          // used to render when partial streaming didn't run (fallback).
+          if (!currentAssistantStreamed) {
+            for (const part of chunk.message.content) {
+              if (part.type === 'text') text += part.text;
+            }
           }
         } else if (chunk && chunk.type === 'result' && typeof chunk.result === 'string') {
           // Final result event — use as fallback if the assistant bubble is still empty.
@@ -12072,6 +12091,7 @@
       currentAssistantBubble.className = 'chat-bubble chat-bubble-assistant streaming';
       currentAssistantBubble.dataset.status = 'thinking';
       currentAssistantRaw = '';
+      currentAssistantStreamed = false;
       recallChatMessages.appendChild(currentAssistantBubble);
       // Sending is a deliberate action — always drop to the bottom + clear the pill.
       scrollRecallChatToBottom();


### PR DESCRIPTION
The chat panel rendered the whole agent reply at once after a long "thinking…" wait — no token streaming like Claude Code/Codex. Root cause: the claude invocation used `--output-format stream-json` but not `--include-partial-messages`, so claude emitted one complete `assistant` message at the end.

Verified empirically against claude 2.1.207: `--include-partial-messages` produces `stream_event`/`content_block_delta`/`text_delta` events. This adds the flag (claude stream_json path only) and handles those deltas in the frontend, appending incrementally. The trailing complete `assistant` message is a duplicate, skipped via a per-turn `currentAssistantStreamed` flag (its tool_use blocks are still read for the grounding narration).

Reply now types out live. Recall-chat surface only — does **not** touch `live_transcript.rs` (no collision with the copilot work). Backend test asserts the flag; fmt clean; JS parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)