### PR TITLE
fix(desktop): stop meetings list flashing from Linux inotify noise

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1331,8 +1331,7 @@ fn is_content_change(kind: &notify::EventKind) -> bool {
     use notify::event::ModifyKind;
     !matches!(
         kind,
-        notify::EventKind::Access(_)
-            | notify::EventKind::Modify(ModifyKind::Metadata(_))
+        notify::EventKind::Access(_) | notify::EventKind::Modify(ModifyKind::Metadata(_))
     )
 }
 
@@ -1418,9 +1417,7 @@ fn spawn_meetings_refresh_watcher(app: &tauri::AppHandle, output_dir: std::path:
             // a row. Each emit drives a full list rebuild in the UI, so
             // without this drain the list visibly flashes once per raw event
             // instead of once per save.
-            while let Ok(Ok(_event)) =
-                rx.recv_timeout(std::time::Duration::from_millis(250))
-            {
+            while let Ok(Ok(_event)) = rx.recv_timeout(std::time::Duration::from_millis(250)) {
                 // drained, ignored
             }
             let _ = app_handle.emit("artifacts:changed", ());

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1320,6 +1320,22 @@ fn should_refresh_meetings_for_paths(paths: &[std::path::PathBuf]) -> bool {
     })
 }
 
+/// Reads/atime-only touches never change what the meetings list shows, but
+/// desktop search indexers (Tracker on GNOME, Baloo on KDE) commonly `stat`
+/// or touch atime on files under a watched, recursive home-dir tree like
+/// `~/meetings`. On Linux those show up as their own inotify events
+/// (`Access`, `Modify(Metadata(AccessTime))`) distinct from a real write, so
+/// filter them out here instead of treating every touch as a reason to
+/// rebuild the list.
+fn is_content_change(kind: &notify::EventKind) -> bool {
+    use notify::event::ModifyKind;
+    !matches!(
+        kind,
+        notify::EventKind::Access(_)
+            | notify::EventKind::Modify(ModifyKind::Metadata(_))
+    )
+}
+
 fn bind_meetings_refresh_watcher(
     watcher: &mut RecommendedWatcher,
     output_dir: &std::path::Path,
@@ -1384,7 +1400,10 @@ fn spawn_meetings_refresh_watcher(app: &tauri::AppHandle, output_dir: std::path:
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
             };
 
-            let hit = matches!(&event, Ok(event) if should_refresh_meetings_for_paths(&event.paths));
+            let hit = matches!(
+                &event,
+                Ok(event) if is_content_change(&event.kind) && should_refresh_meetings_for_paths(&event.paths)
+            );
             if let Err(error) = &event {
                 eprintln!("[meetings-watcher] watch error: {}", error);
             }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1384,15 +1384,27 @@ fn spawn_meetings_refresh_watcher(app: &tauri::AppHandle, output_dir: std::path:
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
             };
 
-            match event {
-                Ok(event) if should_refresh_meetings_for_paths(&event.paths) => {
-                    let _ = app_handle.emit("artifacts:changed", ());
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    eprintln!("[meetings-watcher] watch error: {}", error);
-                }
+            let hit = matches!(&event, Ok(event) if should_refresh_meetings_for_paths(&event.paths));
+            if let Err(error) = &event {
+                eprintln!("[meetings-watcher] watch error: {}", error);
             }
+            if !hit {
+                continue;
+            }
+
+            // Coalesce a burst of raw fs events into a single emit. On Linux,
+            // inotify delivers one event per syscall (write/chmod/rename/
+            // close-write) instead of the batched events FSEvents gives us on
+            // macOS, so a single logical save can fire this arm many times in
+            // a row. Each emit drives a full list rebuild in the UI, so
+            // without this drain the list visibly flashes once per raw event
+            // instead of once per save.
+            while let Ok(Ok(_event)) =
+                rx.recv_timeout(std::time::Duration::from_millis(250))
+            {
+                // drained, ignored
+            }
+            let _ = app_handle.emit("artifacts:changed", ());
         }
     });
 }


### PR DESCRIPTION
## What

Two fixes to `spawn_meetings_refresh_watcher` in `tauri/src-tauri/src/main.rs`, found while validating the desktop app builds/runs on Linux.

## Why

The meetings list was continuously flashing/re-rendering on Linux with no new meeting content. Root cause: the fs watcher backing the `artifacts:changed` event assumed macOS FSEvents-style coalesced notifications. On Linux, `notify`'s inotify backend fires one raw event per syscall (write, chmod, close-write, rename, atime touch) instead of batching them — and this watcher emitted `artifacts:changed` for every single one, with no filtering by event kind. The UI does a full `replaceChildren()` rebuild of the list on that event, so every raw fs event became a visible flash.

Two independent causes, two commits:

1. **`d4cbccd` — coalesce bursts.** A single logical save (e.g. finishing a recording) triggers several raw inotify events in quick succession. Drain a 250ms trailing window after the first hit before emitting once.
2. **`0593b70` — ignore metadata-only events.** Coalescing alone didn't fully fix it: desktop search indexers (Tracker on GNOME, Baloo on KDE) commonly `stat`/touch atime on files under a watched, recursive tree like `~/meetings`, and those show up as their own inotify events distinct from a real write. Filter `EventKind::Access` and `Modify(Metadata(_))` — only real content changes now trigger a refresh.

## Verification

Manual instrumentation + synthetic fs bursts against the built Linux binary (not part of the diff, done locally):

- 20 rapid writes + touch + chmod on a meeting `.md`: **861 emits before, 6 after** commit 1
- 30 metadata-only touches (touch/chmod, indexer-style): **0 emits** after commit 2, vs 1 with only commit 1
- 1 real content write still produces exactly 1 emit

`cargo build -p minutes-app` succeeds on Linux (Wayland session, GTK3/webkit2gtk-4.1/libsoup-3), app launches and stays alive with no crash.

`cargo test --workspace --no-fail-fast`: 242 passed / 2 failed in `minutes-app`, same 2 failures reproduced identically on `main` before this change (hardcoded `/home/geert/meetings` path assumption in two unrelated tests) — not caused by this PR. Other pre-existing failures in `minutes-core` are environmental (missing whisper model file, mutex poisoning from parallel test runs), also present on `main` and unrelated to this diff.

## Scope

Only `tauri/src-tauri/src/main.rs` changed. No UI, no API, no config changes.