### PR TITLE
ci: enforce skills-compiler sync as a required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,25 @@ jobs:
       - name: Handshake smoke test
         run: ./scripts/smoke_mcpb_handshake.sh minutes.mcpb
 
+  skills_compiler:
+    name: Skills Compiler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install skill compiler dependencies
+        working-directory: tooling/skills
+        run: npm ci
+
+      - name: Verify canonical skills and generated mirrors
+        working-directory: tooling/skills
+        run: npm run ci
+
   site_release_consistency:
     name: Site Release Link Consistency
     runs-on: ubuntu-latest
@@ -460,14 +479,9 @@ jobs:
 
       - name: Install and build canonical skill router
         working-directory: tooling/skills
-        # This private compiler package intentionally has no lockfile or
-        # declared runtime dependencies. Pin the two build-only packages here
-        # and override its repo-local typeRoots so a clean runner is sufficient.
         run: |
-          npm install --no-save --no-audit --no-fund \
-            typescript@5.9.3 @types/node@22.19.11
-          ./node_modules/.bin/tsc \
-            -p tsconfig.json --typeRoots node_modules/@types
+          npm ci
+          npm run build
 
       - name: Replay routing fixture twice through canonical router
         run: node tests/eval/live_sidekick_routing_eval.mjs
@@ -503,6 +517,7 @@ jobs:
       - linux_full_build
       - desktop_windows
       - mcp
+      - skills_compiler
       - agents_sync
       - site_release_consistency
       - llms_sync

--- a/tooling/skills/compiler/compile.test.ts
+++ b/tooling/skills/compiler/compile.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const COMPILE_CLI = fileURLToPath(new URL("./compile.js", import.meta.url));
+
+function runCompile(repoRoot: string, dryRun: boolean) {
+  return spawnSync(
+    process.execPath,
+    [
+      COMPILE_CLI,
+      "--root",
+      repoRoot,
+      ...(dryRun ? ["--dry-run"] : []),
+      "--host",
+      "claude",
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+async function createFixtureRepo(): Promise<string> {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "minutes-compile-drift-"));
+  const sourceDir = path.join(repoRoot, "tooling", "skills", "sources", "minutes-fixture");
+  const pluginDir = path.join(repoRoot, ".claude", "plugins", "minutes");
+
+  await mkdir(sourceDir, { recursive: true });
+  await mkdir(pluginDir, { recursive: true });
+  await writeFile(
+    path.join(sourceDir, "skill.md"),
+    `---
+name: minutes-fixture
+description: Fixture skill used to verify generated-file drift detection.
+triggers:
+  - verify fixture drift
+metadata:
+  display_name: Minutes Fixture
+  short_description: Verify generated skill drift.
+  default_prompt: Use Minutes Fixture.
+  site_category: Testing
+  site_example: /minutes-fixture
+  site_best_for: Exercising the compiler drift gate.
+assets:
+  scripts: []
+  templates: []
+  references: []
+output:
+  claude:
+    path: .claude/plugins/minutes/skills/minutes-fixture/SKILL.md
+---
+
+# Minutes Fixture
+`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(pluginDir, "plugin.json"),
+    `${JSON.stringify(
+      {
+        name: "minutes-fixture",
+        version: "0.0.0",
+        description: "Compiler drift fixture",
+        skills: [],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  return repoRoot;
+}
+
+test("compile:dry passes clean generated skills and rejects drift", async (t) => {
+  const repoRoot = await createFixtureRepo();
+  t.after(async () => rm(repoRoot, { recursive: true, force: true }));
+
+  const generated = runCompile(repoRoot, false);
+  assert.equal(generated.status, 0, generated.stderr);
+  assert.match(generated.stdout, /"status":"written"/);
+
+  const clean = runCompile(repoRoot, true);
+  assert.equal(clean.status, 0, clean.stderr);
+  assert.match(clean.stdout, /"status":"clean"/);
+
+  const generatedSkill = path.join(
+    repoRoot,
+    ".claude",
+    "plugins",
+    "minutes",
+    "skills",
+    "minutes-fixture",
+    "SKILL.md",
+  );
+  await appendFile(generatedSkill, "\nmutated generated content\n", "utf8");
+
+  const drifted = runCompile(repoRoot, true);
+  assert.equal(drifted.status, 1, drifted.stderr);
+  assert.match(drifted.stdout, /"status":"drift"/);
+  assert.match(drifted.stdout, /minutes-fixture\/SKILL\.md/);
+});

--- a/tooling/skills/compiler/compile.ts
+++ b/tooling/skills/compiler/compile.ts
@@ -12,14 +12,22 @@ import { renderSiteSkillCatalog } from "./site.js";
 interface CompileOptions {
   dryRun: boolean;
   hosts: HostName[];
+  repoRoot: string | null;
 }
 
 function parseArgs(argv: string[]): CompileOptions {
   const dryRun = argv.includes("--dry-run");
   const hostValues: string[] = [];
+  let repoRoot: string | null = null;
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === "--host" && argv[i + 1]) {
       hostValues.push(argv[i + 1]);
+      i += 1;
+    } else if (argv[i] === "--root") {
+      if (!argv[i + 1]) {
+        throw new Error('Missing value for "--root"');
+      }
+      repoRoot = path.resolve(argv[i + 1]);
       i += 1;
     }
   }
@@ -34,7 +42,7 @@ function parseArgs(argv: string[]): CompileOptions {
     }
   }
 
-  return { dryRun, hosts };
+  return { dryRun, hosts, repoRoot };
 }
 
 async function compareOrWrite(
@@ -64,9 +72,11 @@ async function compareOrWrite(
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
-  const rootDir = cwd().endsWith(path.join("tooling", "skills"))
-    ? cwd()
-    : path.join(cwd(), "tooling", "skills");
+  const rootDir = options.repoRoot
+    ? path.join(options.repoRoot, "tooling", "skills")
+    : cwd().endsWith(path.join("tooling", "skills"))
+      ? cwd()
+      : path.join(cwd(), "tooling", "skills");
   const skills = await discoverCanonicalSkills(rootDir);
 
   const changes: Array<{ host: string; path: string; kind: string }> = [];

--- a/tooling/skills/package-lock.json
+++ b/tooling/skills/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "minutes-skill-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "minutes-skill-tooling",
+      "devDependencies": {
+        "@types/node": "22.19.11",
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tooling/skills/package.json
+++ b/tooling/skills/package.json
@@ -17,5 +17,9 @@
     "golden:write": "node dist/compiler/golden.js --write",
     "doctor": "node dist/compiler/doctor.js",
     "ci": "npm run build && npm run test && npm run check && npm run golden && npm run compile:dry"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.11",
+    "typescript": "5.9.3"
   }
 }

--- a/tooling/skills/tsconfig.json
+++ b/tooling/skills/tsconfig.json
@@ -11,7 +11,7 @@
     "declaration": false,
     "types": ["node"],
     "typeRoots": [
-      "../../crates/mcp/node_modules/@types"
+      "node_modules/@types"
     ]
   },
   "include": [


### PR DESCRIPTION
## What

Turns on the repo's dark automation: `tooling/skills` defines a complete verification pipeline (`npm run ci` = build + test + check + golden + compile:dry) that validates every generated skill mirror (`.claude/plugins`, `.agents`, `.opencode`), the plugin manifest, the site skills catalog, codex sidecars, and runtime helpers — but nothing ever ran it in CI. Skill-mirror drift was only caught by hand ("sync derived files" release commits).

- `tooling/skills` is now self-contained: pinned devDependencies (`typescript@5.9.3`, `@types/node@22.19.11`), committed lockfile, local `typeRoots` (no more reach into `crates/mcp/node_modules`)
- New unconditional `skills_compiler` job running `npm ci && npm run ci`, wired into `ci_gate.needs`
- `live_sidekick_eval`'s manual bootstrap hack replaced with `npm ci && npm run build`
- `compile.ts` gains an optional `--root` flag (defaults unchanged) to support fixtures
- Committed drift-detection fixture test (`compile.test.ts`): clean fixture passes, mutated generated SKILL.md fails `compile:dry` — the checker is proven able to go red

## Verification

Independently re-verified from clean state: `rm -rf node_modules dist && npm ci && npm run ci` → 30/30 tests, all checks green, `compile:dry` clean across all three hosts.

Part of the agent-infra hardening epic (bead `minutes-4a9r`, PR-A). Plan reviewed adversarially across 4 rounds by codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)