### PR TITLE
feat(design): token enforcement with shrink-only baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,41 @@ jobs:
       - name: Test version policy checker
         run: node --test scripts/check_version_sync.test.mjs
 
+  design_tokens:
+    name: Design Tokens
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Fetch pull request base baseline
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          if git cat-file -e "$BASE_SHA:design/token-baseline.json"; then
+            git show "$BASE_SHA:design/token-baseline.json" > "$RUNNER_TEMP/design-token-base.json"
+            echo "DESIGN_TOKEN_BASELINE=$RUNNER_TEMP/design-token-base.json" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify design-token policy
+        shell: bash
+        run: |
+          if [[ -n "${DESIGN_TOKEN_BASELINE:-}" ]]; then
+            node scripts/check_design_tokens.mjs --base-baseline "$DESIGN_TOKEN_BASELINE"
+          else
+            node scripts/check_design_tokens.mjs
+          fi
+
+      - name: Test design-token checker
+        run: node --test scripts/check_design_tokens.test.mjs
+
   skills_compiler:
     name: Skills Compiler
     runs-on: ubuntu-latest
@@ -554,6 +589,7 @@ jobs:
       - mcp
       - mcp_lockfile_check
       - version_sync
+      - design_tokens
       - skills_compiler
       - agents_sync
       - site_release_consistency

--- a/SPEC_NOTES.md
+++ b/SPEC_NOTES.md
@@ -6,3 +6,23 @@ PR-D completion also requires verifying that the `actionlint` check is required 
 test "$(gh api repos/silverstein/minutes/branches/main/protection \
   --jq '[.required_status_checks.contexts[], .required_status_checks.checks[].context] | any(. == "actionlint")')" = true
 ```
+
+## PR-E baseline report
+
+The initial `design/token-baseline.json` contains **528** distinct, line-agnostic
+`(file, property, value)` violations on the current tree.
+
+Top five burn-down candidates by violation count:
+
+| Rank | File | Violations |
+| ---: | --- | ---: |
+| 1 | `tauri/src/styles/theme-tokens.css` | 179 |
+| 2 | `tauri/src/index.html` | 102 |
+| 3 | `tauri/src/dictation-overlay.html` | 53 |
+| 4 | `tauri/src/copilot-hud.html` | 45 |
+| 5 | `tauri/src/note.html` | 40 |
+
+Counts are based on the checker's exact baseline identity, so repeated uses of
+the same property/value pair in one file count once. The definition files remain
+in the report when a custom-property value is not sanctioned by
+`design/tokens.json`; sanctioned definition values themselves are not violations.

--- a/design/token-baseline.json
+++ b/design/token-baseline.json
@@ -1,0 +1,2642 @@
+[
+  {
+    "file": "site/app/globals.css",
+    "property": "--font-display",
+    "value": "var(--font-instrument-serif), \"Iowan Old Style\", \"Palatino Linotype\", serif"
+  },
+  {
+    "file": "site/app/globals.css",
+    "property": "--font-mono",
+    "value": "var(--font-geist-mono), \"SFMono-Regular\", \"SF Mono\", Menlo, Consolas, monospace"
+  },
+  {
+    "file": "site/app/globals.css",
+    "property": "--font-sans",
+    "value": "var(--font-geist-sans), -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif"
+  },
+  {
+    "file": "site/app/globals.css",
+    "property": "--shadow-panel",
+    "value": "rgba(0, 0, 0, 0.34)"
+  },
+  {
+    "file": "site/app/globals.css",
+    "property": "--shadow-panel",
+    "value": "rgba(26, 25, 22, 0.08)"
+  },
+  {
+    "file": "site/components/conversation-topology.tsx",
+    "property": "background",
+    "value": "rgba(42,90,143,0.07)"
+  },
+  {
+    "file": "site/components/conversation-topology.tsx",
+    "property": "color",
+    "value": "#8899bb"
+  },
+  {
+    "file": "site/components/minutes-demo.tsx",
+    "property": "background",
+    "value": "rgba(255,255,255,0.03)"
+  },
+  {
+    "file": "site/components/minutes-demo.tsx",
+    "property": "fontFamily",
+    "value": "var(--font-mono), SF Mono, Menlo, Consolas, monospace"
+  },
+  {
+    "file": "site/components/minutes-demo.tsx",
+    "property": "fontFamily",
+    "value": "var(--font-mono), SF Mono, Menlo, monospace"
+  },
+  {
+    "file": "site/components/minutes-demo.tsx",
+    "property": "fontFamily",
+    "value": "var(--font-mono), SF Mono, monospace"
+  },
+  {
+    "file": "site/components/minutes-demo.tsx",
+    "property": "fontFamily",
+    "value": "var(--font-sans), -apple-system, sans-serif"
+  },
+  {
+    "file": "site/public/download/apple-silicon.html",
+    "property": "background",
+    "value": "#f4efe6"
+  },
+  {
+    "file": "site/public/download/apple-silicon.html",
+    "property": "background",
+    "value": "rgba(255, 255, 255, 0.82)"
+  },
+  {
+    "file": "site/public/download/apple-silicon.html",
+    "property": "box-shadow",
+    "value": "rgba(29, 27, 23, 0.08)"
+  },
+  {
+    "file": "site/public/download/apple-silicon.html",
+    "property": "color",
+    "value": "#1d1b17"
+  },
+  {
+    "file": "site/public/download/apple-silicon.html",
+    "property": "color",
+    "value": "rgba(29, 27, 23, 0.72)"
+  },
+  {
+    "file": "site/public/download/apple-silicon.html",
+    "property": "font-family",
+    "value": "\"Geist Mono\", \"SFMono-Regular\", \"SF Mono\", ui-monospace, Menlo, Monaco, Consolas, monospace"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--accent",
+    "value": "#0a84ff"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--accent-hover",
+    "value": "#409cff"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--bg",
+    "value": "#1c1c1e"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--bg-elevated",
+    "value": "#2c2c2e"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--border",
+    "value": "#38383a"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--font-sans",
+    "value": "-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', sans-serif"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--text",
+    "value": "#f5f5f7"
+  },
+  {
+    "file": "site/public/privacy.html",
+    "property": "--text-secondary",
+    "value": "#86868b"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--accent",
+    "value": "#62d77d"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--accent",
+    "value": "#9b432e"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--accent-soft",
+    "value": "rgba(201, 107, 78, 0.11)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--accent-soft",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--amber",
+    "value": "#864a27"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--amber",
+    "value": "#e7b16f"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--amber-soft",
+    "value": "rgba(134, 74, 39, 0.10)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--amber-soft",
+    "value": "rgba(231, 177, 111, 0.13)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--blue",
+    "value": "#315f7b"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--blue",
+    "value": "#8fc5e8"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--blue-soft",
+    "value": "rgba(143, 197, 232, 0.13)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--blue-soft",
+    "value": "rgba(49, 95, 123, 0.10)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--line",
+    "value": "rgba(244, 240, 231, 0.13)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--line",
+    "value": "rgba(26, 25, 22, 0.12)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--line-strong",
+    "value": "rgba(244, 240, 231, 0.23)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--line-strong",
+    "value": "rgba(26, 25, 22, 0.22)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--muted",
+    "value": "#625e56"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--muted",
+    "value": "#b6b0a5"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--neutral",
+    "value": "#56534d"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--neutral",
+    "value": "#aaa59c"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--neutral-soft",
+    "value": "rgba(170, 165, 156, 0.11)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--neutral-soft",
+    "value": "rgba(86, 83, 77, 0.09)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--panel",
+    "value": "rgba(20, 20, 18, 0.975)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--panel",
+    "value": "rgba(248, 244, 237, 0.985)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--panel-hover",
+    "value": "rgba(244, 240, 231, 0.075)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--panel-hover",
+    "value": "rgba(26, 25, 22, 0.065)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--panel-raised",
+    "value": "#1c1c19"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--panel-raised",
+    "value": "#eee9df"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--quiet",
+    "value": "#706b63"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--quiet",
+    "value": "#9d978d"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--red",
+    "value": "#923e37"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--red",
+    "value": "#f09187"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--red-soft",
+    "value": "rgba(146, 62, 55, 0.10)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--red-soft",
+    "value": "rgba(240, 145, 135, 0.13)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.28)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.42)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--shadow",
+    "value": "rgba(58, 47, 30, 0.10)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--shadow",
+    "value": "rgba(58, 47, 30, 0.17)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--text",
+    "value": "#1a1916"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "--text",
+    "value": "#f4f0e7"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "box-shadow",
+    "value": "rgba(255, 255, 255, 0.055)"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "font-family",
+    "value": "'Geist Mono'"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "font-family",
+    "value": "'Geist Mono', ui-monospace, monospace"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "font-family",
+    "value": "'Geist'"
+  },
+  {
+    "file": "tauri/src/copilot-hud.html",
+    "property": "font-family",
+    "value": "'Geist', -apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--accent",
+    "value": "#30D158"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--accent",
+    "value": "#C96B4E"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--accent-glow",
+    "value": "rgba(201, 107, 78, 0.20)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--accent-glow",
+    "value": "rgba(48, 209, 88, 0.28)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--accent-ring",
+    "value": "rgba(201, 107, 78, 0.14)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--accent-ring",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--bg-hover",
+    "value": "#1C1C1A"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--bg-hover",
+    "value": "#E8E2D8"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--border",
+    "value": "rgba(0, 0, 0, 0.07)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--border",
+    "value": "rgba(255, 255, 255, 0.06)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--border-mid",
+    "value": "#2A2924"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--border-mid",
+    "value": "rgba(0, 0, 0, 0.13)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--green",
+    "value": "#2E7D46"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--green",
+    "value": "#30D158"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--green-glow",
+    "value": "rgba(46, 125, 70, 0.20)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--green-glow",
+    "value": "rgba(48, 209, 88, 0.28)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--green-ring",
+    "value": "rgba(46, 125, 70, 0.14)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--green-ring",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red",
+    "value": "#C0392B"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red",
+    "value": "#FF453A"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-border-strong",
+    "value": "rgba(192, 57, 43, 0.32)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-border-strong",
+    "value": "rgba(255, 69, 58, 0.45)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-glow",
+    "value": "rgba(192, 57, 43, 0.18)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-glow",
+    "value": "rgba(255, 69, 58, 0.28)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-halo",
+    "value": "rgba(192, 57, 43, 0.06)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-halo",
+    "value": "rgba(255, 69, 58, 0.08)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-outline",
+    "value": "rgba(192, 57, 43, 0.12)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-outline",
+    "value": "rgba(255, 69, 58, 0.14)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-ring",
+    "value": "rgba(192, 57, 43, 0.12)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--red-ring",
+    "value": "rgba(255, 69, 58, 0.16)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.25)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.35)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--shadow",
+    "value": "rgba(255,255,255,0.06)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--spinner-track",
+    "value": "rgba(201, 107, 78, 0.14)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--spinner-track",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--text",
+    "value": "#1A1916"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--text",
+    "value": "#E8E4DA"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--text-secondary",
+    "value": "#6B6760"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--text-secondary",
+    "value": "#8C8880"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--text-tertiary",
+    "value": "#3D3B38"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--text-tertiary",
+    "value": "#BDB9B0"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--waveform-bottom",
+    "value": "rgba(255,255,255,0.42)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--waveform-bottom",
+    "value": "rgba(26, 25, 22, 0.28)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--waveform-top",
+    "value": "rgba(255,255,255,0.85)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "--waveform-top",
+    "value": "rgba(26, 25, 22, 0.70)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "box-shadow",
+    "value": "rgba(0, 0, 0, 0.14)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "box-shadow",
+    "value": "rgba(0, 0, 0, 0.18)"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "font-family",
+    "value": "'Geist Mono'"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "font-family",
+    "value": "'Geist'"
+  },
+  {
+    "file": "tauri/src/dictation-overlay.html",
+    "property": "font-family",
+    "value": "'Geist', -apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--accent-border",
+    "value": "rgba(201, 107, 78, 0.15)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--accent-border",
+    "value": "rgba(48, 209, 88, 0.15)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--accent-border-strong",
+    "value": "rgba(201, 107, 78, 0.28)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--accent-border-strong",
+    "value": "rgba(48, 209, 88, 0.40)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--accent-tint",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--accent-tint-soft",
+    "value": "rgba(201, 107, 78, 0.05)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--accent-tint-soft",
+    "value": "rgba(48, 209, 88, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--focus-ring",
+    "value": "rgba(201, 107, 78, 0.16)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--focus-ring",
+    "value": "rgba(48, 209, 88, 0.20)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--focus-ring-soft",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--focus-ring-subtle",
+    "value": "rgba(201, 107, 78, 0.07)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--focus-ring-subtle",
+    "value": "rgba(48, 209, 88, 0.08)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--font-display",
+    "value": "'Instrument Serif', ui-serif, 'Iowan Old Style', Georgia, serif"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--font-mono",
+    "value": "'Geist Mono', 'SF Mono', 'Menlo', monospace"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--font-sans",
+    "value": "'Geist', -apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-border",
+    "value": "rgba(46, 125, 70, 0.14)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-border",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-border-soft",
+    "value": "rgba(46, 125, 70, 0.10)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-border-soft",
+    "value": "rgba(48, 209, 88, 0.08)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-glow",
+    "value": "rgba(46, 125, 70, 0.22)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-glow",
+    "value": "rgba(48, 209, 88, 0.28)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-glow-soft",
+    "value": "rgba(46, 125, 70, 0.14)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-glow-soft",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-solid-soft",
+    "value": "rgba(46, 125, 70, 0.72)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-solid-soft",
+    "value": "rgba(48, 209, 88, 0.70)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-solid-strong",
+    "value": "rgba(46, 125, 70, 0.84)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-solid-strong",
+    "value": "rgba(48, 209, 88, 0.85)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-tint",
+    "value": "rgba(46, 125, 70, 0.10)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-tint",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-tint-soft",
+    "value": "rgba(46, 125, 70, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--green-tint-soft",
+    "value": "rgba(48, 209, 88, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--info-ring",
+    "value": "rgba(98, 188, 233, 0.24)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--info-ring",
+    "value": "rgba(98, 188, 233, 0.35)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--inset-highlight",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--inset-highlight",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--modal-scrim",
+    "value": "rgba(248, 244, 237, 0.82)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--modal-scrim",
+    "value": "rgba(8, 10, 16, 0.66)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--muted-badge",
+    "value": "rgba(140, 136, 128, 0.16)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--muted-badge",
+    "value": "rgba(142, 142, 147, 0.15)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--neutral-border",
+    "value": "rgba(0, 0, 0, 0.10)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--neutral-border",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--neutral-tint",
+    "value": "rgba(0, 0, 0, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--neutral-tint-soft",
+    "value": "rgba(0, 0, 0, 0.04)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--neutral-tint-soft",
+    "value": "rgba(255, 255, 255, 0.05)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--orange",
+    "value": "#B8731E"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--orange-border",
+    "value": "rgba(184, 115, 30, 0.16)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--orange-border",
+    "value": "rgba(212, 160, 60, 0.16)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--orange-tint",
+    "value": "rgba(184, 115, 30, 0.10)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--orange-tint",
+    "value": "rgba(212, 160, 60, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--orange-tint-soft",
+    "value": "rgba(184, 115, 30, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--orange-tint-soft",
+    "value": "rgba(212, 160, 60, 0.08)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--overlay-scrim",
+    "value": "rgba(10, 10, 12, 0.68)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--overlay-scrim",
+    "value": "rgba(248, 244, 237, 0.78)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--purple",
+    "value": "#8B5CF6"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--purple-solid-soft",
+    "value": "rgba(139, 92, 246, 0.58)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--purple-solid-soft",
+    "value": "rgba(155, 133, 196, 0.70)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--purple-solid-strong",
+    "value": "rgba(139, 92, 246, 0.72)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--purple-solid-strong",
+    "value": "rgba(155, 133, 196, 0.85)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-bg",
+    "value": "rgba(192, 57, 43, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-border",
+    "value": "rgba(192, 57, 43, 0.10)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-border",
+    "value": "rgba(255, 69, 58, 0.10)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-border-strong",
+    "value": "rgba(192, 57, 43, 0.24)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-border-strong",
+    "value": "rgba(255, 69, 58, 0.30)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-border-stronger",
+    "value": "rgba(192, 57, 43, 0.38)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-border-stronger",
+    "value": "rgba(255, 69, 58, 0.50)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-glow-soft",
+    "value": "rgba(192, 57, 43, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-glow-soft",
+    "value": "rgba(255, 69, 58, 0.04)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-tint",
+    "value": "rgba(192, 57, 43, 0.10)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-tint-soft",
+    "value": "rgba(192, 57, 43, 0.05)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-tint-soft",
+    "value": "rgba(255, 69, 58, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-tint-strong",
+    "value": "rgba(192, 57, 43, 0.15)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-tint-strong",
+    "value": "rgba(255, 69, 58, 0.20)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-tint-stronger",
+    "value": "rgba(192, 57, 43, 0.20)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--red-tint-stronger",
+    "value": "rgba(255, 69, 58, 0.25)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-color",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-color",
+    "value": "rgba(0, 0, 0, 0.34)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-soft",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-soft",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-strong",
+    "value": "rgba(0, 0, 0, 0.16)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-strong",
+    "value": "rgba(0, 0, 0, 0.40)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-stronger",
+    "value": "rgba(0, 0, 0, 0.18)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--shadow-stronger",
+    "value": "rgba(0, 0, 0, 0.42)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill",
+    "value": "rgba(255, 255, 255, 0.03)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-hover",
+    "value": "rgba(0, 0, 0, 0.05)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-hover",
+    "value": "rgba(255, 255, 255, 0.05)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-strong",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-strong",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-stronger",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-stronger",
+    "value": "rgba(255, 255, 255, 0.14)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-strongest",
+    "value": "rgba(0, 0, 0, 0.18)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-strongest",
+    "value": "rgba(255, 255, 255, 0.25)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-strongest-hover",
+    "value": "rgba(0, 0, 0, 0.24)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-fill-strongest-hover",
+    "value": "rgba(255, 255, 255, 0.35)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-stroke-subtle",
+    "value": "rgba(0, 0, 0, 0.06)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "--surface-stroke-subtle",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "background",
+    "value": "rgba(7, 8, 10, 0.64)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "border-color",
+    "value": "rgba(48, 209, 88, 0.28)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "border-color",
+    "value": "rgba(48, 209, 88, 0.35)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "box-shadow",
+    "value": "rgba(0, 0, 0, 0.25)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "box-shadow",
+    "value": "rgba(0, 0, 0, 0.35)"
+  },
+  {
+    "file": "tauri/src/index.html",
+    "property": "font-family",
+    "value": "'Geist Mono', 'SF Mono', Menlo, monospace"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--accent",
+    "value": "#30D158"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--accent",
+    "value": "#C96B4E"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--accent-hover",
+    "value": "#4ADE70"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--accent-hover",
+    "value": "#B85A3E"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--accent-soft",
+    "value": "rgba(201, 107, 78, 0.10)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--accent-soft",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--bg",
+    "value": "#0D0D0B"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--bg",
+    "value": "#F8F4ED"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--bg-elevated",
+    "value": "#141412"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--bg-elevated",
+    "value": "#EFEBE2"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--bg-hover",
+    "value": "#1C1C1A"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--bg-hover",
+    "value": "#E8E2D8"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--border",
+    "value": "rgba(0, 0, 0, 0.07)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--border",
+    "value": "rgba(255, 255, 255, 0.06)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--border-mid",
+    "value": "#2A2924"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--border-mid",
+    "value": "rgba(0, 0, 0, 0.13)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--inset-shadow",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--inset-shadow",
+    "value": "rgba(0, 0, 0, 0.14)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--red",
+    "value": "#C0392B"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--red",
+    "value": "#FF453A"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--red-bg",
+    "value": "rgba(192, 57, 43, 0.12)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--red-bg",
+    "value": "rgba(255, 69, 58, 0.12)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.34)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--shadow",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--surface-fill",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--surface-fill",
+    "value": "rgba(255, 255, 255, 0.02)"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--text",
+    "value": "#1A1916"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--text",
+    "value": "#E8E4DA"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--text-secondary",
+    "value": "#6B6760"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--text-secondary",
+    "value": "#8C8880"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--text-tertiary",
+    "value": "#3D3B38"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "--text-tertiary",
+    "value": "#BDB9B0"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "font-family",
+    "value": "'Geist'"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "font-family",
+    "value": "'Geist', -apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "font-family",
+    "value": "'Instrument Serif'"
+  },
+  {
+    "file": "tauri/src/meeting-prompt.html",
+    "property": "font-family",
+    "value": "'Instrument Serif', ui-serif, Georgia, serif"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--accent",
+    "value": "#30D158"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--accent",
+    "value": "#C96B4E"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--accent-hover",
+    "value": "#4ADE70"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--accent-hover",
+    "value": "#B85A3E"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--accent-soft",
+    "value": "rgba(201, 107, 78, 0.10)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--accent-soft",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--bg",
+    "value": "#0D0D0B"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--bg",
+    "value": "#F8F4ED"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--bg-elevated",
+    "value": "#141412"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--bg-elevated",
+    "value": "#EFEBE2"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--bg-hover",
+    "value": "#1C1C1A"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--bg-hover",
+    "value": "#E8E2D8"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--border",
+    "value": "rgba(0, 0, 0, 0.07)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--border",
+    "value": "rgba(255, 255, 255, 0.06)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--border-mid",
+    "value": "#2A2924"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--border-mid",
+    "value": "rgba(0, 0, 0, 0.13)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--inset-shadow",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--inset-shadow",
+    "value": "rgba(0, 0, 0, 0.14)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--red",
+    "value": "#C0392B"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--red",
+    "value": "#FF453A"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.34)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--shadow",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--surface-fill",
+    "value": "rgba(20, 20, 18, 0.96)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--surface-fill",
+    "value": "rgba(239, 235, 226, 0.96)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--surface-fill-soft",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--surface-fill-soft",
+    "value": "rgba(255, 255, 255, 0.02)"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--text",
+    "value": "#1A1916"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--text",
+    "value": "#E8E4DA"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--text-secondary",
+    "value": "#6B6760"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--text-secondary",
+    "value": "#8C8880"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--text-tertiary",
+    "value": "#3D3B38"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "--text-tertiary",
+    "value": "#BDB9B0"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "font-family",
+    "value": "'Geist Mono'"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "font-family",
+    "value": "'Geist Mono', 'SF Mono', monospace"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "font-family",
+    "value": "'Geist'"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "font-family",
+    "value": "'Geist', -apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "font-family",
+    "value": "'Instrument Serif'"
+  },
+  {
+    "file": "tauri/src/note.html",
+    "property": "font-family",
+    "value": "'Instrument Serif', ui-serif, Georgia, serif"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--accent",
+    "value": "#4da8d9"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--accent-soft",
+    "value": "rgba(77, 168, 217, 0.18)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--panel",
+    "value": "rgba(28, 28, 34, 0.98)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--panel-edge",
+    "value": "rgba(255, 255, 255, 0.06)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--row-focus",
+    "value": "rgba(77, 168, 217, 0.16)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--row-hover",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--section-label",
+    "value": "#6e6e73"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.24)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--shadow",
+    "value": "rgba(0, 0, 0, 0.32)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--shadow",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--text",
+    "value": "#f5f5f7"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--text-secondary",
+    "value": "#98989d"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "--text-tertiary",
+    "value": "#636366"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "background",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "background",
+    "value": "rgba(255, 255, 255, 0.06)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "background",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "font-family",
+    "value": "-apple-system, BlinkMacSystemFont, \"SF Pro Text\", \"Helvetica Neue\", sans-serif"
+  },
+  {
+    "file": "tauri/src/palette/index.html",
+    "property": "font-family",
+    "value": "-apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--accent-border",
+    "value": "rgba(201, 107, 78, 0.15)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--accent-border",
+    "value": "rgba(48, 209, 88, 0.15)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--accent-border-strong",
+    "value": "rgba(201, 107, 78, 0.28)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--accent-border-strong",
+    "value": "rgba(48, 209, 88, 0.4)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--accent-tint",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--accent-tint-soft",
+    "value": "rgba(201, 107, 78, 0.05)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--accent-tint-soft",
+    "value": "rgba(48, 209, 88, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--bg",
+    "value": "#ededee"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--bg-elevated",
+    "value": "#e4e4e6"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--bg-hover",
+    "value": "#dadadd"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-accent-glow",
+    "value": "rgba(201, 107, 78, 0.2)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-accent-glow",
+    "value": "rgba(48, 209, 88, 0.28)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-accent-ring",
+    "value": "rgba(201, 107, 78, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-accent-ring",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-border",
+    "value": "rgba(192, 57, 43, 0.32)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-border",
+    "value": "rgba(255, 69, 58, 0.45)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-glow",
+    "value": "rgba(192, 57, 43, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-glow",
+    "value": "rgba(255, 69, 58, 0.28)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-halo",
+    "value": "rgba(192, 57, 43, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-halo",
+    "value": "rgba(255, 69, 58, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-outline",
+    "value": "rgba(192, 57, 43, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-outline",
+    "value": "rgba(255, 69, 58, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-ring",
+    "value": "rgba(192, 57, 43, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-error-ring",
+    "value": "rgba(255, 69, 58, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-listening-glow",
+    "value": "rgba(46, 125, 70, 0.2)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-listening-glow",
+    "value": "rgba(48, 209, 88, 0.28)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-listening-ring",
+    "value": "rgba(46, 125, 70, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-listening-ring",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-pill-error-shadow",
+    "value": "rgba(0, 0, 0, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-pill-error-shadow",
+    "value": "rgba(0, 0, 0, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-pill-shadow",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-pill-shadow",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-pill-shadow",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-pill-shadow",
+    "value": "rgba(0, 0, 0, 0.25)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-pill-shadow",
+    "value": "rgba(0, 0, 0, 0.35)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-spinner-track",
+    "value": "rgba(201, 107, 78, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-spinner-track",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-waveform-bottom",
+    "value": "rgba(255, 255, 255, 0.42)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-waveform-bottom",
+    "value": "rgba(26, 25, 22, 0.28)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-waveform-top",
+    "value": "rgba(255, 255, 255, 0.85)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--dictation-waveform-top",
+    "value": "rgba(26, 25, 22, 0.7)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--focus-ring",
+    "value": "rgba(201, 107, 78, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--focus-ring",
+    "value": "rgba(48, 209, 88, 0.2)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--focus-ring-soft",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--focus-ring-subtle",
+    "value": "rgba(201, 107, 78, 0.07)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--focus-ring-subtle",
+    "value": "rgba(48, 209, 88, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--font-display",
+    "value": "'Instrument Serif', ui-serif, 'Iowan Old Style', Georgia, serif"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--font-mono",
+    "value": "'Geist Mono', 'SF Mono', 'Menlo', monospace"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--font-sans",
+    "value": "'Geist', -apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--footer-secondary-ink",
+    "value": "rgba(232, 228, 218, 0.88)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--footer-secondary-ink",
+    "value": "rgba(26, 26, 30, 0.78)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--footer-secondary-stroke",
+    "value": "rgba(232, 228, 218, 0.32)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--footer-secondary-stroke",
+    "value": "rgba(26, 26, 30, 0.28)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-border",
+    "value": "rgba(46, 125, 70, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-border",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-border-soft",
+    "value": "rgba(46, 125, 70, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-border-soft",
+    "value": "rgba(48, 209, 88, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-glow",
+    "value": "rgba(46, 125, 70, 0.22)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-glow",
+    "value": "rgba(48, 209, 88, 0.28)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-glow-soft",
+    "value": "rgba(46, 125, 70, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-glow-soft",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-ring",
+    "value": "rgba(46, 125, 70, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-ring",
+    "value": "rgba(48, 209, 88, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-solid-soft",
+    "value": "rgba(46, 125, 70, 0.72)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-solid-soft",
+    "value": "rgba(48, 209, 88, 0.7)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-solid-strong",
+    "value": "rgba(46, 125, 70, 0.84)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-solid-strong",
+    "value": "rgba(48, 209, 88, 0.85)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-tint",
+    "value": "rgba(46, 125, 70, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-tint",
+    "value": "rgba(48, 209, 88, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-tint-soft",
+    "value": "rgba(46, 125, 70, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--green-tint-soft",
+    "value": "rgba(48, 209, 88, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--info-ring",
+    "value": "rgba(98, 188, 233, 0.24)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--info-ring",
+    "value": "rgba(98, 188, 233, 0.35)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--inset-highlight",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--inset-highlight",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--inset-shadow",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--inset-shadow",
+    "value": "rgba(0, 0, 0, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--meeting-prompt-shadow",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--meeting-prompt-shadow",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--meeting-prompt-shadow",
+    "value": "rgba(0, 0, 0, 0.34)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--meeting-prompt-shadow",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--meeting-surface-fill",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--meeting-surface-fill",
+    "value": "rgba(255, 255, 255, 0.02)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--modal-scrim",
+    "value": "rgba(237, 237, 238, 0.82)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--modal-scrim",
+    "value": "rgba(8, 10, 16, 0.66)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--muted-badge",
+    "value": "rgba(134, 134, 139, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--muted-badge",
+    "value": "rgba(142, 142, 147, 0.15)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--neutral-border",
+    "value": "rgba(0, 0, 0, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--neutral-border",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--neutral-tint",
+    "value": "rgba(0, 0, 0, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--neutral-tint-soft",
+    "value": "rgba(0, 0, 0, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--neutral-tint-soft",
+    "value": "rgba(255, 255, 255, 0.05)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--note-shell-shadow",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--note-shell-shadow",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--note-shell-shadow",
+    "value": "rgba(0, 0, 0, 0.34)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--note-shell-shadow",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--note-surface-fill",
+    "value": "rgba(20, 20, 18, 0.96)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--note-surface-fill",
+    "value": "rgba(228, 228, 230, 0.96)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--orange",
+    "value": "#b8731e"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--orange-border",
+    "value": "rgba(184, 115, 30, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--orange-border",
+    "value": "rgba(212, 160, 60, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--orange-tint",
+    "value": "rgba(184, 115, 30, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--orange-tint",
+    "value": "rgba(212, 160, 60, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--orange-tint-soft",
+    "value": "rgba(184, 115, 30, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--orange-tint-soft",
+    "value": "rgba(212, 160, 60, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--overlay-scrim",
+    "value": "rgba(10, 10, 12, 0.68)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--overlay-scrim",
+    "value": "rgba(237, 237, 238, 0.78)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-accent",
+    "value": "#4da8d9"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-accent-soft",
+    "value": "rgba(201, 107, 78, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-accent-soft",
+    "value": "rgba(77, 168, 217, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-badge-bg",
+    "value": "rgba(0, 0, 0, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-badge-bg",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-footer-kbd-bg",
+    "value": "rgba(0, 0, 0, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-icon-bg",
+    "value": "rgba(0, 0, 0, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-scroll-thumb",
+    "value": "rgba(0, 0, 0, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-scroll-thumb",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-shadow",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-shadow",
+    "value": "rgba(0, 0, 0, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-shadow",
+    "value": "rgba(0, 0, 0, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-shadow",
+    "value": "rgba(0, 0, 0, 0.24)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-shadow",
+    "value": "rgba(0, 0, 0, 0.32)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--palette-shadow",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--panel",
+    "value": "rgba(245, 245, 247, 0.98)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--panel",
+    "value": "rgba(28, 28, 34, 0.98)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--panel-edge",
+    "value": "rgba(0, 0, 0, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--purple",
+    "value": "#8b5cf6"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--purple-solid-soft",
+    "value": "rgba(139, 92, 246, 0.58)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--purple-solid-soft",
+    "value": "rgba(155, 133, 196, 0.7)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--purple-solid-strong",
+    "value": "rgba(139, 92, 246, 0.72)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--purple-solid-strong",
+    "value": "rgba(155, 133, 196, 0.85)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-bg",
+    "value": "rgba(192, 57, 43, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-border",
+    "value": "rgba(192, 57, 43, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-border",
+    "value": "rgba(255, 69, 58, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-border-strong",
+    "value": "rgba(192, 57, 43, 0.24)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-border-strong",
+    "value": "rgba(255, 69, 58, 0.3)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-border-stronger",
+    "value": "rgba(192, 57, 43, 0.38)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-border-stronger",
+    "value": "rgba(255, 69, 58, 0.5)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-glow-soft",
+    "value": "rgba(192, 57, 43, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-glow-soft",
+    "value": "rgba(255, 69, 58, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-tint",
+    "value": "rgba(192, 57, 43, 0.1)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-tint-soft",
+    "value": "rgba(192, 57, 43, 0.05)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-tint-soft",
+    "value": "rgba(255, 69, 58, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-tint-strong",
+    "value": "rgba(192, 57, 43, 0.15)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-tint-strong",
+    "value": "rgba(255, 69, 58, 0.2)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-tint-stronger",
+    "value": "rgba(192, 57, 43, 0.2)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--red-tint-stronger",
+    "value": "rgba(255, 69, 58, 0.25)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--row-focus",
+    "value": "rgba(201, 107, 78, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--row-focus",
+    "value": "rgba(77, 168, 217, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--row-hover",
+    "value": "rgba(0, 0, 0, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--row-hover",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--section-label",
+    "value": "#6e6e73"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--section-label",
+    "value": "#86868b"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-color",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-color",
+    "value": "rgba(0, 0, 0, 0.34)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-soft",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-soft",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-strong",
+    "value": "rgba(0, 0, 0, 0.16)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-strong",
+    "value": "rgba(0, 0, 0, 0.4)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-stronger",
+    "value": "rgba(0, 0, 0, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--shadow-stronger",
+    "value": "rgba(0, 0, 0, 0.42)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--success-contrast",
+    "value": "#ededee"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill",
+    "value": "rgba(0, 0, 0, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill",
+    "value": "rgba(255, 255, 255, 0.03)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-hover",
+    "value": "rgba(0, 0, 0, 0.05)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-hover",
+    "value": "rgba(255, 255, 255, 0.05)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-strong",
+    "value": "rgba(0, 0, 0, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-strong",
+    "value": "rgba(255, 255, 255, 0.08)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-stronger",
+    "value": "rgba(0, 0, 0, 0.12)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-stronger",
+    "value": "rgba(255, 255, 255, 0.14)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-strongest",
+    "value": "rgba(0, 0, 0, 0.18)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-strongest",
+    "value": "rgba(255, 255, 255, 0.25)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-strongest-hover",
+    "value": "rgba(0, 0, 0, 0.24)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-fill-strongest-hover",
+    "value": "rgba(255, 255, 255, 0.35)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-stroke-subtle",
+    "value": "rgba(0, 0, 0, 0.06)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--surface-stroke-subtle",
+    "value": "rgba(255, 255, 255, 0.04)"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--text",
+    "value": "#1a1a1e"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--text-primary",
+    "value": "#1a1a1e"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--text-secondary",
+    "value": "#86868b"
+  },
+  {
+    "file": "tauri/src/styles/theme-tokens.css",
+    "property": "--text-tertiary",
+    "value": "#aeaeb2"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--accent",
+    "value": "#30D158"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--accent",
+    "value": "#C96B4E"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--bg",
+    "value": "#0D0D0B"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--bg",
+    "value": "#F8F4ED"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--bg-elevated",
+    "value": "#141412"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--bg-elevated",
+    "value": "#EFEBE2"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--bg-hover",
+    "value": "#1C1C1A"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--bg-hover",
+    "value": "#E8E2D8"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--border",
+    "value": "#2A2924"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--border",
+    "value": "rgba(0,0,0,0.13)"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--font-mono",
+    "value": "'Geist Mono', 'SF Mono', 'Menlo', monospace"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--font-sans",
+    "value": "'Geist', -apple-system, BlinkMacSystemFont, sans-serif"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--green",
+    "value": "#2E7D46"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--green",
+    "value": "#30D158"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--red",
+    "value": "#C0392B"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--red",
+    "value": "#FF453A"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--text",
+    "value": "#1A1916"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--text",
+    "value": "#E8E4DA"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--text-secondary",
+    "value": "#6B6760"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--text-secondary",
+    "value": "#8C8880"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--text-tertiary",
+    "value": "#3D3B38"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "--text-tertiary",
+    "value": "#BDB9B0"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "font-family",
+    "value": "'Geist Mono'"
+  },
+  {
+    "file": "tauri/src/terminal.html",
+    "property": "font-family",
+    "value": "'Geist'"
+  },
+  {
+    "file": "tauri/src/vendor/xterm/xterm.css",
+    "property": "background",
+    "value": "#000"
+  },
+  {
+    "file": "tauri/src/vendor/xterm/xterm.css",
+    "property": "background-color",
+    "value": "#000"
+  },
+  {
+    "file": "tauri/src/vendor/xterm/xterm.css",
+    "property": "color",
+    "value": "#FFF"
+  }
+]

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -1,0 +1,50 @@
+{
+  "colors": {
+    "light-background": "#F8F4ED",
+    "light-background-elevated": "#EFEBE2",
+    "light-background-hover": "#E8E2D8",
+    "light-border": "rgba(0, 0, 0, 0.07)",
+    "light-border-mid": "rgba(0, 0, 0, 0.13)",
+    "light-text": "#1A1916",
+    "light-text-secondary": "#8C8880",
+    "light-text-tertiary": "#BDB9B0",
+    "light-accent": "#C96B4E",
+    "light-accent-hover": "#B85A3E",
+    "light-accent-soft": "rgba(201, 107, 78, 0.10)",
+    "light-red": "#C0392B",
+    "light-green": "#2E7D46",
+    "dark-background": "#0D0D0B",
+    "dark-background-elevated": "#141412",
+    "dark-background-hover": "#1C1C1A",
+    "dark-border": "rgba(255, 255, 255, 0.06)",
+    "dark-border-mid": "#2A2924",
+    "dark-text": "#E8E4DA",
+    "dark-text-secondary": "#6B6760",
+    "dark-text-tertiary": "#3D3B38",
+    "dark-accent": "#30D158",
+    "dark-accent-hover": "#4ADE70",
+    "dark-accent-soft": "rgba(48, 209, 88, 0.10)",
+    "dark-red": "#FF453A",
+    "dark-red-background": "rgba(255, 69, 58, 0.12)",
+    "dark-purple": "#BF5AF2",
+    "dark-orange": "#D4832A",
+    "primary-button-light-text": "#FFFFFF",
+    "panel-shadow-light": "rgba(0, 0, 0, 0.30)",
+    "panel-shadow-dark": "rgba(0, 0, 0, 0.50)"
+  },
+  "fonts": [
+    "Instrument Serif",
+    "Geist",
+    "Geist Mono"
+  ],
+  "allowedKeywords": [
+    "transparent",
+    "currentColor",
+    "inherit",
+    "initial",
+    "unset",
+    "revert",
+    "revert-layer",
+    "none"
+  ]
+}

--- a/scripts/check_design_tokens.mjs
+++ b/scripts/check_design_tokens.mjs
@@ -1,0 +1,556 @@
+#!/usr/bin/env node
+
+/**
+ * Design-token enforcement invariant. These are the only syntax positions in
+ * which this checker interprets a literal as a design color or font:
+ *
+ * (a) CSS declarations in .css files, <style> blocks, and style="" attributes:
+ *     color, background*, border*-color, fill, stroke, outline-color,
+ *     box-shadow colors, font-family, and token custom properties.
+ * (b) TS/TSX style-object values whose keys are color, background*,
+ *     border*Color, fill, stroke, or fontFamily.
+ * (c) Tailwind arbitrary color classes such as text-[#...] and bg-[rgb(...)].
+ * (d) Literal JSX/SVG fill=, stroke=, and color= attributes.
+ *
+ * The scanner deliberately does not grep prose. Raw sanctioned values are
+ * accepted only in TOKEN_DEFINITION_FILES; all other findings are compared to
+ * the exact, line-agnostic shrink-only baseline.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const SCAN_ROOTS = ["site", "tauri/src"];
+const TOKEN_DEFINITION_FILES = new Set([
+  "site/app/globals.css",
+  "tauri/src/index.html",
+  "tauri/src/styles/theme-tokens.css",
+]);
+const SOURCE_EXTENSIONS = new Set([".css", ".html", ".js", ".jsx", ".ts", ".tsx"]);
+const CSS_NAMED_COLORS = new Set([
+  "aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige", "bisque",
+  "black", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood", "cadetblue",
+  "chartreuse", "chocolate", "coral", "cornflowerblue", "cornsilk", "crimson", "cyan",
+  "darkblue", "darkcyan", "darkgoldenrod", "darkgray", "darkgreen", "darkgrey", "darkkhaki",
+  "darkmagenta", "darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon",
+  "darkseagreen", "darkslateblue", "darkslategray", "darkslategrey", "darkturquoise",
+  "darkviolet", "deeppink", "deepskyblue", "dimgray", "dimgrey", "dodgerblue",
+  "firebrick", "floralwhite", "forestgreen", "fuchsia", "gainsboro", "ghostwhite", "gold",
+  "goldenrod", "gray", "green", "greenyellow", "grey", "honeydew", "hotpink", "indianred",
+  "indigo", "ivory", "khaki", "lavender", "lavenderblush", "lawngreen", "lemonchiffon",
+  "lightblue", "lightcoral", "lightcyan", "lightgoldenrodyellow", "lightgray", "lightgreen",
+  "lightgrey", "lightpink", "lightsalmon", "lightseagreen", "lightskyblue", "lightslategray",
+  "lightslategrey", "lightsteelblue", "lightyellow", "lime", "limegreen", "linen", "magenta",
+  "maroon", "mediumaquamarine", "mediumblue", "mediumorchid", "mediumpurple",
+  "mediumseagreen", "mediumslateblue", "mediumspringgreen", "mediumturquoise",
+  "mediumvioletred", "midnightblue", "mintcream", "mistyrose", "moccasin", "navajowhite",
+  "navy", "oldlace", "olive", "olivedrab", "orange", "orangered", "orchid",
+  "palegoldenrod", "palegreen", "paleturquoise", "palevioletred", "papayawhip",
+  "peachpuff", "peru", "pink", "plum", "powderblue", "purple", "rebeccapurple", "red",
+  "rosybrown", "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen", "seashell",
+  "sienna", "silver", "skyblue", "slateblue", "slategray", "slategrey", "snow",
+  "springgreen", "steelblue", "tan", "teal", "thistle", "tomato", "turquoise", "violet",
+  "wheat", "white", "whitesmoke", "yellow", "yellowgreen",
+]);
+
+function usage(message) {
+  const suffix = message ? `\nError: ${message}` : "";
+  return `Usage: node scripts/check_design_tokens.mjs [--root DIR] [--base-baseline FILE] [--write-baseline] [--json]${suffix}`;
+}
+
+function parseArguments(argv) {
+  let root;
+  let baseBaseline;
+  let writeBaseline = false;
+  let json = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--root" || argument === "--base-baseline") {
+      if (index + 1 >= argv.length) throw new Error(usage(`${argument} requires a value`));
+      const value = argv[index + 1];
+      if (argument === "--root") root = value;
+      else baseBaseline = value;
+      index += 1;
+    } else if (argument === "--write-baseline") {
+      writeBaseline = true;
+    } else if (argument === "--json") {
+      json = true;
+    } else {
+      throw new Error(usage(`unknown argument: ${argument}`));
+    }
+  }
+  const defaultRoot = path.resolve(path.dirname(process.argv[1]), "..");
+  return {
+    root: path.resolve(root ?? defaultRoot),
+    baseBaseline: baseBaseline ? path.resolve(baseBaseline) : null,
+    writeBaseline,
+    json,
+  };
+}
+
+function normalizePath(file) {
+  return file.split(path.sep).join("/");
+}
+
+function normalizeNumber(number) {
+  const parsed = Number(number);
+  return Number.isFinite(parsed) ? String(parsed) : number;
+}
+
+function normalizeColor(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("#")) {
+    const digits = trimmed.slice(1).toLowerCase();
+    if (digits.length === 3 || digits.length === 4) {
+      return `#${[...digits].map((digit) => digit + digit).join("")}`;
+    }
+    return `#${digits}`;
+  }
+  if (/^[a-z]+$/i.test(trimmed)) return trimmed.toLowerCase();
+  return trimmed
+    .toLowerCase()
+    .replace(/[-+]?(?:\d*\.\d+|\d+\.?\d*)/g, normalizeNumber)
+    .replace(/\s+/g, "");
+}
+
+function findClosingParenthesis(text, openingIndex) {
+  let depth = 0;
+  let quote = null;
+  for (let index = openingIndex; index < text.length; index += 1) {
+    const character = text[index];
+    if (quote) {
+      if (character === "\\") index += 1;
+      else if (character === quote) quote = null;
+      continue;
+    }
+    if (character === "'" || character === '"') quote = character;
+    else if (character === "(") depth += 1;
+    else if (character === ")" && --depth === 0) return index;
+  }
+  return -1;
+}
+
+function extractColorLiterals(text) {
+  const literals = [];
+  let plain = "";
+  const flushPlain = () => {
+    for (const match of plain.matchAll(/#(?:[0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{4}|[0-9a-f]{3})(?![0-9a-f])|\b[a-z]+\b/gi)) {
+      const value = match[0];
+      if (value.startsWith("#") || CSS_NAMED_COLORS.has(value.toLowerCase())) literals.push(value);
+    }
+    plain = "";
+  };
+
+  for (let index = 0; index < text.length; index += 1) {
+    const identifier = /^[a-z][a-z0-9-]*/i.exec(text.slice(index));
+    if (identifier && text[index + identifier[0].length] === "(") {
+      flushPlain();
+      const name = identifier[0].toLowerCase();
+      const opening = index + identifier[0].length;
+      const closing = findClosingParenthesis(text, opening);
+      if (closing === -1) {
+        plain += text[index];
+        continue;
+      }
+      const whole = text.slice(index, closing + 1);
+      if (["rgb", "rgba", "hsl", "hsla", "oklch"].includes(name)) literals.push(whole);
+      else if (name !== "var" && name !== "url") {
+        literals.push(...extractColorLiterals(text.slice(opening + 1, closing)));
+      }
+      index = closing;
+    } else {
+      plain += text[index];
+    }
+  }
+  flushPlain();
+  return literals;
+}
+
+function stripComments(source, html = false, lineComments = true) {
+  const output = [...source];
+  let quote = null;
+  for (let index = 0; index < source.length; index += 1) {
+    if (quote) {
+      if (source[index] === "\\") index += 1;
+      else if (source[index] === quote) quote = null;
+      continue;
+    }
+    if (source[index] === "'" || source[index] === '"' || source[index] === "`") {
+      quote = source[index];
+      continue;
+    }
+    const isHtmlComment = html && source.startsWith("<!--", index);
+    const isLineComment = lineComments && source.startsWith("//", index);
+    const isBlockComment = source.startsWith("/*", index);
+    if (!isHtmlComment && !isLineComment && !isBlockComment) continue;
+    const terminator = isHtmlComment ? "-->" : isLineComment ? "\n" : "*/";
+    const end = source.indexOf(terminator, index + 2);
+    const stop = end === -1 ? source.length : end + (isLineComment ? 0 : terminator.length);
+    for (let cursor = index; cursor < stop; cursor += 1) {
+      if (output[cursor] !== "\n" && output[cursor] !== "\r") output[cursor] = " ";
+    }
+    index = stop - 1;
+  }
+  return output.join("");
+}
+
+function splitCssDeclarations(text) {
+  const declarations = [];
+  let start = 0;
+  let quote = null;
+  let parentheses = 0;
+  for (let index = 0; index <= text.length; index += 1) {
+    const character = text[index];
+    if (quote) {
+      if (character === "\\") index += 1;
+      else if (character === quote) quote = null;
+      continue;
+    }
+    if (character === "'" || character === '"') quote = character;
+    else if (character === "(") parentheses += 1;
+    else if (character === ")") parentheses = Math.max(0, parentheses - 1);
+    else if ((character === ";" || index === text.length) && parentheses === 0) {
+      declarations.push(text.slice(start, index));
+      start = index + 1;
+    }
+  }
+  return declarations;
+}
+
+function cssBlocks(source) {
+  const blocks = [];
+  function walk(start, stopCharacter = null) {
+    let segmentStart = start;
+    let quote = null;
+    let parentheses = 0;
+    for (let index = start; index < source.length; index += 1) {
+      const character = source[index];
+      if (quote) {
+        if (character === "\\") index += 1;
+        else if (character === quote) quote = null;
+        continue;
+      }
+      if (character === "'" || character === '"') quote = character;
+      else if (character === "(") parentheses += 1;
+      else if (character === ")") parentheses = Math.max(0, parentheses - 1);
+      else if (parentheses === 0 && character === "{") {
+        const closing = walk(index + 1, "}");
+        index = closing;
+        segmentStart = index + 1;
+      } else if (parentheses === 0 && character === stopCharacter) {
+        blocks.push(source.slice(segmentStart, index));
+        return index;
+      }
+    }
+    return source.length;
+  }
+  walk(0);
+  return blocks;
+}
+
+function propertyCarriesColor(property) {
+  return property === "color" || property.startsWith("background") ||
+    (/^border(?:-[a-z0-9]+)*-color$/.test(property)) || property === "fill" ||
+    property === "stroke" || property === "outline-color" || property === "box-shadow";
+}
+
+function styleObjectKeyCarriesColor(key) {
+  return key === "color" || key.startsWith("background") ||
+    (/^border.*Color$/.test(key)) || key === "fill" || key === "stroke";
+}
+
+function parseFontFamilies(value) {
+  return value.split(",").map((family) => family.trim().replace(/^(['"])(.*)\1$/, "$2"))
+    .filter((family) => family && !/^var\(/i.test(family));
+}
+
+function readJson(file, description) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    throw new Error(`cannot read ${description} ${file}: ${error.message}`);
+  }
+}
+
+function validateTokens(tokens) {
+  if (!tokens || typeof tokens.colors !== "object" || Array.isArray(tokens.colors)) {
+    throw new Error("design/tokens.json must contain a colors object");
+  }
+  if (!Array.isArray(tokens.fonts) || !Array.isArray(tokens.allowedKeywords)) {
+    throw new Error("design/tokens.json must contain fonts and allowedKeywords arrays");
+  }
+  for (const [name, value] of Object.entries(tokens.colors)) {
+    if (typeof value !== "string" || extractColorLiterals(value).length !== 1) {
+      throw new Error(`design token color ${name} must be one color literal`);
+    }
+  }
+  if (![...tokens.fonts, ...tokens.allowedKeywords].every((value) => typeof value === "string")) {
+    throw new Error("font and allowed-keyword tokens must be strings");
+  }
+}
+
+function walkFiles(root) {
+  const files = [];
+  for (const relativeRoot of SCAN_ROOTS) {
+    const absoluteRoot = path.join(root, relativeRoot);
+    if (!fs.existsSync(absoluteRoot)) continue;
+    const queue = [absoluteRoot];
+    while (queue.length > 0) {
+      const directory = queue.pop();
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const absolute = path.join(directory, entry.name);
+        if (entry.isDirectory()) queue.push(absolute);
+        else if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name))) files.push(absolute);
+      }
+    }
+  }
+  return files.sort();
+}
+
+function collectViolations(root, tokens) {
+  const tokenColors = new Set(Object.values(tokens.colors).map(normalizeColor));
+  const tokenFonts = new Set(tokens.fonts.map((font) => font.toLowerCase()));
+  const allowedKeywords = new Set(tokens.allowedKeywords.map((keyword) => keyword.toLowerCase()));
+  const entries = new Map();
+
+  function add(file, property, value) {
+    const entry = { file, property, value: value.trim().replace(/\s+/g, " ") };
+    entries.set(JSON.stringify(entry), entry);
+  }
+
+  function checkColors(file, property, value) {
+    const isDefinition = TOKEN_DEFINITION_FILES.has(file);
+    for (const literal of extractColorLiterals(value)) {
+      const normalized = normalizeColor(literal);
+      if (allowedKeywords.has(normalized)) continue;
+      if (!isDefinition || !tokenColors.has(normalized)) add(file, property, literal);
+    }
+  }
+
+  function checkFont(file, property, value) {
+    const normalizedValue = value.trim().toLowerCase();
+    if (allowedKeywords.has(normalizedValue) || /^var\([^)]*\)$/.test(normalizedValue)) return;
+    const families = parseFontFamilies(value);
+    if (families.length === 0) return;
+    const isDefinition = TOKEN_DEFINITION_FILES.has(file);
+    if (!isDefinition || families.some((family) => !tokenFonts.has(family.toLowerCase()))) {
+      add(file, property, value);
+    }
+  }
+
+  function checkDeclaration(file, declaration) {
+    const colon = declaration.indexOf(":");
+    if (colon === -1) return;
+    const property = declaration.slice(0, colon).trim().toLowerCase();
+    const value = declaration.slice(colon + 1).trim().replace(/\s*!important\s*$/i, "");
+    if (!property || !value) return;
+    if (property.startsWith("--")) {
+      checkColors(file, property, value);
+      if (property.startsWith("--font")) checkFont(file, property, value);
+    } else if (property === "font-family") {
+      checkFont(file, property, value);
+    } else if (propertyCarriesColor(property)) {
+      checkColors(file, property, value);
+    }
+  }
+
+  function checkCss(file, css, declarationsOnly = false) {
+    const stripped = stripComments(css, false, false);
+    const blocks = declarationsOnly ? [stripped] : cssBlocks(stripped);
+    for (const block of blocks) {
+      for (const declaration of splitCssDeclarations(block)) checkDeclaration(file, declaration);
+    }
+  }
+
+  function checkTailwind(file, source) {
+    const pattern = /\b(text|bg|border|fill|stroke|outline|shadow)-\[([^\]\r\n]+)\]/gi;
+    for (const match of source.matchAll(pattern)) {
+      const literals = extractColorLiterals(match[2]);
+      for (const literal of literals) {
+        if (!allowedKeywords.has(normalizeColor(literal))) add(file, match[1].toLowerCase(), literal);
+      }
+    }
+  }
+
+  function jsTokens(source) {
+    const result = [];
+    for (let index = 0; index < source.length;) {
+      if (/\s/.test(source[index])) { index += 1; continue; }
+      if (source.startsWith("//", index)) {
+        index = source.indexOf("\n", index + 2);
+        if (index === -1) break;
+        continue;
+      }
+      if (source.startsWith("/*", index)) {
+        const end = source.indexOf("*/", index + 2);
+        index = end === -1 ? source.length : end + 2;
+        continue;
+      }
+      const character = source[index];
+      if (character === "'" || character === '"' || character === "`") {
+        const quote = character;
+        let cursor = index + 1;
+        let value = "";
+        while (cursor < source.length) {
+          if (source[cursor] === "\\") {
+            value += source.slice(cursor, cursor + 2);
+            cursor += 2;
+          } else if (source[cursor] === quote) {
+            cursor += 1;
+            break;
+          } else {
+            value += source[cursor++];
+          }
+        }
+        result.push({ type: "string", value });
+        index = cursor;
+        continue;
+      }
+      const identifier = /^[A-Za-z_$][\w$-]*/.exec(source.slice(index));
+      if (identifier) {
+        result.push({ type: "identifier", value: identifier[0] });
+        index += identifier[0].length;
+      } else {
+        result.push({ type: "punctuation", value: character });
+        index += 1;
+      }
+    }
+    return result;
+  }
+
+  function checkStyleObjects(file, source) {
+    const tokensList = jsTokens(source);
+    for (let index = 1; index + 2 < tokensList.length; index += 1) {
+      const key = tokensList[index];
+      const previous = tokensList[index - 1];
+      const colon = tokensList[index + 1];
+      const value = tokensList[index + 2];
+      if (!["{", ","].includes(previous.value) || colon.value !== ":" || value.type !== "string") continue;
+      if (key.value === "fontFamily") checkFont(file, key.value, value.value);
+      else if (styleObjectKeyCarriesColor(key.value)) checkColors(file, key.value, value.value);
+    }
+  }
+
+  function checkTagAttributes(file, source, includeStyle) {
+    const withoutComments = stripComments(source, true);
+    for (const tag of withoutComments.matchAll(/<[A-Za-z][^<>]*>/gs)) {
+      const text = tag[0];
+      const attributePattern = /(?:^|\s)(fill|stroke|color)\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*(["'`])(.*?)\4\s*\})/gi;
+      for (const match of text.matchAll(attributePattern)) {
+        const value = match[2] ?? match[3] ?? match[5] ?? "";
+        checkColors(file, match[1].toLowerCase(), value);
+      }
+      if (includeStyle) {
+        const stylePattern = /(?:^|\s)style\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+        for (const match of text.matchAll(stylePattern)) checkCss(file, match[1] ?? match[2], true);
+      }
+    }
+  }
+
+  for (const absolute of walkFiles(root)) {
+    const file = normalizePath(path.relative(root, absolute));
+    const extension = path.extname(file);
+    const source = fs.readFileSync(absolute, "utf8");
+    if (extension === ".css") checkCss(file, source);
+    if (extension === ".html") {
+      const withoutComments = stripComments(source, true);
+      for (const match of withoutComments.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi)) {
+        checkCss(file, match[1]);
+      }
+      checkTagAttributes(file, source, true);
+    }
+    if ([".ts", ".tsx"].includes(extension)) checkStyleObjects(file, source);
+    if ([".html", ".jsx", ".tsx"].includes(extension)) checkTagAttributes(file, source, false);
+    checkTailwind(file, stripComments(source, extension === ".html"));
+  }
+
+  return [...entries.values()].sort((left, right) =>
+    left.file.localeCompare(right.file) || left.property.localeCompare(right.property) ||
+    left.value.localeCompare(right.value));
+}
+
+function validateBaseline(value, description) {
+  if (!Array.isArray(value)) throw new Error(`${description} must be a JSON array`);
+  const entries = value.map((entry, index) => {
+    if (!entry || typeof entry.file !== "string" || typeof entry.property !== "string" ||
+        typeof entry.value !== "string" || Object.keys(entry).length !== 3) {
+      throw new Error(`${description} entry ${index} must contain only string file, property, and value fields`);
+    }
+    return entry;
+  });
+  const keys = entries.map(JSON.stringify);
+  if (new Set(keys).size !== keys.length) throw new Error(`${description} contains duplicate entries`);
+  return entries;
+}
+
+function compareEntries(expected, actual) {
+  const expectedKeys = new Set(expected.map(JSON.stringify));
+  const actualKeys = new Set(actual.map(JSON.stringify));
+  return {
+    missing: expected.filter((entry) => !actualKeys.has(JSON.stringify(entry))),
+    unexpected: actual.filter((entry) => !expectedKeys.has(JSON.stringify(entry))),
+  };
+}
+
+function renderEntry(entry) {
+  return `${entry.file} [${entry.property}] ${entry.value}`;
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const tokensFile = path.join(options.root, "design/tokens.json");
+  const baselineFile = path.join(options.root, "design/token-baseline.json");
+  const tokens = readJson(tokensFile, "token contract");
+  validateTokens(tokens);
+  const current = collectViolations(options.root, tokens);
+
+  if (options.writeBaseline) {
+    fs.mkdirSync(path.dirname(baselineFile), { recursive: true });
+    fs.writeFileSync(baselineFile, `${JSON.stringify(current, null, 2)}\n`);
+  }
+
+  const baseline = validateBaseline(readJson(baselineFile, "baseline"), "design/token-baseline.json");
+  const equality = compareEntries(baseline, current);
+  let additions = [];
+  if (options.baseBaseline) {
+    const base = validateBaseline(readJson(options.baseBaseline, "base baseline"), "base baseline");
+    additions = compareEntries(base, baseline).unexpected;
+  }
+  const ok = equality.missing.length === 0 && equality.unexpected.length === 0 && additions.length === 0;
+  const report = {
+    ok,
+    violations: current.length,
+    staleBaselineEntries: equality.missing,
+    unbaselinedViolations: equality.unexpected,
+    addedBaselineEntries: additions,
+  };
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else if (ok) {
+    process.stdout.write(`Design tokens: ${current.length} current violations exactly match the shrink-only baseline.\n`);
+  } else {
+    process.stderr.write("Design token check failed.\n");
+    if (equality.unexpected.length) {
+      process.stderr.write("Unbaselined violations:\n");
+      for (const entry of equality.unexpected) process.stderr.write(`  + ${renderEntry(entry)}\n`);
+    }
+    if (equality.missing.length) {
+      process.stderr.write("Stale baseline entries (remove these as violations burn down):\n");
+      for (const entry of equality.missing) process.stderr.write(`  - ${renderEntry(entry)}\n`);
+    }
+    if (additions.length) {
+      process.stderr.write("Baseline additions are forbidden; the baseline may only shrink:\n");
+      for (const entry of additions) process.stderr.write(`  + ${renderEntry(entry)}\n`);
+    }
+  }
+  process.exitCode = ok ? 0 : 1;
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`Design token check failed: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/check_design_tokens.mjs
+++ b/scripts/check_design_tokens.mjs
@@ -364,7 +364,8 @@ function collectViolations(root, tokens) {
   }
 
   function checkTailwind(file, source) {
-    const pattern = /\b(text|bg|border|fill|stroke|outline|shadow)-\[([^\]\r\n]+)\]/gi;
+    const pattern =
+      /\b(text|bg|border|fill|stroke|outline|shadow|ring|ring-offset|caret|accent|divide|decoration|placeholder|from|via|to)-\[([^\]\r\n]+)\]/gi;
     for (const match of source.matchAll(pattern)) {
       const literals = extractColorLiterals(match[2]);
       for (const literal of literals) {

--- a/scripts/check_design_tokens.test.mjs
+++ b/scripts/check_design_tokens.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const checker = path.resolve(path.dirname(process.argv[1]), "check_design_tokens.mjs");
+const tokens = {
+  colors: {
+    background: "#F8F4ED",
+    accent: "#C96B4E",
+  },
+  fonts: ["Instrument Serif", "Geist", "Geist Mono"],
+  allowedKeywords: [
+    "transparent",
+    "currentColor",
+    "inherit",
+    "initial",
+    "unset",
+    "revert",
+    "revert-layer",
+    "none",
+  ],
+};
+
+async function writeFixture(root, file, contents) {
+  const destination = path.join(root, file);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, contents);
+}
+
+async function writeJson(root, file, value) {
+  await writeFixture(root, file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function makeRepo(t) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minutes-design-tokens-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeJson(root, "design/tokens.json", tokens);
+  await writeJson(root, "design/token-baseline.json", []);
+  await writeFixture(root, "site/app/clean.css", ".clean { color: var(--text); }\n");
+  return root;
+}
+
+function runChecker(root, ...args) {
+  return spawnSync(process.execPath, [checker, "--root", root, "--json", ...args], {
+    encoding: "utf8",
+  });
+}
+
+function report(result) {
+  assert.equal(result.stdout.startsWith("{"), true, result.stderr || result.stdout);
+  return JSON.parse(result.stdout);
+}
+
+function assertViolation(result, property, value) {
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const parsed = report(result);
+  assert.equal(parsed.ok, false);
+  assert.ok(
+    parsed.unbaselinedViolations.some(
+      (entry) => entry.property === property && entry.value.toLowerCase() === value.toLowerCase(),
+    ),
+    result.stdout,
+  );
+}
+
+test("clean fixture passes", async (t) => {
+  const root = await makeRepo(t);
+  const result = runChecker(root);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(report(result).ok, true);
+});
+
+test("raw color in a non-token CSS file fails", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(root, "site/app/bad.css", ".bad { color: #ff0000; }\n");
+  assertViolation(runChecker(root), "color", "#ff0000");
+});
+
+test("Tailwind arbitrary color class fails", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "site/app/page.tsx",
+    "export const Page = () => <p className=\"text-[#ff0000]\">bad</p>;\n",
+  );
+  assertViolation(runChecker(root), "text", "#ff0000");
+});
+
+test("TSX style-object color fails", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "site/app/page.tsx",
+    "export const Page = () => <p style={{ color: '#ff0000' }}>bad</p>;\n",
+  );
+  assertViolation(runChecker(root), "color", "#ff0000");
+});
+
+test("literal SVG fill attribute fails", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "site/app/icon.tsx",
+    "export const Icon = () => <svg><path fill=\"#ff0000\" /></svg>;\n",
+  );
+  assertViolation(runChecker(root), "fill", "#ff0000");
+});
+
+test("sanctioned hex outside a token-definition file still fails", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(root, "site/app/bad.css", ".bad { background: #F8F4ED; }\n");
+  assertViolation(runChecker(root), "background", "#F8F4ED");
+});
+
+test("sanctioned hex inside a token-definition file passes", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(root, "site/app/globals.css", ":root { --bg: #F8F4ED; }\n");
+  const result = runChecker(root);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("an unsanctioned custom-property value in a token-definition file fails consistency", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(root, "site/app/globals.css", ":root { --decorative: #ff0000; }\n");
+  assertViolation(runChecker(root), "--decorative", "#ff0000");
+});
+
+test("comment-only mentions pass", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "site/app/comments.css",
+    "/* .old { color: #ff0000; background: rgb(255, 0, 0); } */\n.clean { color: var(--text); }\n",
+  );
+  await writeFixture(
+    root,
+    "site/app/comments.tsx",
+    "// <svg fill=\"#ff0000\" className=\"text-[#ff0000]\" />\nexport const ok = true;\n",
+  );
+  const result = runChecker(root);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("stale baseline entry fails", async (t) => {
+  const root = await makeRepo(t);
+  await writeJson(root, "design/token-baseline.json", [
+    { file: "site/app/removed.css", property: "color", value: "#ff0000" },
+  ]);
+  const result = runChecker(root);
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.deepEqual(report(result).staleBaselineEntries, [
+    { file: "site/app/removed.css", property: "color", value: "#ff0000" },
+  ]);
+});
+
+test("base-versus-head comparison rejects baseline additions", async (t) => {
+  const root = await makeRepo(t);
+  const entry = { file: "site/app/legacy.css", property: "color", value: "#ff0000" };
+  await writeFixture(root, entry.file, ".legacy { color: #ff0000; }\n");
+  await writeJson(root, "design/token-baseline.json", [entry]);
+  await writeJson(root, "base-token-baseline.json", []);
+
+  const result = runChecker(root, "--base-baseline", path.join(root, "base-token-baseline.json"));
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.deepEqual(report(result).addedBaselineEntries, [entry]);
+});

--- a/scripts/check_design_tokens.test.mjs
+++ b/scripts/check_design_tokens.test.mjs
@@ -89,6 +89,21 @@ test("Tailwind arbitrary color class fails", async (t) => {
   assertViolation(runChecker(root), "text", "#ff0000");
 });
 
+test("Tailwind ring/caret/gradient arbitrary colors fail", async (t) => {
+  const root = await makeRepo(t);
+  await writeFixture(
+    root,
+    "site/app/page.tsx",
+    'export const Page = () => (\n' +
+      '  <p className="ring-[#ff0000] caret-[rgb(1,2,3)] from-[#123456]">bad</p>\n' +
+      ");\n",
+  );
+  const result = runChecker(root);
+  assertViolation(result, "ring", "#ff0000");
+  assertViolation(result, "caret", "rgb(1,2,3)");
+  assertViolation(result, "from", "#123456");
+});
+
 test("TSX style-object color fails", async (t) => {
   const root = await makeRepo(t);
   await writeFixture(


### PR DESCRIPTION
## What

DESIGN.md defines the sanctioned palette and fonts; CLAUDE.md tells agents to "flag any code that introduces" others — but nothing enforced it. Now:

- **`design/tokens.json`**: hand-curated machine-readable tokens (deliberately never parsed from DESIGN.md prose, which also names *prohibited* values like #000). Token-definition CSS blocks are validated against it, so the file can't go decorative.
- **Rule**: raw color/font literals only in designated token-definition files; everything else under `site/` and `tauri/src/` consumes variables/classes.
- **`scripts/check_design_tokens.mjs`**, syntax-aware with enumerated coverage: CSS (files, `<style>` blocks, `style=` attrs), TS/TSX style objects, Tailwind arbitrary color classes (`text-[#...]`), JSX/SVG color attributes. Comments and prose never flag.
- **Shrink-only baseline**: the 528 current violations are recorded exactly (`design/token-baseline.json`); stale entries fail, and on PRs the baseline is diffed against the fetched base SHA — additions fail. Burn-down report in SPEC_NOTES.md (top offender: tauri HTML surfaces).
- New unconditional `design_tokens` CI job in `ci_gate.needs`; 11 committed fixture tests including red paths.

## Verification
Green on current tree; injected `color:#ff0000` in site CSS flagged by file/property/value; 11/11 fixtures.

Part of the agent-infra hardening epic (bead `minutes-4a9r`, PR-E). Plan reviewed adversarially by codex to SHIP 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)