### PR TITLE
feat: make agents aware of live screen context

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ command = "npx"
 args = ["minutes-mcp"]
 ```
 
-All 35 tools are available in Vibe as `minutes_*` (e.g. `minutes_start_recording`, `minutes_search_meetings`).
+All 36 tools are available in Vibe as `minutes_*` (e.g. `minutes_start_recording`, `minutes_search_meetings`).
 
 ### Claude Code (Plugin)
 
@@ -1200,6 +1200,21 @@ agent = "claude"          # CLI launched by the Tauri AI Assistant
 agent_args = []           # Optional extra args, e.g. ["--dangerously-skip-permissions"]
 ```
 
+When screen context is enabled, Minutes records its observed state separately
+from desktop app/window metadata. Inspect the current state without exposing an
+image, or retrieve up to three verified PNGs nearest a meeting moment:
+
+```bash
+minutes context status --json
+minutes context screen --session <context-session-id> --at <rfc3339-time> --limit 1 --json
+```
+
+MCP clients can request the same bounded images with `get_screen_context`.
+Images are never attached to every prompt automatically, and an assistant
+should only claim it can see the screen after it has opened or received a
+specific returned image. Unless `keep_after_summary = true`, Minutes deletes
+the PNGs and their readable references after summarization.
+
 ## Architecture
 
 ```
@@ -1210,7 +1225,7 @@ minutes/
 ├── crates/reader/        Lightweight read-only meeting parser (no audio deps)
 ├── crates/assets/        Bundled assets (demo.wav)
 ├── crates/sdk/           TypeScript SDK — `npm install minutes-sdk` (query meetings programmatically)
-├── crates/mcp/           MCP server — 35 tools + 8 resources + interactive dashboard
+├── crates/mcp/           MCP server — 36 tools + 8 resources + interactive dashboard
 │   └── ui/               MCP App dashboard (vanilla TS → single-file HTML)
 ├── tauri/                Menu bar app — system tray, recording UI, singleton AI Assistant
 └── .claude/plugins/minutes/   Claude Code plugin — 19 skills + 1 agent + 2 hooks

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1472,6 +1472,44 @@ enum TemplateCmd {
 
 #[derive(Subcommand)]
 enum ContextAction {
+    /// Report observed desktop and screen-context state for the current session
+    Status {
+        /// Explicit context session id
+        #[arg(long)]
+        session: Option<String>,
+
+        /// Artifact path already linked to a context session
+        #[arg(long)]
+        path: Option<PathBuf>,
+
+        /// Output raw JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Retrieve verified screenshots linked to a context session
+    Screen {
+        /// Explicit context session id
+        #[arg(long)]
+        session: Option<String>,
+
+        /// Artifact path already linked to a context session
+        #[arg(long)]
+        path: Option<PathBuf>,
+
+        /// Select the nearest screenshot around this RFC3339 timestamp
+        #[arg(long)]
+        at: Option<String>,
+
+        /// Maximum screenshots to return (1-3)
+        #[arg(short, long, default_value = "1")]
+        limit: usize,
+
+        /// Output raw JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Summarize desktop context for a session, artifact, or explicit time window
     ActivitySummary {
         /// Explicit context session id
@@ -2495,6 +2533,7 @@ fn cmd_record(
     }
     let context_session_id = minutes_core::desktop_context::maybe_start_capture_session(
         &config.desktop_context,
+        config.screen_context.enabled,
         capture_mode,
         title.clone(),
         recording_started_at,
@@ -5924,6 +5963,7 @@ fn build_capability_report() -> CapabilityReport {
     features.insert("activity_summary".into(), true);
     features.insert("search_context".into(), true);
     features.insert("get_moment".into(), true);
+    features.insert("screen_context".into(), true);
 
     // Stable surfaces. Listed explicitly so consumers can probe for
     // them without relying on version-string inference.
@@ -11883,6 +11923,24 @@ fn cmd_insights(
 
 fn cmd_context(action: ContextAction) -> Result<()> {
     match action {
+        ContextAction::Status {
+            session,
+            path,
+            json,
+        } => cmd_context_status(session.as_deref(), path.as_deref(), json),
+        ContextAction::Screen {
+            session,
+            path,
+            at,
+            limit,
+            json,
+        } => cmd_context_screen(
+            session.as_deref(),
+            path.as_deref(),
+            at.as_deref(),
+            limit,
+            json,
+        ),
         ContextAction::ActivitySummary {
             session,
             path,
@@ -11942,6 +12000,82 @@ fn resolve_context_session(
         )?);
     }
     Ok(None)
+}
+
+fn resolve_context_session_or_latest(
+    session: Option<&str>,
+    path: Option<&Path>,
+) -> Result<Option<minutes_core::context_store::ContextSession>> {
+    match resolve_context_session(session, path)? {
+        Some(session) => Ok(Some(session)),
+        None if session.is_some() || path.is_some() => {
+            anyhow::bail!("the requested context session or linked path was not found")
+        }
+        None => Ok(minutes_core::context_store::latest_context_session()?),
+    }
+}
+
+fn cmd_context_status(session: Option<&str>, path: Option<&Path>, json: bool) -> Result<()> {
+    let session = resolve_context_session_or_latest(session, path)?;
+    let status = if let Some(session) = &session {
+        minutes_core::context_store::screen_context_status_for_session(&session.id)?
+            .unwrap_or_default()
+    } else {
+        minutes_core::context_store::ScreenContextStatus::default()
+    };
+    let output = serde_json::json!({
+        "session": session,
+        "screen_context": status,
+        "desktop_context": {
+            "configured": minutes_core::config::Config::load().desktop_context.enabled,
+            "note": "Desktop context contains app/window metadata, not screen pixels."
+        }
+    });
+    if !json {
+        eprintln!(
+            "Screen context: {} ({} successful captures)",
+            serde_json::to_string(&status.state)?.trim_matches('"'),
+            status.successful_capture_count
+        );
+    }
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn cmd_context_screen(
+    session: Option<&str>,
+    path: Option<&Path>,
+    at: Option<&str>,
+    limit: usize,
+    json: bool,
+) -> Result<()> {
+    let anchor = at.map(parse_rfc3339_local).transpose()?;
+    let explicitly_selected = session.is_some() || path.is_some();
+    let resolved = if let Some(session) = resolve_context_session(session, path)? {
+        Some(session)
+    } else if explicitly_selected {
+        anyhow::bail!("the requested context session or linked path was not found");
+    } else if let Some(anchor) = anchor {
+        minutes_core::context_store::get_session_covering_time(anchor)?
+    } else {
+        minutes_core::context_store::latest_context_session()?
+    };
+    let Some(session) = resolved else {
+        anyhow::bail!("no context session is available");
+    };
+    let output = minutes_core::context_store::get_screen_context(&session.id, anchor, limit)?;
+    if !json {
+        eprintln!(
+            "Screen context: {} — {} verified image(s)",
+            serde_json::to_string(&output.status.state)?.trim_matches('"'),
+            output.images.len()
+        );
+        if let Some(reason) = &output.reason {
+            eprintln!("  {reason}");
+        }
+    }
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
 }
 
 fn summarize_counts(values: impl Iterator<Item = Option<String>>) -> Vec<ContextCount> {

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -1160,6 +1160,19 @@ fn record_to_wav_dual_source(
 
     let (live_tx, sidecar_handle) = start_live_sidecar(config, &stop_flag);
 
+    // Screen context is an independent evidence lane. Start it before opening
+    // either audio stream so a slow or blocked microphone/system-audio setup
+    // cannot leave an opted-in session falsely reporting `off`.
+    let screen_context_session_id = started_context
+        .as_ref()
+        .and_then(|context| context.session_id.clone());
+    let _screen_handle = start_screen_capture_if_enabled(
+        config,
+        output_path,
+        &stop_flag,
+        screen_context_session_id.as_deref(),
+    );
+
     let mut voice_stream = Some(AudioStream::start(plan.voice_override.as_deref())?);
     let (system_tx, system_backend_rx) = crossbeam_channel::bounded(64);
     let mut system_backend = crate::system_audio_backend::system_audio_backend_for_config(
@@ -1195,8 +1208,6 @@ fn record_to_wav_dual_source(
         "using dual-source audio input devices"
     );
     emit_recording_started(started_context);
-
-    let _screen_handle = start_screen_capture_if_enabled(config, output_path, &stop_flag);
 
     let preflight_intent = config
         .recording
@@ -1568,6 +1579,19 @@ pub fn record_to_wav_with_lifecycle(
     // so agents can see what's being discussed during the recording.
     let (live_tx, sidecar_handle) = start_live_sidecar(config, &stop_flag);
 
+    // Screen context is independent of microphone readiness. Start it before
+    // building the audio stream so permission prompts or a slow device cannot
+    // strand the observed state at `off` after the recording session starts.
+    let screen_context_session_id = started_context
+        .as_ref()
+        .and_then(|context| context.session_id.clone());
+    let _screen_handle = start_screen_capture_if_enabled(
+        config,
+        output_path,
+        &stop_flag,
+        screen_context_session_id.as_deref(),
+    );
+
     // Build initial stream (wrapped in Option for reconnection)
     let mut stream = Some(build_capture_stream(
         &device,
@@ -1590,9 +1614,6 @@ pub fn record_to_wav_with_lifecycle(
         crate::device_monitor::DeviceMonitor::new(&device_name)
     };
     let mut current_device_name = device_name;
-
-    // Start screen context capture if enabled (with permission check)
-    let _screen_handle = start_screen_capture_if_enabled(config, output_path, &stop_flag);
 
     // Safety guard for auto-stop on silence, time cap, disk space
     let preflight_intent = config
@@ -1791,23 +1812,98 @@ fn start_screen_capture_if_enabled(
     config: &crate::config::Config,
     output_path: &Path,
     stop_flag: &Arc<AtomicBool>,
+    context_session_id: Option<&str>,
 ) -> Option<crate::screen::ScreenCaptureHandle> {
+    if let Some(session_id) = context_session_id {
+        match crate::context_store::initialize_screen_context(
+            session_id,
+            config.screen_context.enabled,
+            config.screen_context.interval_secs,
+            config.screen_context.keep_after_summary,
+        ) {
+            Ok(status) => {
+                crate::screen::write_current_session_status(&status).ok();
+            }
+            Err(error) => {
+                tracing::warn!(session_id, error = %error, "failed to initialize screen context state");
+            }
+        }
+    }
+
     if !config.screen_context.enabled {
         return None;
     }
 
     if !crate::screen::check_screen_permission() {
+        if let Some(session_id) = context_session_id {
+            if let Ok(status) = crate::context_store::mark_screen_context_unavailable(
+                session_id,
+                "Screen Recording permission is unavailable",
+            ) {
+                crate::screen::write_current_session_status(&status).ok();
+            }
+        }
         report_screen_permission_failure(output_path);
         return None;
     }
 
     let screen_dir = crate::screen::screens_dir_for(output_path);
-    match crate::screen::start_capture(
+    let event_sink = context_session_id.map(|session_id| {
+        let session_id = session_id.to_string();
+        std::sync::Arc::new(move |event| {
+            let update = match event {
+                crate::screen::ScreenCaptureEvent::Captured {
+                    path,
+                    observed_at,
+                    capture_index,
+                    elapsed_seconds,
+                    byte_size,
+                } => crate::context_store::record_screen_capture_success(
+                    &session_id,
+                    &path,
+                    observed_at,
+                    capture_index,
+                    elapsed_seconds,
+                    byte_size,
+                ),
+                crate::screen::ScreenCaptureEvent::Failed { observed_at, error } => {
+                    crate::context_store::record_screen_capture_failure(
+                        &session_id,
+                        observed_at,
+                        &error,
+                    )
+                }
+                crate::screen::ScreenCaptureEvent::Stopped { observed_at } => {
+                    crate::context_store::mark_screen_context_stopped(&session_id, observed_at)
+                }
+            };
+            match update {
+                Ok(status) => {
+                    crate::screen::write_current_session_status(&status).ok();
+                }
+                Err(error) => {
+                    tracing::warn!(session_id, error = %error, "failed to persist screen capture event");
+                }
+            }
+        }) as crate::screen::ScreenCaptureEventSink
+    });
+    match crate::screen::start_capture_with_events(
         &screen_dir,
-        std::time::Duration::from_secs(config.screen_context.interval_secs),
+        std::time::Duration::from_secs(config.screen_context.interval_secs.max(1)),
         Arc::clone(stop_flag),
+        event_sink,
     ) {
         Ok(handle) => {
+            if let Some(session_id) = context_session_id {
+                match crate::context_store::mark_screen_context_waiting(session_id, &screen_dir) {
+                    Ok(status) => {
+                        crate::screen::write_current_session_status(&status).ok();
+                    }
+                    Err(error) => {
+                        tracing::warn!(session_id, error = %error, "failed to link screen capture directory");
+                    }
+                }
+            }
             eprintln!(
                 "[minutes] Screen context capture enabled (every {}s)",
                 config.screen_context.interval_secs
@@ -1815,6 +1911,15 @@ fn start_screen_capture_if_enabled(
             Some(handle)
         }
         Err(e) => {
+            if let Some(session_id) = context_session_id {
+                if let Ok(status) = crate::context_store::record_screen_capture_failure(
+                    session_id,
+                    chrono::Local::now(),
+                    &e.to_string(),
+                ) {
+                    crate::screen::write_current_session_status(&status).ok();
+                }
+            }
             tracing::warn!(
                 "screen capture init failed: {} — continuing without screen context",
                 e

--- a/crates/core/src/context_store.rs
+++ b/crates/core/src/context_store.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::markdown::ContentType;
 use crate::pid::CaptureMode;
 use chrono::{DateTime, Local};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
@@ -40,6 +40,8 @@ pub enum ContextStoreError {
         value: String,
         source: chrono::ParseError,
     },
+    #[error("invalid context request: {0}")]
+    InvalidRequest(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -175,6 +177,73 @@ pub enum ContextLinkKind {
     LiveTranscriptWav,
     ScreenshotDirectory,
     PreservedCapture,
+}
+
+pub const MAX_SCREEN_CONTEXT_IMAGES: usize = 3;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ScreenContextState {
+    #[default]
+    Off,
+    Configured,
+    PermissionUnavailable,
+    WaitingForFirstCapture,
+    Capturing,
+    CaptureDegraded,
+    Stopped,
+    Cleaned,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ScreenContextRetention {
+    #[default]
+    Ephemeral,
+    Retained,
+    Cleaned,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScreenContextStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_session_id: Option<String>,
+    pub state: ScreenContextState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub configured_interval_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_started_at: Option<DateTime<Local>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_stopped_at: Option<DateTime<Local>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attempt_at: Option<DateTime<Local>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_successful_capture_at: Option<DateTime<Local>>,
+    #[serde(default)]
+    pub successful_capture_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub most_recent_error: Option<String>,
+    pub retention: ScreenContextRetention,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScreenContextImage {
+    pub path: String,
+    pub captured_at: DateTime<Local>,
+    pub distance_seconds: i64,
+    pub byte_size: u64,
+    pub exists: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScreenContextResult {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<ContextSession>,
+    pub status: ScreenContextStatus,
+    #[serde(default)]
+    pub images: Vec<ScreenContextImage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 impl ContextLinkKind {
@@ -995,6 +1064,9 @@ pub fn mark_capture_session_discarded(
     session_id: &str,
     ended_at: Option<DateTime<Local>>,
 ) -> Result<(), ContextStoreError> {
+    if let Ok(status) = cleanup_screen_context(session_id) {
+        crate::screen::write_current_session_status(&status).ok();
+    }
     update_session_state(
         session_id,
         ContextSessionState::Discarded,
@@ -1067,6 +1139,468 @@ pub fn mark_live_transcript_failed(
         None,
         json!({ "diagnostic": diagnostic }),
     )
+}
+
+fn screen_status_from_session(session: &ContextSession) -> ScreenContextStatus {
+    session
+        .metadata
+        .get("screen_context")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_else(|| ScreenContextStatus {
+            context_session_id: Some(session.id.clone()),
+            ..ScreenContextStatus::default()
+        })
+}
+
+pub fn screen_context_status_for_session(
+    session_id: &str,
+) -> Result<Option<ScreenContextStatus>, ContextStoreError> {
+    Ok(get_session(session_id)?.map(|session| screen_status_from_session(&session)))
+}
+
+pub fn set_screen_context_status(
+    session_id: &str,
+    mut status: ScreenContextStatus,
+) -> Result<ScreenContextStatus, ContextStoreError> {
+    let conn = open_db()?;
+    let Some(session) = get_session_with_conn(&conn, session_id)? else {
+        return Err(ContextStoreError::InvalidRequest(format!(
+            "unknown context session '{session_id}'"
+        )));
+    };
+    status.context_session_id = Some(session_id.to_string());
+    update_session_state_with_conn(
+        &conn,
+        session_id,
+        session.state,
+        None,
+        None,
+        None,
+        json!({ "screen_context": status }),
+    )?;
+    Ok(status)
+}
+
+pub fn latest_context_session() -> Result<Option<ContextSession>, ContextStoreError> {
+    let conn = open_db()?;
+    let mut stmt = conn.prepare(
+        "SELECT id, session_type, state, capture_mode, content_type, title, started_at, ended_at, metadata_json
+         FROM context_sessions
+         ORDER BY started_at DESC
+         LIMIT 1",
+    )?;
+    let mut rows = stmt.query([])?;
+    if let Some(row) = rows.next()? {
+        Ok(Some(row_to_session(row)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn latest_active_context_session() -> Result<Option<ContextSession>, ContextStoreError> {
+    let conn = open_db()?;
+    let mut stmt = conn.prepare(
+        "SELECT id, session_type, state, capture_mode, content_type, title, started_at, ended_at, metadata_json
+         FROM context_sessions
+         WHERE state = ?1
+         ORDER BY started_at DESC
+         LIMIT 1",
+    )?;
+    let mut rows = stmt.query(params![ContextSessionState::Active.as_str()])?;
+    if let Some(row) = rows.next()? {
+        Ok(Some(row_to_session(row)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn initialize_screen_context(
+    session_id: &str,
+    enabled: bool,
+    interval_secs: u64,
+    keep_after_summary: bool,
+) -> Result<ScreenContextStatus, ContextStoreError> {
+    set_screen_context_status(
+        session_id,
+        ScreenContextStatus {
+            context_session_id: Some(session_id.to_string()),
+            state: if enabled {
+                ScreenContextState::Configured
+            } else {
+                ScreenContextState::Off
+            },
+            configured_interval_secs: enabled.then_some(interval_secs),
+            retention: if keep_after_summary {
+                ScreenContextRetention::Retained
+            } else {
+                ScreenContextRetention::Ephemeral
+            },
+            ..ScreenContextStatus::default()
+        },
+    )
+}
+
+pub fn mark_screen_context_waiting(
+    session_id: &str,
+    directory: &Path,
+) -> Result<ScreenContextStatus, ContextStoreError> {
+    let canonical = directory.canonicalize()?;
+    upsert_link(
+        session_id,
+        ContextLinkKind::ScreenshotDirectory,
+        &canonical.display().to_string(),
+        json!({}),
+    )?;
+    let mut status = screen_context_status_for_session(session_id)?.ok_or_else(|| {
+        ContextStoreError::InvalidRequest(format!("unknown context session '{session_id}'"))
+    })?;
+    status.state = ScreenContextState::WaitingForFirstCapture;
+    status.worker_started_at = Some(Local::now());
+    status.worker_stopped_at = None;
+    status.most_recent_error = None;
+    set_screen_context_status(session_id, status)
+}
+
+pub fn mark_screen_context_unavailable(
+    session_id: &str,
+    error: &str,
+) -> Result<ScreenContextStatus, ContextStoreError> {
+    let mut status = screen_context_status_for_session(session_id)?.ok_or_else(|| {
+        ContextStoreError::InvalidRequest(format!("unknown context session '{session_id}'"))
+    })?;
+    status.state = ScreenContextState::PermissionUnavailable;
+    status.last_attempt_at = Some(Local::now());
+    status.most_recent_error = Some(error.to_string());
+    set_screen_context_status(session_id, status)
+}
+
+pub fn record_screen_capture_success(
+    session_id: &str,
+    path: &Path,
+    observed_at: DateTime<Local>,
+    capture_index: u32,
+    elapsed_seconds: u64,
+    byte_size: u64,
+) -> Result<ScreenContextStatus, ContextStoreError> {
+    let canonical = path.canonicalize()?;
+    append_event(
+        session_id,
+        NewContextEvent {
+            observed_at,
+            source: ContextEventSource::ScreenshotRef,
+            app_name: None,
+            bundle_id: None,
+            window_title: None,
+            url: None,
+            domain: None,
+            artifact_path: Some(canonical.display().to_string()),
+            privacy_scope: ContextPrivacyScope::Normal,
+            metadata: json!({
+                "capture_index": capture_index,
+                "elapsed_seconds": elapsed_seconds,
+                "byte_size": byte_size,
+            }),
+        },
+    )?;
+    let mut status = screen_context_status_for_session(session_id)?.ok_or_else(|| {
+        ContextStoreError::InvalidRequest(format!("unknown context session '{session_id}'"))
+    })?;
+    status.state = ScreenContextState::Capturing;
+    status.last_attempt_at = Some(observed_at);
+    status.last_successful_capture_at = Some(observed_at);
+    status.successful_capture_count = status.successful_capture_count.saturating_add(1);
+    status.most_recent_error = None;
+    set_screen_context_status(session_id, status)
+}
+
+pub fn record_screen_capture_failure(
+    session_id: &str,
+    observed_at: DateTime<Local>,
+    error: &str,
+) -> Result<ScreenContextStatus, ContextStoreError> {
+    let mut status = screen_context_status_for_session(session_id)?.ok_or_else(|| {
+        ContextStoreError::InvalidRequest(format!("unknown context session '{session_id}'"))
+    })?;
+    status.state = ScreenContextState::CaptureDegraded;
+    status.last_attempt_at = Some(observed_at);
+    status.most_recent_error = Some(error.to_string());
+    set_screen_context_status(session_id, status)
+}
+
+pub fn mark_screen_context_stopped(
+    session_id: &str,
+    stopped_at: DateTime<Local>,
+) -> Result<ScreenContextStatus, ContextStoreError> {
+    let mut status = screen_context_status_for_session(session_id)?.ok_or_else(|| {
+        ContextStoreError::InvalidRequest(format!("unknown context session '{session_id}'"))
+    })?;
+    if status.state != ScreenContextState::Cleaned
+        && status.state != ScreenContextState::PermissionUnavailable
+        && status.state != ScreenContextState::Off
+    {
+        status.state = ScreenContextState::Stopped;
+    }
+    status.worker_stopped_at = Some(stopped_at);
+    set_screen_context_status(session_id, status)
+}
+
+pub fn relink_screen_context_directory(
+    session_id: &str,
+    new_directory: &Path,
+) -> Result<(), ContextStoreError> {
+    let new_directory = new_directory.canonicalize()?;
+    let canonical_root = screen_root().canonicalize()?;
+    if !new_directory.starts_with(&canonical_root) {
+        return Err(ContextStoreError::InvalidRequest(format!(
+            "screen directory is outside {}",
+            canonical_root.display()
+        )));
+    }
+    let new_target = new_directory.display().to_string();
+    let mut conn = open_db()?;
+    let tx = conn.transaction()?;
+    let old_target: Option<String> = tx
+        .query_row(
+            "SELECT target FROM context_links
+             WHERE session_id = ?1 AND kind = ?2
+             ORDER BY linked_at DESC LIMIT 1",
+            params![session_id, ContextLinkKind::ScreenshotDirectory.as_str()],
+            |row| row.get(0),
+        )
+        .optional()?;
+
+    if let Some(old_target) = old_target {
+        tx.execute(
+            "UPDATE context_links SET target = ?3, linked_at = ?4
+             WHERE session_id = ?1 AND kind = ?2 AND target = ?5",
+            params![
+                session_id,
+                ContextLinkKind::ScreenshotDirectory.as_str(),
+                new_target,
+                timestamp_to_db(Local::now()),
+                old_target,
+            ],
+        )?;
+
+        let mut stmt = tx.prepare(
+            "SELECT id, artifact_path FROM context_events
+             WHERE session_id = ?1 AND source = ?2 AND artifact_path IS NOT NULL",
+        )?;
+        let rows = stmt
+            .query_map(
+                params![session_id, ContextEventSource::ScreenshotRef.as_str()],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(stmt);
+        let old_directory = PathBuf::from(old_target);
+        for (id, old_path) in rows {
+            let relative = Path::new(&old_path)
+                .strip_prefix(&old_directory)
+                .map_err(|_| {
+                    ContextStoreError::InvalidRequest(format!(
+                        "screenshot ref is outside its linked directory: {old_path}"
+                    ))
+                })?;
+            let new_path = new_directory.join(relative).display().to_string();
+            tx.execute(
+                "UPDATE context_events SET artifact_path = ?2 WHERE id = ?1",
+                params![id, new_path],
+            )?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+fn screen_root() -> PathBuf {
+    Config::minutes_dir().join("screens")
+}
+
+fn canonical_screen_file(
+    path: &Path,
+    linked_directories: &[PathBuf],
+) -> Result<PathBuf, ContextStoreError> {
+    if path.extension().and_then(|value| value.to_str()) != Some("png") {
+        return Err(ContextStoreError::InvalidRequest(
+            "screen context only supports PNG artifacts".into(),
+        ));
+    }
+    let canonical = path.canonicalize()?;
+    let canonical_root = screen_root().canonicalize()?;
+    if !canonical.starts_with(&canonical_root) {
+        return Err(ContextStoreError::InvalidRequest(format!(
+            "screen artifact is outside {}",
+            canonical_root.display()
+        )));
+    }
+    if !linked_directories
+        .iter()
+        .any(|directory| canonical.starts_with(directory))
+    {
+        return Err(ContextStoreError::InvalidRequest(
+            "screen artifact is not linked to the selected session".into(),
+        ));
+    }
+    Ok(canonical)
+}
+
+pub fn get_screen_context(
+    session_id: &str,
+    anchor: Option<DateTime<Local>>,
+    limit: usize,
+) -> Result<ScreenContextResult, ContextStoreError> {
+    if limit == 0 || limit > MAX_SCREEN_CONTEXT_IMAGES {
+        return Err(ContextStoreError::InvalidRequest(format!(
+            "screen image limit must be between 1 and {MAX_SCREEN_CONTEXT_IMAGES}"
+        )));
+    }
+    let Some(session) = get_session(session_id)? else {
+        return Err(ContextStoreError::InvalidRequest(format!(
+            "unknown context session '{session_id}'"
+        )));
+    };
+    let status = screen_status_from_session(&session);
+    let linked_directories = list_links_for_session(session_id)?
+        .into_iter()
+        .filter(|link| link.kind == ContextLinkKind::ScreenshotDirectory)
+        .filter_map(|link| PathBuf::from(link.target).canonicalize().ok())
+        .collect::<Vec<_>>();
+
+    let mut events = list_events_for_session(session_id, None, None)?
+        .into_iter()
+        .filter(|event| event.source == ContextEventSource::ScreenshotRef)
+        .collect::<Vec<_>>();
+    if let Some(anchor) = anchor {
+        let (mut before, mut after): (Vec<_>, Vec<_>) = events
+            .into_iter()
+            .partition(|event| event.observed_at <= anchor);
+        before.sort_by_key(|event| std::cmp::Reverse(event.observed_at));
+        after.sort_by_key(|event| event.observed_at);
+        events = Vec::with_capacity(before.len() + after.len());
+        if !before.is_empty() {
+            events.push(before.remove(0));
+        }
+        if !after.is_empty() {
+            events.push(after.remove(0));
+        }
+        before.extend(after);
+        before.sort_by_key(|event| (event.observed_at - anchor).num_seconds().unsigned_abs());
+        events.extend(before);
+    } else {
+        events.sort_by_key(|event| std::cmp::Reverse(event.observed_at));
+    }
+
+    let reference_time = anchor.unwrap_or_else(Local::now);
+    let mut images = Vec::new();
+    for event in events {
+        let Some(path) = event.artifact_path.as_deref() else {
+            continue;
+        };
+        let canonical = match canonical_screen_file(Path::new(path), &linked_directories) {
+            Ok(path) => path,
+            Err(_) => continue,
+        };
+        let byte_size = canonical.metadata()?.len();
+        images.push(ScreenContextImage {
+            path: canonical.display().to_string(),
+            captured_at: event.observed_at,
+            distance_seconds: (event.observed_at - reference_time).num_seconds(),
+            byte_size,
+            exists: true,
+        });
+        if images.len() == limit {
+            break;
+        }
+    }
+
+    let reason = if images.is_empty() {
+        Some(
+            match status.state {
+                ScreenContextState::Off => "screen context is disabled for this session",
+                ScreenContextState::Configured | ScreenContextState::WaitingForFirstCapture => {
+                    "screen context is waiting for its first successful capture"
+                }
+                ScreenContextState::PermissionUnavailable => {
+                    "screen context permission is unavailable"
+                }
+                ScreenContextState::Cleaned => "screen context was cleaned after summarization",
+                ScreenContextState::CaptureDegraded => {
+                    "screen capture is degraded and no readable image is available"
+                }
+                ScreenContextState::Capturing | ScreenContextState::Stopped => {
+                    "no verified readable screenshot is available"
+                }
+            }
+            .to_string(),
+        )
+    } else {
+        None
+    };
+
+    Ok(ScreenContextResult {
+        session: Some(session),
+        status,
+        images,
+        reason,
+    })
+}
+
+pub fn cleanup_screen_context(session_id: &str) -> Result<ScreenContextStatus, ContextStoreError> {
+    let links = list_links_for_session(session_id)?;
+    let canonical_root = screen_root().canonicalize().ok();
+    let mut cleanup_error = None;
+    for link in links
+        .iter()
+        .filter(|link| link.kind == ContextLinkKind::ScreenshotDirectory)
+    {
+        let directory = PathBuf::from(&link.target);
+        let allowed = directory
+            .canonicalize()
+            .ok()
+            .zip(canonical_root.as_ref())
+            .map(|(candidate, root)| candidate.starts_with(root))
+            .unwrap_or(false);
+        if allowed && directory.exists() {
+            if let Err(error) = std::fs::remove_dir_all(&directory) {
+                cleanup_error = Some(error);
+            }
+        }
+    }
+
+    let mut conn = open_db()?;
+    let tx = conn.transaction()?;
+    tx.execute(
+        "DELETE FROM context_events WHERE session_id = ?1 AND source = ?2",
+        params![session_id, ContextEventSource::ScreenshotRef.as_str()],
+    )?;
+    tx.execute(
+        "DELETE FROM context_links WHERE session_id = ?1 AND kind = ?2",
+        params![session_id, ContextLinkKind::ScreenshotDirectory.as_str()],
+    )?;
+    let session = get_session_with_conn(&tx, session_id)?.ok_or_else(|| {
+        ContextStoreError::InvalidRequest(format!("unknown context session '{session_id}'"))
+    })?;
+    let mut status = screen_status_from_session(&session);
+    status.state = ScreenContextState::Cleaned;
+    status.retention = ScreenContextRetention::Cleaned;
+    status.worker_stopped_at.get_or_insert_with(Local::now);
+    update_session_state_with_conn(
+        &tx,
+        session_id,
+        session.state,
+        None,
+        None,
+        None,
+        json!({ "screen_context": status }),
+    )?;
+    tx.commit()?;
+
+    if let Some(error) = cleanup_error {
+        tracing::warn!(session_id, error = %error, "screen files could not be fully removed; retrieval references were cleaned");
+    }
+    Ok(status)
 }
 
 #[cfg(test)]
@@ -1201,6 +1735,143 @@ mod tests {
             )
             .unwrap();
             assert_eq!(window_events.len(), 2);
+        });
+    }
+
+    #[test]
+    fn screen_context_links_retrieves_nearest_image_and_cleans_honestly() {
+        with_temp_home(|_| {
+            let started_at = Local::now();
+            let session = start_capture_session(CaptureMode::Meeting, None, started_at).unwrap();
+            let initial = initialize_screen_context(&session.id, true, 30, false).unwrap();
+            assert_eq!(initial.state, ScreenContextState::Configured);
+
+            let directory = screen_root().join("current");
+            std::fs::create_dir_all(&directory).unwrap();
+            mark_screen_context_waiting(&session.id, &directory).unwrap();
+
+            let first = directory.join("screen-0000-0030s.png");
+            let second = directory.join("screen-0001-0060s.png");
+            std::fs::write(&first, b"png-one").unwrap();
+            std::fs::write(&second, b"png-two").unwrap();
+            record_screen_capture_success(
+                &session.id,
+                &first,
+                started_at + Duration::seconds(30),
+                0,
+                30,
+                7,
+            )
+            .unwrap();
+            record_screen_capture_success(
+                &session.id,
+                &second,
+                started_at + Duration::seconds(60),
+                1,
+                60,
+                7,
+            )
+            .unwrap();
+
+            let result =
+                get_screen_context(&session.id, Some(started_at + Duration::seconds(45)), 2)
+                    .unwrap();
+            assert_eq!(result.status.state, ScreenContextState::Capturing);
+            assert_eq!(result.images.len(), 2);
+            assert!(result.images[0].path.ends_with("screen-0000-0030s.png"));
+            assert!(result.images[1].path.ends_with("screen-0001-0060s.png"));
+            assert_eq!(result.images[0].distance_seconds, -15);
+            assert_eq!(result.images[1].distance_seconds, 15);
+
+            let cleaned = cleanup_screen_context(&session.id).unwrap();
+            assert_eq!(cleaned.state, ScreenContextState::Cleaned);
+            assert_eq!(cleaned.retention, ScreenContextRetention::Cleaned);
+            assert!(!directory.exists());
+            let after = get_screen_context(&session.id, None, 1).unwrap();
+            assert!(after.images.is_empty());
+            assert_eq!(
+                after.reason.as_deref(),
+                Some("screen context was cleaned after summarization")
+            );
+            assert!(list_links_for_session(&session.id)
+                .unwrap()
+                .into_iter()
+                .all(|link| link.kind != ContextLinkKind::ScreenshotDirectory));
+        });
+    }
+
+    #[test]
+    fn screen_context_rejects_unbounded_image_requests() {
+        with_temp_home(|_| {
+            let session = start_capture_session(CaptureMode::Meeting, None, Local::now()).unwrap();
+            let error =
+                get_screen_context(&session.id, None, MAX_SCREEN_CONTEXT_IMAGES + 1).unwrap_err();
+            assert!(error.to_string().contains("between 1 and 3"));
+        });
+    }
+
+    #[test]
+    fn screen_context_never_returns_an_unlinked_image() {
+        with_temp_home(|home| {
+            let started_at = Local::now();
+            let session = start_capture_session(CaptureMode::Meeting, None, started_at).unwrap();
+            initialize_screen_context(&session.id, true, 30, true).unwrap();
+            let linked = screen_root().join("linked");
+            std::fs::create_dir_all(&linked).unwrap();
+            mark_screen_context_waiting(&session.id, &linked).unwrap();
+
+            let outside = home.path().join("private.png");
+            std::fs::write(&outside, b"not-session-linked").unwrap();
+            append_event(
+                &session.id,
+                NewContextEvent {
+                    observed_at: started_at,
+                    source: ContextEventSource::ScreenshotRef,
+                    app_name: None,
+                    bundle_id: None,
+                    window_title: None,
+                    url: None,
+                    domain: None,
+                    artifact_path: Some(outside.display().to_string()),
+                    privacy_scope: ContextPrivacyScope::Normal,
+                    metadata: json!({}),
+                },
+            )
+            .unwrap();
+
+            let result = get_screen_context(&session.id, None, 1).unwrap();
+            assert!(result.images.is_empty());
+        });
+    }
+
+    #[test]
+    fn screen_context_relinks_refs_when_job_moves_capture_directory() {
+        with_temp_home(|_| {
+            let started_at = Local::now();
+            let session = start_capture_session(CaptureMode::Meeting, None, started_at).unwrap();
+            initialize_screen_context(&session.id, true, 30, true).unwrap();
+            let old_directory = screen_root().join("current");
+            let new_directory = screen_root().join("job-123");
+            std::fs::create_dir_all(&old_directory).unwrap();
+            mark_screen_context_waiting(&session.id, &old_directory).unwrap();
+            let old_image = old_directory.join("screen-0000-0030s.png");
+            std::fs::write(&old_image, b"png").unwrap();
+            record_screen_capture_success(
+                &session.id,
+                &old_image,
+                started_at + Duration::seconds(30),
+                0,
+                30,
+                3,
+            )
+            .unwrap();
+
+            std::fs::rename(&old_directory, &new_directory).unwrap();
+            relink_screen_context_directory(&session.id, &new_directory).unwrap();
+            let result = get_screen_context(&session.id, None, 1).unwrap();
+            assert_eq!(result.images.len(), 1);
+            assert!(result.images[0].path.contains("job-123"));
+            assert!(!result.images[0].path.contains("/current/"));
         });
     }
 

--- a/crates/core/src/desktop_context.rs
+++ b/crates/core/src/desktop_context.rs
@@ -59,18 +59,22 @@ pub fn session_tracking_enabled(settings: &DesktopContextConfig) -> bool {
 
 pub fn maybe_start_capture_session(
     settings: &DesktopContextConfig,
+    screen_context_enabled: bool,
     mode: CaptureMode,
     title: Option<String>,
     started_at: DateTime<Local>,
 ) -> Option<String> {
-    if !session_tracking_enabled(settings) {
+    // Screen capture and desktop metadata are separate opt-in features, but
+    // both need the same canonical session identity. A screen-only user must
+    // not lose screenshot linkage merely because desktop_context is off.
+    if !session_tracking_enabled(settings) && !screen_context_enabled {
         return None;
     }
 
     match context_store::start_capture_session(mode, title, started_at) {
         Ok(session) => Some(session.id),
         Err(error) => {
-            tracing::warn!(error = %error, mode = ?mode, "failed to create desktop context session for capture");
+            tracing::warn!(error = %error, mode = ?mode, "failed to create context session for capture");
             None
         }
     }
@@ -940,11 +944,26 @@ mod tests {
     fn desktop_context_disabled_capture_session_does_not_touch_store() {
         let session = maybe_start_capture_session(
             &DesktopContextConfig::default(),
+            false,
             CaptureMode::Meeting,
             Some("test".into()),
             Local::now(),
         );
         assert!(session.is_none());
+    }
+
+    #[test]
+    fn screen_only_capture_still_gets_a_context_session() {
+        with_temp_home(|_| {
+            let session = maybe_start_capture_session(
+                &DesktopContextConfig::default(),
+                true,
+                CaptureMode::Meeting,
+                Some("screen-only".into()),
+                Local::now(),
+            );
+            assert!(session.is_some());
+        });
     }
 
     #[test]

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -244,6 +244,20 @@ pub fn queue_live_capture_with_recording_health(
         }
         return Err(error);
     }
+    if new_screen_dir.exists() {
+        if let Some(session_id) = job.context_session_id.as_deref() {
+            if let Err(error) =
+                crate::context_store::relink_screen_context_directory(session_id, &new_screen_dir)
+            {
+                tracing::warn!(
+                    session_id,
+                    directory = %new_screen_dir.display(),
+                    error = %error,
+                    "failed to relink moved screen context directory"
+                );
+            }
+        }
+    }
     maybe_mark_context_session_processing(&job, &audio_path);
     Ok(job)
 }
@@ -1169,6 +1183,11 @@ pub fn remove_capture_artifacts(job: &ProcessingJob) {
     if screens_dir.exists() {
         fs::remove_dir_all(screens_dir).ok();
     }
+    if let Some(session_id) = job.context_session_id.as_deref() {
+        if let Ok(status) = crate::context_store::cleanup_screen_context(session_id) {
+            crate::screen::write_current_session_status(&status).ok();
+        }
+    }
 }
 
 fn terminal_state_for_artifact(artifact: &pipeline::TranscriptArtifact) -> JobState {
@@ -1365,6 +1384,7 @@ fn job_context(job: &ProcessingJob) -> BackgroundPipelineContext {
         recorded_at: job.recording_started_at.or(job.recording_finished_at),
         requested_title: job.title.clone(),
         recording_health: job.recording_health.clone(),
+        context_session_id: job.context_session_id.clone(),
         template,
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -1375,6 +1375,9 @@ pub struct BackgroundPipelineContext {
     pub recorded_at: Option<DateTime<Local>>,
     pub requested_title: Option<String>,
     pub recording_health: Option<crate::markdown::RecordingHealth>,
+    /// Canonical context session for desktop and screen evidence captured
+    /// alongside this recording.
+    pub context_session_id: Option<String>,
     /// Optional template applied to summarization. Recorded in frontmatter
     /// so Phase 2 reprocessing knows which template produced this file.
     pub template: Option<crate::template::Template>,
@@ -1988,11 +1991,20 @@ where
         );
     }
 
-    if !screen_files.is_empty()
-        && !config.screen_context.keep_after_summary
-        && std::fs::remove_dir_all(&screen_dir).is_ok()
-    {
-        tracing::info!(dir = %screen_dir.display(), "screen captures cleaned up");
+    if !config.screen_context.keep_after_summary {
+        if let Some(session_id) = context.context_session_id.as_deref() {
+            match crate::context_store::cleanup_screen_context(session_id) {
+                Ok(status) => {
+                    crate::screen::write_current_session_status(&status).ok();
+                    tracing::info!(session_id, "screen captures and retrieval refs cleaned up");
+                }
+                Err(error) => {
+                    tracing::warn!(session_id, error = %error, "failed to clean screen context");
+                }
+            }
+        } else if screen_dir.exists() && std::fs::remove_dir_all(&screen_dir).is_ok() {
+            tracing::info!(dir = %screen_dir.display(), "screen captures cleaned up");
+        }
     }
 
     let attendees = merge_attendees(&artifact.frontmatter.attendees, &summary_participants);
@@ -2601,8 +2613,8 @@ where
     }
 
     // Clean up screen captures (runs regardless of summarization setting — fixes race)
-    if !screen_files.is_empty()
-        && !config.screen_context.keep_after_summary
+    if !config.screen_context.keep_after_summary
+        && screen_dir.exists()
         && std::fs::remove_dir_all(&screen_dir).is_ok()
     {
         tracing::info!(dir = %screen_dir.display(), "screen captures cleaned up");

--- a/crates/core/src/screen.rs
+++ b/crates/core/src/screen.rs
@@ -3,6 +3,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::{DateTime, Local};
+
 // ──────────────────────────────────────────────────────────────
 // Screen context capture.
 //
@@ -66,6 +68,38 @@ pub fn start_capture(
     interval: Duration,
     stop_flag: Arc<AtomicBool>,
 ) -> std::io::Result<ScreenCaptureHandle> {
+    start_capture_with_events(output_dir, interval, stop_flag, None)
+}
+
+#[derive(Debug, Clone)]
+pub enum ScreenCaptureEvent {
+    Captured {
+        path: PathBuf,
+        observed_at: DateTime<Local>,
+        capture_index: u32,
+        elapsed_seconds: u64,
+        byte_size: u64,
+    },
+    Failed {
+        observed_at: DateTime<Local>,
+        error: String,
+    },
+    Stopped {
+        observed_at: DateTime<Local>,
+    },
+}
+
+pub type ScreenCaptureEventSink = Arc<dyn Fn(ScreenCaptureEvent) + Send + Sync + 'static>;
+
+/// Start capture with a lightweight event callback. The callback runs only
+/// after the platform screenshot command has returned, so context-store work
+/// never blocks the OS capture operation itself.
+pub fn start_capture_with_events(
+    output_dir: &Path,
+    interval: Duration,
+    stop_flag: Arc<AtomicBool>,
+    event_sink: Option<ScreenCaptureEventSink>,
+) -> std::io::Result<ScreenCaptureHandle> {
     std::fs::create_dir_all(output_dir)?;
 
     // Set directory permissions to 0700 (owner-only)
@@ -106,6 +140,11 @@ pub fn start_capture(
                     captures = 0,
                     "screen capture stopped (before first capture)"
                 );
+                if let Some(sink) = &event_sink {
+                    sink(ScreenCaptureEvent::Stopped {
+                        observed_at: Local::now(),
+                    });
+                }
                 return;
             }
             std::thread::sleep(Duration::from_millis(250));
@@ -116,8 +155,15 @@ pub fn start_capture(
             let filename = format!("screen-{:04}-{:04}s.png", index, elapsed);
             let path = dir.join(&filename);
 
+            let capture_index = index;
             if let Err(e) = capture_screenshot(&path) {
                 tracing::warn!("screen capture failed: {}", e);
+                if let Some(sink) = &event_sink {
+                    sink(ScreenCaptureEvent::Failed {
+                        observed_at: Local::now(),
+                        error: e.to_string(),
+                    });
+                }
                 // Don't break — transient failures (e.g., screen locked) are OK
             } else {
                 // Set file permissions to 0600 (owner-only)
@@ -127,6 +173,15 @@ pub fn start_capture(
                     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).ok();
                 }
                 tracing::debug!(file = %filename, "screen captured");
+                if let Some(sink) = &event_sink {
+                    sink(ScreenCaptureEvent::Captured {
+                        path: path.clone(),
+                        observed_at: Local::now(),
+                        capture_index,
+                        elapsed_seconds: elapsed,
+                        byte_size: path.metadata().map(|metadata| metadata.len()).unwrap_or(0),
+                    });
+                }
                 index += 1;
             }
 
@@ -141,12 +196,71 @@ pub fn start_capture(
         }
 
         tracing::info!(captures = index, "screen capture stopped");
+        if let Some(sink) = &event_sink {
+            sink(ScreenCaptureEvent::Stopped {
+                observed_at: Local::now(),
+            });
+        }
     });
 
     Ok(ScreenCaptureHandle {
         stop: own_stop,
         thread: Some(handle),
     })
+}
+
+pub const CURRENT_SESSION_FILE: &str = "CURRENT_SESSION.md";
+
+/// Write the small dynamic state breadcrumb consumed by PTY assistants. It
+/// deliberately contains no image bytes or transcript text; the CLI remains
+/// the authoritative bounded retrieval path.
+pub fn write_current_session_status(
+    status: &crate::context_store::ScreenContextStatus,
+) -> std::io::Result<PathBuf> {
+    let workspace = crate::config::Config::minutes_dir().join("assistant");
+    std::fs::create_dir_all(&workspace)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&workspace, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    let path = workspace.join(CURRENT_SESSION_FILE);
+    let session_id = status
+        .context_session_id
+        .as_deref()
+        .unwrap_or("unavailable");
+    let last_capture = status
+        .last_successful_capture_at
+        .map(|timestamp| timestamp.to_rfc3339())
+        .unwrap_or_else(|| "none".into());
+    let error = status.most_recent_error.as_deref().unwrap_or("none");
+    let state = serde_json::to_string(&status.state)
+        .unwrap_or_else(|_| "\"unknown\"".into())
+        .trim_matches('"')
+        .to_string();
+    let content = format!(
+        "# Current Minutes Session\n\n\
+- Context session: `{session_id}`\n\
+- Screen context state: `{state}`\n\
+- Successful captures: {}\n\
+- Last successful capture: `{last_capture}`\n\
+- Most recent error: `{error}`\n\
+- Updated: `{}`\n\n\
+Screen images and desktop app/window metadata are separate evidence lanes. Run \
+`minutes context status --json` to refresh state and `minutes context screen \
+--session {session_id} --limit 1 --json` to retrieve a verified image. Never \
+claim to see screen contents until a specific returned image has been opened.\n",
+        status.successful_capture_count,
+        Local::now().to_rfc3339(),
+    );
+    std::fs::write(&path, content)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(path)
 }
 
 /// Maximum number of screenshots per recording session.
@@ -347,5 +461,42 @@ mod tests {
         );
         assert!(!external_stop.load(Ordering::Relaxed));
         assert!(list_screenshots(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn current_session_breadcrumb_is_metadata_only_and_requires_image_inspection() {
+        let _lock = crate::test_home_env_lock();
+        let home = tempfile::tempdir().unwrap();
+        let original_home = std::env::var_os("HOME");
+        #[cfg(windows)]
+        let original_userprofile = std::env::var_os("USERPROFILE");
+        std::env::set_var("HOME", home.path());
+        #[cfg(windows)]
+        std::env::set_var("USERPROFILE", home.path());
+
+        let status = crate::context_store::ScreenContextStatus {
+            context_session_id: Some("ctx-test".into()),
+            state: crate::context_store::ScreenContextState::Capturing,
+            successful_capture_count: 2,
+            ..crate::context_store::ScreenContextStatus::default()
+        };
+        let path = write_current_session_status(&status).unwrap();
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("Screen context state: `capturing`"));
+        assert!(content.contains("minutes context screen"));
+        assert!(content.contains("Never claim to see screen contents"));
+        assert!(!content.contains(".png"));
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        #[cfg(windows)]
+        if let Some(profile) = original_userprofile {
+            std::env::set_var("USERPROFILE", profile);
+        } else {
+            std::env::remove_var("USERPROFILE");
+        }
     }
 }

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -990,6 +990,7 @@ const CHAT_ALLOWED_MCP_TOOLS: &[&str] = &[
     "activity_summary",
     "search_context",
     "get_moment",
+    "get_screen_context",
     "consistency_report",
     "get_person_profile",
     "research_topic",
@@ -3581,6 +3582,7 @@ PARTICIPANTS:
             .expect("--allowedTools must be present");
         assert!(allowed_tools.contains("mcp__minutes__search_meetings"));
         assert!(allowed_tools.contains("mcp__minutes__get_meeting"));
+        assert!(allowed_tools.contains("mcp__minutes__get_screen_context"));
         assert!(!allowed_tools.contains("start_recording"));
         assert!(!allowed_tools.contains("add_note"));
         assert!(!allowed_tools.contains("open_dashboard"));

--- a/crates/mcp/src/capabilities.test.ts
+++ b/crates/mcp/src/capabilities.test.ts
@@ -15,6 +15,7 @@ describe("parseCapabilityReport", () => {
       features: {
         activity_summary: true,
         search_context: true,
+        screen_context: true,
         parakeet: false,
       },
     });
@@ -23,6 +24,7 @@ describe("parseCapabilityReport", () => {
     expect(report?.version).toBe("0.14.0");
     expect(report?.api_version).toBe(1);
     expect(report?.features.activity_summary).toBe(true);
+    expect(report?.features.screen_context).toBe(true);
     expect(report?.features.parakeet).toBe(false);
   });
 

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -15,6 +15,7 @@
  *   - activity_summary: Summarize meeting-adjacent desktop context for a session/path/window
  *   - search_context: Search app and captured window-title desktop context
  *   - get_moment: Show the local rewind around a linked artifact, session, or timestamp
+ *   - get_screen_context: Retrieve bounded, session-linked screen images
  *   - consistency_report: Flag conflicting decisions and stale commitments
  *   - get_person_profile: Rich relationship profile for a person (graph index)
  *   - track_commitments: List open/stale commitments, filter by person
@@ -2837,6 +2838,81 @@ registerDocsAppTool(
       content: [{ type: "text" as const, text }],
       structuredContent: { ...(parsed as any), view: "context", kind: "get_moment" },
       _meta: { ui: { resourceUri: UI_RESOURCE_URI }, view: "context", kind: "get_moment" },
+    };
+  }
+);
+
+// ── Tool: consistency_report ───────────────────────────────
+
+// ── Tool: get_screen_context ───────────────────────────────
+// Direct image content is returned only for paths that the CLI resolved from
+// ScreenshotRef events and that this process independently canonicalizes under
+// ~/.minutes/screens. This is intentionally not a generic local-file tool.
+
+if (hasFeature(CLI_CAPABILITIES, "screen_context"))
+registerDocsAppTool(
+  server,
+  "get_screen_context",
+  {
+    description: "Retrieve up to three verified PNG screenshots linked to a Minutes context session, optionally nearest a timestamp.",
+    inputSchema: {
+      session_id: z.string().optional().describe("Explicit Minutes context session id"),
+      path: z.string().optional().describe("Linked meeting, audio, or live-transcript artifact path"),
+      at: z.string().optional().describe("Nearest-image anchor timestamp (RFC3339)"),
+      limit: z.number().int().min(1).max(3).optional().default(1).describe("Maximum verified images (1-3)"),
+    },
+    annotations: { title: "Get Screen Context", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    _meta: { ui: { resourceUri: UI_RESOURCE_URI } },
+  },
+  async ({ session_id, path, at, limit }) => {
+    if (!(await isCliAvailable())) {
+      return { content: [{ type: "text" as const, text: `Screen-context retrieval requires the full CLI.\n\n${CLI_INSTALL_MSG}` }] };
+    }
+
+    const args = ["context", "screen", "--json", "--limit", String(limit)];
+    if (session_id) args.push("--session", session_id);
+    if (path) args.push("--path", path);
+    if (at) args.push("--at", at);
+
+    const { stdout, stderr } = await runMinutes(args);
+    const parsed = parseJsonOutput(stdout);
+    if (!parsed || typeof parsed !== "object") {
+      return { content: [{ type: "text" as const, text: stderr || stdout }] };
+    }
+
+    const status = (parsed as any).status || {};
+    const images = Array.isArray((parsed as any).images) ? (parsed as any).images.slice(0, 3) : [];
+    const reason = typeof (parsed as any).reason === "string" ? (parsed as any).reason : "";
+    const text = [
+      `Screen context state: ${status.state || "unknown"}`,
+      `Verified images delivered: ${images.length}`,
+      reason,
+      "An image must be inspected before making any visual claim; app/window metadata alone is not sight.",
+    ].filter(Boolean).join("\n");
+
+    const content: Array<
+      | { type: "text"; text: string }
+      | { type: "image"; data: string; mimeType: string }
+    > = [{ type: "text", text }];
+    const screenRoot = join(homedir(), ".minutes", "screens");
+    for (const image of images) {
+      if (!image || typeof image.path !== "string") continue;
+      const resolved = validatePathInDirectory(image.path, screenRoot, [".png"]);
+      const metadata = await stat(resolved);
+      if (metadata.size > 10 * 1024 * 1024) {
+        throw new Error("Screen-context image exceeds the 10 MiB delivery limit");
+      }
+      content.push({
+        type: "image",
+        data: (await readFile(resolved)).toString("base64"),
+        mimeType: "image/png",
+      });
+    }
+
+    return {
+      content,
+      structuredContent: { ...(parsed as any), view: "context", kind: "get_screen_context" },
+      _meta: { ui: { resourceUri: UI_RESOURCE_URI }, view: "context", kind: "get_screen_context" },
     };
   }
 );

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -363,6 +363,17 @@ This section is intentionally narrow:
 - it only affects screenshots during an active recording
 - it is off by default
 - it is not a general ambient desktop-capture mode
+- it is independent of `[desktop_context]`, which stores app/window metadata
+- screenshots are retrieved on demand with `minutes context screen` or the
+  read-only MCP `get_screen_context` tool; they are not attached to every query
+- assistants must not claim they can see the screen unless they opened or were
+  delivered a specific returned image
+
+Use `minutes context status --json` to inspect the observed runtime state. Use
+`minutes context screen --session <id> --at <rfc3339-time> --limit 1 --json` to
+retrieve bounded, verified PNG paths nearest a meeting moment. A limit above
+three is rejected. When `keep_after_summary` is false, cleanup removes both the
+PNG files and their readable context-store references.
 
 ### `[desktop_context]` — meeting-adjacent app/window context
 

--- a/docs/plans/agent-screen-awareness-2026-07-15.md
+++ b/docs/plans/agent-screen-awareness-2026-07-15.md
@@ -1,0 +1,525 @@
+# Plan — Agent-Aware Live Screen Context
+
+Status: implemented on `feat/agent-screen-awareness`; tracked by `minutes-id3j`;
+rebased onto `origin/main` at `ebca4e1` on 2026-07-15. Signed-Mac dogfood
+verified the honest `permission-unavailable` path; the Minutes Dev identity
+still needs a refreshed Screen Recording grant before a real PNG can be
+captured with that identity.
+
+Implementation decisions resolved on 2026-07-15:
+
+- cleanup hard-deletes screenshot events and directory links after removing files;
+- MCP returns direct, bounded image content after CLI and server path validation;
+- the dynamic PTY breadcrumb is `CURRENT_SESSION.md`;
+- native Claude Recall uses the read-only MCP image tool, while providers without
+  image-tool support degrade explicitly rather than receiving ambient attachments;
+- v1 is tool-on-demand and does not add an “include latest screen” UI affordance.
+
+Origin: live dogfood during an external partner meeting. Minutes was recording and
+successfully writing PNGs under `~/.minutes/screens/current/`, but the active
+Codex assistant did not know those images existed until it manually inspected
+the config, source tree, recording metadata, and filesystem. Once the latest
+PNG was opened explicitly, the assistant could see and reason about the Google
+Meet presentation. The model capability worked; the product contract did not.
+
+## Outcome
+
+When screen context is enabled for an active recording, every supported Minutes
+agent surface should be able to answer four questions from observed state:
+
+1. Is screen context configured for this session?
+2. Is it actually capturing, waiting for its first image, unavailable, or
+   stopped?
+3. What is the latest relevant screenshot for this session or moment?
+4. Has the agent actually inspected an image, or does it only have desktop
+   metadata such as app and window titles?
+
+The system must make those answers available without automatically exposing the
+user's screen to every query or conflating screenshots with the separate
+`desktop_context` collector.
+
+## Product contract
+
+### Capability versus observed reality
+
+The agent must distinguish:
+
+- `screen_context.enabled = true`: user intent to capture recording-time
+  screenshots.
+- permission/tool readiness: the current process identity can attempt capture.
+- active capture state: the current recording started a screenshot worker.
+- image availability: at least one screenshot was successfully written and is
+  still readable.
+- visual awareness: the model received or opened a specific image.
+
+Only the final state permits language such as “I can see the slide.” Config
+presence, permission readiness, a directory path, or an app/window event does
+not.
+
+### Screen context versus desktop context
+
+The two existing features remain separate and should be named precisely:
+
+- `screen_context`: periodic PNG screenshots during an active recording.
+- `desktop_context`: event-first app focus, window title, and opted-in browser
+  title metadata during recordings and live sessions.
+
+An agent with only desktop context may say “Google Meet was focused” or quote a
+captured window title. It may not infer the slide contents.
+
+### Privacy boundary
+
+- No ambient or 24/7 screen recording.
+- No screenshot capture when `screen_context.enabled` is false.
+- No image is automatically attached to every Recall message.
+- Screen retrieval is read-only, local-first, bounded, and tied to a known
+  Minutes context session.
+- Retrieval defaults to the nearest one image and caps requests at three.
+- Paths must resolve to screenshot artifacts linked to the selected context
+  session; arbitrary filesystem reads are not accepted.
+- Provider delivery follows the user's configured agent/provider. The UI and
+  agent contract must not imply that a local screenshot stays local if the
+  configured model is remote.
+- `keep_after_summary = false` removes both image files and live retrieval
+  references so tools never advertise stale or deleted images.
+
+## Current implementation and verified gaps
+
+### Capture exists
+
+`crates/core/src/capture.rs::start_screen_capture_if_enabled` checks config and
+permission, derives the screenshot directory, and calls
+`crates/core/src/screen.rs::start_capture`. The capture thread writes
+timestamped PNG files and logs success or failure.
+
+The capture function receives the config, audio output path, and stop flag. It
+does not receive the active `context_session_id`, a context-store handle, or a
+callback that can register successful captures.
+
+### The context schema anticipates screenshots but production does not use it
+
+`crates/core/src/context_store.rs` defines:
+
+- `ContextEventSource::ScreenshotRef`
+- `ContextLinkKind::ScreenshotDirectory`
+- an `artifact_path` on context events
+
+The only verified `ScreenshotRef` append is in a context-store unit test. A
+repo-wide search found no production append and no production screenshot-
+directory link. The architecture document says screenshot references live in
+`context.db`, but actual recording-time PNGs currently bypass that contract.
+
+### Full PTY assistant discovery is incomplete
+
+`tauri/src-tauri/src/context.rs::generate_assistant_context` generates the
+workspace `AGENTS.md` and `CLAUDE.md`. Its CLI inventory includes recording,
+transcript, search, and QMD commands, but omits:
+
+- `minutes context activity-summary`
+- `minutes context search`
+- `minutes context get-moment`
+- screen-context state and retrieval
+- the distinction between screenshot and desktop metadata
+- the requirement to verify an observed image before claiming sight
+
+The live-coaching instruction only controls response style. It supplies no
+screen-awareness workflow.
+
+### Native Recall is a separate surface
+
+Native Recall deliberately runs from a neutral chat workspace rather than the
+full PTY assistant workspace. It writes its own static
+`CHAT_WORKSPACE_CLAUDE_MD`, injects focused meeting text plus keyword search
+excerpts, and gives Claude a read-only MCP allowlist.
+
+`crates/core/src/summarize.rs::build_chat_invocation` explicitly passes an empty
+screenshot list with the comment that chat has no screenshots to deliver.
+Changing only the generated PTY `AGENTS.md` therefore cannot fix native Recall.
+
+### Existing MCP context tools are text-first
+
+`activity_summary`, `search_context`, and `get_moment` expose app/window events
+through CLI and MCP. Their MCP responses contain text and structured JSON, but
+no image content and, because capture does not register screenshot events, no
+reliable screenshot artifact path.
+
+### Existing provider adapters can deliver screenshots
+
+The batch summarization path already knows how to deliver image files to
+different agent CLIs. In particular:
+
+- Claude receives the `Read` tool plus an allowed screenshot directory.
+- Codex receives native image attachments.
+
+This machinery should be reused or factored into a shared image-delivery helper
+instead of creating a second provider-specific implementation.
+
+## Architecture
+
+### 1. Canonical session-linked screen state
+
+Add a core screen-context state model owned by the recording lifecycle:
+
+```text
+off
+configured
+permission-unavailable
+waiting-for-first-capture
+capturing
+capture-degraded
+stopped
+cleaned
+```
+
+The state record should include:
+
+- `context_session_id`
+- recording mode and source
+- screenshot directory link, when created
+- configured interval
+- worker start/stop timestamps
+- last attempt timestamp
+- last successful capture timestamp
+- successful capture count
+- most recent error, when any
+- retention state (`ephemeral`, `retained`, or `cleaned`)
+
+This is observed runtime state, not a restatement of config. It must be written
+by the same process identity that starts capture so macOS TCC identity
+differences cannot produce false readiness claims.
+
+### 2. Context-store linkage
+
+Thread the active `context_session_id` into screen capture startup. At worker
+start:
+
+1. Create the screenshot directory with existing owner-only permissions.
+2. Link it to the context session with
+   `ContextLinkKind::ScreenshotDirectory`.
+3. Set runtime state to `waiting-for-first-capture`.
+
+After each successful PNG write, append a context event:
+
+```text
+source: ScreenshotRef
+observed_at: wall-clock capture time
+artifact_path: canonical PNG path
+privacy_scope: Normal or the active filtered scope
+metadata:
+  capture_index
+  elapsed_seconds
+  width/height when cheaply available
+  byte_size
+```
+
+If current app/window metadata can be joined by timestamp without blocking the
+capture loop, enrich the event. Failure to enrich must never prevent the image
+from being registered.
+
+Do not write image bytes into SQLite. `context.db` remains an index and linkage
+surface; PNGs remain owner-only files.
+
+The capture thread should send lightweight success/failure messages to its
+owner. Context-store writes and state-file updates should happen outside the
+platform screenshot call so SQLite latency cannot stall capture.
+
+### 3. Honest cleanup
+
+When `keep_after_summary = false`, cleanup must be one logical operation:
+
+1. Stop and join the capture worker.
+2. Delete the PNG files and screenshot directory using the existing cleanup
+   path.
+3. Remove screenshot-reference events and the screenshot-directory link, or
+   atomically mark them unavailable with no readable artifact path.
+4. Set runtime state to `cleaned` and retain only non-sensitive aggregate facts
+   needed for diagnostics, such as count and cleanup timestamp.
+
+The implementation should choose one store contract—hard deletion or an
+explicit tombstone—and test it end to end. Retrieval must never return a path
+that it describes as readable after cleanup.
+
+When `keep_after_summary = true`, retained refs remain linked to the completed
+session and can be resolved later by meeting path, session ID, or timestamp.
+
+### 4. Core retrieval contract
+
+Add a provider-neutral core query, conceptually:
+
+```text
+get_screen_context(
+  session_id | linked_path | timestamp,
+  limit = 1,
+  before/after window
+) -> ScreenContextResult
+```
+
+`ScreenContextResult` includes:
+
+- observed screen state
+- selected context session and time window
+- zero to three verified, readable screenshot refs
+- capture timestamps and distance from the requested moment
+- whether each file still exists and passed path validation
+- a clear reason when no image is available
+
+Selection should favor the nearest successful capture at or before the anchor,
+then the nearest after it. This is more useful for questions such as “what was
+on screen when we made that decision?” than simply returning the newest file.
+
+### 5. CLI and MCP surfaces
+
+Add or extend small, opinionated retrieval surfaces rather than a generic file
+API:
+
+- `minutes context status --json`
+  reports current observed desktop and screen-context state.
+- `minutes context screen --session <id> --at <time> --limit 1 --json`
+  returns bounded metadata and local paths for trusted local clients.
+- MCP `get_screen_context`
+  returns a concise text state plus structured metadata and image content for
+  verified refs when the client supports images.
+
+MCP validation must reject:
+
+- paths not linked to the selected session
+- paths outside the expected screenshot root after canonicalization
+- missing files
+- unsupported file types
+- requests above the maximum image count
+
+If an MCP client cannot consume images, it should still receive an honest text
+state and timestamps, not a claim that the image was visually inspected.
+
+### 6. Full PTY agent contract
+
+Extend generated `AGENTS.md` and `CLAUDE.md` with a section named
+`Live Screen and Desktop Context`. It should tell the agent:
+
+- the features are opt-in and separate;
+- how to check current observed state;
+- how to retrieve screen context for the active session or a timestamp;
+- to inspect the image before describing visible content;
+- to use visual context when the user explicitly references the screen, asks
+  whether the feed is visible, or requests live meeting strategy that depends
+  on the presentation;
+- to avoid describing unrelated private material visible elsewhere;
+- how disabled, waiting, permission-denied, degraded, stopped, and cleaned
+  states should be reported.
+
+Add a lightweight dynamic workspace artifact such as `CURRENT_SESSION.md`,
+updated by recording start, first successful capture, failure, stop, and
+cleanup. The generated instructions tell PTY agents to read it when present.
+It should contain state and safe references, not image bytes or transcript
+content.
+
+This file solves “right off the bat” discovery for an agent that opens halfway
+through a meeting. The CLI remains the authoritative refresh path if the file
+is stale or absent.
+
+### 7. Native Recall contract
+
+Native Recall must receive the same observed state even though it intentionally
+does not load the PTY workspace instructions.
+
+Update `CHAT_WORKSPACE_CLAUDE_MD` to advertise the bounded screen-context tool
+and the visual-claim rule. Inject a short current-session state block into each
+message while a recording is active.
+
+Preferred v1 behavior:
+
+- The prompt tells the model that a screen image is available without embedding
+  it automatically.
+- The model calls the read-only `get_screen_context` tool when the question
+  depends on visible content.
+- An explicit Recall affordance may later let the user choose “include latest
+  screen,” but that is not required for the first implementation.
+
+If provider/client limitations make MCP image content unreliable, pass only the
+selected verified files into the existing agent invocation image-delivery path.
+That fallback must be gated by an explicit screen-related user request or UI
+action, not every Recall message.
+
+### 8. Copilot integration boundary
+
+The first-class real-time copilot has its own runtime and prompt construction.
+It should consume the same core `ScreenContextResult` and observed state rather
+than tailing the screenshot directory or inventing a second session resolver.
+
+Copilot integration can land after the core, PTY, and native Recall slices, but
+the core interface should be stable enough that copilot does not need a
+filesystem-specific adapter.
+
+## Implementation slices
+
+### Slice A — observed state and session linkage
+
+Primary files:
+
+- `crates/core/src/capture.rs`
+- `crates/core/src/screen.rs`
+- `crates/core/src/context_store.rs`
+- recording/job cleanup code that honors `keep_after_summary`
+
+Deliverable: successful captures become canonical session-linked context, and
+runtime state distinguishes waiting, capturing, degraded, stopped, and cleaned.
+
+### Slice B — bounded retrieval and adapters
+
+Primary files:
+
+- context-store/core query modules
+- CLI `context` commands and capability advertisement
+- `crates/mcp/src/index.ts`
+- MCP tool tests and manifest/capability fixtures
+
+Deliverable: local CLI and MCP clients can retrieve the correct image nearest a
+session moment without receiving arbitrary filesystem access.
+
+### Slice C — agent discovery
+
+Primary files:
+
+- `tauri/src-tauri/src/context.rs`
+- workspace state-file lifecycle
+- generated `AGENTS.md` / `CLAUDE.md` tests
+
+Deliverable: a newly opened full PTY assistant immediately knows screen context
+may exist, sees current observed state, and has exact retrieval instructions.
+
+### Slice D — native Recall
+
+Primary files:
+
+- `tauri/src-tauri/src/commands.rs`
+- `crates/core/src/summarize.rs`
+- native Recall integration tests
+
+Deliverable: native Recall sees the active state and can obtain a relevant image
+through the read-only path without broad file access or unconditional image
+attachment.
+
+### Slice E — real-machine UX and privacy validation
+
+Use the signed `~/Applications/Minutes Dev.app` identity. Do not replace the
+production app with ad-hoc builds for TCC-sensitive testing.
+
+Deliverable: visible, truthful transitions and no silent gap between enabled
+intent and agent availability.
+
+## Acceptance scenarios
+
+1. Enabled, permission granted, before first interval:
+   the agent reports `waiting for first capture`; it does not claim sight.
+2. Enabled, permission granted, first PNG succeeds:
+   state becomes `capturing`; the session has a directory link and screenshot
+   event; “can you see the live feed?” retrieves and inspects that image.
+3. Enabled, permission denied or stale TCC grant:
+   the desktop and agent report `unavailable` with a concrete fix; recording
+   continues without screenshots.
+4. Disabled:
+   no worker, directory, image event, attachment, or misleading capability
+   claim is produced.
+5. Desktop context enabled, screen context disabled:
+   the agent can report app/window metadata and explicitly says it has no visual
+   image.
+6. A transient screenshot failure after prior success:
+   state becomes degraded while the last successful image remains identifiable
+   with its timestamp; recovery returns state to capturing.
+7. Recording stops before the first screenshot:
+   worker joins promptly and state becomes stopped with zero images.
+8. `keep_after_summary = false`:
+   files and live refs are cleaned; later retrieval reports cleaned/unavailable,
+   never a stale readable path.
+9. `keep_after_summary = true`:
+   a completed meeting can resolve its retained screenshot nearest a requested
+   timestamp.
+10. Full PTY assistant starts halfway through a recording:
+    generated instructions plus current-session state make the capability
+    discoverable without source or filesystem archaeology.
+11. Native Recall asks a screen-dependent question:
+    it receives the verified image through the bounded path and distinguishes
+    what it saw from transcript-derived facts.
+12. Native Recall asks an unrelated historical question:
+    no current screen image is automatically attached.
+13. Path traversal or arbitrary image request:
+    CLI/MCP rejects it even if the file exists and is readable by the process.
+14. Multi-agent parity:
+    generated Claude and agent-agnostic instructions remain identical where
+    intended, and provider adapters either support images or degrade explicitly.
+
+## Verification
+
+Automated coverage should include:
+
+- screen worker success/failure messages and shutdown behavior
+- directory-link creation exactly once per session
+- screenshot events with correct session, timestamps, and artifact paths
+- nearest-image selection before/after an anchor
+- cleanup behavior for both retention settings
+- missing-file and canonical-path rejection
+- CLI JSON state contracts
+- MCP text plus image response contracts and maximum limits
+- generated `AGENTS.md` / `CLAUDE.md` screen-context section and parity
+- native Recall instructions and allowlist
+- native chat invocation behavior when zero, one, and multiple images are
+  selected
+
+Real-Mac dogfood should cover:
+
+- production and signed-dev TCC identities separately
+- permission granted, denied, and stale-grant repair
+- enabled-to-waiting-to-capturing transition
+- live “what is on this slide?” question in full PTY and native Recall
+- stop during interval sleep
+- cleanup after summarization
+- a screen containing unrelated private content to verify bounded, intentional
+  use and non-disclosure in the response
+
+Required repo gates follow `docs/checklists/pre-commit.md`, including Rust fmt,
+clippy/tests, MCP checks, generated manifest/capability parity, and dev-app click
+testing for any changed Tauri surface.
+
+## Rollout and compatibility
+
+- Keep both context features off by default unless a separate product decision
+  changes that policy.
+- No migration is needed for old meetings without screenshot refs; retrieval
+  returns `not captured` or `unavailable` honestly.
+- Existing retained screenshot directories may be importable later, but
+  backfilling them is not required for v1 because session identity may be
+  ambiguous.
+- Add capability flags before advertising new MCP tools to mixed-version
+  clients.
+- Treat image-return support as additive. Text-only clients retain current
+  desktop-context behavior.
+
+## Explicit non-goals
+
+- Ambient screen recording or a Screenpipe-style timeline.
+- OCR/indexing of every screenshot.
+- Continuous video capture or streaming the meeting feed.
+- Autonomous clicking or control of the user's screen.
+- Accessibility-tree ingestion.
+- Solving Linux/Windows capture parity in this issue.
+- Replacing transcript-first live coaching; screen context is an additional
+  evidence lane.
+
+## Decisions to make before implementation
+
+1. Cleanup representation: hard-delete screenshot events/links or retain an
+   explicit tombstone with no artifact path. Privacy and non-stale retrieval are
+   non-negotiable either way.
+2. MCP image transport: direct image content versus a protected local resource
+   URI, validated against the actual clients Minutes supports.
+3. Dynamic state artifact name: `CURRENT_SESSION.md` versus extending another
+   existing current-focus artifact. It must not overload `CURRENT_MEETING.md`
+   with runtime-only capture state unless that lifecycle is made explicit.
+4. Native non-Claude Recall parity: whether each supported CLI gets the MCP
+   image tool, direct provider attachment, or an explicit unsupported state in
+   the first release.
+5. Whether the Recall UI needs an “include latest screen” affordance in v1 or
+   tool-on-demand is sufficient after dogfood.
+
+These decisions should be resolved in the implementation spec or first slice,
+not guessed independently by each adapter.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "minutes",
   "display_name": "Minutes Conversation Memory",
   "description": "The private, owned conversation-memory layer for AI. Record, transcribe, and search every meeting, voice memo, and dictation entirely on your own machine — nothing uploaded — then let any AI you connect recall it. Plain-markdown output you keep forever; no cloud, no API key, no vendor to outlive.",
-  "long_description": "Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.\n\n31 tools • 7 resources • Interactive MCP App dashboard • Prompt templates\n\nWhat you get:\n• On-device transcription (whisper.cpp or parakeet.cpp) and optional on-device summarization (Apple Foundation Models on macOS 26+) — your audio never leaves the machine.\n• A native chat panel that recalls your meetings, with token streaming and read-only search of your own corpus.\n• Dictation that types straight at your cursor, on the same local engine.\n• Live sessions that promote into diarized, summarized meetings when you stop.\n• Consent provenance in every file, and sensitivity gating agents must respect.\n• Diarized speaker labels, structured action items and decisions, and a cross-meeting relationship graph — all queryable via MCP.",
+  "long_description": "Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.\n\n36 tools • 7 resources • Interactive MCP App dashboard • Prompt templates\n\nWhat you get:\n• On-device transcription (whisper.cpp or parakeet.cpp) and optional on-device summarization (Apple Foundation Models on macOS 26+) — your audio never leaves the machine.\n• A native chat panel that recalls your meetings, with token streaming and read-only search of your own corpus.\n• Dictation that types straight at your cursor, on the same local engine.\n• Live sessions that promote into diarized, summarized meetings when you stop.\n• Consent provenance in every file, and sensitivity gating agents must respect.\n• Diarized speaker labels, structured action items and decisions, and a cross-meeting relationship graph — all queryable via MCP.",
   "version": "0.21.0",
   "author": {
     "name": "Mat Silverstein",
@@ -78,6 +78,10 @@
     {
       "name": "get_moment",
       "description": "Show the local desktop-context rewind around a linked artifact, session, or timestamp"
+    },
+    {
+      "name": "get_screen_context",
+      "description": "Retrieve bounded, verified screenshots linked to a Minutes context session"
     },
     {
       "name": "process_audio",

--- a/manifest.mcpb.json
+++ b/manifest.mcpb.json
@@ -3,7 +3,7 @@
   "name": "minutes",
   "display_name": "Minutes Conversation Memory",
   "description": "The private, owned conversation-memory layer for AI. Record, transcribe, and search every meeting, voice memo, and dictation entirely on your own machine — nothing uploaded — then let any AI you connect recall it. Plain-markdown output you keep forever; no cloud, no API key, no vendor to outlive.",
-  "long_description": "Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.\n\n31 tools • 7 resources • Interactive MCP App dashboard • Prompt templates\n\nWhat you get:\n• On-device transcription (whisper.cpp or parakeet.cpp) and optional on-device summarization (Apple Foundation Models on macOS 26+) — your audio never leaves the machine.\n• A native chat panel that recalls your meetings, with token streaming and read-only search of your own corpus.\n• Dictation that types straight at your cursor, on the same local engine.\n• Live sessions that promote into diarized, summarized meetings when you stop.\n• Consent provenance in every file, and sensitivity gating agents must respect.\n• Diarized speaker labels, structured action items and decisions, and a cross-meeting relationship graph — all queryable via MCP.",
+  "long_description": "Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.\n\n36 tools • 7 resources • Interactive MCP App dashboard • Prompt templates\n\nWhat you get:\n• On-device transcription (whisper.cpp or parakeet.cpp) and optional on-device summarization (Apple Foundation Models on macOS 26+) — your audio never leaves the machine.\n• A native chat panel that recalls your meetings, with token streaming and read-only search of your own corpus.\n• Dictation that types straight at your cursor, on the same local engine.\n• Live sessions that promote into diarized, summarized meetings when you stop.\n• Consent provenance in every file, and sensitivity gating agents must respect.\n• Diarized speaker labels, structured action items and decisions, and a cross-meeting relationship graph — all queryable via MCP.",
   "version": "0.21.0",
   "author": {
     "name": "Mat Silverstein",
@@ -78,6 +78,10 @@
     {
       "name": "get_moment",
       "description": "Show the local desktop-context rewind around a linked artifact, session, or timestamp"
+    },
+    {
+      "name": "get_screen_context",
+      "description": "Retrieve bounded, verified screenshots linked to a Minutes context session"
     },
     {
       "name": "process_audio",

--- a/scripts/generate_llms_txt.mjs
+++ b/scripts/generate_llms_txt.mjs
@@ -205,6 +205,7 @@ function categorizeTool(name) {
       "activity_summary",
       "search_context",
       "get_moment",
+      "get_screen_context",
       "research_topic",
     ]),
     "People and relationships": new Set(["get_person_profile", "relationship_map", "track_commitments", "consistency_report"]),

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-14",
+  "generatedAt": "2026-07-15",
   "visibleCount": 59,
   "hiddenCount": 16,
   "groups": [

--- a/site/app/docs/mcp/tools/data.json
+++ b/site/app/docs/mcp/tools/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-14",
+  "generatedAt": "2026-07-15",
   "installCommand": "npx minutes-mcp",
   "documentationUrl": "https://useminutes.app/for-agents",
   "supportUrl": "https://github.com/silverstein/minutes/discussions",
@@ -73,6 +73,13 @@
       "group": "Search and recall",
       "anchorId": "tool-get-moment",
       "docsUrl": "https://useminutes.app/docs/mcp/tools#tool-get-moment"
+    },
+    {
+      "name": "get_screen_context",
+      "description": "Retrieve bounded, verified screenshots linked to a Minutes context session",
+      "group": "Search and recall",
+      "anchorId": "tool-get-screen-context",
+      "docsUrl": "https://useminutes.app/docs/mcp/tools#tool-get-screen-context"
     },
     {
       "name": "process_audio",

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -5,9 +5,9 @@
 export const MINUTES_RELEASE_VERSION = "0.21.0";
 export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
-export const MINUTES_MCP_TOOL_COUNT = 35;
+export const MINUTES_MCP_TOOL_COUNT = 36;
 export const MINUTES_CLI_COMMAND_COUNT = 56;
-export const MINUTES_TEST_COUNT = 1528;
+export const MINUTES_TEST_COUNT = 1534;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: crates/core thiserror definitions
-> Last generated: 2026-07-14
+> Last generated: 2026-07-15
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 

--- a/site/public/docs/mcp/tools.md
+++ b/site/public/docs/mcp/tools.md
@@ -3,9 +3,9 @@
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts
 > Regenerate: node scripts/generate_llms_txt.mjs
-> Last generated: 2026-07-14
+> Last generated: 2026-07-15
 
-Minutes exposes 35 tools, 8 resources, and 6 prompt templates through the MCP server.
+Minutes exposes 36 tools, 8 resources, and 6 prompt templates through the MCP server.
 
 ## Install
 
@@ -139,6 +139,14 @@ Reference URL: https://useminutes.app/docs/mcp/tools#tool-search-context
 Show the local desktop-context rewind around a linked artifact, session, or timestamp
 
 Reference URL: https://useminutes.app/docs/mcp/tools#tool-get-moment
+
+<a id="tool-get-screen-context"></a>
+
+#### `get_screen_context`
+
+Retrieve bounded, verified screenshots linked to a Minutes context session
+
+Reference URL: https://useminutes.app/docs/mcp/tools#tool-get-screen-context
 
 <a id="tool-research-topic"></a>
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,13 +2,13 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-07-14
+> Last generated: 2026-07-15
 
 ## Product
 
 Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.
 
-31 tools • 7 resources • Interactive MCP App dashboard • Prompt templates
+36 tools • 7 resources • Interactive MCP App dashboard • Prompt templates
 
 What you get:
 • On-device transcription (whisper.cpp or parakeet.cpp) and optional on-device summarization (Apple Foundation Models on macOS 26+) — your audio never leaves the machine.
@@ -70,6 +70,7 @@ What you get:
 - `activity_summary` — Summarize meeting-adjacent desktop context for a linked artifact, context session, or time window Docs: https://useminutes.app/docs/mcp/tools#tool-activity-summary
 - `search_context` — Search desktop-context events across app focus and captured window titles, including opted-in browser titles Docs: https://useminutes.app/docs/mcp/tools#tool-search-context
 - `get_moment` — Show the local desktop-context rewind around a linked artifact, session, or timestamp Docs: https://useminutes.app/docs/mcp/tools#tool-get-moment
+- `get_screen_context` — Retrieve bounded, verified screenshots linked to a Minutes context session Docs: https://useminutes.app/docs/mcp/tools#tool-get-screen-context
 - `process_audio` — Process an audio file through the transcription pipeline Docs: https://useminutes.app/docs/mcp/tools#tool-process-audio
 - `add_note` — Add a timestamped note to the current recording or an existing meeting Docs: https://useminutes.app/docs/mcp/tools#tool-add-note
 - `consistency_report` — Flag conflicting decisions and stale commitments Docs: https://useminutes.app/docs/mcp/tools#tool-consistency-report

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-07-14
+> Last generated: 2026-07-15
 
 Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.
 
@@ -18,7 +18,7 @@ Minutes is the private, owned conversation-memory layer. Record meetings, voice 
 
 ## For AI Agents
 
-minutes exposes a standard MCP server with 35 tools, 8 resources, and 6 prompt templates. Any MCP-compatible client can use it as a conversation memory layer.
+minutes exposes a standard MCP server with 36 tools, 8 resources, and 6 prompt templates. Any MCP-compatible client can use it as a conversation memory layer.
 
 ## Choose Your Surface
 
@@ -53,6 +53,7 @@ Recommended install:
 - `activity_summary` — Summarize meeting-adjacent desktop context for a linked artifact, context session, or time window Docs: https://useminutes.app/docs/mcp/tools#tool-activity-summary
 - `search_context` — Search desktop-context events across app focus and captured window titles, including opted-in browser titles Docs: https://useminutes.app/docs/mcp/tools#tool-search-context
 - `get_moment` — Show the local desktop-context rewind around a linked artifact, session, or timestamp Docs: https://useminutes.app/docs/mcp/tools#tool-get-moment
+- `get_screen_context` — Retrieve bounded, verified screenshots linked to a Minutes context session Docs: https://useminutes.app/docs/mcp/tools#tool-get-screen-context
 - `process_audio` — Process an audio file through the transcription pipeline Docs: https://useminutes.app/docs/mcp/tools#tool-process-audio
 - `add_note` — Add a timestamped note to the current recording or an existing meeting Docs: https://useminutes.app/docs/mcp/tools#tool-add-note
 - `consistency_report` — Flag conflicting decisions and stale commitments Docs: https://useminutes.app/docs/mcp/tools#tool-consistency-report

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3199,6 +3199,7 @@ fn start_native_call_recording(
     let recording_started_at = chrono::Local::now();
     let context_session_id = minutes_core::desktop_context::maybe_start_capture_session(
         &config.desktop_context,
+        config.screen_context.enabled,
         mode,
         requested_title.clone(),
         recording_started_at,
@@ -5614,6 +5615,7 @@ pub fn start_recording(
     set_latest_output(&latest_output, None);
     let context_session_id = minutes_core::desktop_context::maybe_start_capture_session(
         &config.desktop_context,
+        config.screen_context.enabled,
         mode,
         requested_title.clone(),
         recording_started_at,
@@ -8693,8 +8695,16 @@ context doesn't cover:
 - `list_processing_jobs`, `get_status`, `list_voices`, `knowledge_status`, `qmd_collection_status` — status/inventory checks
 - `read_live_transcript` — read an in-progress recording or live-transcript session
 - `activity_summary`, `search_context`, `get_moment` — desktop-context lookups (app focus, window titles)
+- `get_screen_context` — retrieve up to three verified screenshots linked to the selected Minutes session
 
 Prefer these over guessing when the inline context is missing something concrete and answerable.
+
+## Visual claims
+
+Screen screenshots and desktop app/window metadata are separate. Call `get_screen_context` only when \
+the user's question depends on visible content; screenshots are never attached automatically. Never \
+say you can see the screen or describe a slide unless this turn actually received a specific image. \
+Configured, waiting, unavailable, degraded, stopped, and cleaned states do not prove visual awareness.
 
 ## What you don't have
 
@@ -8731,6 +8741,41 @@ fn build_recall_chat_prompt(history: &[(String, String)], enriched_message: &str
 
     prompt.push_str(enriched_message);
     prompt
+}
+
+fn current_screen_context_prompt() -> String {
+    let Ok(Some(session)) = minutes_core::context_store::latest_active_context_session() else {
+        return String::new();
+    };
+    let Ok(Some(status)) =
+        minutes_core::context_store::screen_context_status_for_session(&session.id)
+    else {
+        return String::new();
+    };
+    if status.state == minutes_core::context_store::ScreenContextState::Off {
+        return String::new();
+    }
+    let state = serde_json::to_string(&status.state)
+        .unwrap_or_else(|_| "\"unknown\"".into())
+        .trim_matches('"')
+        .to_string();
+    format!(
+        "Current screen-context state (metadata only; no image has been inspected):\n\
+- session_id: {}\n\
+- state: {}\n\
+- successful_captures: {}\n\
+- last_successful_capture_at: {}\n\
+Use the bounded read-only get_screen_context tool only if the question depends on pixels. If this \
+provider cannot call that tool, say image retrieval is unavailable in this provider instead of \
+claiming visual awareness.\n\n",
+        session.id,
+        state,
+        status.successful_capture_count,
+        status
+            .last_successful_capture_at
+            .map(|timestamp| timestamp.to_rfc3339())
+            .unwrap_or_else(|| "none".into()),
+    )
 }
 
 struct RecallChatProcessIo {
@@ -9071,7 +9116,11 @@ pub async fn cmd_recall_chat_send(
     // answers in the excerpts below" guidance still applies to them, so it's
     // still useful context — just no longer claiming zero tool access, since
     // claude's chat session does have a pre-approved read-only allow-list.
-    let enriched_message = format!("{}User question: {}", meeting_context, message);
+    let screen_context = current_screen_context_prompt();
+    let enriched_message = format!(
+        "{}{}User question: {}",
+        meeting_context, screen_context, message
+    );
 
     // ── Step 2: build prompt with history ─────────────────────────────────────
     let history_snapshot: Vec<(String, String)> = {
@@ -10952,6 +11001,15 @@ mod tests {
 
         assert!(!cancel_recall_chat_turn(&state.recall_chat_turn));
         assert!(state.recall_chat_turn.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn recall_chat_contract_exposes_bounded_screen_tool_and_visual_claim_rule() {
+        assert!(CHAT_WORKSPACE_CLAUDE_MD.contains("`get_screen_context`"));
+        assert!(CHAT_WORKSPACE_CLAUDE_MD.contains("screenshots are never attached automatically"));
+        assert!(CHAT_WORKSPACE_CLAUDE_MD
+            .contains("unless this turn actually received a specific image"));
+        assert!(CHAT_WORKSPACE_CLAUDE_MD.contains("desktop app/window metadata are separate"));
     }
 
     #[test]

--- a/tauri/src-tauri/src/context.rs
+++ b/tauri/src-tauri/src/context.rs
@@ -415,6 +415,11 @@ pub fn generate_assistant_context(config: &Config) -> Result<String, String> {
     md.push_str("- `minutes live` / `minutes stop` — start/stop live transcript (real-time)\n");
     md.push_str("- `minutes transcript --since 5m` — read last 5 minutes of live transcript\n");
     md.push_str("- `minutes transcript --status` — check if a live session is active\n");
+    md.push_str(
+        "- `minutes context status --json` — check observed screen and desktop-context state\n",
+    );
+    md.push_str("- `minutes context screen --limit 1 --json` — retrieve the latest verified session-linked screenshot\n");
+    md.push_str("- `minutes context screen --at <RFC3339> --limit 1 --json` — retrieve the nearest screenshot for a moment\n");
     md.push_str("- `minutes note \"text\"` — add a timestamped note to current recording\n");
     md.push_str("- `minutes process <file>` — process an audio file\n");
     md.push_str("- `minutes qmd status` — check QMD collection status\n");
@@ -439,6 +444,15 @@ pub fn generate_assistant_context(config: &Config) -> Result<String, String> {
     md.push_str("These can be unified by symlinking or configuring output_dir in config.toml.\n\n");
     md.push_str("**Daily Notes** — Minutes can append session summaries to daily notes.\n");
     md.push_str("Configure in ~/.config/minutes/config.toml under [daily_notes].\n");
+
+    md.push_str("\n## Live Screen and Desktop Context\n\n");
+    md.push_str("Minutes has two separate opt-in evidence lanes:\n");
+    md.push_str(
+        "- `screen_context` captures periodic PNG screenshots only during an active recording.\n",
+    );
+    md.push_str("- `desktop_context` captures app focus and opted-in window/browser title metadata; it does not contain screen pixels.\n\n");
+    md.push_str("If `CURRENT_SESSION.md` exists, read it when the user references the screen, asks whether a live feed is visible, or requests presentation-aware live coaching. Refresh stale or missing state with `minutes context status --json`. Retrieve only the bounded image needed with `minutes context screen --limit 1 --json` or anchor it with `--at <RFC3339>`.\n\n");
+    md.push_str("Never say ‘I can see’, describe a slide, or infer visible content unless you actually opened a specific image returned by the screen-context command. Configured, waiting, unavailable, degraded, stopped, and cleaned states are not visual awareness. If only desktop context is available, report app/window metadata precisely and say that no image was inspected. Do not inspect or describe unrelated private material visible elsewhere on the screen.\n");
 
     md.push_str("\n## Active Meeting Focus\n\n");
     md.push_str(&format!(
@@ -637,6 +651,19 @@ mod tests {
         assert!(content.contains("Do not assume the user always wants short bullet points"));
         assert!(content.contains("conversational, narrative, or report-style answer"));
         assert!(content.contains("Never attribute a statement to a named person"));
+    }
+
+    #[test]
+    fn assistant_context_explains_honest_live_screen_retrieval() {
+        let config = Config::default();
+        let content = generate_assistant_context(&config).expect("assistant context");
+
+        assert!(content.contains("## Live Screen and Desktop Context"));
+        assert!(content.contains("CURRENT_SESSION.md"));
+        assert!(content.contains("minutes context status --json"));
+        assert!(content.contains("minutes context screen --limit 1 --json"));
+        assert!(content.contains("unless you actually opened a specific image"));
+        assert!(content.contains("does not contain screen pixels"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- link successful recording-time PNGs to their active context sessions and track honest runtime states
- add bounded CLI and MCP retrieval with independent path validation and direct image content
- teach PTY agents and native Claude Recall how to discover screen context without ambient attachment or unsupported visual claims
- clean files and readable references together, including job-directory relinking and retention behavior

## Verification

- cargo test -p minutes-core --no-default-features --lib (1065 passed, 1 ignored)
- cargo test -p minutes-cli --no-default-features (70 passed)
- cargo test -p minutes-app --no-default-features -- --test-threads=1 (258 passed)
- cargo clippy --all --no-default-features -- -D warnings
- MCP unit tests (70 passed), TypeScript/Vite build, CLI integration (10 passed)
- MCP Copilot contract passed after rebasing current main
- MCPB pack, bundle guard, and handshake passed
- generated site/llms docs verified current
- signed Minutes Dev.app built with Developer ID, strict seal verified, hotkey diagnostic passed

## Signed-Mac dogfood

The installed Minutes Dev identity correctly reported permission-unavailable, zero captures, and the visual-claim warning in both context status and CURRENT_SESSION.md. Its Screen Recording grant is stale/missing, so producing a real PNG with that identity still requires toggling Screen Recording for Minutes Dev in macOS System Settings. The success/linkage/retrieval and cleanup paths are covered by the Rust and MCP suites.