### PR TITLE
ci: three-domain version-policy checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,23 @@ jobs:
       - name: Handshake smoke test
         run: ./scripts/smoke_mcpb_handshake.sh minutes.mcpb
 
+  version_sync:
+    name: Version Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Verify version policy
+        run: node scripts/check_version_sync.mjs
+
+      - name: Test version policy checker
+        run: node --test scripts/check_version_sync.test.mjs
+
   site_release_consistency:
     name: Site Release Link Consistency
     runs-on: ubuntu-latest
@@ -503,6 +520,7 @@ jobs:
       - linux_full_build
       - desktop_windows
       - mcp
+      - version_sync
       - agents_sync
       - site_release_consistency
       - llms_sync

--- a/scripts/check_version_sync.mjs
+++ b/scripts/check_version_sync.mjs
@@ -5,12 +5,15 @@ import path from "node:path";
 
 function parseArgs(argv) {
   let json = false;
+  let release = false;
   let root;
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--json") {
       json = true;
+    } else if (argument === "--release") {
+      release = true;
     } else if (argument === "--root") {
       if (index + 1 >= argv.length) {
         throw new Error("--root requires a directory argument");
@@ -25,6 +28,7 @@ function parseArgs(argv) {
   const scriptRoot = path.resolve(path.dirname(process.argv[1]), "..");
   return {
     json,
+    release,
     root: root === undefined ? scriptRoot : path.resolve(root),
   };
 }
@@ -42,6 +46,18 @@ function requireVersion(value, description) {
     throw new Error(`${description} is missing or is not a string`);
   }
   return value;
+}
+
+const numericSemverIdentifier = "(?:0|[1-9]\\d*)";
+const prereleaseSemverIdentifier = `(?:${numericSemverIdentifier}|\\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const exactSemverPattern = new RegExp(
+  `^${numericSemverIdentifier}\\.${numericSemverIdentifier}\\.${numericSemverIdentifier}` +
+    `(?:-${prereleaseSemverIdentifier}(?:\\.${prereleaseSemverIdentifier})*)?` +
+    "(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+);
+
+function isExactSemver(value) {
+  return exactSemverPattern.test(value);
 }
 
 function tomlSectionValue(text, section, key) {
@@ -221,16 +237,54 @@ function collectDomains(root) {
   return { domain1, domain2 };
 }
 
-function jsonReport(domain1, domain2) {
+function collectRelease(root) {
+  const sdkVersion = source("crates/sdk/package.json", ".version", () =>
+    requireVersion(readJson(root, "crates/sdk/package.json").version, ".version"),
+  );
+  const dependency = source(
+    "crates/mcp/package.json",
+    '.dependencies["minutes-sdk"]',
+    () =>
+      requireVersion(
+        readJson(root, "crates/mcp/package.json").dependencies?.["minutes-sdk"],
+        '.dependencies["minutes-sdk"]',
+      ),
+  );
+  const expected = sdkVersion.error === null ? sdkVersion.value : null;
+
+  let reason = dependency.error;
+  if (reason === null && !isExactSemver(dependency.value)) {
+    reason = "must be an exact semantic version";
+  } else if (reason === null && dependency.value !== expected) {
+    reason = `does not equal crates/sdk/package.json [.version] = ${expected ?? "<unknown>"}`;
+  }
+
+  const evaluatedDependency = {
+    ...dependency,
+    ok: expected !== null && reason === null,
+    reason,
+  };
+  return {
+    expected,
+    sources: [evaluatedDependency],
+    ok: sdkVersion.error === null && evaluatedDependency.ok,
+  };
+}
+
+function jsonReport(domains) {
   const publicDomain = (domain) => ({
     expected: domain.expected,
     sources: domain.sources.map(({ file, key, value, ok }) => ({ file, key, value, ok })),
   });
-  return {
-    ok: domain1.ok && domain2.ok,
-    domain1: publicDomain(domain1),
-    domain2: publicDomain(domain2),
+  const report = {
+    ok: domains.domain1.ok && domains.domain2.ok && (domains.release?.ok ?? true),
+    domain1: publicDomain(domains.domain1),
+    domain2: publicDomain(domains.domain2),
   };
+  if (domains.release !== undefined) {
+    report.release = publicDomain(domains.release);
+  }
+  return report;
 }
 
 function printHumanReport(report, domains) {
@@ -238,6 +292,9 @@ function printHumanReport(report, domains) {
     console.log("Version sync check passed.");
     console.log(`Domain 1 (main release): ${domains.domain1.expected}`);
     console.log(`Domain 2 (plugin lockstep): ${domains.domain2.expected}`);
+    if (domains.release !== undefined) {
+      console.log(`Release (minutes-sdk dependency): ${domains.release.expected}`);
+    }
     return;
   }
 
@@ -245,14 +302,18 @@ function printHumanReport(report, domains) {
   for (const [name, label] of [
     ["domain1", "Domain 1 (main release)"],
     ["domain2", "Domain 2 (plugin lockstep)"],
+    ...(domains.release === undefined ? [] : [["release", "Release (minutes-sdk dependency)"]]),
   ]) {
     const domain = domains[name];
     if (domain.ok) continue;
     const expected = domain.expected ?? "<unknown>";
-    console.error(`${label} failed; expected ${expected}:`);
+    const expectation =
+      name === "release" ? `exact semantic version ${expected}` : expected;
+    console.error(`${label} failed; expected ${expectation}:`);
     for (const item of domain.sources.filter((candidate) => !candidate.ok)) {
       const found = item.error === null ? item.value : `<error: ${item.error}>`;
-      console.error(`  ${item.file} [${item.key}] = ${found} (expected ${expected})`);
+      const detail = item.reason ?? `expected ${expected}`;
+      console.error(`  ${item.file} [${item.key}] = ${found} (${detail})`);
     }
   }
 }
@@ -266,7 +327,10 @@ try {
 }
 
 const domains = collectDomains(options.root);
-const report = jsonReport(domains.domain1, domains.domain2);
+if (options.release) {
+  domains.release = collectRelease(options.root);
+}
+const report = jsonReport(domains);
 
 if (options.json) {
   console.log(JSON.stringify(report, null, 2));

--- a/scripts/check_version_sync.mjs
+++ b/scripts/check_version_sync.mjs
@@ -93,7 +93,10 @@ function cliMinutesCoreVersion(text) {
 }
 
 function mcpServerVersion(text) {
-  const declaration = /\bconst\s+MCP_SERVER_VERSION\s*=\s*"([^"]+)"/.exec(text);
+  const declaration =
+    /^[\t ]*(?:export[\t ]+)?const[\t ]+MCP_SERVER_VERSION[\t ]*=[\t ]*"([^"\r\n]+)"[\t ]*;?[\t ]*$/m.exec(
+      text,
+    );
   if (!declaration) {
     throw new Error('declaration `const MCP_SERVER_VERSION = "X.Y.Z"` not found');
   }

--- a/scripts/check_version_sync.mjs
+++ b/scripts/check_version_sync.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function parseArgs(argv) {
+  let json = false;
+  let root;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--json") {
+      json = true;
+    } else if (argument === "--root") {
+      if (index + 1 >= argv.length) {
+        throw new Error("--root requires a directory argument");
+      }
+      root = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+
+  const scriptRoot = path.resolve(path.dirname(process.argv[1]), "..");
+  return {
+    json,
+    root: root === undefined ? scriptRoot : path.resolve(root),
+  };
+}
+
+function readText(root, file) {
+  return fs.readFileSync(path.join(root, file), "utf8");
+}
+
+function readJson(root, file) {
+  return JSON.parse(readText(root, file));
+}
+
+function requireVersion(value, description) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${description} is missing or is not a string`);
+  }
+  return value;
+}
+
+function tomlSectionValue(text, section, key) {
+  let currentSection = null;
+  const keyPattern = new RegExp(`^${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=\\s*\"([^\"]+)\"`);
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const sectionMatch = /^\[([^\]]+)\]$/.exec(line);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      continue;
+    }
+    if (currentSection === section) {
+      const valueMatch = keyPattern.exec(line);
+      if (valueMatch) return valueMatch[1];
+    }
+  }
+
+  throw new Error(`[${section}].${key} declaration not found`);
+}
+
+function cliMinutesCoreVersion(text) {
+  const dependency = /^minutes-core\s*=\s*\{([\s\S]*?)\}/m.exec(text);
+  if (!dependency) {
+    throw new Error("minutes-core dependency declaration not found");
+  }
+  const version = /\bversion\s*=\s*"([^"]+)"/.exec(dependency[1]);
+  if (!version) {
+    throw new Error("minutes-core dependency version field not found");
+  }
+  return version[1];
+}
+
+function mcpServerVersion(text) {
+  const declaration = /\bconst\s+MCP_SERVER_VERSION\s*=\s*"([^"]+)"/.exec(text);
+  if (!declaration) {
+    throw new Error('declaration `const MCP_SERVER_VERSION = "X.Y.Z"` not found');
+  }
+  return declaration[1];
+}
+
+function cargoLockVersion(text, packageName) {
+  const matches = [];
+  for (const block of text.split(/^\[\[package\]\]\s*$/m).slice(1)) {
+    const name = /^name\s*=\s*"([^"]+)"\s*$/m.exec(block)?.[1];
+    if (name !== packageName) continue;
+    const version = /^version\s*=\s*"([^"]+)"\s*$/m.exec(block)?.[1];
+    if (!version) {
+      throw new Error(`Cargo.lock package ${packageName} has no version`);
+    }
+    matches.push(version);
+  }
+
+  if (matches.length === 0) {
+    throw new Error(`Cargo.lock package ${packageName} not found`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`Cargo.lock contains multiple exact packages named ${packageName}`);
+  }
+  return matches[0];
+}
+
+function source(file, key, extract) {
+  try {
+    return { file, key, value: extract(), error: null };
+  } catch (error) {
+    return {
+      file,
+      key,
+      value: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function expectedVersion(sources) {
+  const counts = new Map();
+  let expected = null;
+  let highestCount = 0;
+
+  for (const item of sources) {
+    if (item.error !== null) continue;
+    const count = (counts.get(item.value) ?? 0) + 1;
+    counts.set(item.value, count);
+    if (count > highestCount) {
+      expected = item.value;
+      highestCount = count;
+    }
+  }
+
+  return expected;
+}
+
+function evaluateDomain(sources) {
+  const expected = expectedVersion(sources);
+  const evaluatedSources = sources.map((item) => ({
+    ...item,
+    ok: item.error === null && item.value === expected,
+  }));
+  return {
+    expected,
+    sources: evaluatedSources,
+    ok: expected !== null && evaluatedSources.every((item) => item.ok),
+  };
+}
+
+function collectDomains(root) {
+  const domain1 = evaluateDomain([
+    source("Cargo.toml", "[workspace.package].version", () =>
+      tomlSectionValue(readText(root, "Cargo.toml"), "workspace.package", "version"),
+    ),
+    source("crates/cli/Cargo.toml", "dependencies.minutes-core.version", () =>
+      cliMinutesCoreVersion(readText(root, "crates/cli/Cargo.toml")),
+    ),
+    source("tauri/src-tauri/tauri.conf.json", ".version", () =>
+      requireVersion(readJson(root, "tauri/src-tauri/tauri.conf.json").version, ".version"),
+    ),
+    source("crates/mcp/package.json", ".version", () =>
+      requireVersion(readJson(root, "crates/mcp/package.json").version, ".version"),
+    ),
+    source("crates/sdk/package.json", ".version", () =>
+      requireVersion(readJson(root, "crates/sdk/package.json").version, ".version"),
+    ),
+    source("manifest.json", ".version", () =>
+      requireVersion(readJson(root, "manifest.json").version, ".version"),
+    ),
+    source("manifest.mcpb.json", ".version", () =>
+      requireVersion(readJson(root, "manifest.mcpb.json").version, ".version"),
+    ),
+    source("crates/mcp/src/index.ts", "MCP_SERVER_VERSION", () =>
+      mcpServerVersion(readText(root, "crates/mcp/src/index.ts")),
+    ),
+    source("crates/mcp/package-lock.json", ".version", () =>
+      requireVersion(readJson(root, "crates/mcp/package-lock.json").version, ".version"),
+    ),
+    source("crates/mcp/package-lock.json", '.packages[""].version', () =>
+      requireVersion(
+        readJson(root, "crates/mcp/package-lock.json").packages?.[""]?.version,
+        '.packages[""].version',
+      ),
+    ),
+    source("crates/sdk/package-lock.json", ".version", () =>
+      requireVersion(readJson(root, "crates/sdk/package-lock.json").version, ".version"),
+    ),
+    source("crates/sdk/package-lock.json", '.packages[""].version', () =>
+      requireVersion(
+        readJson(root, "crates/sdk/package-lock.json").packages?.[""]?.version,
+        '.packages[""].version',
+      ),
+    ),
+    ...["minutes-core", "minutes-cli", "minutes-reader"].map((packageName) =>
+      source("Cargo.lock", `package[${packageName}].version`, () =>
+        cargoLockVersion(readText(root, "Cargo.lock"), packageName),
+      ),
+    ),
+  ]);
+
+  const domain2 = evaluateDomain([
+    source(".claude-plugin/marketplace.json", ".plugins[0].version", () =>
+      requireVersion(
+        readJson(root, ".claude-plugin/marketplace.json").plugins?.[0]?.version,
+        ".plugins[0].version",
+      ),
+    ),
+    source(".claude/plugins/minutes/plugin.json", ".version", () =>
+      requireVersion(readJson(root, ".claude/plugins/minutes/plugin.json").version, ".version"),
+    ),
+    source(".claude/plugins/minutes/.claude-plugin/plugin.json", ".version", () =>
+      requireVersion(
+        readJson(root, ".claude/plugins/minutes/.claude-plugin/plugin.json").version,
+        ".version",
+      ),
+    ),
+  ]);
+
+  return { domain1, domain2 };
+}
+
+function jsonReport(domain1, domain2) {
+  const publicDomain = (domain) => ({
+    expected: domain.expected,
+    sources: domain.sources.map(({ file, key, value, ok }) => ({ file, key, value, ok })),
+  });
+  return {
+    ok: domain1.ok && domain2.ok,
+    domain1: publicDomain(domain1),
+    domain2: publicDomain(domain2),
+  };
+}
+
+function printHumanReport(report, domains) {
+  if (report.ok) {
+    console.log("Version sync check passed.");
+    console.log(`Domain 1 (main release): ${domains.domain1.expected}`);
+    console.log(`Domain 2 (plugin lockstep): ${domains.domain2.expected}`);
+    return;
+  }
+
+  console.error("Version sync check failed.");
+  for (const [name, label] of [
+    ["domain1", "Domain 1 (main release)"],
+    ["domain2", "Domain 2 (plugin lockstep)"],
+  ]) {
+    const domain = domains[name];
+    if (domain.ok) continue;
+    const expected = domain.expected ?? "<unknown>";
+    console.error(`${label} failed; expected ${expected}:`);
+    for (const item of domain.sources.filter((candidate) => !candidate.ok)) {
+      const found = item.error === null ? item.value : `<error: ${item.error}>`;
+      console.error(`  ${item.file} [${item.key}] = ${found} (expected ${expected})`);
+    }
+  }
+}
+
+let options;
+try {
+  options = parseArgs(process.argv.slice(2));
+} catch (error) {
+  console.error(`check_version_sync: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(2);
+}
+
+const domains = collectDomains(options.root);
+const report = jsonReport(domains.domain1, domains.domain2);
+
+if (options.json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  printHumanReport(report, domains);
+}
+
+process.exitCode = report.ok ? 0 : 1;

--- a/scripts/check_version_sync.test.mjs
+++ b/scripts/check_version_sync.test.mjs
@@ -253,6 +253,45 @@ test("missing MCP_SERVER_VERSION declaration fails with a clear message", async 
   assert.match(result.stderr, /MCP_SERVER_VERSION.*not found/);
 });
 
+test("commented-out MCP_SERVER_VERSION declaration does not satisfy extraction", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "crates/mcp/src/index.ts",
+    `// const MCP_SERVER_VERSION = "${mainVersion}";\n`,
+  );
+
+  const result = runChecker(root);
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.match(result.stderr, /MCP_SERVER_VERSION.*not found/);
+});
+
+test("string containing an MCP_SERVER_VERSION declaration does not satisfy extraction", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "crates/mcp/src/index.ts",
+    `const example = 'const MCP_SERVER_VERSION = "${mainVersion}"';\n`,
+  );
+
+  const result = runChecker(root);
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.match(result.stderr, /MCP_SERVER_VERSION.*not found/);
+});
+
+test("live exported MCP_SERVER_VERSION declaration satisfies extraction", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "crates/mcp/src/index.ts",
+    `export const MCP_SERVER_VERSION = "${mainVersion}";\n`,
+  );
+
+  const result = runChecker(root, "--json");
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(parseReport(result).ok, true);
+});
+
 test("release mode rejects minutes-sdk ranges while default mode ignores them", async (t) => {
   for (const rangePrefix of ["^", "~"]) {
     const root = await makeRepo(t);

--- a/scripts/check_version_sync.test.mjs
+++ b/scripts/check_version_sync.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const checker = path.resolve(path.dirname(process.argv[1]), "check_version_sync.mjs");
+const mainVersion = "1.2.3";
+const changedVersion = "8.8.8";
+const pluginVersion = "0.9.0";
+
+async function writeFixture(root, file, contents) {
+  const destination = path.join(root, file);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, contents);
+}
+
+async function writeJson(root, file, value) {
+  await writeFixture(root, file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function makeRepo(t) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minutes-version-sync-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  await writeFixture(
+    root,
+    "Cargo.toml",
+    `[workspace]\nmembers = []\n\n[workspace.package]\nversion = "${mainVersion}"\nedition = "2021"\n`,
+  );
+  await writeFixture(
+    root,
+    "crates/cli/Cargo.toml",
+    `[package]\nname = "minutes-cli"\nversion.workspace = true\n\n[dependencies]\nminutes-core = { path = "../core", version = "${mainVersion}", default-features = false }\n`,
+  );
+  await writeJson(root, "tauri/src-tauri/tauri.conf.json", { version: mainVersion });
+  await writeJson(root, "crates/mcp/package.json", { name: "minutes-mcp", version: mainVersion });
+  await writeJson(root, "crates/sdk/package.json", { name: "minutes-sdk", version: mainVersion });
+  await writeJson(root, "manifest.json", { version: mainVersion });
+  await writeJson(root, "manifest.mcpb.json", { version: mainVersion });
+  await writeFixture(
+    root,
+    "crates/mcp/src/index.ts",
+    `const MCP_SERVER_VERSION = "${mainVersion}";\n`,
+  );
+  await writeJson(root, "crates/mcp/package-lock.json", {
+    name: "minutes-mcp",
+    version: mainVersion,
+    lockfileVersion: 3,
+    packages: { "": { name: "minutes-mcp", version: mainVersion } },
+  });
+  await writeJson(root, "crates/sdk/package-lock.json", {
+    name: "minutes-sdk",
+    version: mainVersion,
+    lockfileVersion: 3,
+    packages: { "": { name: "minutes-sdk", version: mainVersion } },
+  });
+  await writeFixture(
+    root,
+    "Cargo.lock",
+    ["minutes-core", "minutes-cli", "minutes-reader", "whisper-guard"]
+      .map(
+        (name) =>
+          `[[package]]\nname = "${name}"\nversion = "${name === "whisper-guard" ? "77.0.0" : mainVersion}"\n`,
+      )
+      .join("\n"),
+  );
+  await writeJson(root, ".claude-plugin/marketplace.json", {
+    plugins: [{ name: "minutes", version: pluginVersion }],
+  });
+  await writeJson(root, ".claude/plugins/minutes/plugin.json", { version: pluginVersion });
+  await writeJson(root, ".claude/plugins/minutes/.claude-plugin/plugin.json", {
+    version: pluginVersion,
+  });
+  await writeFixture(
+    root,
+    "crates/whisper-guard/Cargo.toml",
+    `[package]\nname = "whisper-guard"\nversion = "77.0.0"\n`,
+  );
+  await writeFixture(
+    root,
+    "tauri/src-tauri/Cargo.toml",
+    `[package]\nname = "minutes-app"\nversion = "0.1.0"\n`,
+  );
+
+  return root;
+}
+
+function runChecker(root, ...args) {
+  return spawnSync(process.execPath, [checker, "--root", root, ...args], {
+    encoding: "utf8",
+  });
+}
+
+async function replaceInFile(root, file, before, after) {
+  const target = path.join(root, file);
+  const contents = await readFile(target, "utf8");
+  assert.ok(contents.includes(before), `${file} contains mutation target`);
+  await writeFile(target, contents.replace(before, after));
+}
+
+async function mutateJson(root, file, mutate) {
+  const target = path.join(root, file);
+  const value = JSON.parse(await readFile(target, "utf8"));
+  mutate(value);
+  await writeFile(target, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseReport(result) {
+  assert.equal(result.stderr, "");
+  return JSON.parse(result.stdout);
+}
+
+test("matching miniature repo passes with independent plugin and ignored versions", async (t) => {
+  const root = await makeRepo(t);
+  const result = runChecker(root, "--json");
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = parseReport(result);
+  assert.equal(report.ok, true);
+  assert.equal(report.domain1.expected, mainVersion);
+  assert.equal(report.domain2.expected, pluginVersion);
+  assert.equal(report.domain1.sources.length, 15);
+  assert.equal(report.domain2.sources.length, 3);
+});
+
+const domain1Mutations = [
+  {
+    name: "workspace package version",
+    file: "Cargo.toml",
+    key: "[workspace.package].version",
+    mutate: (root) =>
+      replaceInFile(root, "Cargo.toml", `version = "${mainVersion}"`, `version = "${changedVersion}"`),
+  },
+  {
+    name: "CLI minutes-core dependency version",
+    file: "crates/cli/Cargo.toml",
+    key: "dependencies.minutes-core.version",
+    mutate: (root) =>
+      replaceInFile(
+        root,
+        "crates/cli/Cargo.toml",
+        `version = "${mainVersion}"`,
+        `version = "${changedVersion}"`,
+      ),
+  },
+  ...[
+    "tauri/src-tauri/tauri.conf.json",
+    "crates/mcp/package.json",
+    "crates/sdk/package.json",
+    "manifest.json",
+    "manifest.mcpb.json",
+  ].map((file) => ({
+    name: `${file} version`,
+    file,
+    key: ".version",
+    mutate: (root) => mutateJson(root, file, (value) => (value.version = changedVersion)),
+  })),
+  {
+    name: "MCP server constant",
+    file: "crates/mcp/src/index.ts",
+    key: "MCP_SERVER_VERSION",
+    mutate: (root) => replaceInFile(root, "crates/mcp/src/index.ts", mainVersion, changedVersion),
+  },
+  ...["crates/mcp/package-lock.json", "crates/sdk/package-lock.json"].flatMap((file) => [
+    {
+      name: `${file} top-level version`,
+      file,
+      key: ".version",
+      mutate: (root) => mutateJson(root, file, (value) => (value.version = changedVersion)),
+    },
+    {
+      name: `${file} root package version`,
+      file,
+      key: '.packages[""].version',
+      mutate: (root) =>
+        mutateJson(root, file, (value) => (value.packages[""].version = changedVersion)),
+    },
+  ]),
+  ...["minutes-core", "minutes-cli", "minutes-reader"].map((packageName) => ({
+    name: `Cargo.lock ${packageName} package version`,
+    file: "Cargo.lock",
+    key: `package[${packageName}].version`,
+    mutate: (root) =>
+      replaceInFile(
+        root,
+        "Cargo.lock",
+        `name = "${packageName}"\nversion = "${mainVersion}"`,
+        `name = "${packageName}"\nversion = "${changedVersion}"`,
+      ),
+  })),
+];
+
+for (const fixture of domain1Mutations) {
+  test(`Domain 1 detects ${fixture.name}`, async (t) => {
+    const root = await makeRepo(t);
+    await fixture.mutate(root);
+
+    const result = runChecker(root, "--json");
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    const report = parseReport(result);
+    assert.equal(report.ok, false);
+    assert.equal(report.domain1.expected, mainVersion);
+    assert.ok(
+      report.domain1.sources.some(
+        (source) => source.file === fixture.file && source.key === fixture.key && source.ok === false,
+      ),
+      `${fixture.file} [${fixture.key}] is reported as mismatched`,
+    );
+    assert.equal(report.domain2.sources.every((source) => source.ok), true);
+  });
+}
+
+test("Domain 2 detects one mutated plugin version and names its file", async (t) => {
+  const root = await makeRepo(t);
+  const file = ".claude/plugins/minutes/.claude-plugin/plugin.json";
+  await mutateJson(root, file, (value) => (value.version = changedVersion));
+
+  const result = runChecker(root, "--json");
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const report = parseReport(result);
+  assert.equal(report.domain1.sources.every((source) => source.ok), true);
+  assert.ok(report.domain2.sources.some((source) => source.file === file && source.ok === false));
+});
+
+test("whisper-guard versions are explicitly ignored", async (t) => {
+  const root = await makeRepo(t);
+  await replaceInFile(root, "crates/whisper-guard/Cargo.toml", "77.0.0", "9999.42.7");
+  await replaceInFile(
+    root,
+    "Cargo.lock",
+    'name = "whisper-guard"\nversion = "77.0.0"',
+    'name = "whisper-guard"\nversion = "1234.5.6"',
+  );
+
+  const result = runChecker(root, "--json");
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(parseReport(result).ok, true);
+});
+
+test("missing MCP_SERVER_VERSION declaration fails with a clear message", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(root, "crates/mcp/src/index.ts", "export const unrelated = true;\n");
+
+  const result = runChecker(root);
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.match(result.stderr, /crates\/mcp\/src\/index\.ts \[MCP_SERVER_VERSION\]/);
+  assert.match(result.stderr, /MCP_SERVER_VERSION.*not found/);
+});

--- a/scripts/check_version_sync.test.mjs
+++ b/scripts/check_version_sync.test.mjs
@@ -35,7 +35,11 @@ async function makeRepo(t) {
     `[package]\nname = "minutes-cli"\nversion.workspace = true\n\n[dependencies]\nminutes-core = { path = "../core", version = "${mainVersion}", default-features = false }\n`,
   );
   await writeJson(root, "tauri/src-tauri/tauri.conf.json", { version: mainVersion });
-  await writeJson(root, "crates/mcp/package.json", { name: "minutes-mcp", version: mainVersion });
+  await writeJson(root, "crates/mcp/package.json", {
+    name: "minutes-mcp",
+    version: mainVersion,
+    dependencies: { "minutes-sdk": mainVersion },
+  });
   await writeJson(root, "crates/sdk/package.json", { name: "minutes-sdk", version: mainVersion });
   await writeJson(root, "manifest.json", { version: mainVersion });
   await writeJson(root, "manifest.mcpb.json", { version: mainVersion });
@@ -247,4 +251,77 @@ test("missing MCP_SERVER_VERSION declaration fails with a clear message", async 
   assert.equal(result.status, 1, result.stderr || result.stdout);
   assert.match(result.stderr, /crates\/mcp\/src\/index\.ts \[MCP_SERVER_VERSION\]/);
   assert.match(result.stderr, /MCP_SERVER_VERSION.*not found/);
+});
+
+test("release mode rejects minutes-sdk ranges while default mode ignores them", async (t) => {
+  for (const rangePrefix of ["^", "~"]) {
+    const root = await makeRepo(t);
+    const dependency = `${rangePrefix}${mainVersion}`;
+    await mutateJson(
+      root,
+      "crates/mcp/package.json",
+      (value) => (value.dependencies["minutes-sdk"] = dependency),
+    );
+
+    const defaultResult = runChecker(root, "--json");
+    assert.equal(defaultResult.status, 0, defaultResult.stderr || defaultResult.stdout);
+    assert.equal(Object.hasOwn(parseReport(defaultResult), "release"), false);
+
+    const releaseResult = runChecker(root, "--release", "--json");
+    assert.equal(releaseResult.status, 1, releaseResult.stderr || releaseResult.stdout);
+    const report = parseReport(releaseResult);
+    assert.equal(report.ok, false);
+    assert.equal(report.release.expected, mainVersion);
+    assert.deepEqual(report.release.sources, [
+      {
+        file: "crates/mcp/package.json",
+        key: '.dependencies["minutes-sdk"]',
+        value: dependency,
+        ok: false,
+      },
+    ]);
+  }
+});
+
+test("release mode rejects an exact minutes-sdk version that does not match the SDK", async (t) => {
+  const root = await makeRepo(t);
+  await mutateJson(
+    root,
+    "crates/mcp/package.json",
+    (value) => (value.dependencies["minutes-sdk"] = changedVersion),
+  );
+
+  const result = runChecker(root, "--release", "--json");
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const report = parseReport(result);
+  assert.equal(report.release.expected, mainVersion);
+  assert.equal(report.release.sources[0].value, changedVersion);
+  assert.equal(report.release.sources[0].ok, false);
+});
+
+test("release mode accepts an exact minutes-sdk version equal to the SDK", async (t) => {
+  const root = await makeRepo(t);
+
+  const result = runChecker(root, "--release", "--json");
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = parseReport(result);
+  assert.equal(report.ok, true);
+  assert.equal(report.release.expected, mainVersion);
+  assert.equal(report.release.sources[0].value, mainVersion);
+  assert.equal(report.release.sources[0].ok, true);
+});
+
+test("release mode rejects a file minutes-sdk dependency", async (t) => {
+  const root = await makeRepo(t);
+  await mutateJson(
+    root,
+    "crates/mcp/package.json",
+    (value) => (value.dependencies["minutes-sdk"] = "file:../sdk"),
+  );
+
+  const result = runChecker(root, "--release", "--json");
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const report = parseReport(result);
+  assert.equal(report.release.sources[0].value, "file:../sdk");
+  assert.equal(report.release.sources[0].ok, false);
 });


### PR DESCRIPTION
## What

`scripts/check_version_sync.mjs` + an unconditional `version_sync` CI job (wired into `ci_gate.needs`) enforcing the repo's version policy mechanically. Kills two recurring classes: the incomplete-bump class (d52f0b6 needed 0e41793 "complete the bump") and the marketplace/plugin lockstep scar from the pre-commit checklist.

**Three explicit domains:**
1. **Main release set** (must be equal): workspace Cargo.toml, cli's `minutes-core` dep version, tauri.conf.json, mcp+sdk package.json, manifest.json, manifest.mcpb.json, `MCP_SERVER_VERSION` in mcp/src/index.ts, own-version fields in both package-locks, and Cargo.lock entries for exactly `minutes-core`/`minutes-cli`/`minutes-reader`.
2. **Plugin lockstep** (equal to each other, never compared to the app): marketplace.json + both plugin.json files.
3. **Independent, never asserted**: whisper-guard, minutes-app's pinned crate version.

**`--release` mode** additionally asserts mcp's `minutes-sdk` dependency is an exact semver equal to the sdk's version — the invariant the npm publish-lag bug violated twice. Intentionally fails on today's tree (`^0.19.0` vs `0.21.0`); consumed by release automation (follow-up PR), not the day-to-day CI job.

## Verification

23/23 committed fixture tests (every Domain-1 source mutated individually → detected by name; plugin-trio mutation; whisper-guard immunity; release-mode range/mismatch/file: rejections). Current tree passes default mode; `--json` valid.

Part of the agent-infra hardening epic (bead `minutes-4a9r`, PR-B). Plan reviewed adversarially by codex to SHIP 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)