### PR TITLE
fix(capture): honor [recording].device in native call capture + never discard recoverable audio (#463)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,6 +3348,7 @@ dependencies = [
  "chrono",
  "dirs 6.0.0",
  "futures-util",
+ "hound",
  "libc",
  "minisign-verify",
  "minutes-core",

--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -377,7 +377,15 @@ pub(crate) enum SourceAwareDiarizationPlan {
     SilentSystemStem(StemPaths),
 }
 
-pub(crate) fn stem_has_audio(path: &Path) -> bool {
+/// Return true when a WAV stem contains detectable signal in any one-second
+/// window. The whole file is scanned for silent captures so callers do not
+/// confuse a full-duration digital-silence stem with usable audio.
+///
+/// This is public so the desktop's native-call queue and the core pipeline use
+/// exactly the same signal classifier. A file-size check is insufficient: a
+/// disconnected/default microphone can produce a correctly sized WAV whose
+/// samples are all digital silence (#463).
+pub fn stem_has_audio(path: &Path) -> bool {
     let Ok(reader) = hound::WavReader::open(path) else {
         return false;
     };
@@ -564,6 +572,25 @@ fn probe_stem_observed_signal<T>(
 }
 
 pub(crate) fn discover_stem_plan(audio_path: &Path) -> Option<SourceAwareDiarizationPlan> {
+    // A signal-aware native-call queue may hand the surviving system stem to
+    // the background worker directly (#463). Preserve the established
+    // system-stem-only diarization path instead of treating that WAV as an
+    // unrelated single-source recording.
+    if audio_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".system.wav"))
+        && stem_has_audio(audio_path)
+    {
+        tracing::warn!(
+            system = %audio_path.display(),
+            "processing surviving native-call system stem with system-only diarization"
+        );
+        return Some(SourceAwareDiarizationPlan::SystemStemOnly(
+            audio_path.to_path_buf(),
+        ));
+    }
+
     let stem = audio_path.file_stem()?.to_str()?;
     let dir = audio_path.parent()?;
     let voice = dir.join(format!("{}.voice.wav", stem));
@@ -1387,6 +1414,18 @@ fn diarize_system_stem_with_full_audio_fallback(
 ) -> Option<DiarizationResult> {
     if let Some(result) = run_engine(system_stem, config, resolved_engine) {
         return Some(result);
+    }
+
+    // Single-stem native-call recovery deliberately passes the survivor as
+    // both paths. Retrying the same PCM is pointless, and—more importantly—
+    // callers must never substitute the known-broken dual-track `.mov` after
+    // recovery selected a safe stem (#463).
+    if system_stem == audio_path {
+        tracing::warn!(
+            system_stem = %system_stem.display(),
+            "system-stem-only diarization failed; keeping the transcript unlabeled"
+        );
+        return None;
     }
 
     tracing::warn!(
@@ -3578,6 +3617,24 @@ mod tests {
     }
 
     #[test]
+    fn discover_stem_plan_keeps_system_only_path_for_direct_survivor() {
+        let dir = tempfile::tempdir().unwrap();
+        let system = dir.path().join("job-463.system.wav");
+        write_i16_wav(&system, 16_000, 1, 16_000, |frame, _| {
+            if frame % 16 < 8 {
+                8_000
+            } else {
+                -8_000
+            }
+        });
+
+        assert!(matches!(
+            discover_stem_plan(&system),
+            Some(SourceAwareDiarizationPlan::SystemStemOnly(path)) if path == system
+        ));
+    }
+
+    #[test]
     fn system_stem_only_falls_back_to_full_audio_when_engine_fails() {
         let config = Config::default();
         let system_stem = Path::new("/tmp/call.system.wav");
@@ -3618,6 +3675,27 @@ mod tests {
             vec![system_stem.to_path_buf(), audio.to_path_buf()]
         );
         assert_eq!(result.unwrap().segments[0].speaker, "SPEAKER_0");
+    }
+
+    #[test]
+    fn recovered_system_stem_engine_failure_never_reopens_original_mov() {
+        let config = Config::default();
+        let system_stem = Path::new("/tmp/call.system.wav");
+        let mut attempted_paths = Vec::new();
+
+        let result = diarize_system_stem_with_full_audio_fallback(
+            system_stem,
+            system_stem,
+            &config,
+            "test-engine",
+            |path, _config, _engine| {
+                attempted_paths.push(path.to_path_buf());
+                None
+            },
+        );
+
+        assert!(result.is_none());
+        assert_eq!(attempted_paths, vec![system_stem.to_path_buf()]);
     }
 
     #[test]

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -169,6 +169,61 @@ pub fn recording_health_for_system_audio_probe_failure(
     }
 }
 
+pub const NATIVE_CALL_MICROPHONE_RECOVERY_CODE: &str = "native-call-microphone-stem-recovery";
+pub const NATIVE_CALL_SYSTEM_RECOVERY_CODE: &str = "native-call-system-stem-recovery";
+pub const NATIVE_CALL_CAPTURE_WARNING_CODE: &str = "native-call-capture-warning";
+
+/// Describe a native call recovered from only one usable PCM stem.
+///
+/// `surviving_source` is the audio that will actually be transcribed. Keeping
+/// that convention consistent makes the frontmatter useful to both people and
+/// automated recovery tooling.
+pub fn recording_health_for_native_call_stem_recovery(
+    surviving_source: CaptureSource,
+) -> RecordingHealth {
+    let (code, message) = match surviving_source {
+        CaptureSource::System => (
+            NATIVE_CALL_MICROPHONE_RECOVERY_CODE,
+            "Microphone audio was missing or silent; the probable cause is microphone device selection or permission. This transcript contains call/remote audio only.",
+        ),
+        CaptureSource::Voice => (
+            NATIVE_CALL_SYSTEM_RECOVERY_CODE,
+            "Call/remote audio was missing or silent. This transcript contains local microphone audio only.",
+        ),
+        CaptureSource::Both | CaptureSource::Backend => (
+            NATIVE_CALL_CAPTURE_WARNING_CODE,
+            "Native call capture was degraded, but recoverable audio was preserved.",
+        ),
+    };
+
+    RecordingHealth {
+        voice_stem_active_ratio: None,
+        system_stem_active_ratio: None,
+        system_dominant_ratio: None,
+        capture_warnings: vec![CaptureWarning {
+            kind: FailureKind::Other { code: code.into() },
+            source: surviving_source,
+            message: message.into(),
+            diagnostic_confidence: DiagnosticConfidence::Inferred,
+        }],
+        diarization_path: Some(DiarizationPath::None),
+    }
+}
+
+pub fn append_native_call_capture_warning(
+    health: &mut RecordingHealth,
+    message: impl Into<String>,
+) {
+    health.capture_warnings.push(CaptureWarning {
+        kind: FailureKind::Other {
+            code: NATIVE_CALL_CAPTURE_WARNING_CODE.into(),
+        },
+        source: CaptureSource::Both,
+        message: message.into(),
+        diagnostic_confidence: DiagnosticConfidence::Inferred,
+    });
+}
+
 /// Check if the whisper model is downloaded and ready.
 pub fn model_status(config: &Config) -> HealthItem {
     if config.transcription.engine == "parakeet" {

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -195,9 +195,15 @@ pub fn queue_live_capture_with_recording_health(
     recording_health: Option<crate::markdown::RecordingHealth>,
 ) -> std::io::Result<ProcessingJob> {
     let job_id = next_job_id();
-    let old_screen_dir = crate::screen::screens_dir_for(current_wav);
+    let old_screen_anchor = native_stem_group_for_survivor(current_wav)
+        .map(|group| group.anchor)
+        .unwrap_or_else(|| current_wav.to_path_buf());
+    let old_screen_dir = crate::screen::screens_dir_for(&old_screen_anchor);
     let audio_path = move_capture_into_job(&job_id, current_wav)?;
-    let new_screen_dir = crate::screen::screens_dir_for(&audio_path);
+    let new_screen_anchor = native_stem_group_for_survivor(&audio_path)
+        .map(|group| group.anchor)
+        .unwrap_or_else(|| audio_path.clone());
+    let new_screen_dir = crate::screen::screens_dir_for(&new_screen_anchor);
     let job = ProcessingJob {
         id: job_id,
         mode,
@@ -228,8 +234,7 @@ pub fn queue_live_capture_with_recording_health(
     };
     if let Err(error) = write_job(&job) {
         if audio_path.exists() {
-            fs::rename(&audio_path, current_wav).ok();
-            move_stems_with_audio(&audio_path, current_wav).ok();
+            move_capture_artifacts(&audio_path, current_wav).ok();
         }
         if new_screen_dir.exists() {
             if old_screen_dir.exists() {
@@ -280,12 +285,100 @@ pub fn job_capture_path(job_id: &str) -> PathBuf {
 }
 
 fn job_capture_path_for_source(job_id: &str, source: &Path) -> PathBuf {
+    if let Some(role) = native_stem_role(source) {
+        return jobs_dir().join(format!("{}.{}.wav", job_id, role));
+    }
     let ext = source
         .extension()
         .and_then(|value| value.to_str())
         .filter(|value| !value.is_empty())
         .unwrap_or("wav");
     jobs_dir().join(format!("{}.{}", job_id, ext))
+}
+
+#[derive(Debug, Clone)]
+struct NativeStemGroup {
+    anchor: PathBuf,
+    voice: PathBuf,
+    system: PathBuf,
+}
+
+fn native_stem_role(path: &Path) -> Option<&'static str> {
+    let name = path.file_name()?.to_str()?;
+    if name.ends_with(".voice.wav") {
+        Some("voice")
+    } else if name.ends_with(".system.wav") {
+        Some("system")
+    } else {
+        None
+    }
+}
+
+fn native_stem_group_for_survivor(path: &Path) -> Option<NativeStemGroup> {
+    let role = native_stem_role(path)?;
+    let name = path.file_name()?.to_str()?;
+    let suffix = format!(".{role}.wav");
+    let base = name.strip_suffix(&suffix)?;
+    let dir = path.parent()?;
+    Some(NativeStemGroup {
+        anchor: dir.join(format!("{base}.mov")),
+        voice: dir.join(format!("{base}.voice.wav")),
+        system: dir.join(format!("{base}.system.wav")),
+    })
+}
+
+fn move_native_stem_group(src_primary: &Path, dest_primary: &Path) -> std::io::Result<()> {
+    if !src_primary.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("native-call survivor is missing: {}", src_primary.display()),
+        ));
+    }
+    let src = native_stem_group_for_survivor(src_primary).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("not a native-call stem path: {}", src_primary.display()),
+        )
+    })?;
+    let dest = native_stem_group_for_survivor(dest_primary).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("not a native-call destination: {}", dest_primary.display()),
+        )
+    })?;
+    let pairs = [
+        (src.anchor, dest.anchor),
+        (src.voice, dest.voice),
+        (src.system, dest.system),
+    ];
+    let mut moved = Vec::new();
+    for (source, destination) in pairs {
+        if !source.exists() {
+            continue;
+        }
+        if let Err(error) = fs::rename(&source, &destination) {
+            for (rollback_source, rollback_destination) in moved.into_iter().rev() {
+                fs::rename(rollback_destination, rollback_source).ok();
+            }
+            return Err(error);
+        }
+        moved.push((source, destination));
+    }
+    Ok(())
+}
+
+fn move_capture_artifacts(src_audio: &Path, dest_audio: &Path) -> std::io::Result<()> {
+    if native_stem_role(src_audio).is_some() {
+        return move_native_stem_group(src_audio, dest_audio);
+    }
+
+    fs::rename(src_audio, dest_audio)?;
+    if let Err(error) = move_stems_with_audio(src_audio, dest_audio) {
+        fs::rename(dest_audio, src_audio).ok();
+        move_stems_with_audio(dest_audio, src_audio).ok();
+        return Err(error);
+    }
+    Ok(())
 }
 
 pub fn create_worker_guard() -> Result<PidGuard, crate::error::PidError> {
@@ -308,27 +401,51 @@ pub fn worker_active() -> bool {
 }
 
 pub fn move_capture_into_job(job_id: &str, current_wav: &Path) -> std::io::Result<PathBuf> {
+    move_capture_into_job_with_screen_mover(job_id, current_wav, |source, destination| {
+        fs::rename(source, destination)
+    })
+}
+
+fn move_capture_into_job_with_screen_mover(
+    job_id: &str,
+    current_wav: &Path,
+    mut move_screen_dir: impl FnMut(&Path, &Path) -> std::io::Result<()>,
+) -> std::io::Result<PathBuf> {
     let dest = job_capture_path_for_source(job_id, current_wav);
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::rename(current_wav, &dest)?;
-    if let Err(error) = move_stems_with_audio(current_wav, &dest) {
-        fs::rename(&dest, current_wav).ok();
-        move_stems_with_audio(&dest, current_wav).ok();
-        return Err(error);
-    }
+    move_capture_artifacts(current_wav, &dest)?;
 
-    let old_screen_dir = crate::screen::screens_dir_for(current_wav);
+    let screen_source = native_stem_group_for_survivor(current_wav)
+        .map(|group| group.anchor)
+        .unwrap_or_else(|| current_wav.to_path_buf());
+    let screen_dest = native_stem_group_for_survivor(&dest)
+        .map(|group| group.anchor)
+        .unwrap_or_else(|| dest.clone());
+    let old_screen_dir = crate::screen::screens_dir_for(&screen_source);
     if old_screen_dir.exists() {
-        let new_screen_dir = crate::screen::screens_dir_for(&dest);
-        if let Some(parent) = new_screen_dir.parent() {
-            fs::create_dir_all(parent)?;
+        let new_screen_dir = crate::screen::screens_dir_for(&screen_dest);
+        let screen_move_result = (|| -> std::io::Result<()> {
+            if let Some(parent) = new_screen_dir.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            if new_screen_dir.exists() {
+                fs::remove_dir_all(&new_screen_dir)?;
+            }
+            move_screen_dir(&old_screen_dir, &new_screen_dir)
+        })();
+        if let Err(error) = screen_move_result {
+            if let Err(rollback_error) = move_capture_artifacts(&dest, current_wav) {
+                tracing::error!(
+                    source = %dest.display(),
+                    destination = %current_wav.display(),
+                    error = %rollback_error,
+                    "failed to roll capture artifacts back after screen-directory move failure"
+                );
+            }
+            return Err(error);
         }
-        if new_screen_dir.exists() {
-            fs::remove_dir_all(&new_screen_dir).ok();
-        }
-        fs::rename(old_screen_dir, new_screen_dir)?;
     }
 
     Ok(dest)
@@ -1036,10 +1153,19 @@ where
 
 pub fn remove_capture_artifacts(job: &ProcessingJob) {
     let audio_path = PathBuf::from(&job.audio_path);
-    if audio_path.exists() {
+    let screen_anchor = native_stem_group_for_survivor(&audio_path)
+        .map(|group| group.anchor)
+        .unwrap_or_else(|| audio_path.clone());
+    if let Some(group) = native_stem_group_for_survivor(&audio_path) {
+        for path in [group.anchor, group.voice, group.system] {
+            if path.exists() {
+                fs::remove_file(path).ok();
+            }
+        }
+    } else if audio_path.exists() {
         fs::remove_file(&audio_path).ok();
     }
-    let screens_dir = crate::screen::screens_dir_for(&audio_path);
+    let screens_dir = crate::screen::screens_dir_for(&screen_anchor);
     if screens_dir.exists() {
         fs::remove_dir_all(screens_dir).ok();
     }
@@ -1053,6 +1179,20 @@ fn terminal_state_for_artifact(artifact: &pipeline::TranscriptArtifact) -> JobSt
     }
 }
 
+fn apply_transcript_artifact_metadata(
+    job: &mut ProcessingJob,
+    artifact: &pipeline::TranscriptArtifact,
+) {
+    job.output_path = Some(artifact.write_result.path.display().to_string());
+    job.title = Some(artifact.write_result.title.clone());
+    job.word_count = Some(artifact.write_result.word_count);
+    // Core-only `.mov` recovery discovers degradation after the job was
+    // queued, so the artifact is authoritative. Persist it back to the job;
+    // the desktop completion notice reads this field rather than reparsing
+    // Markdown (#463).
+    job.recording_health = artifact.frontmatter.recording_health.clone();
+}
+
 /// Move the captured audio alongside the output markdown so users can reprocess later.
 /// e.g. ~/meetings/2026-04-02-standup.md → ~/meetings/2026-04-02-standup.wav
 /// or, for native call captures, ~/meetings/2026-04-02-call.mov.
@@ -1063,6 +1203,56 @@ fn preserve_audio_alongside_output(job: &ProcessingJob, config: &Config) {
     let output = PathBuf::from(output_path);
     let audio_src = PathBuf::from(&job.audio_path);
     if !audio_src.exists() {
+        return;
+    }
+    if let Some(role) = native_stem_role(&audio_src) {
+        let audio_dest = output.with_extension(format!("{role}.wav"));
+        let Some(src_group) = native_stem_group_for_survivor(&audio_src) else {
+            return;
+        };
+        let Some(dest_group) = native_stem_group_for_survivor(&audio_dest) else {
+            return;
+        };
+        let source_screens_dir = crate::screen::screens_dir_for(&src_group.anchor);
+        let preserved_anchor = dest_group.anchor.clone();
+        for (src, dest) in [
+            (src_group.anchor, dest_group.anchor),
+            (src_group.voice, dest_group.voice),
+            (src_group.system, dest_group.system),
+        ] {
+            if !src.exists() {
+                continue;
+            }
+            if let Err(rename_error) = fs::rename(&src, &dest) {
+                if let Err(copy_error) = fs::copy(&src, &dest) {
+                    tracing::warn!(
+                        src = %src.display(),
+                        dest = %dest.display(),
+                        error = %copy_error,
+                        "failed to preserve native-call artifact (rename: {rename_error})"
+                    );
+                    continue;
+                }
+                fs::remove_file(&src).ok();
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&dest, fs::Permissions::from_mode(0o600)).ok();
+            }
+        }
+        if !config.screen_context.keep_after_summary && source_screens_dir.exists() {
+            fs::remove_dir_all(source_screens_dir).ok();
+        }
+        update_job_state(&job.id, |j| {
+            j.audio_path = audio_dest.display().to_string();
+        })
+        .ok();
+        tracing::info!(
+            path = %preserved_anchor.display(),
+            survivor = %audio_dest.display(),
+            "preserved native-call capture group alongside transcript"
+        );
         return;
     }
     let audio_dest = match audio_src.extension().filter(|ext| !ext.is_empty()) {
@@ -1281,9 +1471,7 @@ where
             let Some(review_job) = update_job_state(&job.id, |job| {
                 job.state = terminal_state;
                 job.stage = terminal_state.default_stage();
-                job.output_path = Some(artifact.write_result.path.display().to_string());
-                job.title = Some(artifact.write_result.title.clone());
-                job.word_count = Some(artifact.write_result.word_count);
+                apply_transcript_artifact_metadata(job, &artifact);
                 job.finished_at = Some(Local::now());
                 job.owner_pid = None;
                 job.error = Some(
@@ -1319,9 +1507,7 @@ where
         let Some(updated_job) = update_job_state(&job.id, |job| {
             job.state = JobState::TranscriptOnly;
             job.stage = JobState::TranscriptOnly.default_stage();
-            job.output_path = Some(artifact.write_result.path.display().to_string());
-            job.title = Some(artifact.write_result.title.clone());
-            job.word_count = Some(artifact.write_result.word_count);
+            apply_transcript_artifact_metadata(job, &artifact);
         })?
         else {
             sync_processing_status();
@@ -1380,6 +1566,7 @@ where
                     job.output_path = Some(result.path.display().to_string());
                     job.title = Some(result.title.clone());
                     job.word_count = Some(result.word_count);
+                    job.recording_health = artifact.frontmatter.recording_health.clone();
                     job.finished_at = Some(Local::now());
                     job.owner_pid = None;
                 })?
@@ -1570,6 +1757,116 @@ mod tests {
             assert!(moved_stems.system.exists());
             assert!(!stems.voice.exists());
             assert!(!stems.system.exists());
+        });
+    }
+
+    #[test]
+    fn queueing_surviving_native_stem_keeps_and_preserves_capture_group() {
+        with_temp_home(|tmp| {
+            let native_dir = tmp.path().join(".minutes/native-captures");
+            fs::create_dir_all(&native_dir).unwrap();
+            let anchor = native_dir.join("2026-07-15-120148-call.mov");
+            let voice = native_dir.join("2026-07-15-120148-call.voice.wav");
+            let system = native_dir.join("2026-07-15-120148-call.system.wav");
+            fs::write(&anchor, b"mov-anchor").unwrap();
+            fs::write(&voice, b"silent-mic-placeholder").unwrap();
+            fs::write(&system, b"recoverable-system-audio").unwrap();
+
+            let mut job = queue_live_capture(
+                CaptureMode::Meeting,
+                Some("Recovered native call".into()),
+                &system,
+                None,
+                None,
+                Some(Local::now()),
+                Some(Local::now()),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+            let queued_system = PathBuf::from(&job.audio_path);
+            assert!(queued_system
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".system.wav")));
+            let queued_group = native_stem_group_for_survivor(&queued_system).unwrap();
+            assert!(
+                queued_group.anchor.exists(),
+                ".mov anchor must follow survivor"
+            );
+            assert!(
+                queued_group.voice.exists(),
+                "silent mic stem must remain recoverable"
+            );
+            assert!(
+                queued_group.system.exists(),
+                "surviving stem must be queued"
+            );
+            assert!(!anchor.exists());
+            assert!(!voice.exists());
+            assert!(!system.exists());
+
+            let output_path = tmp.path().join("meetings/recovered.md");
+            fs::create_dir_all(output_path.parent().unwrap()).unwrap();
+            fs::write(&output_path, "# recovered").unwrap();
+            job.output_path = Some(output_path.display().to_string());
+            preserve_audio_alongside_output(&job, &Config::default());
+
+            let preserved_anchor = output_path.with_extension("mov");
+            let preserved_stems = crate::capture::stem_paths_for(&preserved_anchor).unwrap();
+            assert!(preserved_anchor.exists());
+            assert!(preserved_stems.voice.exists());
+            assert!(preserved_stems.system.exists());
+            assert!(!queued_group.anchor.exists());
+            assert!(!queued_group.voice.exists());
+            assert!(!queued_group.system.exists());
+        });
+    }
+
+    #[test]
+    fn screen_move_failure_rolls_surviving_native_group_back_before_queue() {
+        with_temp_home(|tmp| {
+            let native_dir = tmp.path().join(".minutes/native-captures");
+            fs::create_dir_all(&native_dir).unwrap();
+            let anchor = native_dir.join("screen-rollback.mov");
+            let voice = native_dir.join("screen-rollback.voice.wav");
+            let system = native_dir.join("screen-rollback.system.wav");
+            fs::write(&anchor, b"mov-anchor").unwrap();
+            fs::write(&voice, b"silent-mic-placeholder").unwrap();
+            fs::write(&system, b"recoverable-system-audio").unwrap();
+            let old_screens = crate::screen::screens_dir_for(&anchor);
+            fs::create_dir_all(&old_screens).unwrap();
+            fs::write(old_screens.join("source.png"), b"source").unwrap();
+
+            let job_id = "screen-move-failure";
+            let queued_system = job_capture_path_for_source(job_id, &system);
+            let queued_group = native_stem_group_for_survivor(&queued_system).unwrap();
+            let error = move_capture_into_job_with_screen_mover(
+                job_id,
+                &system,
+                |_source, _destination| {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "injected screen move failure",
+                    ))
+                },
+            )
+            .expect_err("injected screen move must fail the queue operation");
+
+            assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+            assert!(anchor.exists(), ".mov anchor must roll back");
+            assert!(voice.exists(), "voice stem must roll back");
+            assert!(system.exists(), "surviving system stem must roll back");
+            assert!(!queued_group.anchor.exists());
+            assert!(!queued_group.voice.exists());
+            assert!(!queued_group.system.exists());
+            assert!(old_screens.join("source.png").exists());
+            assert!(
+                !job_path(job_id).exists(),
+                "no manifest may exist for a rolled-back queue"
+            );
         });
     }
 
@@ -1886,6 +2183,7 @@ mod tests {
                 filter_diagnosis: Some("silence strip removed ALL audio".into()),
             },
             transcript: String::new(),
+            diarization_audio_path: None,
         };
 
         assert_eq!(
@@ -2275,6 +2573,80 @@ mod tests {
             owner_pid: None,
             retry_count: 0,
         }
+    }
+
+    fn make_test_artifact(
+        id: &str,
+        status: OutputStatus,
+        recording_health: Option<crate::markdown::RecordingHealth>,
+    ) -> pipeline::TranscriptArtifact {
+        pipeline::TranscriptArtifact {
+            write_result: WriteResult {
+                path: PathBuf::from(format!("/tmp/{id}.md")),
+                title: format!("title-{id}"),
+                word_count: 42,
+                content_type: ContentType::Meeting,
+            },
+            frontmatter: Frontmatter {
+                title: format!("title-{id}"),
+                r#type: ContentType::Meeting,
+                date: Local::now(),
+                duration: "5m".into(),
+                source: None,
+                status: Some(status),
+                tags: vec![],
+                attendees: vec![],
+                attendees_raw: None,
+                calendar_event: None,
+                people: vec![],
+                entities: crate::markdown::EntityLinks::default(),
+                device: None,
+                captured_at: None,
+                context: None,
+                action_items: vec![],
+                decisions: vec![],
+                intents: vec![],
+                recorded_by: None,
+                capture: None,
+                sensitivity: None,
+                debrief: None,
+                consent: None,
+                consent_notice: None,
+                visibility: None,
+                speaker_map: vec![],
+                name_corrections: Vec::new(),
+                recording_health,
+                speaker_mapping: None,
+                processing_warnings: Vec::new(),
+                template: None,
+                filter_diagnosis: None,
+            },
+            transcript: "[0:00] recovered call audio".into(),
+            diarization_audio_path: None,
+        }
+    }
+
+    #[test]
+    fn legacy_recovery_job_persists_artifact_health_for_completion_notice() {
+        let health = crate::health::recording_health_for_native_call_stem_recovery(
+            crate::diarize::CaptureSource::System,
+        );
+        let artifact = make_test_artifact(
+            "legacy-recovered-mov",
+            OutputStatus::Degraded,
+            Some(health.clone()),
+        );
+        let mut job = make_test_job("legacy-recovered-mov", JobState::Transcribing);
+        assert!(job.recording_health.is_none());
+
+        apply_transcript_artifact_metadata(&mut job, &artifact);
+
+        assert_eq!(job.recording_health, Some(health));
+        assert!(job
+            .recording_health
+            .as_ref()
+            .and_then(|health| health.capture_warnings.first())
+            .is_some_and(|warning| warning.message.contains("call/remote audio only")));
     }
 
     #[test]

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -191,15 +191,29 @@ fn detect_summarization_warnings(
 
 const SILENT_REMOTE_WARNING_MESSAGE: &str =
     "Call/remote audio was not captured (system stem silent); transcript reflects only your microphone";
+const SILENT_MICROPHONE_WARNING_MESSAGE: &str =
+    "Microphone audio was not captured (mic stem silent or missing); transcript reflects only call/remote audio";
 
 fn warning_is_native_call_system_stem_recovery(warning: &markdown::CaptureWarning) -> bool {
     match &warning.kind {
-        diarize::FailureKind::Other { code } if code == "native-call-stem-recovery" => warning
-            .message
-            .to_ascii_lowercase()
-            .contains("system-audio stem"),
+        diarize::FailureKind::Other { code } => {
+            code == crate::health::NATIVE_CALL_SYSTEM_RECOVERY_CODE
+                || (code == "native-call-stem-recovery"
+                    && warning
+                        .message
+                        .to_ascii_lowercase()
+                        .contains("system-audio stem"))
+        }
         _ => false,
     }
+}
+
+fn warning_is_native_call_microphone_stem_recovery(warning: &markdown::CaptureWarning) -> bool {
+    matches!(
+        &warning.kind,
+        diarize::FailureKind::Other { code }
+            if code == crate::health::NATIVE_CALL_MICROPHONE_RECOVERY_CODE
+    )
 }
 
 fn detect_silent_remote_stem_warning(
@@ -213,21 +227,29 @@ fn detect_silent_remote_stem_warning(
     }
 
     let health = recording_health?;
-    let native_call_lost_system = health
+    if health
         .capture_warnings
         .iter()
-        .any(warning_is_native_call_system_stem_recovery);
-
-    if !native_call_lost_system {
-        return None;
+        .any(warning_is_native_call_microphone_stem_recovery)
+    {
+        return Some(ProcessingWarning {
+            step: "capture".to_string(),
+            reason: "microphone_audio_not_captured".to_string(),
+            timeout_secs: None,
+            message: Some(SILENT_MICROPHONE_WARNING_MESSAGE.to_string()),
+        });
     }
 
-    Some(ProcessingWarning {
-        step: "capture".to_string(),
-        reason: "remote_audio_not_captured".to_string(),
-        timeout_secs: None,
-        message: Some(SILENT_REMOTE_WARNING_MESSAGE.to_string()),
-    })
+    health
+        .capture_warnings
+        .iter()
+        .any(warning_is_native_call_system_stem_recovery)
+        .then(|| ProcessingWarning {
+            step: "capture".to_string(),
+            reason: "remote_audio_not_captured".to_string(),
+            timeout_secs: None,
+            message: Some(SILENT_REMOTE_WARNING_MESSAGE.to_string()),
+        })
 }
 
 /// Result of Level 2 voice enrollment matching.
@@ -602,6 +624,41 @@ impl Drop for MixedStemTempFile {
     }
 }
 
+enum PreparedTranscriptionInput {
+    Original,
+    Mixed(MixedStemTempFile),
+    SingleStem {
+        path: std::path::PathBuf,
+        recording_health: markdown::RecordingHealth,
+    },
+}
+
+impl PreparedTranscriptionInput {
+    fn as_path<'a>(&'a self, original: &'a Path) -> &'a Path {
+        match self {
+            Self::Original => original,
+            Self::Mixed(handle) => handle.as_path(),
+            Self::SingleStem { path, .. } => path,
+        }
+    }
+
+    fn recording_health(&self) -> Option<&markdown::RecordingHealth> {
+        match self {
+            Self::SingleStem {
+                recording_health, ..
+            } => Some(recording_health),
+            Self::Original | Self::Mixed(_) => None,
+        }
+    }
+
+    fn diarization_audio_path(&self) -> Option<&Path> {
+        match self {
+            Self::SingleStem { path, .. } => Some(path),
+            Self::Original | Self::Mixed(_) => None,
+        }
+    }
+}
+
 /// Prepare the input handed to the transcription coordinator, working around
 /// the macOS 26 SCRecordingOutput dual-track `.mov` 2x decode bug (#234).
 ///
@@ -610,22 +667,25 @@ impl Drop for MixedStemTempFile {
 /// the `.mov` for transcription produces audio at 2x real duration, so whisper
 /// receives garbled samples and emits gibberish. When the stems are present and
 /// valid, this helper mixes them into a 16kHz mono PCM via `ffmpeg amix` and
-/// returns a `MixedStemTempFile` for the caller to hand to the transcriber;
-/// the handle's `Drop` impl cleans up the temp file on success, Err, panic, or
-/// any future early-return.
+/// returns a prepared input for the caller to hand to the transcriber. When
+/// both stems are usable, the mixed handle's `Drop` impl cleans up the temp
+/// file on success, Err, panic, or any future early-return. When exactly one
+/// stem is usable, the surviving PCM is returned directly with explicit
+/// degraded recording health; it is never deleted by this helper (#463).
 ///
 /// Return contract:
-/// - `Ok(None)` — input does not need stem-mixing. Either it is not a `.mov`,
+/// - `Ok(Original)` — input does not need stem-mixing. Either it is not a `.mov`,
 ///   or it is a `.mov` with no sibling stems at all (treated as an ordinary
 ///   non-native-call container; the caller hands the original path to the
 ///   transcriber and accepts whatever the decoder does with it).
-/// - `Ok(Some(handle))` — input is a native-call `.mov` and stems mixed cleanly.
+/// - `Ok(Mixed(handle))` — both native-call stems mixed cleanly.
+/// - `Ok(SingleStem { .. })` — exactly one native-call stem contains signal;
+///   transcribe it directly and surface the attached health warning.
 /// - `Err(MinutesError::Transcribe(NativeCaptureStemMixUnavailable))` — input is
-///   a native-call `.mov` (one or both stems present, indicating a SCRecording-
-///   Output capture) but the mix cannot be produced. This is the "should-have-
-///   mixed-but-couldn't" case from PR #235 review item #4: silent fallback to
-///   the broken `.mov` decode would re-enter exactly the bug this helper exists
-///   to prevent, so the caller is forced to propagate.
+///   a native-call `.mov` whose sibling stem files exist but neither contains
+///   usable signal, or whose two valid stems cannot be mixed. Falling back to
+///   the broken `.mov` decode would re-enter the 2x bug, so that case remains a
+///   clear failure.
 ///
 /// Path handling: the `.mov` is canonicalized before stem lookup so a symlinked
 /// recording resolves to its target before sibling lookup (#237 touched the
@@ -634,7 +694,7 @@ impl Drop for MixedStemTempFile {
 /// a single source of truth governs which side files count as "stems present".
 fn prepare_transcription_input(
     audio_path: &Path,
-) -> Result<Option<MixedStemTempFile>, MinutesError> {
+) -> Result<PreparedTranscriptionInput, MinutesError> {
     // Only `.mov` containers can hit the 2x decode bug. Everything else is
     // either a clean PCM wav (Jake's manual reprocess flow), a single-stream
     // m4a/mp3/ogg (voice memos), or a format that does not exercise the
@@ -644,7 +704,7 @@ fn prepare_transcription_input(
         .and_then(|e| e.to_str())
         .map(|s| s.to_lowercase());
     if ext.as_deref() != Some("mov") {
-        return Ok(None);
+        return Ok(PreparedTranscriptionInput::Original);
     }
 
     // Canonicalize so a symlinked `.mov` resolves to its target before stem
@@ -666,30 +726,31 @@ fn prepare_transcription_input(
     let stems = match plan {
         Some(crate::diarize::SourceAwareDiarizationPlan::FullStems(paths)) => paths,
         Some(crate::diarize::SourceAwareDiarizationPlan::SystemStemOnly(system)) => {
-            return Err(
-                crate::error::TranscribeError::NativeCaptureStemMixUnavailable {
-                    reason: format!(
-                        "voice stem missing or empty for {} (system stem present at {}). \
-                     Cannot mix to PCM; recording is unrecoverable without the mic side.",
-                        canonical.display(),
-                        system.display()
-                    ),
-                }
-                .into(),
+            tracing::warn!(
+                audio = %canonical.display(),
+                system = %system.display(),
+                "microphone stem is missing or silent; transcribing surviving system stem"
             );
+            return Ok(PreparedTranscriptionInput::SingleStem {
+                path: system,
+                recording_health: crate::health::recording_health_for_native_call_stem_recovery(
+                    crate::diarize::CaptureSource::System,
+                ),
+            });
         }
         Some(crate::diarize::SourceAwareDiarizationPlan::SilentSystemStem(paths)) => {
-            return Err(
-                crate::error::TranscribeError::NativeCaptureStemMixUnavailable {
-                    reason: format!(
-                        "system stem at {} is empty (voice stem present at {}). \
-                     Partial-crash signature; mix would substitute silence for the far-side audio.",
-                        paths.system.display(),
-                        paths.voice.display()
-                    ),
-                }
-                .into(),
+            tracing::warn!(
+                audio = %canonical.display(),
+                voice = %paths.voice.display(),
+                system = %paths.system.display(),
+                "system stem is missing or silent; transcribing surviving microphone stem"
             );
+            return Ok(PreparedTranscriptionInput::SingleStem {
+                path: paths.voice,
+                recording_health: crate::health::recording_health_for_native_call_stem_recovery(
+                    crate::diarize::CaptureSource::Voice,
+                ),
+            });
         }
         None => {
             // `discover_stem_plan` returns None for two semantically different
@@ -703,24 +764,34 @@ fn prepare_transcription_input(
             // exact 2x-duration bug this helper exists to prevent. Codex
             // review of PR #235 v2 caught this.
             //
-            // Distinguish by independently checking for a usable sibling
-            // voice stem. If one exists, surface the same typed error as
-            // the other should-have-mixed-but-couldn't branches.
+            // Distinguish by independently checking the sibling paths. A
+            // usable voice stem is recoverable even when the system file is
+            // absent. If either sibling exists but neither has signal, this
+            // is definitely a native capture and must fail clearly instead
+            // of decoding the known-broken dual-track `.mov`.
             if let Some(parent) = canonical.parent() {
                 if let Some(stem_name) = canonical.file_stem().and_then(|s| s.to_str()) {
                     let voice = parent.join(format!("{}.voice.wav", stem_name));
-                    if voice.exists() && crate::diarize::stem_has_audio(&voice) {
-                        return Err(
-                            crate::error::TranscribeError::NativeCaptureStemMixUnavailable {
-                                reason: format!(
-                                    "voice stem present at {} but system stem is missing from disk. \
-                                     Partial-crash signature; mix would substitute silence for the \
-                                     far-side audio.",
-                                    voice.display()
+                    let system = parent.join(format!("{}.system.wav", stem_name));
+                    if crate::diarize::stem_has_audio(&voice) {
+                        return Ok(PreparedTranscriptionInput::SingleStem {
+                            path: voice,
+                            recording_health:
+                                crate::health::recording_health_for_native_call_stem_recovery(
+                                    crate::diarize::CaptureSource::Voice,
                                 ),
-                            }
-                            .into(),
-                        );
+                        });
+                    }
+                    if voice.exists() || system.exists() {
+                        return Err(crate::error::TranscribeError::NativeCaptureStemMixUnavailable {
+                            reason: format!(
+                                "native call capture at {} has no usable PCM stem: voice={}, system={}. Both stems are missing, empty, invalid, or digitally silent.",
+                                canonical.display(),
+                                voice.display(),
+                                system.display()
+                            ),
+                        }
+                        .into());
                     }
                 }
             }
@@ -730,7 +801,7 @@ fn prepare_transcription_input(
             // treat as ordinary `.mov` and let the existing decoder handle
             // it. Hard-erroring on every stemless `.mov` would break
             // legitimate non-native-call use cases.
-            return Ok(None);
+            return Ok(PreparedTranscriptionInput::Original);
         }
     };
 
@@ -862,7 +933,9 @@ fn prepare_transcription_input(
         mixed = %tmp.display(),
         "using mixed stems instead of .mov for transcription (workaround for dual-track 2x bug)"
     );
-    Ok(Some(MixedStemTempFile { path: tmp }))
+    Ok(PreparedTranscriptionInput::Mixed(MixedStemTempFile {
+        path: tmp,
+    }))
 }
 
 fn log_attribution_decision(
@@ -1312,6 +1385,10 @@ pub struct TranscriptArtifact {
     pub write_result: WriteResult,
     pub frontmatter: Frontmatter,
     pub transcript: String,
+    /// Signal-verified surviving native-call stem selected during
+    /// transcription. Diarization must reuse it rather than reopening the
+    /// dual-track `.mov` that recovery deliberately bypassed.
+    pub diarization_audio_path: Option<std::path::PathBuf>,
 }
 
 /// Optional metadata from a sidecar JSON file (e.g., from iPhone Apple Shortcut).
@@ -1464,13 +1541,14 @@ pub fn transcribe_to_artifact(
     // so background-job and `minutes process` callers (which reach the
     // pipeline via `transcribe_to_artifact` and bypass the foreground
     // entry point) are not exposed to the macOS 26 dual-track `.mov` 2x
-    // bug. The MixedStemTempFile handle's Drop impl cleans up the temp PCM
-    // on success, on Err propagation, or on panic. #235 review item #6.
-    let mixed_stem_path = prepare_transcription_input(audio_path)?;
-    let transcribe_input = mixed_stem_path
-        .as_ref()
-        .map(|f| f.as_path())
-        .unwrap_or(audio_path);
+    // bug. A mixed temp handle cleans itself up; a single surviving stem is
+    // borrowed in place and contributes explicit recording health (#463).
+    let prepared_input = prepare_transcription_input(audio_path)?;
+    let prepared_recording_health = prepared_input.recording_health().cloned();
+    let diarization_audio_path = prepared_input
+        .diarization_audio_path()
+        .map(Path::to_path_buf);
+    let transcribe_input = prepared_input.as_path(audio_path);
     let step_start = std::time::Instant::now();
     let result = crate::transcription_coordinator::transcribe_path_for_content_with_hints(
         transcribe_input,
@@ -1479,7 +1557,7 @@ pub fn transcribe_to_artifact(
         decode_hints,
     )?;
     crate::process_trace::stage("transcribe.done");
-    drop(mixed_stem_path);
+    drop(prepared_input);
     let transcript = if content_type == ContentType::Meeting {
         normalize_transcript_for_self_name_participant(&result.text, &attendees, &config.identity)
     } else {
@@ -1487,17 +1565,26 @@ pub fn transcribe_to_artifact(
     };
     let filter_stats = result.stats;
     crate::process_trace::stage("pipeline.write.start");
+    let mut effective_context = context.clone();
+    effective_context.recording_health = merge_recording_health(
+        prepared_recording_health,
+        effective_context.recording_health,
+    );
     let artifact = write_transcript_artifact(
         audio_path,
         content_type,
         title,
         config,
-        context,
+        &effective_context,
         existing_output_path,
         transcript,
         filter_stats,
         step_start.elapsed().as_millis() as u64,
     );
+    let artifact = artifact.map(|mut artifact| {
+        artifact.diarization_audio_path = diarization_audio_path;
+        artifact
+    });
     match &artifact {
         Ok(_) => crate::process_trace::stage("pipeline.write.done"),
         Err(error) => crate::process_trace::stage_with_extra(
@@ -1704,6 +1791,7 @@ pub fn write_transcript_artifact(
         write_result,
         frontmatter,
         transcript,
+        diarization_audio_path: None,
     })
 }
 
@@ -1721,6 +1809,10 @@ where
         return Ok(artifact.write_result.clone());
     }
 
+    let diarization_audio_path = artifact
+        .diarization_audio_path
+        .as_deref()
+        .unwrap_or(audio_path);
     let mut transcript = artifact.transcript.clone();
     let mut diarization_num_speakers = 0usize;
     let mut diarization_from_stems = false;
@@ -1733,13 +1825,13 @@ where
         let diarize_start = std::time::Instant::now();
         let transcript_windows = build_transcript_windows(
             &transcript,
-            diarize::audio_duration_secs(audio_path).unwrap_or(f64::INFINITY),
+            diarize::audio_duration_secs(diarization_audio_path).unwrap_or(f64::INFINITY),
         );
         let ctx = diarize::DiarizationContext {
             purpose: diarize::DiarizationPurpose::PrimaryMeeting,
             transcript_windows: Some(&transcript_windows),
         };
-        match diarize::diarize_with_context(audio_path, config, ctx) {
+        match diarize::diarize_with_context(diarization_audio_path, config, ctx) {
             diarize::DiarizationOutcome::Result(result) => {
                 let diarize_ms = diarize_start.elapsed().as_millis() as u64;
                 diarization_num_speakers = result.num_speakers;
@@ -2244,20 +2336,17 @@ where
     // Step 1: Transcribe (always)
     on_progress(PipelineStage::Transcribing);
     // Workaround: if this is a native-call .mov with stems beside it, transcribe
-    // a freshly-mixed PCM from the stems to avoid the .mov dual-track 2x bug.
-    // `mixed_stem_path` is held in this scope so its Drop impl removes the
-    // temp file when this function returns, including on Err propagation
-    // from the transcription coordinator (#235 review item #1: meeting
-    // audio in /tmp is a privacy issue and the previous manual cleanup
-    // was skipped by the `?` early-return). The `?` here propagates the
-    // typed `NativeCaptureStemMixUnavailable` error (#235 review item #4)
-    // up to the pipeline boundary so the UI surfaces the real failure
-    // instead of silently transcribing the broken `.mov`.
-    let mixed_stem_path = prepare_transcription_input(audio_path)?;
-    let transcribe_input = mixed_stem_path
-        .as_ref()
-        .map(|f| f.as_path())
-        .unwrap_or(audio_path);
+    // a freshly-mixed PCM from both valid stems or the one surviving stem.
+    // `prepared_input` owns any temporary mix so Err/panic cleanup remains
+    // automatic; a surviving original stem is borrowed and never removed.
+    // If neither sibling contains signal, the typed mix error still prevents
+    // unsafe fallback to the broken dual-track `.mov` decoder.
+    let prepared_input = prepare_transcription_input(audio_path)?;
+    let prepared_recording_health = prepared_input.recording_health().cloned();
+    let diarization_audio_path = prepared_input
+        .diarization_audio_path()
+        .map(Path::to_path_buf);
+    let transcribe_input = prepared_input.as_path(audio_path);
     tracing::info!(step = "transcribe", file = %transcribe_input.display(), "transcribing audio");
     let step_start = std::time::Instant::now();
     let result = crate::transcription_coordinator::transcribe_path_for_content_with_hints(
@@ -2267,7 +2356,7 @@ where
         decode_hints,
     )?;
     crate::process_trace::stage("transcribe.done");
-    drop(mixed_stem_path);
+    drop(prepared_input);
     let transcribe_ms = step_start.elapsed().as_millis() as u64;
     let transcript = if content_type == ContentType::Meeting {
         normalize_transcript_for_self_name_participant(
@@ -2315,27 +2404,31 @@ where
     let mut degraded_ml_fallback = false;
     let mut diarization_embeddings: std::collections::HashMap<String, Vec<f32>> =
         std::collections::HashMap::new();
-    let mut recording_health: Option<markdown::RecordingHealth> = None;
+    let mut recording_health = prepared_recording_health;
+    let diarization_audio_path = diarization_audio_path.as_deref().unwrap_or(audio_path);
     let transcript = if config.diarization.engine != "none" && content_type == ContentType::Meeting
     {
         on_progress(PipelineStage::Diarizing);
         tracing::info!(step = "diarize", "running speaker diarization");
         let transcript_windows = build_transcript_windows(
             &transcript,
-            diarize::audio_duration_secs(audio_path).unwrap_or(f64::INFINITY),
+            diarize::audio_duration_secs(diarization_audio_path).unwrap_or(f64::INFINITY),
         );
         let ctx = diarize::DiarizationContext {
             purpose: diarize::DiarizationPurpose::PrimaryMeeting,
             transcript_windows: Some(&transcript_windows),
         };
-        match diarize::diarize_with_context(audio_path, config, ctx) {
+        match diarize::diarize_with_context(diarization_audio_path, config, ctx) {
             diarize::DiarizationOutcome::Result(result) => {
                 diarization_num_speakers = result.num_speakers;
                 diarization_from_stems = result.source_aware;
                 degraded_ml_fallback = is_degraded_ml_fallback_result(&result);
                 if degraded_ml_fallback {
                     if let Some(reason) = result.degraded_capture.clone() {
-                        recording_health = Some(degraded_ml_recording_health(reason));
+                        recording_health = merge_recording_health(
+                            Some(degraded_ml_recording_health(reason)),
+                            recording_health,
+                        );
                     }
                 }
                 diarization_embeddings = result.speaker_embeddings.clone();
@@ -2344,7 +2437,7 @@ where
                 transcript
             }
             diarize::DiarizationOutcome::Skipped { reason } => {
-                recording_health = Some(reason.into());
+                recording_health = merge_recording_health(Some(reason.into()), recording_health);
                 transcript
             }
             diarize::DiarizationOutcome::NotConfigured => transcript,
@@ -4935,20 +5028,13 @@ mod tests {
     }
 
     fn native_call_system_recovery_health() -> markdown::RecordingHealth {
-        markdown::RecordingHealth {
-            voice_stem_active_ratio: None,
-            system_stem_active_ratio: None,
-            system_dominant_ratio: None,
-            capture_warnings: vec![markdown::CaptureWarning {
-                kind: diarize::FailureKind::Other {
-                    code: "native-call-stem-recovery".into(),
-                },
-                source: diarize::CaptureSource::Voice,
-                message: "Native call capture did not produce a usable system-audio stem; processing the local microphone stem only.".into(),
-                diagnostic_confidence: diarize::DiagnosticConfidence::Inferred,
-            }],
-            diarization_path: Some(markdown::DiarizationPath::None),
-        }
+        crate::health::recording_health_for_native_call_stem_recovery(diarize::CaptureSource::Voice)
+    }
+
+    fn native_call_microphone_recovery_health() -> markdown::RecordingHealth {
+        crate::health::recording_health_for_native_call_stem_recovery(
+            diarize::CaptureSource::System,
+        )
     }
 
     #[test]
@@ -5199,6 +5285,27 @@ mod tests {
         assert_eq!(
             warnings[0].message.as_deref(),
             Some(SILENT_REMOTE_WARNING_MESSAGE)
+        );
+    }
+
+    #[test]
+    fn native_call_microphone_recovery_warns_and_degrades() {
+        let health = native_call_microphone_recovery_health();
+        let (warnings, status) = apply_silent_remote_warning_on_batch_path(
+            ContentType::Meeting,
+            Path::new("/Users/test/.minutes/jobs/job-123.system.wav"),
+            None,
+            Some(&health),
+            Some(OutputStatus::TranscriptOnly),
+        );
+
+        assert_eq!(status, Some(OutputStatus::Degraded));
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].step, "capture");
+        assert_eq!(warnings[0].reason, "microphone_audio_not_captured");
+        assert_eq!(
+            warnings[0].message.as_deref(),
+            Some(SILENT_MICROPHONE_WARNING_MESSAGE)
         );
     }
 
@@ -7003,6 +7110,56 @@ mod tests {
     }
 
     #[test]
+    fn enrich_transcript_artifact_writes_degraded_native_call_banner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let audio_path = dir.path().join("recovered.system.wav");
+        std::fs::write(&audio_path, vec![0u8; 64_044]).unwrap();
+
+        let mut config = Config {
+            output_dir: dir.path().join("meetings"),
+            ..Config::default()
+        };
+        config.transcription.min_words = 1;
+        config.summarization.engine = "none".into();
+        config.diarization.engine = "none".into();
+        let context = BackgroundPipelineContext {
+            recording_health: Some(
+                crate::health::recording_health_for_native_call_stem_recovery(
+                    crate::diarize::CaptureSource::System,
+                ),
+            ),
+            ..BackgroundPipelineContext::default()
+        };
+
+        let artifact = write_transcript_artifact(
+            &audio_path,
+            ContentType::Meeting,
+            Some("Recovered call"),
+            &config,
+            &context,
+            None,
+            "[0:00] The remote participant confirmed the pricing decision.\n".into(),
+            crate::transcribe::FilterStats::default(),
+            0,
+        )
+        .unwrap();
+        let result =
+            enrich_transcript_artifact(&audio_path, &artifact, &config, &context, |_| {}).unwrap();
+
+        let written = std::fs::read_to_string(&result.path).unwrap();
+        assert!(written.contains("status: degraded"), "{written}");
+        assert!(
+            written.contains(crate::health::NATIVE_CALL_MICROPHONE_RECOVERY_CODE),
+            "{written}"
+        );
+        assert!(written.contains("call/remote audio only"), "{written}");
+        assert!(
+            written.contains("reason: microphone_audio_not_captured"),
+            "{written}"
+        );
+    }
+
+    #[test]
     fn is_task_like_project_candidate_requires_more_than_a_verb_like_start() {
         assert!(!is_task_like_project_candidate(
             "review board",
@@ -7316,6 +7473,20 @@ mod prepare_transcription_input_tests {
         writer.finalize().unwrap();
     }
 
+    fn write_digital_silence_wav(path: &std::path::Path) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).unwrap();
+        for _ in 0..16_000 {
+            writer.write_sample(-0.000_028_f32).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
     /// Build the `<name>.mov` + `<name>.voice.wav` + `<name>.system.wav`
     /// trio that a native-call capture produces. The `.mov` itself is a
     /// 1-byte stub because `prepare_transcription_input` sniffs only the
@@ -7351,8 +7522,8 @@ mod prepare_transcription_input_tests {
         write_audible_wav(&wav);
         let result = prepare_transcription_input(&wav).expect("non-.mov should not error");
         assert!(
-            result.is_none(),
-            ".wav input must return Ok(None) so the caller uses it as-is"
+            matches!(result, PreparedTranscriptionInput::Original),
+            ".wav input must remain unchanged"
         );
     }
 
@@ -7368,8 +7539,8 @@ mod prepare_transcription_input_tests {
         fs::write(&mov, b"x").unwrap();
         let result = prepare_transcription_input(&mov).expect("stemless .mov should not error");
         assert!(
-            result.is_none(),
-            "stemless .mov must return Ok(None); hard-erroring would break non-native-call .mov use"
+            matches!(result, PreparedTranscriptionInput::Original),
+            "stemless .mov must remain unchanged; hard-erroring would break non-native-call .mov use"
         );
     }
 
@@ -7382,7 +7553,9 @@ mod prepare_transcription_input_tests {
         let (_dir, mov) = fake_native_call_capture("call-clean");
         let result = prepare_transcription_input(&mov)
             .expect("mix must succeed when both stems are valid PCM");
-        let handle = result.expect("must return Some on the happy path");
+        let PreparedTranscriptionInput::Mixed(handle) = result else {
+            panic!("both valid stems must be mixed")
+        };
         let mixed_path = handle.as_path().to_path_buf();
         assert!(mixed_path.exists(), "mixed PCM file must exist on disk");
 
@@ -7405,7 +7578,7 @@ mod prepare_transcription_input_tests {
     }
 
     #[test]
-    fn errors_when_voice_stem_missing() {
+    fn degrades_to_system_stem_when_voice_stem_missing() {
         let dir = tempfile::TempDir::new().unwrap();
         let mov = dir.path().join("partial-voice.mov");
         let system = dir.path().join("partial-voice.system.wav");
@@ -7414,26 +7587,32 @@ mod prepare_transcription_input_tests {
         // voice.wav deliberately not created — simulates a partial-crash
         // where the system side survived but the mic side did not.
 
-        let result = prepare_transcription_input(&mov);
-        match result {
-            Err(MinutesError::Transcribe(
-                crate::error::TranscribeError::NativeCaptureStemMixUnavailable { reason },
-            )) => {
-                assert!(
-                    reason.to_lowercase().contains("voice stem"),
-                    "error reason must mention the missing voice stem; got: {}",
-                    reason
-                );
-            }
-            other => panic!(
-                "expected NativeCaptureStemMixUnavailable, got: {:?}",
-                other.map(|opt| opt.is_some())
-            ),
-        }
+        let result = prepare_transcription_input(&mov).expect("system stem is recoverable");
+        let canonical_system = system.canonicalize().unwrap();
+        assert_eq!(
+            result.diarization_audio_path(),
+            Some(canonical_system.as_path()),
+            "downstream diarization must reuse the selected survivor"
+        );
+        let PreparedTranscriptionInput::SingleStem {
+            path,
+            recording_health,
+        } = result
+        else {
+            panic!("missing voice must select surviving system stem")
+        };
+        assert_eq!(path, canonical_system);
+        assert_eq!(
+            recording_health.capture_warnings[0].source,
+            crate::diarize::CaptureSource::System
+        );
+        assert!(recording_health.capture_warnings[0]
+            .message
+            .contains("call/remote audio only"));
     }
 
     #[test]
-    fn errors_when_voice_present_and_system_stem_file_absent() {
+    fn degrades_to_voice_stem_when_system_stem_file_absent() {
         // Codex review of PR #235 v2 caught this: `discover_stem_plan`
         // returns None for both the "no stems at all" case AND the
         // "voice ok, system absent from disk" case. The second case is
@@ -7454,27 +7633,29 @@ mod prepare_transcription_input_tests {
         // returned None from discover_stem_plan and would have silently
         // fallen through to the broken `.mov` decode without this fix.
 
-        let result = prepare_transcription_input(&mov);
-        match result {
-            Err(MinutesError::Transcribe(
-                crate::error::TranscribeError::NativeCaptureStemMixUnavailable { reason },
-            )) => {
-                assert!(
-                    reason.to_lowercase().contains("system stem")
-                        && reason.to_lowercase().contains("missing"),
-                    "error reason must call out the missing system stem; got: {}",
-                    reason
-                );
-            }
-            other => panic!(
-                "expected NativeCaptureStemMixUnavailable, got: {:?}",
-                other.map(|opt| opt.is_some())
-            ),
-        }
+        let result = prepare_transcription_input(&mov).expect("voice stem is recoverable");
+        let canonical_voice = voice.canonicalize().unwrap();
+        assert_eq!(
+            result.diarization_audio_path(),
+            Some(canonical_voice.as_path()),
+            "voice-only recovery must not diarize the original .mov"
+        );
+        let PreparedTranscriptionInput::SingleStem {
+            path,
+            recording_health,
+        } = result
+        else {
+            panic!("missing system must select surviving voice stem")
+        };
+        assert_eq!(path, canonical_voice);
+        assert_eq!(
+            recording_health.capture_warnings[0].source,
+            crate::diarize::CaptureSource::Voice
+        );
     }
 
     #[test]
-    fn errors_when_system_stem_is_zero_byte_partial_crash() {
+    fn degrades_to_voice_when_system_stem_is_zero_byte_partial_crash() {
         let dir = tempfile::TempDir::new().unwrap();
         let mov = dir.path().join("partial-system.mov");
         let voice = dir.path().join("partial-system.voice.wav");
@@ -7486,16 +7667,91 @@ mod prepare_transcription_input_tests {
         // `stem_has_audio` (which discover_stem_plan invokes) catches it.
         fs::write(&system, b"").unwrap();
 
-        let result = prepare_transcription_input(&mov);
-        assert!(
-            matches!(
-                result,
-                Err(MinutesError::Transcribe(
-                    crate::error::TranscribeError::NativeCaptureStemMixUnavailable { .. }
-                ))
-            ),
-            "zero-byte system stem must hard-error, not silently fall through to the .mov"
+        let result = prepare_transcription_input(&mov).expect("voice stem is recoverable");
+        let canonical_voice = voice.canonicalize().unwrap();
+        assert!(matches!(
+            result,
+            PreparedTranscriptionInput::SingleStem { path, .. } if path == canonical_voice
+        ));
+    }
+
+    #[test]
+    fn full_duration_digital_silence_voice_degrades_to_system() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mov = dir.path().join("silent-microphone.mov");
+        let voice = dir.path().join("silent-microphone.voice.wav");
+        let system = dir.path().join("silent-microphone.system.wav");
+        fs::write(&mov, b"x").unwrap();
+        write_digital_silence_wav(&voice);
+        write_audible_wav(&system);
+
+        let result = prepare_transcription_input(&mov).expect("system stem is recoverable");
+        let PreparedTranscriptionInput::SingleStem {
+            path,
+            recording_health,
+        } = result
+        else {
+            panic!("digital-silence microphone must select system stem")
+        };
+        assert_eq!(
+            path,
+            system.canonicalize().unwrap(),
+            "transcriber must receive the audible stem"
         );
+        let warning = &recording_health.capture_warnings[0];
+        assert_eq!(warning.source, crate::diarize::CaptureSource::System);
+        assert!(matches!(
+            &warning.kind,
+            crate::diarize::FailureKind::Other { code }
+                if code == crate::health::NATIVE_CALL_MICROPHONE_RECOVERY_CODE
+        ));
+    }
+
+    #[test]
+    fn full_duration_digital_silence_system_degrades_to_voice() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mov = dir.path().join("silent-system.mov");
+        let voice = dir.path().join("silent-system.voice.wav");
+        let system = dir.path().join("silent-system.system.wav");
+        fs::write(&mov, b"x").unwrap();
+        write_audible_wav(&voice);
+        write_digital_silence_wav(&system);
+
+        let result = prepare_transcription_input(&mov).expect("voice stem is recoverable");
+        let PreparedTranscriptionInput::SingleStem {
+            path,
+            recording_health,
+        } = result
+        else {
+            panic!("digital-silence system stem must select microphone stem")
+        };
+        assert_eq!(path, voice.canonicalize().unwrap());
+        let warning = &recording_health.capture_warnings[0];
+        assert_eq!(warning.source, crate::diarize::CaptureSource::Voice);
+        assert!(matches!(
+            &warning.kind,
+            crate::diarize::FailureKind::Other { code }
+                if code == crate::health::NATIVE_CALL_SYSTEM_RECOVERY_CODE
+        ));
+    }
+
+    #[test]
+    fn errors_when_both_stems_are_digitally_silent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mov = dir.path().join("both-silent.mov");
+        let voice = dir.path().join("both-silent.voice.wav");
+        let system = dir.path().join("both-silent.system.wav");
+        fs::write(&mov, b"x").unwrap();
+        write_digital_silence_wav(&voice);
+        write_digital_silence_wav(&system);
+
+        let result = prepare_transcription_input(&mov);
+        assert!(matches!(
+            result,
+            Err(MinutesError::Transcribe(
+                crate::error::TranscribeError::NativeCaptureStemMixUnavailable { .. }
+            ))
+        ));
     }
 
     #[cfg(unix)]
@@ -7518,8 +7774,9 @@ mod prepare_transcription_input_tests {
 
         let result = prepare_transcription_input(&link)
             .expect("symlink resolution must succeed and stems must be found");
-        let handle = result
-            .expect("symlinked .mov must resolve to canonical target and mix the stems there");
+        let PreparedTranscriptionInput::Mixed(handle) = result else {
+            panic!("symlinked .mov must resolve and mix its stems")
+        };
         assert!(handle.as_path().exists(), "mixed PCM must exist post-mix");
 
         // Drop the handle before the tempdirs so cleanup is observable.

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 35;
 export const MINUTES_CLI_COMMAND_COUNT = 56;
-export const MINUTES_TEST_COUNT = 1518;
+export const MINUTES_TEST_COUNT = 1528;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -55,3 +55,4 @@ tauri-build = { version = "2", features = [] }
 
 [dev-dependencies]
 tempfile = "3"
+hound = { workspace = true }

--- a/tauri/src-tauri/src/call_capture.rs
+++ b/tauri/src-tauri/src/call_capture.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -45,6 +46,91 @@ pub struct NativeCallCaptureSession {
     /// takes longer than 15s, the helper was SIGKILLed, and the .mov was
     /// truncated with no `moov` box.
     last_progress: Arc<Mutex<Instant>>,
+    capture_warnings: Arc<Mutex<Vec<String>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MicrophoneSelection {
+    Configured(String),
+    ConfiguredMissing(String),
+    Default,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MicrophoneStartupStatus {
+    Selected(String),
+    Fallback(String),
+}
+
+const MICROPHONE_STARTUP_STATUS_TIMEOUT: Duration = Duration::from_secs(2);
+
+fn finish_microphone_startup_handshake(
+    status_expected: bool,
+    status_rx: &mpsc::Receiver<MicrophoneStartupStatus>,
+    capture_warnings: &Arc<Mutex<Vec<String>>>,
+    timeout: Duration,
+) {
+    if !status_expected {
+        return;
+    }
+
+    match status_rx.recv_timeout(timeout) {
+        Ok(MicrophoneStartupStatus::Selected(name)) => {
+            tracing::info!(
+                microphone = name,
+                "native call capture is using configured microphone"
+            );
+        }
+        Ok(MicrophoneStartupStatus::Fallback(name)) => {
+            let message = format!("configured mic not found, using default: '{}'.", name);
+            tracing::warn!(
+                microphone = name,
+                "configured mic disappeared before native call capture started; using default"
+            );
+            if let Ok(mut warnings) = capture_warnings.lock() {
+                if !warnings.contains(&message) {
+                    warnings.push(message);
+                }
+            }
+        }
+        Err(error) => {
+            let message = format!(
+                "Configured microphone selection was not acknowledged before capture start ({error}); verify the selected input."
+            );
+            tracing::warn!(error = %error, "native call microphone startup status timed out");
+            if let Ok(mut warnings) = capture_warnings.lock() {
+                warnings.push(message);
+            }
+        }
+    }
+}
+
+fn resolve_microphone_selection(
+    configured: Option<&str>,
+    available_names: &[String],
+) -> MicrophoneSelection {
+    let configured = configured.map(str::trim).filter(|name| !name.is_empty());
+    match configured {
+        Some(name) if available_names.iter().any(|candidate| candidate == name) => {
+            MicrophoneSelection::Configured(name.to_string())
+        }
+        Some(name) => MicrophoneSelection::ConfiguredMissing(name.to_string()),
+        None => MicrophoneSelection::Default,
+    }
+}
+
+fn native_call_helper_args(output_path: &Path, selection: &MicrophoneSelection) -> Vec<OsString> {
+    let mut args = vec![output_path.as_os_str().to_os_string()];
+    if let MicrophoneSelection::Configured(name) = selection {
+        args.push(OsString::from("--microphone-name"));
+        args.push(OsString::from(name));
+    }
+    args
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct MicrophoneInventory {
+    devices: Vec<String>,
 }
 
 /// Absolute ceiling on `stop()` after SIGTERM is sent. The helper has to be
@@ -108,6 +194,13 @@ impl NativeCallCaptureSession {
                 call_audio_level: 0,
                 last_update: chrono::Local::now().to_rfc3339(),
             })
+    }
+
+    pub fn capture_warning(&self) -> Option<String> {
+        self.capture_warnings
+            .lock()
+            .ok()
+            .and_then(|warnings| (!warnings.is_empty()).then(|| warnings.join(" ")))
     }
 
     /// Send SIGKILL after a timeout, but reap once more first so a helper
@@ -239,7 +332,9 @@ pub fn availability() -> CallCaptureAvailability {
 }
 
 #[cfg(target_os = "macos")]
-pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
+pub fn start_native_call_capture(
+    configured_microphone: Option<&str>,
+) -> Result<NativeCallCaptureSession, String> {
     if let Some(major) = macos_major_version() {
         if major < 15 {
             return Err(format!(
@@ -251,6 +346,36 @@ pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
 
     let helper = find_native_call_helper_binary()
         .ok_or_else(|| "native call helper binary is unavailable".to_string())?;
+    let mut capture_warnings = Vec::new();
+    let microphone_selection = if configured_microphone
+        .map(str::trim)
+        .is_some_and(|name| !name.is_empty())
+    {
+        match list_native_call_microphones(&helper) {
+            Ok(inventory) => {
+                resolve_microphone_selection(configured_microphone, &inventory.devices)
+            }
+            Err(error) => {
+                let name = configured_microphone.unwrap_or_default().trim();
+                tracing::warn!(
+                    configured_microphone = name,
+                    error = %error,
+                    "could not enumerate native-call microphones; using default"
+                );
+                MicrophoneSelection::ConfiguredMissing(name.to_string())
+            }
+        }
+    } else {
+        MicrophoneSelection::Default
+    };
+    if let MicrophoneSelection::ConfiguredMissing(name) = &microphone_selection {
+        let message = format!("configured mic not found, using default: '{}'.", name);
+        tracing::warn!(
+            configured_microphone = name,
+            "configured mic not found, using default"
+        );
+        capture_warnings.push(message);
+    }
     let output_path = native_call_output_path()?;
     let health = Arc::new(Mutex::new(CallSourceHealth {
         backend: "screencapturekit-helper".into(),
@@ -260,8 +385,9 @@ pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
         call_audio_level: 0,
         last_update: chrono::Local::now().to_rfc3339(),
     }));
-    let mut child = Command::new(helper)
-        .arg(&output_path)
+    let mut command = Command::new(&helper);
+    command.args(native_call_helper_args(&output_path, &microphone_selection));
+    let mut child = command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -273,11 +399,16 @@ pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
         .take()
         .ok_or_else(|| "native call helper did not expose stdout".to_string())?;
     let (tx, rx) = mpsc::channel();
+    let (microphone_status_tx, microphone_status_rx) = mpsc::channel();
+    let microphone_status_expected =
+        matches!(microphone_selection, MicrophoneSelection::Configured(_));
     let stem_paths: Arc<Mutex<Option<StemPaths>>> = Arc::new(Mutex::new(None));
     let last_progress: Arc<Mutex<Instant>> = Arc::new(Mutex::new(Instant::now()));
     let health_for_thread = Arc::clone(&health);
     let stems_for_thread = Arc::clone(&stem_paths);
     let progress_for_thread = Arc::clone(&last_progress);
+    let capture_warnings = Arc::new(Mutex::new(capture_warnings));
+    let warnings_for_thread = Arc::clone(&capture_warnings);
     std::thread::spawn(move || {
         let mut reader = BufReader::new(stdout);
         let mut line = String::new();
@@ -369,6 +500,37 @@ pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
                             }
                         }
                     }
+                    Some("microphone_selected") => {
+                        if let Some(name) = value.get("name").and_then(|value| value.as_str()) {
+                            let _ = microphone_status_tx
+                                .send(MicrophoneStartupStatus::Selected(name.to_string()));
+                        }
+                    }
+                    Some("microphone_disconnected") => {
+                        let name = value
+                            .get("name")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("configured microphone");
+                        let message = format!(
+                            "Configured microphone '{}' disconnected during capture; ScreenCaptureKit continued with its default behavior.",
+                            name
+                        );
+                        tracing::warn!(
+                            microphone = name,
+                            "configured microphone disconnected during native call capture"
+                        );
+                        if let Ok(mut warnings) = warnings_for_thread.lock() {
+                            warnings.push(message);
+                        }
+                    }
+                    Some("microphone_fallback") => {
+                        let name = value
+                            .get("name")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("configured microphone");
+                        let _ = microphone_status_tx
+                            .send(MicrophoneStartupStatus::Fallback(name.to_string()));
+                    }
                     _ => {}
                 }
             }
@@ -376,13 +538,26 @@ pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
     });
 
     match rx.recv_timeout(Duration::from_secs(10)) {
-        Ok(Ok(line)) if line == "ready" => Ok(NativeCallCaptureSession {
-            child,
-            output_path,
-            health,
-            stem_paths,
-            last_progress,
-        }),
+        Ok(Ok(line)) if line == "ready" => {
+            // A configured-device helper emits exactly one selected/fallback
+            // status immediately after `ready`. Wait for that acknowledged
+            // second phase before returning so the capture-start notice cannot
+            // race the stdout reader (#463).
+            finish_microphone_startup_handshake(
+                microphone_status_expected,
+                &microphone_status_rx,
+                &capture_warnings,
+                MICROPHONE_STARTUP_STATUS_TIMEOUT,
+            );
+            Ok(NativeCallCaptureSession {
+                child,
+                output_path,
+                health,
+                stem_paths,
+                last_progress,
+                capture_warnings,
+            })
+        }
         Ok(Ok(line)) => {
             let _ = child.kill();
             Err(format!(
@@ -402,8 +577,27 @@ pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn start_native_call_capture() -> Result<NativeCallCaptureSession, String> {
+pub fn start_native_call_capture(
+    _configured_microphone: Option<&str>,
+) -> Result<NativeCallCaptureSession, String> {
     Err("native call capture is unsupported on this platform".into())
+}
+
+#[cfg(target_os = "macos")]
+fn list_native_call_microphones(helper: &Path) -> Result<MicrophoneInventory, String> {
+    let output = Command::new(helper)
+        .arg("--list-microphones")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| format!("failed to enumerate native-call microphones: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "native call helper microphone enumeration exited with {}",
+            output.status
+        ));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("invalid native-call microphone inventory: {error}"))
 }
 
 #[cfg(target_os = "macos")]
@@ -438,7 +632,16 @@ fn find_native_call_helper_binary() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_macos_major_version;
+    use super::{
+        finish_microphone_startup_handshake, native_call_helper_args, parse_macos_major_version,
+        resolve_microphone_selection, MicrophoneSelection, MicrophoneStartupStatus,
+    };
+    use std::{
+        ffi::OsString,
+        path::Path,
+        sync::{mpsc, Arc, Mutex},
+        time::Duration,
+    };
 
     #[test]
     fn parses_major_version_from_product_version() {
@@ -446,5 +649,75 @@ mod tests {
         assert_eq!(parse_macos_major_version("14.7"), Some(14));
         assert_eq!(parse_macos_major_version(""), None);
         assert_eq!(parse_macos_major_version("not-a-version"), None);
+    }
+
+    #[test]
+    fn selects_exact_configured_microphone_when_present() {
+        let available = vec![
+            "MacBook Pro Microphone".to_string(),
+            "Studio Display Microphone".to_string(),
+        ];
+        assert_eq!(
+            resolve_microphone_selection(Some("Studio Display Microphone"), &available),
+            MicrophoneSelection::Configured("Studio Display Microphone".into())
+        );
+    }
+
+    #[test]
+    fn reports_configured_microphone_missing_before_defaulting() {
+        let available = vec!["MacBook Pro Microphone".to_string()];
+        assert_eq!(
+            resolve_microphone_selection(Some("Studio Display Microphone"), &available),
+            MicrophoneSelection::ConfiguredMissing("Studio Display Microphone".into())
+        );
+    }
+
+    #[test]
+    fn uses_default_when_no_microphone_is_configured() {
+        let available = vec!["MacBook Pro Microphone".to_string()];
+        assert_eq!(
+            resolve_microphone_selection(None, &available),
+            MicrophoneSelection::Default
+        );
+    }
+
+    #[test]
+    fn configured_microphone_is_passed_to_native_helper() {
+        let args = native_call_helper_args(
+            Path::new("/tmp/call.mov"),
+            &MicrophoneSelection::Configured("Studio Display Microphone".into()),
+        );
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("/tmp/call.mov"),
+                OsString::from("--microphone-name"),
+                OsString::from("Studio Display Microphone"),
+            ]
+        );
+
+        let default_args =
+            native_call_helper_args(Path::new("/tmp/call.mov"), &MicrophoneSelection::Default);
+        assert_eq!(default_args, vec![OsString::from("/tmp/call.mov")]);
+    }
+
+    #[test]
+    fn actual_start_fallback_is_visible_before_session_return() {
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(10));
+            tx.send(MicrophoneStartupStatus::Fallback(
+                "Studio Display Microphone".into(),
+            ))
+            .unwrap();
+        });
+
+        finish_microphone_startup_handshake(true, &rx, &warnings, Duration::from_secs(1));
+
+        assert_eq!(
+            warnings.lock().unwrap().as_slice(),
+            ["configured mic not found, using default: 'Studio Display Microphone'."]
+        );
     }
 }

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2737,7 +2737,7 @@ fn preserve_failed_capture_path(path: &std::path::Path, config: &Config) -> Opti
 #[derive(Debug, Clone)]
 struct NativeCallProcessingInput {
     path: PathBuf,
-    recovery_warning: Option<String>,
+    recovery_health: Option<minutes_core::markdown::RecordingHealth>,
 }
 
 fn file_has_bytes(path: &Path) -> bool {
@@ -2749,24 +2749,18 @@ fn viable_native_call_stem(path: &Path) -> bool {
         .is_ok_and(|metadata| metadata.len() >= min_viable_stem_bytes(path))
 }
 
-fn native_call_recovery_health(
+fn native_call_capture_warning_health(
     message: impl Into<String>,
-    source: minutes_core::diarize::CaptureSource,
 ) -> minutes_core::markdown::RecordingHealth {
-    minutes_core::markdown::RecordingHealth {
+    let mut health = minutes_core::markdown::RecordingHealth {
         voice_stem_active_ratio: None,
         system_stem_active_ratio: None,
         system_dominant_ratio: None,
-        capture_warnings: vec![minutes_core::markdown::CaptureWarning {
-            kind: minutes_core::diarize::FailureKind::Other {
-                code: "native-call-stem-recovery".into(),
-            },
-            source,
-            message: message.into(),
-            diagnostic_confidence: minutes_core::diarize::DiagnosticConfidence::Inferred,
-        }],
+        capture_warnings: Vec::new(),
         diarization_path: Some(minutes_core::markdown::DiarizationPath::None),
-    }
+    };
+    minutes_core::health::append_native_call_capture_warning(&mut health, message);
+    health
 }
 
 fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProcessingInput> {
@@ -2774,8 +2768,15 @@ fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProc
     let stems = minutes_core::capture::stem_paths_for(output_path);
     let voice = stems.as_ref().map(|stems| stems.voice.as_path());
     let system = stems.as_ref().map(|stems| stems.system.as_path());
-    let voice_viable = voice.is_some_and(viable_native_call_stem);
-    let system_viable = system.is_some_and(viable_native_call_stem);
+    // Size catches abort-at-start fragments; the shared core signal probe
+    // catches full-duration digital silence. The latter is the #463 gap: a
+    // 74-minute all-null mic WAV easily passed the former check.
+    let voice_viable = voice.is_some_and(|path| {
+        viable_native_call_stem(path) && minutes_core::diarize::stem_has_audio(path)
+    });
+    let system_viable = system.is_some_and(|path| {
+        viable_native_call_stem(path) && minutes_core::diarize::stem_has_audio(path)
+    });
 
     if voice_viable && system_viable {
         if !primary_has_bytes {
@@ -2787,15 +2788,15 @@ fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProc
             std::fs::write(output_path, b"minutes native-call stem anchor")?;
             return Ok(NativeCallProcessingInput {
                 path: output_path.to_path_buf(),
-                recovery_warning: Some(
-                    "Native call capture did not produce a usable .mov container; processing recovered PCM stems instead.".into(),
-                ),
+                recovery_health: Some(native_call_capture_warning_health(
+                    "Native call capture did not produce a usable .mov container; processing recovered PCM stems instead.",
+                )),
             });
         }
 
         return Ok(NativeCallProcessingInput {
             path: output_path.to_path_buf(),
-            recovery_warning: None,
+            recovery_health: None,
         });
     }
 
@@ -2803,8 +2804,10 @@ fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProc
         let voice = voice.expect("voice path present when viable");
         return Ok(NativeCallProcessingInput {
             path: voice.to_path_buf(),
-            recovery_warning: Some(
-                "Native call capture did not produce a usable system-audio stem; processing the local microphone stem only.".into(),
+            recovery_health: Some(
+                minutes_core::health::recording_health_for_native_call_stem_recovery(
+                    minutes_core::diarize::CaptureSource::Voice,
+                ),
             ),
         });
     }
@@ -2813,27 +2816,27 @@ fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProc
         let system = system.expect("system path present when viable");
         return Ok(NativeCallProcessingInput {
             path: system.to_path_buf(),
-            recovery_warning: Some(
-                "Native call capture did not produce a usable microphone stem; processing the system-audio stem only.".into(),
+            recovery_health: Some(
+                minutes_core::health::recording_health_for_native_call_stem_recovery(
+                    minutes_core::diarize::CaptureSource::System,
+                ),
             ),
-        });
-    }
-
-    if primary_has_bytes {
-        return Ok(NativeCallProcessingInput {
-            path: output_path.to_path_buf(),
-            recovery_warning: None,
         });
     }
 
     Err(io::Error::new(
         io::ErrorKind::NotFound,
         format!(
-            "native call capture did not produce a usable .mov or PCM stem under {}",
+            "native call capture did not produce a usable PCM stem under {}{}",
             output_path
                 .parent()
                 .map(|path| path.display().to_string())
-                .unwrap_or_else(|| "<unknown>".into())
+                .unwrap_or_else(|| "<unknown>".into()),
+            if primary_has_bytes {
+                "; the .mov was preserved but its dual-track decode is unsafe"
+            } else {
+                ""
+            }
         ),
     ))
 }
@@ -2854,30 +2857,18 @@ fn queue_native_call_capture_for_processing(
     let input = native_call_processing_input(output_path).map_err(|error| {
         format!("failed to prepare native call capture for processing: {error}")
     })?;
-    let warning = match (extra_warning, input.recovery_warning) {
-        (Some(extra), Some(recovery)) => Some(format!("{extra} {recovery}")),
-        (Some(extra), None) => Some(extra),
-        (None, Some(recovery)) => Some(recovery),
-        (None, None) => None,
-    };
-    let source = if input
-        .path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".system.wav"))
-    {
-        minutes_core::diarize::CaptureSource::System
-    } else if input
-        .path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".voice.wav"))
-    {
-        minutes_core::diarize::CaptureSource::Voice
-    } else {
-        minutes_core::diarize::CaptureSource::Both
-    };
-    let recording_health = warning.map(|message| native_call_recovery_health(message, source));
+    let mut recording_health = input.recovery_health;
+    if let Some(extra_warning) = extra_warning {
+        let health = recording_health
+            .get_or_insert_with(|| native_call_capture_warning_health(extra_warning.clone()));
+        if health
+            .capture_warnings
+            .iter()
+            .all(|warning| warning.message != extra_warning)
+        {
+            minutes_core::health::append_native_call_capture_warning(health, extra_warning);
+        }
+    }
     let (consent, consent_notice) = if mode == CaptureMode::Meeting {
         minutes_core::notes::load_consent()
     } else {
@@ -2900,6 +2891,18 @@ fn queue_native_call_capture_for_processing(
         recording_health,
     )
     .map_err(|error| error.to_string())
+}
+
+fn combine_native_call_warnings(
+    capture_warning: Option<String>,
+    operational_warning: Option<String>,
+) -> Option<String> {
+    match (capture_warning, operational_warning) {
+        (Some(capture), Some(operational)) => Some(format!("{capture} {operational}")),
+        (Some(capture), None) => Some(capture),
+        (None, Some(operational)) => Some(operational),
+        (None, None) => None,
+    }
 }
 
 /// Copy `src` to `dest` with two invariants beyond `std::fs::copy`:
@@ -3175,13 +3178,23 @@ fn start_native_call_recording(
         minutes_core::pid::remove().ok();
         return Err(error.to_string());
     }
-    let mut session = match call_capture::start_native_call_capture() {
-        Ok(session) => session,
-        Err(error) => {
-            minutes_core::pid::remove().ok();
-            return Err(error);
-        }
-    };
+    // Config written through Settings is already canonical, but older/manual
+    // TOML may still contain the picker decoration (sample rate/channels).
+    // ScreenCaptureKit resolves AVCaptureDevice.localizedName exactly, so
+    // normalize at this boundary as well.
+    let configured_microphone = config
+        .recording
+        .device
+        .as_deref()
+        .and_then(minutes_core::capture::canonicalize_input_device_setting);
+    let mut session =
+        match call_capture::start_native_call_capture(configured_microphone.as_deref()) {
+            Ok(session) => session,
+            Err(error) => {
+                minutes_core::pid::remove().ok();
+                return Err(error);
+            }
+        };
     let output_path = session.output_path().to_path_buf();
     let recording_started_at = chrono::Local::now();
     let context_session_id = minutes_core::desktop_context::maybe_start_capture_session(
@@ -3196,6 +3209,18 @@ fn start_native_call_recording(
     stop_flag.store(false, Ordering::Relaxed);
     sync_processing_indicator(processing, processing_stage);
     set_latest_output(latest_output, None);
+    if let Some(warning) = session.capture_warning() {
+        set_latest_output(
+            latest_output,
+            Some(OutputNotice {
+                kind: "warning".into(),
+                title: "Using default microphone".into(),
+                path: output_path.display().to_string(),
+                detail: warning,
+                job_id: None,
+            }),
+        );
+    }
     if let Ok(mut health) = call_capture_health.lock() {
         *health = Some(session.source_health());
     }
@@ -3256,7 +3281,10 @@ fn start_native_call_recording(
                     recording_finished_at,
                     context_session_id.clone(),
                     None,
-                    Some("Native call capture helper exited before normal stop.".into()),
+                    combine_native_call_warnings(
+                        session.capture_warning(),
+                        Some("Native call capture helper exited before normal stop.".into()),
+                    ),
                 ) {
                     Ok(job) => {
                         processing.store(true, Ordering::Relaxed);
@@ -3357,9 +3385,12 @@ fn start_native_call_recording(
             recording_finished_at,
             context_session_id.clone(),
             None,
-            Some(format!(
-                "Native call capture finalization reported an error: {error}."
-            )),
+            combine_native_call_warnings(
+                session.capture_warning(),
+                Some(format!(
+                    "Native call capture finalization reported an error: {error}."
+                )),
+            ),
         );
 
         match queue_result {
@@ -3496,7 +3527,7 @@ fn start_native_call_recording(
         recording_finished_at,
         context_session_id.clone(),
         calendar_event,
-        None,
+        session.capture_warning(),
     ) {
         Ok(job) => {
             processing.store(true, Ordering::Relaxed);
@@ -4067,7 +4098,20 @@ fn output_notice_from_job(job: &minutes_core::jobs::ProcessingJob) -> Option<Out
                     .clone()
                     .unwrap_or_else(|| "Processed recording".into()),
                 path: path.clone(),
-                detail: "Saved meeting markdown".into(),
+                detail: job
+                    .recording_health
+                    .as_ref()
+                    .map(|health| {
+                        health
+                            .capture_warnings
+                            .iter()
+                            .map(|warning| warning.message.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    })
+                    .filter(|warnings| !warnings.is_empty())
+                    .map(|warnings| format!("Saved meeting markdown. {warnings}"))
+                    .unwrap_or_else(|| "Saved meeting markdown".into()),
                 job_id: None,
             })
         }
@@ -5230,9 +5274,10 @@ fn recovery_title(path: &std::path::Path, fallback: &str) -> String {
 }
 
 /// A dual-source capture writes `<name>.voice.wav` / `<name>.system.wav`
-/// sidecars next to the primary `<name>.wav`. Those stems are processed as part
-/// of the primary, never on their own, so they must not appear as independent
-/// recovery items when their primary is present: otherwise "Retry all" would
+/// sidecars next to the primary `<name>.wav` or native-call `<name>.mov`.
+/// Those stems are processed as part of the primary, never on their own, so
+/// they must not appear as independent recovery items when their primary is
+/// present: otherwise "Retry all" would
 /// enqueue them as standalone jobs that race (and break) the primary's job. An
 /// orphaned stem with no primary still surfaces so the user can see it.
 fn is_dual_source_stem_with_primary(path: &Path) -> bool {
@@ -5244,7 +5289,11 @@ fn is_dual_source_stem_with_primary(path: &Path) -> bool {
     };
     [".voice.wav", ".system.wav"].iter().any(|suffix| {
         name.strip_suffix(suffix)
-            .map(|base| dir.join(format!("{}.wav", base)).exists())
+            .map(|base| {
+                ["wav", "mov"]
+                    .iter()
+                    .any(|extension| dir.join(format!("{base}.{extension}")).exists())
+            })
             .unwrap_or(false)
     })
 }
@@ -12371,23 +12420,40 @@ mod tests {
         }
     }
 
+    fn write_signal_wav(path: &Path, audible: bool) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 48_000,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).expect("create signal wav");
+        for frame in 0..48_000 {
+            let sample = if audible {
+                (frame as f32 * 440.0 * std::f32::consts::TAU / 48_000.0).sin() * 0.2
+            } else {
+                -0.000_028
+            };
+            writer.write_sample(sample).expect("write signal sample");
+        }
+        writer.finalize().expect("finalize signal wav");
+    }
+
     #[test]
     fn native_call_processing_input_uses_voice_stem_when_system_missing() {
         let dir = TempDir::new().unwrap();
         let mov = dir.path().join("2026-05-19-120148-call.mov");
         std::fs::write(&mov, b"mov").unwrap();
         let voice = dir.path().join("2026-05-19-120148-call.voice.wav");
-        write_test_wav(&voice, 48_000, 200_000);
+        write_signal_wav(&voice, true);
 
         let input = native_call_processing_input(&mov).expect("processing input");
 
         assert_eq!(input.path, voice);
-        assert!(
-            input
-                .recovery_warning
-                .as_deref()
-                .is_some_and(|warning| warning.contains("system-audio stem")),
-            "warning should explain the missing system side"
+        let health = input.recovery_health.expect("recovery health");
+        assert_eq!(
+            health.capture_warnings[0].source,
+            minutes_core::diarize::CaptureSource::Voice
         );
     }
 
@@ -12397,8 +12463,8 @@ mod tests {
         let mov = dir.path().join("2026-05-19-120148-call.mov");
         let voice = dir.path().join("2026-05-19-120148-call.voice.wav");
         let system = dir.path().join("2026-05-19-120148-call.system.wav");
-        write_test_wav(&voice, 48_000, 200_000);
-        write_test_wav(&system, 48_000, 200_000);
+        write_signal_wav(&voice, true);
+        write_signal_wav(&system, true);
 
         let input = native_call_processing_input(&mov).expect("processing input");
 
@@ -12407,12 +12473,63 @@ mod tests {
             input.path.exists(),
             "missing .mov should be recreated as a stem anchor"
         );
+        assert!(input.recovery_health.is_some());
+    }
+
+    #[test]
+    fn native_call_processing_input_selects_system_for_full_size_digital_silence_mic() {
+        let dir = TempDir::new().unwrap();
+        let mov = dir.path().join("2026-05-19-120148-call.mov");
+        let voice = dir.path().join("2026-05-19-120148-call.voice.wav");
+        let system = dir.path().join("2026-05-19-120148-call.system.wav");
+        std::fs::write(&mov, b"mov").unwrap();
+        write_signal_wav(&voice, false);
+        write_signal_wav(&system, true);
+
+        let input = native_call_processing_input(&mov).expect("system stem should recover");
+        assert_eq!(input.path, system);
+        let health = input.recovery_health.expect("recovery health");
+        assert!(matches!(
+            &health.capture_warnings[0].kind,
+            minutes_core::diarize::FailureKind::Other { code }
+                if code == minutes_core::health::NATIVE_CALL_MICROPHONE_RECOVERY_CODE
+        ));
+    }
+
+    #[test]
+    fn native_call_processing_input_selects_voice_for_full_size_digital_silence_system() {
+        let dir = TempDir::new().unwrap();
+        let mov = dir.path().join("2026-05-19-120148-call.mov");
+        let voice = dir.path().join("2026-05-19-120148-call.voice.wav");
+        let system = dir.path().join("2026-05-19-120148-call.system.wav");
+        std::fs::write(&mov, b"mov").unwrap();
+        write_signal_wav(&voice, true);
+        write_signal_wav(&system, false);
+
+        let input = native_call_processing_input(&mov).expect("voice stem should recover");
+        assert_eq!(input.path, voice);
+        let health = input.recovery_health.expect("recovery health");
+        assert!(matches!(
+            &health.capture_warnings[0].kind,
+            minutes_core::diarize::FailureKind::Other { code }
+                if code == minutes_core::health::NATIVE_CALL_SYSTEM_RECOVERY_CODE
+        ));
+    }
+
+    #[test]
+    fn native_call_processing_input_rejects_both_digitally_silent_stems() {
+        let dir = TempDir::new().unwrap();
+        let mov = dir.path().join("2026-05-19-120148-call.mov");
+        let voice = dir.path().join("2026-05-19-120148-call.voice.wav");
+        let system = dir.path().join("2026-05-19-120148-call.system.wav");
+        std::fs::write(&mov, b"mov").unwrap();
+        write_signal_wav(&voice, false);
+        write_signal_wav(&system, false);
+
+        let error = native_call_processing_input(&mov).expect_err("no usable stem");
         assert!(
-            input
-                .recovery_warning
-                .as_deref()
-                .is_some_and(|warning| warning.contains("recovered PCM stems")),
-            "warning should explain stem-anchor recovery"
+            error.to_string().contains("usable PCM stem"),
+            "unexpected error: {error}"
         );
     }
 
@@ -13861,6 +13978,51 @@ mod tests {
     }
 
     #[test]
+    fn legacy_recovered_mov_notice_becomes_honest_after_job_health_persists() {
+        let health = minutes_core::health::recording_health_for_native_call_stem_recovery(
+            minutes_core::diarize::CaptureSource::System,
+        );
+        let mut job = minutes_core::jobs::ProcessingJob {
+            id: "job-recovered-system".into(),
+            title: Some("Recovered call".into()),
+            mode: CaptureMode::Meeting,
+            content_type: ContentType::Meeting,
+            state: minutes_core::jobs::JobState::Complete,
+            stage: minutes_core::jobs::JobState::Complete.default_stage(),
+            output_path: Some("/tmp/recovered.md".into()),
+            audio_path: "/tmp/recovered.system.wav".into(),
+            error: None,
+            created_at: chrono::Local::now(),
+            started_at: None,
+            finished_at: Some(chrono::Local::now()),
+            notice_dismissed_at: None,
+            recording_started_at: None,
+            recording_finished_at: None,
+            context_session_id: None,
+            user_notes: None,
+            pre_context: None,
+            calendar_event: None,
+            template_slug: None,
+            word_count: Some(8_329),
+            owner_pid: None,
+            retry_count: 0,
+            consent: None,
+            consent_notice: None,
+            recording_health: None,
+        };
+
+        let stale_notice = output_notice_from_job(&job).expect("legacy completion notice");
+        assert_eq!(stale_notice.detail, "Saved meeting markdown");
+
+        // Core persists this field from the recovered artifact before the
+        // desktop reads the terminal job.
+        job.recording_health = Some(health);
+        let notice = output_notice_from_job(&job).expect("recovered completion notice");
+        assert_eq!(notice.kind, "saved");
+        assert!(notice.detail.contains("call/remote audio only"));
+    }
+
+    #[test]
     fn startup_retryable_notices_do_not_surface_stale_failure_details() {
         let job = minutes_core::jobs::ProcessingJob {
             id: "job-failed".into(),
@@ -14257,6 +14419,29 @@ mod tests {
             assert_eq!(items.len(), 2);
             assert!(items.iter().any(|item| item.kind == "watch-failed"));
             assert!(items.iter().any(|item| item.kind == "preserved-capture"));
+        });
+    }
+
+    #[test]
+    fn scan_recovery_items_groups_native_call_mov_with_surviving_stems() {
+        with_temp_home(|home| {
+            let output_dir = home.join("meetings");
+            let failed_captures = output_dir.join("failed-captures");
+            std::fs::create_dir_all(&failed_captures).unwrap();
+            let mov = failed_captures.join("recovered-call.mov");
+            let voice = failed_captures.join("recovered-call.voice.wav");
+            let system = failed_captures.join("recovered-call.system.wav");
+            std::fs::write(&mov, "mov anchor").unwrap();
+            std::fs::write(&voice, "silent mic stem retained for diagnostics").unwrap();
+            std::fs::write(&system, "surviving system stem").unwrap();
+            let config = Config {
+                output_dir,
+                ..Config::default()
+            };
+
+            let items = scan_recovery_items(&config);
+            assert_eq!(items.len(), 1, "stems must stay grouped with the .mov");
+            assert_eq!(PathBuf::from(&items[0].path), mov);
         });
     }
 

--- a/tauri/src-tauri/src/system_audio_record.swift
+++ b/tauri/src-tauri/src/system_audio_record.swift
@@ -4,11 +4,23 @@ import Dispatch
 import Foundation
 import ScreenCaptureKit
 
+private func availableMicrophones() -> [AVCaptureDevice] {
+    AVCaptureDevice.DiscoverySession(
+        deviceTypes: [.microphone],
+        mediaType: .audio,
+        position: .unspecified
+    ).devices
+}
+
 @available(macOS 15.0, *)
 final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOutput {
     private var stream: SCStream?
     private var recordingOutput: SCRecordingOutput?
     private let outputURL: URL
+    private let requestedMicrophoneName: String?
+    private var selectedMicrophoneID: String?
+    private var selectedMicrophoneName: String?
+    private var microphoneSelectionEvent: [String: Any]?
     private let sampleQueue = DispatchQueue(label: "minutes.system-audio.samples")
     private var monitorTimer: DispatchSourceTimer?
     private var lastSystemAudioSampleAt: Date?
@@ -31,8 +43,13 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
     // follow-on to #216).
     private var finalizeStart: Date?
 
-    init(outputURL: URL) {
+    init(outputURL: URL, requestedMicrophoneName: String?) {
         self.outputURL = outputURL
+        self.requestedMicrophoneName = requestedMicrophoneName
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     func start() async throws {
@@ -64,8 +81,45 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         configuration.excludesCurrentProcessAudio = true
         configuration.showsCursor = false
 
-        if let microphone = AVCaptureDevice.default(for: .audio) {
+        let microphone: AVCaptureDevice?
+        if let requestedMicrophoneName {
+            microphone = availableMicrophones().first {
+                $0.localizedName == requestedMicrophoneName
+            } ?? AVCaptureDevice.default(for: .audio)
+            if microphone?.localizedName == requestedMicrophoneName {
+                microphoneSelectionEvent = [
+                    "event": "microphone_selected",
+                    "name": requestedMicrophoneName,
+                    "configured": true,
+                ]
+            } else {
+                // The Rust parent preflights the same exact-name lookup. This
+                // branch covers the device disappearing in the small race
+                // between preflight and stream configuration. It must be
+                // reported only after `ready` because the first stdout line is
+                // the helper protocol handshake.
+                microphoneSelectionEvent = [
+                    "event": "microphone_fallback",
+                    "name": requestedMicrophoneName,
+                    "message": "configured mic not found, using default",
+                ]
+            }
+        } else {
+            microphone = AVCaptureDevice.default(for: .audio)
+        }
+
+        if let microphone {
             configuration.microphoneCaptureDeviceID = microphone.uniqueID
+            selectedMicrophoneID = microphone.uniqueID
+            selectedMicrophoneName = microphone.localizedName
+            if requestedMicrophoneName != nil {
+                NotificationCenter.default.addObserver(
+                    self,
+                    selector: #selector(microphoneWasDisconnected(_:)),
+                    name: AVCaptureDevice.wasDisconnectedNotification,
+                    object: microphone
+                )
+            }
         }
 
         let stream = SCStream(filter: filter, configuration: configuration, delegate: nil)
@@ -95,6 +149,22 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
 
         self.stream = stream
         self.recordingOutput = recordingOutput
+    }
+
+    @objc private func microphoneWasDisconnected(_ notification: Notification) {
+        guard let device = notification.object as? AVCaptureDevice,
+              device.uniqueID == selectedMicrophoneID else {
+            return
+        }
+        let payload: [String: Any] = [
+            "event": "microphone_disconnected",
+            "name": selectedMicrophoneName ?? device.localizedName,
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let json = String(data: data, encoding: .utf8) {
+            print(json)
+            fflush(stdout)
+        }
     }
 
     func stop() async {
@@ -363,6 +433,15 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         print("ready")
         fflush(stdout)
 
+        // Never emit device-selection status before `ready`: Rust treats the
+        // first stdout line as a strict readiness handshake.
+        if let microphoneSelectionEvent,
+           let data = try? JSONSerialization.data(withJSONObject: microphoneSelectionEvent),
+           let json = String(data: data, encoding: .utf8) {
+            print(json)
+            fflush(stdout)
+        }
+
         // Report stem paths so the Rust side knows where to find them
         let stemInfo: [String: Any] = [
             "event": "stems",
@@ -423,13 +502,37 @@ struct NativeCallRecordMain {
             exit(1)
         }
 
+        if CommandLine.arguments.count == 2,
+           CommandLine.arguments[1] == "--list-microphones" {
+            let payload: [String: Any] = [
+                "devices": availableMicrophones().map(\.localizedName)
+            ]
+            do {
+                let data = try JSONSerialization.data(withJSONObject: payload)
+                FileHandle.standardOutput.write(data)
+                FileHandle.standardOutput.write(Data("\n".utf8))
+                exit(0)
+            } catch {
+                fputs("failed to serialize microphone inventory: \(error)\n", stderr)
+                exit(1)
+            }
+        }
+
         guard CommandLine.arguments.count >= 2 else {
-            fputs("usage: system_audio_record <output.mov>\n", stderr)
+            fputs("usage: system_audio_record <output.mov> [--microphone-name <exact name>]\n", stderr)
             exit(1)
         }
 
         let outputURL = URL(fileURLWithPath: CommandLine.arguments[1])
-        let recorder = NativeCallRecorder(outputURL: outputURL)
+        var requestedMicrophoneName: String?
+        if let flagIndex = CommandLine.arguments.firstIndex(of: "--microphone-name"),
+           CommandLine.arguments.indices.contains(flagIndex + 1) {
+            requestedMicrophoneName = CommandLine.arguments[flagIndex + 1]
+        }
+        let recorder = NativeCallRecorder(
+            outputURL: outputURL,
+            requestedMicrophoneName: requestedMicrophoneName
+        )
 
         signal(SIGTERM, SIG_IGN)
         let stopSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)


### PR DESCRIPTION
Fixes #463. Reported and diagnosed by @gdiab — the report was exact on both defects, down to the silent stem's constant -91 dB floor.

## The two defects

**1. Native call capture ignored `[recording].device`.** The Swift SCK helper hardcoded `AVCaptureDevice.default(for: .audio)`, so a docked/clamshell Mac recorded the lid-disabled built-in mic instead of the configured device — producing a full-duration, digitally silent voice stem. The configured device now flows Rust → helper argv → exact `localizedName` match → `microphoneCaptureDeviceID`, with an honest fallback chain: configured device → logged + surfaced "using default" notice when absent → default. Device selection/fallback is an acknowledged post-`ready` handshake (bounded, honest timeout) so the capture session never starts on silent assumptions, and a mid-call disconnect records a warning instead of crashing the capture.

**2. The empty-stem gate discarded recoverable audio.** The pre-queue check in the desktop app classified stems by *file size* only, so the full-duration silent WAV passed as viable; the core pipeline's signal-aware check then hard-failed the whole job as "unrecoverable" — discarding an intact 74-minute system stem. Both layers now share one public signal classifier (`stem_has_audio`). When exactly one stem carries signal, the pipeline degrades honestly instead of failing: the survivor is transcribed as a single-source meeting with explicit `recording_health` (distinct lost-mic vs lost-system reasons) in frontmatter, the desktop completion notice, and the persisted job. Both-silent still fails clearly. The survivor path is carried through foreground and background diarization so the broken dual-track `.mov` can never re-enter, the `.mov` trio is preserved for Recovery Center grouping, and a failed screen-dir move rolls back transactionally.

## Verification
- Independent adversarial review (second reviewer session): first draft rejected on 3 P1 + 1 P2 findings (survivor re-entering `.mov` diarization, screen-dir move orphaning the trio, job health not persisted, ready-handshake race); all fixed and re-reviewed at this exact SHA — ACCEPT.
- macOS (M4 Max): full default-features core suite 1060 + 10 passed / 0 failed; minutes-app 256/256 serial; fmt + clippy green.
- New tests cover: signal-aware pre-queue classification (including the valid-size all-zero-samples WAV that reproduced this report), five survivor-degradation permutations, digital-silence detection, survivor queue/preserve/archival grouping, screen-dir rollback, persisted job health across completion transitions, and the deterministic capture-start fallback warning.
- Physical clamshell + Studio Display E2E needs maintainer hardware (headless box has no external mic); everything verifiable headless is verified.

## Workaround (until released)
`minutes process <job>.system.wav` recovers the system stem manually — as @gdiab discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
