### PR TITLE
ci: workflow linting as an independent required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set CXXFLAGS for whisper.cpp (macOS)
         if: runner.os == 'macOS'
-        run: echo "CXXFLAGS=-I$(xcrun --show-sdk-path)/usr/include/c++/v1" >> $GITHUB_ENV
+        run: echo "CXXFLAGS=-I$(xcrun --show-sdk-path)/usr/include/c++/v1" >> "$GITHUB_ENV"
 
       # Scope every cache to the exact runner image (ImageOS + ImageVersion).
       # When `macos-latest` rotated from macOS 15 to macOS 26 the old target/ cache

--- a/.github/workflows/coach-model-eval.yml
+++ b/.github/workflows/coach-model-eval.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           brew install ollama
           ollama serve >"$RUNNER_TEMP/ollama.log" 2>&1 &
-          for attempt in {1..60}; do
+          for _ in {1..60}; do
             if curl --fail --silent http://localhost:11434/api/tags >/dev/null; then
               exit 0
             fi

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -26,6 +26,9 @@ jobs:
           "$ACTIONLINT_IMAGE"
           .github/workflows/*.yml
 
+      - name: Check runner context expressions
+        run: node scripts/check_workflow_runner_context.mjs
+
       - name: Verify broken workflow is rejected
         run: |
           if docker run --rm \
@@ -37,3 +40,14 @@ jobs:
             echo "actionlint unexpectedly accepted the broken workflow fixture" >&2
             exit 1
           fi
+
+      - name: Verify runner context checks
+        run: |
+          if node scripts/check_workflow_runner_context.mjs \
+            tests/fixtures/workflows/runner-context.yml
+          then
+            echo "runner-context check unexpectedly accepted the broken fixture" >&2
+            exit 1
+          fi
+          node scripts/check_workflow_runner_context.mjs \
+            tests/fixtures/workflows/runner-context-comment-only.yml

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,39 @@
+name: Lint workflows
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  ACTIONLINT_IMAGE: rhysd/actionlint:1.7.7@sha256:1d74bfc9fd1963af8f89a7c22afaaafd42f49aad711a09951d02cb996398f61d
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint workflows
+        run: >-
+          docker run --rm
+          --volume "$GITHUB_WORKSPACE:/repo"
+          --workdir /repo
+          "$ACTIONLINT_IMAGE"
+          .github/workflows/*.yml
+
+      - name: Verify broken workflow is rejected
+        run: |
+          if docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/repo" \
+            --workdir /repo \
+            "$ACTIONLINT_IMAGE" \
+            tests/fixtures/workflows/broken.yml
+          then
+            echo "actionlint unexpectedly accepted the broken workflow fixture" >&2
+            exit 1
+          fi

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -24,7 +24,6 @@ jobs:
           --volume "$GITHUB_WORKSPACE:/repo"
           --workdir /repo
           "$ACTIONLINT_IMAGE"
-          .github/workflows/*.yml
 
       - name: Check runner context expressions
         run: node scripts/check_workflow_runner_context.mjs
@@ -47,6 +46,18 @@ jobs:
             tests/fixtures/workflows/runner-context.yml
           then
             echo "runner-context check unexpectedly accepted the broken fixture" >&2
+            exit 1
+          fi
+          if node scripts/check_workflow_runner_context.mjs \
+            tests/fixtures/workflows/runner-context-indexed.yaml
+          then
+            echo "runner-context check unexpectedly accepted indexed access" >&2
+            exit 1
+          fi
+          if node scripts/check_workflow_runner_context.mjs \
+            tests/fixtures/workflows/runner-context-format-braces.yml
+          then
+            echo "runner-context check unexpectedly accepted format braces" >&2
             exit 1
           fi
           node scripts/check_workflow_runner_context.mjs \

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -52,6 +52,11 @@ jobs:
         if: runner.os == 'macOS'
         run: echo "CXXFLAGS=-I$(xcrun --show-sdk-path)/usr/include/c++/v1" >> "$GITHUB_ENV"
 
+      - name: Resolve runner image for cache scope
+        id: runner-image
+        shell: bash
+        run: echo "scope=${ImageOS:-noimage}-${ImageVersion:-noversion}" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo
         uses: actions/cache@v4
         with:
@@ -59,10 +64,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # Scope by ImageOS so a runner-image rotation does not restore a stale
+          # Scope by runner image so a runner-image rotation does not restore a stale
           # target/ cache with toolchain paths the new image no longer ships
           # (e.g. macOS 15 -> macOS 26 Xcode change). See ci.yml.
-          key: ${{ runner.os }}-${{ env.ImageOS }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.runner-image.outputs.scope }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Clean stale Windows native build cache
         if: runner.os == 'Windows'

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Resolve runner image for cache scope
+        id: runner-image
+        shell: bash
+        run: echo "scope=${ImageOS:-noimage}-${ImageVersion:-noversion}" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo
         uses: actions/cache@v4
         with:
@@ -56,10 +61,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # Scope by ImageOS so a runner-image rotation (e.g. macos-latest moving
+          # Scope by runner image so a runner-image rotation (e.g. macos-latest moving
           # from macOS 15 to macOS 26) does not restore a stale target/ cache with
           # linker paths for an Xcode the new image no longer ships. See ci.yml.
-          key: ${{ runner.os }}-${{ env.ImageOS }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.runner-image.outputs.scope }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked

--- a/.github/workflows/release-windows-desktop.yml
+++ b/.github/workflows/release-windows-desktop.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Resolve runner image for cache scope
+        id: runner-image
+        shell: bash
+        run: echo "scope=${ImageOS:-noimage}-${ImageVersion:-noversion}" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo
         uses: actions/cache@v4
         with:
@@ -35,9 +40,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # Scope by ImageOS so a runner-image rotation does not restore a stale
+          # Scope by runner image so a runner-image rotation does not restore a stale
           # target/ cache with toolchain paths the new image no longer ships. See ci.yml.
-          key: ${{ runner.os }}-${{ env.ImageOS }}-cargo-release-desktop-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.runner-image.outputs.scope }}-cargo-release-desktop-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Clean stale Windows native build cache
         shell: bash
@@ -52,7 +57,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/AppData/Local/dfbin
-          key: ${{ runner.os }}-${{ env.ImageOS }}-ort-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.runner-image.outputs.scope }}-ort-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Tauri CLI
         shell: bash

--- a/SPEC_NOTES.md
+++ b/SPEC_NOTES.md
@@ -1,0 +1,1 @@
+Maintainer follow-up: add `actionlint` as a required status check in branch protection — it cannot join ci_gate.needs (separate workflow).

--- a/SPEC_NOTES.md
+++ b/SPEC_NOTES.md
@@ -1,1 +1,8 @@
 Maintainer follow-up: add `actionlint` as a required status check in branch protection — it cannot join ci_gate.needs (separate workflow).
+
+PR-D completion also requires verifying that the `actionlint` check is required by branch protection:
+
+```bash
+test "$(gh api repos/silverstein/minutes/branches/main/protection \
+  --jq '[.required_status_checks.contexts[], .required_status_checks.checks[].context] | any(. == "actionlint")')" = true
+```

--- a/scripts/check_workflow_runner_context.mjs
+++ b/scripts/check_workflow_runner_context.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { extname, join } from "node:path";
+
+const DEFAULT_WORKFLOW_DIRECTORY = ".github/workflows";
+const FORBIDDEN_RUNNER_CONTEXT = /\benv\s*\.\s*(ImageOS|ImageVersion)\b/g;
+const EXPRESSION = /\$\{\{[\s\S]*?\}\}/g;
+
+function stripYamlComments(source) {
+  return source
+    .split("\n")
+    .map((line) => {
+      let inSingleQuote = false;
+      let inDoubleQuote = false;
+      let escaped = false;
+
+      for (let index = 0; index < line.length; index += 1) {
+        const character = line[index];
+
+        if (inDoubleQuote) {
+          if (escaped) {
+            escaped = false;
+          } else if (character === "\\") {
+            escaped = true;
+          } else if (character === '"') {
+            inDoubleQuote = false;
+          }
+          continue;
+        }
+
+        if (inSingleQuote) {
+          if (character === "'" && line[index + 1] === "'") {
+            index += 1;
+          } else if (character === "'") {
+            inSingleQuote = false;
+          }
+          continue;
+        }
+
+        if (character === '"') {
+          inDoubleQuote = true;
+        } else if (character === "'") {
+          inSingleQuote = true;
+        } else if (
+          character === "#" &&
+          (index === 0 || /\s/.test(line[index - 1]))
+        ) {
+          return `${line.slice(0, index)}${" ".repeat(line.length - index)}`;
+        }
+      }
+
+      return line;
+    })
+    .join("\n");
+}
+
+function workflowFiles(paths) {
+  const files = [];
+
+  for (const path of paths) {
+    const metadata = statSync(path);
+    if (metadata.isDirectory()) {
+      for (const entry of readdirSync(path, { withFileTypes: true })) {
+        const entryPath = join(path, entry.name);
+        if (entry.isDirectory()) {
+          files.push(...workflowFiles([entryPath]));
+        } else if ([".yml", ".yaml"].includes(extname(entry.name))) {
+          files.push(entryPath);
+        }
+      }
+    } else {
+      files.push(path);
+    }
+  }
+
+  return files.sort();
+}
+
+function lineAndColumn(source, offset) {
+  const precedingText = source.slice(0, offset);
+  const lines = precedingText.split("\n");
+  return { line: lines.length, column: lines.at(-1).length + 1 };
+}
+
+const paths = process.argv.slice(2);
+const files = workflowFiles(
+  paths.length > 0 ? paths : [DEFAULT_WORKFLOW_DIRECTORY],
+);
+let failed = false;
+
+for (const file of files) {
+  const source = readFileSync(file, "utf8");
+  const uncommentedSource = stripYamlComments(source);
+
+  for (const expressionMatch of uncommentedSource.matchAll(EXPRESSION)) {
+    const expression = expressionMatch[0];
+    for (const contextMatch of expression.matchAll(FORBIDDEN_RUNNER_CONTEXT)) {
+      const offset = expressionMatch.index + contextMatch.index;
+      const location = lineAndColumn(uncommentedSource, offset);
+      console.error(
+        `${file}:${location.line}:${location.column}: expressions cannot read env.${contextMatch[1]}; ` +
+          "read ${ImageOS} in a shell step and export a step output",
+      );
+      failed = true;
+    }
+  }
+}
+
+if (failed) {
+  process.exitCode = 1;
+}

--- a/scripts/check_workflow_runner_context.mjs
+++ b/scripts/check_workflow_runner_context.mjs
@@ -4,8 +4,8 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { extname, join } from "node:path";
 
 const DEFAULT_WORKFLOW_DIRECTORY = ".github/workflows";
-const FORBIDDEN_RUNNER_CONTEXT = /\benv\s*\.\s*(ImageOS|ImageVersion)\b/g;
-const EXPRESSION = /\$\{\{[\s\S]*?\}\}/g;
+const FORBIDDEN_RUNNER_CONTEXT =
+  /\benv\s*(?:\.\s*(ImageOS|ImageVersion)\b|\[\s*(['"])(ImageOS|ImageVersion)\2\s*\])/g;
 
 function stripYamlComments(source) {
   return source
@@ -77,6 +77,43 @@ function workflowFiles(paths) {
   return files.sort();
 }
 
+function* expressionSpans(source) {
+  let searchOffset = 0;
+
+  while (searchOffset < source.length) {
+    const start = source.indexOf("${{", searchOffset);
+    if (start === -1) {
+      return;
+    }
+
+    let end;
+    let inSingleQuote = false;
+    for (let index = start + 3; index < source.length - 1; index += 1) {
+      if (source[index] === "'") {
+        if (inSingleQuote && source[index + 1] === "'") {
+          index += 1;
+        } else {
+          inSingleQuote = !inSingleQuote;
+        }
+      } else if (
+        !inSingleQuote &&
+        source[index] === "}" &&
+        source[index + 1] === "}"
+      ) {
+        end = index + 2;
+        break;
+      }
+    }
+
+    if (end === undefined) {
+      return;
+    }
+
+    yield { expression: source.slice(start, end), index: start };
+    searchOffset = end;
+  }
+}
+
 function lineAndColumn(source, offset) {
   const precedingText = source.slice(0, offset);
   const lines = precedingText.split("\n");
@@ -93,13 +130,14 @@ for (const file of files) {
   const source = readFileSync(file, "utf8");
   const uncommentedSource = stripYamlComments(source);
 
-  for (const expressionMatch of uncommentedSource.matchAll(EXPRESSION)) {
-    const expression = expressionMatch[0];
+  for (const expressionMatch of expressionSpans(uncommentedSource)) {
+    const { expression } = expressionMatch;
     for (const contextMatch of expression.matchAll(FORBIDDEN_RUNNER_CONTEXT)) {
       const offset = expressionMatch.index + contextMatch.index;
       const location = lineAndColumn(uncommentedSource, offset);
+      const property = contextMatch[1] ?? contextMatch[3];
       console.error(
-        `${file}:${location.line}:${location.column}: expressions cannot read env.${contextMatch[1]}; ` +
+        `${file}:${location.line}:${location.column}: expressions cannot read env.${property}; ` +
           "read ${ImageOS} in a shell step and export a step output",
       );
       failed = true;

--- a/tests/fixtures/workflows/broken.yml
+++ b/tests/fixtures/workflows/broken.yml
@@ -1,0 +1,15 @@
+# INTENTIONALLY BROKEN: actionlint negative fixture. Keep these errors intact.
+# This lives outside .github/workflows so GitHub never attempts to run it.
+name: Broken workflow fixture
+
+on: push
+
+jobs:
+  broken:
+    runs-on: ubuntu-latest
+    needs: missing-job
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/example
+          key: ${{ runner.os }}-${{ env.ImageOS }}-cache

--- a/tests/fixtures/workflows/runner-context-comment-only.yml
+++ b/tests/fixtures/workflows/runner-context-comment-only.yml
@@ -1,4 +1,4 @@
-# Comment-only fixture: ${{ env.ImageOS }} must not be treated as an expression use.
+# Comment-only fixture: ${{ env.ImageOS }} and ${{ env['ImageVersion'] }} must not be treated as uses.
 name: Runner-context comment-only fixture
 
 on: push

--- a/tests/fixtures/workflows/runner-context-comment-only.yml
+++ b/tests/fixtures/workflows/runner-context-comment-only.yml
@@ -1,0 +1,10 @@
+# Comment-only fixture: ${{ env.ImageOS }} must not be treated as an expression use.
+name: Runner-context comment-only fixture
+
+on: push
+
+jobs:
+  valid:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No forbidden runner context expressions"

--- a/tests/fixtures/workflows/runner-context-format-braces.yml
+++ b/tests/fixtures/workflows/runner-context-format-braces.yml
@@ -1,0 +1,14 @@
+# INTENTIONALLY BROKEN: doubled braces inside a string must not end the expression.
+# This lives outside .github/workflows so GitHub never attempts to run it.
+name: Broken format-braces runner-context fixture
+
+on: push
+
+jobs:
+  broken:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/example
+          key: ${{ format('{{{0}}}', env.ImageOS) }}-cache

--- a/tests/fixtures/workflows/runner-context-indexed.yaml
+++ b/tests/fixtures/workflows/runner-context-indexed.yaml
@@ -1,0 +1,16 @@
+# INTENTIONALLY BROKEN: indexed runner-context negative fixture. Keep these expressions intact.
+# This lives outside .github/workflows so GitHub never attempts to run it.
+name: Broken indexed runner-context fixture
+
+on: push
+
+jobs:
+  broken:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/example
+          key: >-
+            ${{ env ['ImageOS'] }}-${{ env["ImageOS"] }}-
+            ${{ env[ 'ImageVersion' ] }}-${{ env["ImageVersion"] }}-cache

--- a/tests/fixtures/workflows/runner-context.yml
+++ b/tests/fixtures/workflows/runner-context.yml
@@ -1,0 +1,14 @@
+# INTENTIONALLY BROKEN: runner-context negative fixture. Keep this expression intact.
+# This lives outside .github/workflows so GitHub never attempts to run it.
+name: Broken runner-context fixture
+
+on: push
+
+jobs:
+  broken:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/example
+          key: ${{ runner.os }}-${{ env.ImageOS }}-cache


### PR DESCRIPTION
## What

Workflow files were the one code surface with zero linting — which is how `${{ env.ImageOS }}` cache keys silently expanded to empty and a cache fix shipped as a no-op (fixed for ci.yml in debb362, but see below).

- **`.github/workflows/lint-workflows.yml`** (new, deliberately separate): a syntax error severe enough to break ci.yml can't disable its own linting. actionlint 1.7.7 pinned by image digest, lints every workflow.
- **Committed negative fixtures asserted red in the same job** — the linter is proven able to fail: `tests/fixtures/workflows/broken.yml` (undefined `needs` ref) for actionlint, `runner-context.yml` for the new rule.
- **`scripts/check_workflow_runner_context.mjs`**: expression-aware rule (not a grep — comments never flag) that unconditionally forbids `env.ImageOS`/`env.ImageVersion` inside `${{ }}` expressions, since actionlint's loose env model permits them. Error message teaches the correct pattern.
- **Found the bug live**: all three release workflows (`release-cli`, `release-macos`, `release-windows-desktop`) still had `env.ImageOS` cache keys silently expanding to empty. Converted to the shell-derived step-output pattern ci.yml already uses. Caches re-key once on merge; that's the fix working.
- Fixed the two existing actionlint findings (quoted `$GITHUB_ENV`, unused loop var).

## Maintainer follow-up (PR is not "done" at merge)

Add the `actionlint` check as required via branch protection — it cannot join `ci_gate.needs` (separate workflow). Exact command in `SPEC_NOTES.md`; tracked in bead `minutes-4a9r.6`.

Part of the agent-infra hardening epic (bead `minutes-4a9r`, PR-D). Plan reviewed adversarially by codex to SHIP 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)