### PR TITLE
feat(release): transactional bump-version script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,9 @@ jobs:
       - name: Test version policy checker
         run: node --test scripts/check_version_sync.test.mjs
 
+      - name: Test transactional version bump
+        run: node --test scripts/bump_version.test.mjs
+
   skills_compiler:
     name: Skills Compiler
     runs-on: ubuntu-latest

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -4,25 +4,23 @@
 
 ### 1. Version bump (every source must match)
 ```bash
-# Bump in: Cargo.toml, crates/cli/Cargo.toml, tauri/src-tauri/tauri.conf.json,
-#          crates/mcp/package.json, crates/sdk/package.json, manifest.json
-# Also: manifest.mcpb.json  (Claude listing copy; its runtime `version` MUST equal
-#       manifest.json. Only display_name/description/long_description may differ.
-#       The MCP Server CI job's bundle guard fails on version drift here.)
-# Also: crates/mcp/src/index.ts  (const MCP_SERVER_VERSION = "X.Y.Z")
-# Also: the minutes-core dep version in crates/cli/Cargo.toml
-# Also: crates/sdk/package-lock.json AND crates/mcp/package-lock.json
-#       (the package's own "version" field appears twice: at the top and under
-#       packages[""]. `npm version` syncs these; a hand-edited package.json does not.)
-# Then regenerate derived files (pre-push hooks + CI enforce these):
-#   node scripts/sync_site_release_version.mjs   # site/lib/release.ts
-#   node scripts/generate_llms_txt.mjs           # site/public/llms.txt + llms-full.txt
-#   cargo check                                  # refreshes Cargo.lock workspace versions
-# Verify the primary sources:
-grep version Cargo.toml tauri/src-tauri/tauri.conf.json crates/mcp/package.json \
-  crates/sdk/package.json manifest.json manifest.mcpb.json && \
-  grep MCP_SERVER_VERSION crates/mcp/src/index.ts
+# Preview the complete Domain-1 patch without touching this checkout, then apply it.
+node scripts/bump-version.mjs --dry-run X.Y.Z
+node scripts/bump-version.mjs X.Y.Z
+
+# Keep the generated LLM documentation current, then run the public verifier.
+node scripts/generate_llms_txt.mjs
+node scripts/check_version_sync.mjs
 ```
+
+The bump command updates every Domain-1 source, regenerates both npm lockfiles,
+refreshes only the three Minutes workspace entries in `Cargo.lock`, regenerates
+`site/lib/release.ts`, and verifies the result in a temporary git worktree before
+applying one patch to the real checkout. It never changes the independently
+versioned plugin metadata, `whisper-guard`, or the Tauri crate's own version.
+
+For a plugin-only release, update the plugin trio with the same transactional
+flow: `node scripts/bump-version.mjs --plugin X.Y.Z` (add `--dry-run` to preview).
 
 **Independent-cadence crates.** `crates/whisper-guard/Cargo.toml` is published to crates.io on its own cadence — it does NOT need to match the main version. Check whether it has unreleased changes before tagging the main release:
 ```bash

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -366,9 +366,11 @@ async function main() {
     return;
   }
 
+  // Untracked files are ignored: the bump patch only ever touches tracked
+  // sources, so scratch files must not block a release bump.
   const { stdout: status } = await exec(
     "git",
-    ["status", "--porcelain=v1", "--untracked-files=all"],
+    ["status", "--porcelain=v1", "--untracked-files=no"],
     { cwd: root },
   );
   if (status !== "") {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -298,13 +298,13 @@ function parseNulList(output) {
 function assertChangedFiles(actualFiles, expectedFiles, mode) {
   const actual = new Set(actualFiles);
   const expected = new Set(expectedFiles);
-  const missing = [...expected].filter((file) => !actual.has(file));
+  // Only unexpected files are fatal. A subset is legitimate: when repairing a
+  // committed partial bump, sources already at the target version produce no
+  // diff. The temp-worktree checker run still proves the domain ends
+  // synchronized, so "missing" files cannot hide drift.
   const unexpected = [...actual].filter((file) => !expected.has(file));
-  if (missing.length || unexpected.length) {
-    const details = [
-      missing.length ? `missing: ${missing.join(", ")}` : null,
-      unexpected.length ? `unexpected: ${unexpected.join(", ")}` : null,
-    ].filter(Boolean);
+  if (unexpected.length) {
+    const details = [`unexpected: ${unexpected.join(", ")}`];
     throw new Error(`${mode} bump produced the wrong file set (${details.join("; ")})`);
   }
 }
@@ -362,8 +362,26 @@ async function main() {
   const existingVersion = await currentVersion(root, options.plugin);
 
   if (existingVersion === options.version) {
-    console.log(`${mode} version is already at ${options.version}; nothing to do.`);
-    return;
+    // No-op only when the whole domain is already synchronized — a partially
+    // applied bump (canonical source at target, other sources behind) must
+    // fall through and be repaired by the normal bump flow.
+    let domainSynchronized = true;
+    try {
+      await exec(
+        process.execPath,
+        [path.join(root, "scripts", "check_version_sync.mjs"), "--root", root],
+        { cwd: root },
+      );
+    } catch {
+      domainSynchronized = false;
+    }
+    if (domainSynchronized) {
+      console.log(`${mode} version is already at ${options.version}; nothing to do.`);
+      return;
+    }
+    console.log(
+      `${mode} version is already at ${options.version} but the domain is not synchronized; re-applying the bump.`,
+    );
   }
 
   // Untracked files are ignored: the bump patch only ever touches tracked

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const numericIdentifier = "(?:0|[1-9]\\d*)";
+const prereleaseIdentifier = `(?:${numericIdentifier}|\\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const exactVersionPattern = new RegExp(
+  `^${numericIdentifier}\\.${numericIdentifier}\\.${numericIdentifier}` +
+    `(?:-${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)?$`,
+);
+
+const pluginFiles = [
+  ".claude-plugin/marketplace.json",
+  ".claude/plugins/minutes/plugin.json",
+  ".claude/plugins/minutes/.claude-plugin/plugin.json",
+];
+
+const domainOneFiles = [
+  "Cargo.toml",
+  "crates/cli/Cargo.toml",
+  "tauri/src-tauri/tauri.conf.json",
+  "crates/mcp/package.json",
+  "crates/sdk/package.json",
+  "manifest.json",
+  "manifest.mcpb.json",
+  "crates/mcp/src/index.ts",
+  "crates/mcp/package-lock.json",
+  "crates/sdk/package-lock.json",
+  "Cargo.lock",
+];
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/bump-version.mjs [--dry-run] <version>",
+    "  node scripts/bump-version.mjs [--dry-run] --plugin <version>",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  let dryRun = false;
+  let plugin = false;
+  let version;
+
+  for (const argument of argv) {
+    if (argument === "--dry-run") {
+      if (dryRun) throw new Error("--dry-run may only be specified once");
+      dryRun = true;
+    } else if (argument === "--plugin") {
+      if (plugin) throw new Error("--plugin may only be specified once");
+      plugin = true;
+    } else if (argument.startsWith("-")) {
+      throw new Error(`unknown option: ${argument}`);
+    } else if (version === undefined) {
+      version = argument;
+    } else {
+      throw new Error(`unexpected argument: ${argument}`);
+    }
+  }
+
+  if (version === undefined) throw new Error("a version is required");
+  if (!exactVersionPattern.test(version)) {
+    throw new Error(`invalid version ${JSON.stringify(version)}; expected x.y.z or x.y.z-prerelease`);
+  }
+
+  return { dryRun, plugin, version };
+}
+
+const toolPath = process.env.BUMP_TOOL_PATH;
+const childEnvironment = {
+  ...process.env,
+  ...(toolPath
+    ? { PATH: `${toolPath}${path.delimiter}${process.env.PATH ?? ""}` }
+    : {}),
+};
+const activeChildren = new Set();
+
+class CommandError extends Error {
+  constructor(command, args, code, signal, stdout, stderr) {
+    const outcome = signal ? `signal ${signal}` : `exit code ${code}`;
+    const detail = stderr.trim() || stdout.trim();
+    super(`${command} ${args.join(" ")} failed with ${outcome}${detail ? `\n${detail}` : ""}`);
+    this.name = "CommandError";
+  }
+}
+
+function exec(command, args, { cwd, input, env = childEnvironment } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    activeChildren.add(child);
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("error", (error) => {
+      activeChildren.delete(child);
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      activeChildren.delete(child);
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new CommandError(command, args, code, signal, stdout, stderr));
+      }
+    });
+
+    child.stdin.end(input);
+  });
+}
+
+async function readText(root, file) {
+  return readFile(path.join(root, file), "utf8");
+}
+
+async function writeText(root, file, contents) {
+  await writeFile(path.join(root, file), contents, "utf8");
+}
+
+async function readJson(root, file) {
+  return JSON.parse(await readText(root, file));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function updateJsonVersion(root, file, readCurrent, version) {
+  const text = await readText(root, file);
+  const value = JSON.parse(text);
+  const current = readCurrent(value);
+  if (typeof current !== "string") throw new Error(`${file} is missing its version field`);
+  const pattern = new RegExp(
+    `^([\\t ]*"version"[\\t ]*:[\\t ]*")${escapeRegExp(current)}("[\\t ]*,?[\\t ]*)$`,
+    "gm",
+  );
+  const matches = [...text.matchAll(pattern)];
+  if (matches.length !== 1) {
+    throw new Error(`${file} must contain exactly one live JSON version declaration`);
+  }
+  await writeText(root, file, text.replace(pattern, `$1${version}$2`));
+}
+
+function workspaceVersion(text) {
+  const section = /^\[workspace\.package\][\t ]*\r?\n([\s\S]*?)(?=^\[|$(?![\s\S]))/m.exec(text);
+  const match = section && /^version[\t ]*=[\t ]*"([^"]+)"[\t ]*$/m.exec(section[1]);
+  if (!match) throw new Error("[workspace.package].version declaration not found in Cargo.toml");
+  return match[1];
+}
+
+function updateWorkspaceVersion(text, version) {
+  const sectionPattern = /(^\[workspace\.package\][\t ]*\r?\n)([\s\S]*?)(?=^\[|$(?![\s\S]))/m;
+  const section = sectionPattern.exec(text);
+  if (!section) throw new Error("[workspace.package] section not found in Cargo.toml");
+  const versionPattern = /^version[\t ]*=[\t ]*"[^"]+"[\t ]*$/m;
+  if (!versionPattern.test(section[2])) {
+    throw new Error("[workspace.package].version declaration not found in Cargo.toml");
+  }
+  const nextBody = section[2].replace(versionPattern, `version = "${version}"`);
+  return text.slice(0, section.index) + section[1] + nextBody + text.slice(section.index + section[0].length);
+}
+
+function updateCliDependency(text, version) {
+  const dependencyPattern = /^minutes-core\s*=\s*\{([\s\S]*?)\}/m;
+  const dependency = dependencyPattern.exec(text);
+  if (!dependency) throw new Error("minutes-core dependency declaration not found");
+  const versionPattern = /\bversion\s*=\s*"[^"]+"/;
+  if (!versionPattern.test(dependency[1])) {
+    throw new Error("minutes-core dependency version field not found");
+  }
+  const replacement = dependency[0].replace(versionPattern, `version = "${version}"`);
+  return text.slice(0, dependency.index) + replacement + text.slice(dependency.index + dependency[0].length);
+}
+
+function updateMcpServerVersion(text, version) {
+  const declarationPattern =
+    /^[\t ]*(?:export[\t ]+)?const[\t ]+MCP_SERVER_VERSION[\t ]*=[\t ]*"([^"\r\n]+)"[\t ]*;?[\t ]*$/m;
+  const declaration = declarationPattern.exec(text);
+  if (!declaration) {
+    throw new Error('declaration `const MCP_SERVER_VERSION = "X.Y.Z"` not found');
+  }
+  const replacement = declaration[0].replace(`"${declaration[1]}"`, `"${version}"`);
+  return text.slice(0, declaration.index) + replacement + text.slice(declaration.index + declaration[0].length);
+}
+
+function updateCargoLockVersions(text, version) {
+  const packageNames = new Set(["minutes-core", "minutes-cli", "minutes-reader"]);
+  const updated = new Set();
+  const sections = text.split(/(?=^\[\[package\]\][\t ]*$)/m);
+  const nextSections = sections.map((section) => {
+    const name = /^name[\t ]*=[\t ]*"([^"]+)"[\t ]*$/m.exec(section)?.[1];
+    if (!packageNames.has(name)) return section;
+    if (updated.has(name)) throw new Error(`Cargo.lock contains multiple packages named ${name}`);
+    if (!/^version[\t ]*=[\t ]*"[^"]+"[\t ]*$/m.test(section)) {
+      throw new Error(`Cargo.lock package ${name} has no version`);
+    }
+    updated.add(name);
+    return section.replace(/^version[\t ]*=[\t ]*"[^"]+"[\t ]*$/m, `version = "${version}"`);
+  });
+
+  for (const packageName of packageNames) {
+    if (!updated.has(packageName)) throw new Error(`Cargo.lock package ${packageName} not found`);
+  }
+  return nextSections.join("");
+}
+
+async function fileExists(file) {
+  try {
+    return (await stat(file)).isFile();
+  } catch (error) {
+    if (error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function currentVersion(root, plugin) {
+  if (plugin) {
+    const marketplace = await readJson(root, pluginFiles[0]);
+    const version = marketplace.plugins?.[0]?.version;
+    if (typeof version !== "string") throw new Error("marketplace plugin version not found");
+    return version;
+  }
+  return workspaceVersion(await readText(root, "Cargo.toml"));
+}
+
+async function applyDomainOneWrites(root, version) {
+  await writeText(
+    root,
+    "Cargo.toml",
+    updateWorkspaceVersion(await readText(root, "Cargo.toml"), version),
+  );
+  await writeText(
+    root,
+    "crates/cli/Cargo.toml",
+    updateCliDependency(await readText(root, "crates/cli/Cargo.toml"), version),
+  );
+
+  for (const file of [
+    "tauri/src-tauri/tauri.conf.json",
+    "crates/mcp/package.json",
+    "crates/sdk/package.json",
+    "manifest.json",
+    "manifest.mcpb.json",
+  ]) {
+    await updateJsonVersion(root, file, (value) => value.version, version);
+  }
+
+  await writeText(
+    root,
+    "crates/mcp/src/index.ts",
+    updateMcpServerVersion(await readText(root, "crates/mcp/src/index.ts"), version),
+  );
+
+  await exec("npm", ["install", "--package-lock-only"], { cwd: path.join(root, "crates/mcp") });
+  await exec("npm", ["install", "--package-lock-only"], { cwd: path.join(root, "crates/sdk") });
+
+  const cargoLockBefore = await readText(root, "Cargo.lock");
+  const expectedCargoLock = updateCargoLockVersions(cargoLockBefore, version);
+  await exec(
+    "cargo",
+    ["update", "-p", "minutes-core", "-p", "minutes-cli", "-p", "minutes-reader"],
+    { cwd: root },
+  );
+  const cargoLockAfter = await readText(root, "Cargo.lock");
+  if (cargoLockAfter !== expectedCargoLock) {
+    throw new Error(
+      "cargo update changed Cargo.lock beyond the version fields for minutes-core, minutes-cli, and minutes-reader",
+    );
+  }
+
+  const siteSync = path.join(root, "scripts/sync_site_release_version.mjs");
+  if (await fileExists(siteSync)) {
+    await exec(process.execPath, [siteSync], { cwd: root });
+  }
+}
+
+async function applyPluginWrites(root, version) {
+  await updateJsonVersion(root, pluginFiles[0], (value) => value.plugins?.[0]?.version, version);
+  for (const file of pluginFiles.slice(1)) {
+    await updateJsonVersion(root, file, (value) => value.version, version);
+  }
+}
+
+function parseNulList(output) {
+  return output.split("\0").filter(Boolean);
+}
+
+function assertChangedFiles(actualFiles, expectedFiles, mode) {
+  const actual = new Set(actualFiles);
+  const expected = new Set(expectedFiles);
+  const missing = [...expected].filter((file) => !actual.has(file));
+  const unexpected = [...actual].filter((file) => !expected.has(file));
+  if (missing.length || unexpected.length) {
+    const details = [
+      missing.length ? `missing: ${missing.join(", ")}` : null,
+      unexpected.length ? `unexpected: ${unexpected.join(", ")}` : null,
+    ].filter(Boolean);
+    throw new Error(`${mode} bump produced the wrong file set (${details.join("; ")})`);
+  }
+}
+
+let temporaryParent;
+let temporaryWorktree;
+let worktreeAdded = false;
+let cleanupPromise;
+let repositoryRoot;
+
+async function cleanup() {
+  if (cleanupPromise) return cleanupPromise;
+  cleanupPromise = (async () => {
+    let removeFailed = false;
+    if (worktreeAdded && temporaryWorktree) {
+      try {
+        await exec("git", ["worktree", "remove", "--force", temporaryWorktree], {
+          cwd: repositoryRoot,
+        });
+      } catch {
+        removeFailed = true;
+      }
+    }
+    if (temporaryParent) await rm(temporaryParent, { recursive: true, force: true });
+    if (removeFailed) {
+      // Removing the directory first makes the linked-worktree metadata immediately prunable.
+      try {
+        await exec("git", ["worktree", "prune", "--expire", "now"], { cwd: repositoryRoot });
+      } catch {
+        // Preserve the original command failure.
+      }
+    }
+  })();
+  return cleanupPromise;
+}
+
+let handlingSignal = false;
+function handleSignal(signal, exitCode) {
+  if (handlingSignal) return;
+  handlingSignal = true;
+  for (const child of activeChildren) child.kill(signal);
+  void cleanup().finally(() => process.exit(exitCode));
+}
+process.once("SIGINT", () => handleSignal("SIGINT", 130));
+process.once("SIGTERM", () => handleSignal("SIGTERM", 143));
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const { stdout: rootOutput } = await exec("git", ["rev-parse", "--show-toplevel"], {
+    cwd: process.cwd(),
+  });
+  const root = rootOutput.trim();
+  repositoryRoot = root;
+  const mode = options.plugin ? "plugin" : "main";
+  const existingVersion = await currentVersion(root, options.plugin);
+
+  if (existingVersion === options.version) {
+    console.log(`${mode} version is already at ${options.version}; nothing to do.`);
+    return;
+  }
+
+  const { stdout: status } = await exec(
+    "git",
+    ["status", "--porcelain=v1", "--untracked-files=all"],
+    { cwd: root },
+  );
+  if (status !== "") {
+    throw new Error("refusing to bump version: working tree is dirty");
+  }
+
+  temporaryParent = await mkdtemp(path.join(os.tmpdir(), "minutes-bump-version-"));
+  temporaryWorktree = path.join(temporaryParent, "worktree");
+  try {
+    await exec("git", ["worktree", "add", "--detach", temporaryWorktree, "HEAD"], { cwd: root });
+    worktreeAdded = true;
+
+    if (options.plugin) {
+      await applyPluginWrites(temporaryWorktree, options.version);
+    } else {
+      await applyDomainOneWrites(temporaryWorktree, options.version);
+    }
+
+    await exec(
+      process.execPath,
+      [path.join(temporaryWorktree, "scripts/check_version_sync.mjs"), "--root", temporaryWorktree],
+      { cwd: temporaryWorktree },
+    );
+
+    const { stdout: changedOutput } = await exec(
+      "git",
+      ["diff", "--name-only", "-z", "--no-ext-diff"],
+      { cwd: temporaryWorktree },
+    );
+    const changedFiles = parseNulList(changedOutput);
+    const expectedFiles = options.plugin
+      ? pluginFiles
+      : [
+          ...domainOneFiles,
+          ...((await fileExists(path.join(temporaryWorktree, "scripts/sync_site_release_version.mjs")))
+            ? ["site/lib/release.ts"]
+            : []),
+        ];
+    assertChangedFiles(changedFiles, expectedFiles, mode);
+
+    const { stdout: patch } = await exec(
+      "git",
+      ["diff", "--binary", "--full-index", "--no-ext-diff"],
+      { cwd: temporaryWorktree },
+    );
+    if (!patch) throw new Error(`${mode} bump unexpectedly produced an empty patch`);
+
+    if (options.dryRun) {
+      console.log(`Dry run: ${mode} version ${existingVersion} -> ${options.version}`);
+      console.log("Files that would change:");
+      for (const file of changedFiles) console.log(`  ${file}`);
+      console.log("\nUnified diff:");
+      process.stdout.write(patch);
+    } else {
+      await exec("git", ["apply", "--whitespace=nowarn", "-"], { cwd: root, input: patch });
+      console.log(`Updated ${mode} version ${existingVersion} -> ${options.version}:`);
+      for (const file of changedFiles) console.log(`  ${file}`);
+    }
+  } finally {
+    await cleanup();
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  await cleanup();
+  console.error(`bump-version: ${error instanceof Error ? error.message : String(error)}`);
+  if (
+    error instanceof Error &&
+    /^(?:a version is required|invalid version|unknown option|unexpected argument|--)/.test(
+      error.message,
+    )
+  ) {
+    console.error(usage());
+    process.exitCode = 2;
+  } else {
+    process.exitCode = 1;
+  }
+}

--- a/scripts/bump_version.test.mjs
+++ b/scripts/bump_version.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import {
+  appendFile,
   chmod,
   mkdir,
   mkdtemp,
@@ -279,14 +280,22 @@ test("real run updates every Domain-1 source and passes the checker", async (t) 
   );
 });
 
-test("dirty tree is refused", async (t) => {
+test("dirty tree (tracked modification) is refused", async (t) => {
   const { root, tools } = await makeRepo(t);
-  await writeFixture(root, "untracked.txt", "dirty\n");
+  await appendFile(path.join(root, "manifest.json"), "\n");
   const result = runBump(root, tools, nextVersion);
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /working tree is dirty/);
   assert.equal(await readVersion(root, "Cargo.toml"), undefined);
+});
+
+test("untracked files do not block a bump", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  await writeFixture(root, "untracked.txt", "scratch\n");
+  const result = runBump(root, tools, "--dry-run", nextVersion);
+
+  assert.equal(result.status, 0);
 });
 
 test("invalid semantic versions are refused", async (t) => {

--- a/scripts/bump_version.test.mjs
+++ b/scripts/bump_version.test.mjs
@@ -320,6 +320,26 @@ test("re-running the current version is an idempotent no-op", async (t) => {
   await assertSnapshot(root, before);
 });
 
+test("a committed partial bump is repaired, not treated as a no-op", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  const first = runBump(root, tools, nextVersion);
+  assert.equal(first.status, 0, first.stderr || first.stdout);
+
+  // Regress one non-canonical source and commit it: canonical version still
+  // matches the target, so a naive no-op check would accept the drift.
+  const manifestPath = path.join(root, "manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.version = "0.0.1";
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  spawnSync("git", ["commit", "-am", "regress manifest"], { cwd: root });
+
+  const repair = runBump(root, tools, nextVersion);
+  assert.equal(repair.status, 0, repair.stderr || repair.stdout);
+  assert.match(repair.stdout, /not synchronized; re-applying/);
+  const repaired = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(repaired.version, nextVersion);
+});
+
 test("tool failure leaves the real tree byte-identical", async (t) => {
   const { root, tools } = await makeRepo(t);
   const before = await trackedSnapshot(root);

--- a/scripts/bump_version.test.mjs
+++ b/scripts/bump_version.test.mjs
@@ -1,0 +1,401 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const scriptsDirectory = path.dirname(process.argv[1]);
+const bumper = path.resolve(scriptsDirectory, "bump-version.mjs");
+const checker = path.resolve(scriptsDirectory, "check_version_sync.mjs");
+const initialVersion = "1.2.3";
+const nextVersion = "1.3.0-beta.1";
+const initialPluginVersion = "0.9.0";
+const nextPluginVersion = "0.10.0";
+
+async function writeFixture(root, file, contents) {
+  const destination = path.join(root, file);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, contents);
+}
+
+async function writeJson(root, file, value) {
+  await writeFixture(root, file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8", ...options });
+  assert.equal(result.error, undefined, result.error?.message);
+  return result;
+}
+
+function git(root, ...args) {
+  return run("git", args, { cwd: root });
+}
+
+async function installToolShims(root) {
+  const tools = path.join(root, ".test-tools");
+  await mkdir(tools, { recursive: true });
+
+  await writeFixture(
+    tools,
+    "npm",
+    `#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+if (process.env.BUMP_SHIM_FAIL === "npm") {
+  console.error("simulated npm failure");
+  process.exit(51);
+}
+if (process.env.BUMP_SHIM_PAUSE === "npm") {
+  const worktree = path.resolve(process.cwd(), "../..");
+  await writeFile(process.env.BUMP_SHIM_READY_FILE, worktree);
+  await new Promise((resolve) => setTimeout(resolve, 60000));
+}
+const packageJson = JSON.parse(await readFile(path.join(process.cwd(), "package.json"), "utf8"));
+const lockPath = path.join(process.cwd(), "package-lock.json");
+const lock = JSON.parse(await readFile(lockPath, "utf8"));
+lock.version = packageJson.version;
+lock.packages[""].version = packageJson.version;
+await writeFile(lockPath, JSON.stringify(lock, null, 2) + "\\n");
+`,
+  );
+  await writeFixture(
+    tools,
+    "cargo",
+    `#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+if (process.env.BUMP_SHIM_FAIL === "cargo") {
+  console.error("simulated cargo failure");
+  process.exit(52);
+}
+const manifest = await readFile("Cargo.toml", "utf8");
+const version = /^version\\s*=\\s*"([^"]+)"/m.exec(manifest)?.[1];
+if (!version) throw new Error("fixture workspace version not found");
+const lockPath = "Cargo.lock";
+let lock = await readFile(lockPath, "utf8");
+for (const name of ["minutes-core", "minutes-cli", "minutes-reader"]) {
+  const pattern = new RegExp('(name = "' + name + '"\\nversion = ")[^"]+(")');
+  if (!pattern.test(lock)) throw new Error("fixture lock package not found: " + name);
+  lock = lock.replace(pattern, (_match, prefix, suffix = "") => prefix + version + suffix);
+}
+await writeFile(lockPath, lock);
+`,
+  );
+  await chmod(path.join(tools, "npm"), 0o755);
+  await chmod(path.join(tools, "cargo"), 0o755);
+  return tools;
+}
+
+async function makeRepo(t) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minutes-bump-fixture-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  await writeFixture(
+    root,
+    "Cargo.toml",
+    `[workspace]\nmembers = []\n\n[workspace.package]\nversion = "${initialVersion}"\nedition = "2021"\n`,
+  );
+  await writeFixture(
+    root,
+    "crates/cli/Cargo.toml",
+    `[package]\nname = "minutes-cli"\nversion.workspace = true\n\n[dependencies]\nminutes-core = { path = "../core", version = "${initialVersion}", default-features = false }\n`,
+  );
+  await writeJson(root, "tauri/src-tauri/tauri.conf.json", { version: initialVersion });
+  await writeJson(root, "crates/mcp/package.json", {
+    name: "minutes-mcp",
+    version: initialVersion,
+  });
+  await writeJson(root, "crates/sdk/package.json", {
+    name: "minutes-sdk",
+    version: initialVersion,
+  });
+  await writeJson(root, "manifest.json", { version: initialVersion, tools: [] });
+  await writeJson(root, "manifest.mcpb.json", { version: initialVersion });
+  await writeFixture(
+    root,
+    "crates/mcp/src/index.ts",
+    `const MCP_SERVER_VERSION = "${initialVersion}";\n`,
+  );
+  for (const [directory, name] of [
+    ["mcp", "minutes-mcp"],
+    ["sdk", "minutes-sdk"],
+  ]) {
+    await writeJson(root, `crates/${directory}/package-lock.json`, {
+      name,
+      version: initialVersion,
+      lockfileVersion: 3,
+      packages: { "": { name, version: initialVersion } },
+    });
+  }
+  await writeFixture(
+    root,
+    "Cargo.lock",
+    ["minutes-core", "minutes-cli", "minutes-reader", "whisper-guard"]
+      .map(
+        (name) =>
+          `[[package]]\nname = "${name}"\nversion = "${name === "whisper-guard" ? "77.0.0" : initialVersion}"\n`,
+      )
+      .join("\n"),
+  );
+  await writeFixture(
+    root,
+    "crates/whisper-guard/Cargo.toml",
+    `[package]\nname = "whisper-guard"\nversion = "77.0.0"\n`,
+  );
+  await writeFixture(
+    root,
+    "tauri/src-tauri/Cargo.toml",
+    `[package]\nname = "minutes-app"\nversion = "0.1.0"\n`,
+  );
+  await writeJson(root, ".claude-plugin/marketplace.json", {
+    plugins: [{ name: "minutes", version: initialPluginVersion }],
+  });
+  await writeJson(root, ".claude/plugins/minutes/plugin.json", {
+    version: initialPluginVersion,
+  });
+  await writeJson(root, ".claude/plugins/minutes/.claude-plugin/plugin.json", {
+    version: initialPluginVersion,
+  });
+  await writeFixture(root, "site/lib/release.ts", `export const VERSION = "${initialVersion}";\n`);
+  await writeFixture(root, "scripts/check_version_sync.mjs", await readFile(checker, "utf8"));
+  await writeFixture(
+    root,
+    "scripts/sync_site_release_version.mjs",
+    `#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(await readFile(path.join(root, "manifest.json"), "utf8"));
+await writeFile(path.join(root, "site/lib/release.ts"), 'export const VERSION = "' + manifest.version + '";\\n');
+`,
+  );
+  const tools = await installToolShims(root);
+
+  assert.equal(git(root, "init", "-q").status, 0);
+  assert.equal(git(root, "config", "user.email", "fixture@example.com").status, 0);
+  assert.equal(git(root, "config", "user.name", "Fixture Test").status, 0);
+  assert.equal(git(root, "add", ".").status, 0);
+  const commit = git(root, "commit", "-qm", "fixture");
+  assert.equal(commit.status, 0, commit.stderr);
+  return { root, tools };
+}
+
+function runBump(root, tools, ...args) {
+  return run(process.execPath, [bumper, ...args], {
+    cwd: root,
+    env: {
+      ...process.env,
+      BUMP_TOOL_PATH: tools,
+    },
+  });
+}
+
+function runChecker(root) {
+  return run(process.execPath, [checker, "--root", root], { cwd: root });
+}
+
+function status(root) {
+  return git(root, "status", "--porcelain=v1", "--untracked-files=all").stdout;
+}
+
+async function trackedSnapshot(root) {
+  const files = git(root, "ls-files", "-z").stdout.split("\0").filter(Boolean);
+  return new Map(
+    await Promise.all(
+      files.map(async (file) => [file, (await readFile(path.join(root, file))).toString("base64")]),
+    ),
+  );
+}
+
+async function assertSnapshot(root, expected) {
+  assert.deepEqual(await trackedSnapshot(root), expected);
+}
+
+async function readVersion(root, file) {
+  return (await readFile(path.join(root, file), "utf8")).match(/1\.3\.0-beta\.1/)?.[0];
+}
+
+test("dry-run prints its file plan and diff without touching the real tree", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  const before = await trackedSnapshot(root);
+  const result = runBump(root, tools, "--dry-run", nextVersion);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Dry run: main version 1\.2\.3 -> 1\.3\.0-beta\.1/);
+  assert.match(result.stdout, /Files that would change:/);
+  assert.match(result.stdout, /diff --git a\/Cargo\.toml b\/Cargo\.toml/);
+  assert.equal(status(root), "");
+  await assertSnapshot(root, before);
+  assert.equal(git(root, "worktree", "list", "--porcelain").stdout.match(/^worktree /gm)?.length, 1);
+});
+
+test("real run updates every Domain-1 source and passes the checker", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  const result = runBump(root, tools, nextVersion);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  for (const file of [
+    "Cargo.toml",
+    "crates/cli/Cargo.toml",
+    "tauri/src-tauri/tauri.conf.json",
+    "crates/mcp/package.json",
+    "crates/sdk/package.json",
+    "manifest.json",
+    "manifest.mcpb.json",
+    "crates/mcp/src/index.ts",
+    "crates/mcp/package-lock.json",
+    "crates/sdk/package-lock.json",
+    "Cargo.lock",
+    "site/lib/release.ts",
+  ]) {
+    assert.equal(await readVersion(root, file), nextVersion, `${file} contains the new version`);
+  }
+  const check = runChecker(root);
+  assert.equal(check.status, 0, check.stderr || check.stdout);
+  for (const pluginFile of [
+    ".claude-plugin/marketplace.json",
+    ".claude/plugins/minutes/plugin.json",
+    ".claude/plugins/minutes/.claude-plugin/plugin.json",
+  ]) {
+    assert.doesNotMatch(await readFile(path.join(root, pluginFile), "utf8"), /1\.3\.0/);
+  }
+  assert.match(
+    await readFile(path.join(root, "crates/whisper-guard/Cargo.toml"), "utf8"),
+    /version = "77\.0\.0"/,
+  );
+  assert.match(
+    await readFile(path.join(root, "tauri/src-tauri/Cargo.toml"), "utf8"),
+    /version = "0\.1\.0"/,
+  );
+});
+
+test("dirty tree is refused", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  await writeFixture(root, "untracked.txt", "dirty\n");
+  const result = runBump(root, tools, nextVersion);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /working tree is dirty/);
+  assert.equal(await readVersion(root, "Cargo.toml"), undefined);
+});
+
+test("invalid semantic versions are refused", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  for (const invalid of ["1.2", "v1.2.3", "01.2.3", "1.2.3+build"]) {
+    const result = runBump(root, tools, invalid);
+    assert.equal(result.status, 2, `${invalid}: ${result.stderr}`);
+    assert.match(result.stderr, /invalid version/);
+  }
+  assert.equal(status(root), "");
+});
+
+test("re-running the current version is an idempotent no-op", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  const first = runBump(root, tools, nextVersion);
+  assert.equal(first.status, 0, first.stderr || first.stdout);
+  const before = await trackedSnapshot(root);
+
+  const second = runBump(root, tools, nextVersion);
+  assert.equal(second.status, 0, second.stderr || second.stdout);
+  assert.match(second.stdout, /already at 1\.3\.0-beta\.1; nothing to do/);
+  await assertSnapshot(root, before);
+});
+
+test("tool failure leaves the real tree byte-identical", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  const before = await trackedSnapshot(root);
+  const result = run(process.execPath, [bumper, nextVersion], {
+    cwd: root,
+    env: {
+      ...process.env,
+      BUMP_TOOL_PATH: tools,
+      BUMP_SHIM_FAIL: "cargo",
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /simulated cargo failure/);
+  assert.equal(status(root), "");
+  await assertSnapshot(root, before);
+  assert.equal(git(root, "worktree", "list", "--porcelain").stdout.match(/^worktree /gm)?.length, 1);
+});
+
+test(
+  "SIGKILL after worktree creation leaves the real tree byte-identical",
+  { skip: process.platform === "win32" },
+  async (t) => {
+    const { root, tools } = await makeRepo(t);
+    const before = await trackedSnapshot(root);
+    const markerDirectory = await mkdtemp(path.join(os.tmpdir(), "minutes-bump-marker-"));
+    t.after(() => rm(markerDirectory, { recursive: true, force: true }));
+    const marker = path.join(markerDirectory, "ready");
+
+    const child = spawn(process.execPath, [bumper, nextVersion], {
+      cwd: root,
+      env: {
+        ...process.env,
+        BUMP_TOOL_PATH: tools,
+        BUMP_SHIM_PAUSE: "npm",
+        BUMP_SHIM_READY_FILE: marker,
+      },
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const closed = new Promise((resolve) =>
+      child.once("close", (code, signal) => resolve({ code, signal })),
+    );
+
+    let ready = false;
+    for (let attempt = 0; attempt < 250; attempt += 1) {
+      try {
+        await stat(marker);
+        ready = true;
+        break;
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    }
+    assert.equal(ready, true, "bump subprocess created its temporary worktree");
+    process.kill(-child.pid, "SIGKILL");
+    const outcome = await closed;
+    assert.equal(outcome.signal, "SIGKILL");
+
+    assert.equal(status(root), "");
+    await assertSnapshot(root, before);
+
+    const abandonedWorktree = await readFile(marker, "utf8");
+    const remove = git(root, "worktree", "remove", "--force", abandonedWorktree);
+    assert.equal(remove.status, 0, remove.stderr);
+    await rm(path.dirname(abandonedWorktree), { recursive: true, force: true });
+  },
+);
+
+test("plugin mode updates only the plugin trio", async (t) => {
+  const { root, tools } = await makeRepo(t);
+  const result = runBump(root, tools, "--plugin", nextPluginVersion);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const changed = git(root, "diff", "--name-only").stdout.trim().split("\n").sort();
+  assert.deepEqual(changed, [
+    ".claude-plugin/marketplace.json",
+    ".claude/plugins/minutes/.claude-plugin/plugin.json",
+    ".claude/plugins/minutes/plugin.json",
+  ]);
+  for (const file of changed) {
+    assert.match(await readFile(path.join(root, file), "utf8"), /"version": "0\.10\.0"/);
+  }
+  assert.match(await readFile(path.join(root, "Cargo.toml"), "utf8"), /version = "1\.2\.3"/);
+  const check = runChecker(root);
+  assert.equal(check.status, 0, check.stderr || check.stdout);
+});


### PR DESCRIPTION
## What

`node scripts/bump-version.mjs <semver>` writes every Domain-1 version source in one atomic operation, killing the incomplete-bump class (d52f0b6 needed 0e41793 "complete the bump"; every release re-touched 8+ files by hand).

- All writes happen in a **temporary git worktree**; the checker (`check_version_sync.mjs`, #473) validates the result there; the real tree receives a single `git apply` or nothing. No rollback code paths — the real tree is untouched by construction until the final step.
- Covers: workspace Cargo.toml, cli's minutes-core dep, tauri.conf.json, mcp+sdk package.json, both package-locks, Cargo.lock workspace entries (with a diff post-assertion), manifest.json, manifest.mcpb.json, `MCP_SERVER_VERSION`, and derived site constants.
- `--dry-run` prints the full patch; `--plugin <ver>` bumps the plugin trio separately (never mixed with app bumps); dirty trees refused (tracked changes only — scratch files don't block); idempotent no-op on same version.
- 9 fixture tests using PATH tool shims (npm/cargo), including SIGKILL-mid-run leaving the tree byte-identical; wired into the `version_sync` CI job.
- `docs/release/procedure.md`'s 15-line manual bump checklist is now two commands.

## Verification

Demoed on the real repo: `--dry-run 0.21.1` prints the complete cross-file patch, `git status` stays clean, checker stays green at 0.21.0.

Part of the agent-infra hardening epic (bead `minutes-4a9r`, PR-C1). Plan reviewed adversarially by codex to SHIP 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)