### PR TITLE
feat(release): two-phase committed release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,9 @@ jobs:
       - name: Test transactional version bump
         run: node --test scripts/bump_version.test.mjs
 
+      - name: Test committed release flow
+        run: node --test scripts/release.test.mjs
+
   skills_compiler:
     name: Skills Compiler
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -13,8 +13,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  release_readiness:
+    name: Release readiness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Verify committed release invariants
+        run: node scripts/check_version_sync.mjs --release
+
   build:
     name: Build (${{ matrix.target }})
+    needs: release_readiness
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -100,7 +115,7 @@ jobs:
 
   checksums:
     name: Publish CLI checksums
-    needs: build
+    needs: [release_readiness, build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -22,8 +22,26 @@ env:
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
+  release_readiness:
+    name: Release readiness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Verify committed release invariants
+        run: node scripts/check_version_sync.mjs --release
+
   macos-release:
     name: Build signed + notarized Minutes.app
+    needs: release_readiness
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/release-windows-desktop.yml
+++ b/.github/workflows/release-windows-desktop.yml
@@ -14,8 +14,23 @@ env:
   TAURI_CLI_VERSION: "2.10.1"
 
 jobs:
+  release_readiness:
+    name: Release readiness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Verify committed release invariants
+        run: node scripts/check_version_sync.mjs --release
+
   windows-desktop:
     name: Build Windows desktop installer
+    needs: release_readiness
     runs-on: windows-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ tauri/src-tauri/resources/
 # Release note drafts (local working docs; release body is copied into GitHub)
 notes-release-v*.md
 
+# Resumable local release orchestration state
+/.minutes-release-state.json
+
 # Local scratch
 tmp/
 docs/assets/demo*

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -26,7 +26,7 @@ flow: `node scripts/bump-version.mjs --plugin X.Y.Z` (add `--dry-run` to preview
 ```bash
 PUBLISHED=$(curl -s https://crates.io/api/v1/crates/whisper-guard | jq -r '.crate.max_stable_version')
 LAST_PUBLISH_COMMIT=$(git log --grep="whisper-guard $PUBLISHED" --format="%H" | head -1)
-git log "$LAST_PUBLISH_COMMIT"..HEAD -- crates/whisper-guard/   # any commits → bump + publish in Step 11.5
+git log "$LAST_PUBLISH_COMMIT"..HEAD -- crates/whisper-guard/   # any commits → bump + publish in Step 13
 ```
 
 ### 2. Manifest sync
@@ -57,54 +57,115 @@ Every release shows up in followers' GitHub feeds — this is free awareness. Wr
 - Summarize what shipped and why it matters (not commit messages — outcomes)
 - Include install instructions (cargo install, DMG, npx)
 - Match the voice of past releases (see v0.8.0, v0.8.1 for examples)
-- Save to a temp file: `notes.md`
+- Save to the gitignored local file `notes-release-vX.Y.Z.md`
 
-### 6. Push commits to `main` and wait for CI to go green
+### 6. Push the release commit to `main` and wait for CI to go green
 ```bash
 git push origin main
-# Watch CI — do NOT tag or publish until the CI workflow succeeds on this commit.
+# Phase 1 refuses to run until this exact HEAD is pushed. Watch CI before publishing.
 gh run list --branch main --limit 3
 gh run watch $(gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
-**Why this step exists**: if you tag first and CI breaks (e.g. a Windows cross-platform build failure), you've already published the version to the public GitHub feed, npm, and brew. Moving a tag after the fact is messy — force-pushing the tag drops the GitHub release to draft, requires re-publishing, and leaves the npm package / brew formula pointing at a different commit than the release tag. Catch the failure *before* any of that happens.
+**Why this step exists**: Phase 1 publishes `minutes-sdk`, so the version bump must
+already be committed, pushed, and green. The release script verifies the clean
+`main` checkout, pushed HEAD, and normal version-sync policy; the maintainer
+confirms that HEAD's CI run is green before starting Phase 1.
 
-### 7. Create the GitHub release as a DRAFT
+### 7. Phase 1: validate and publish `minutes-sdk`
 ```bash
-gh release create vX.Y.Z -t "vX.Y.Z: Short Title" -F notes.md --target main --draft
+node scripts/release.mjs phase1 X.Y.Z
 ```
-This stages the release with its notes, but does **not** create the git tag yet: GitHub creates the tag only when a draft is published. The three release workflows (`Release CLI Binaries`, `Release macOS`, `Release Windows Desktop`) trigger on `push: tags`, so they do NOT run while the release is a draft. The draft also does not announce in subscribers' feeds or mark "latest".
 
-Do NOT `git tag` locally. The safety here is step 6: it already confirmed `main` CI is green on the exact commit `--target` points to, so publishing cannot announce a commit that failed CI.
+Phase 1 packs the SDK, tests MCP against that exact tarball, and records the
+tarball's SHA-512 integrity in `.minutes-release-state.json`. It publishes the
+SDK only if the registry does not already contain the version; a retry skips an
+existing package only when its registry integrity matches. It then polls for
+exact-version visibility, avoiding the v0.19.0/v0.20 registry-lag failure where
+MCP was published before npm could resolve its SDK dependency.
 
-### 8. Publish the release (creates the tag and triggers the binary workflows)
+If polling times out, stop. The SDK-published/MCP-unpublished state is safe and
+supported: check it with `node scripts/release.mjs status`, then rerun Phase 1
+later. Do not edit package inputs or manually publish MCP.
+
+### 8. Phase 2: commit MCP's exact SDK pin
 ```bash
-gh release edit vX.Y.Z --draft=false
+node scripts/release.mjs phase2 X.Y.Z
 ```
-Publishing creates the `vX.Y.Z` tag at the target commit, which fires the three release workflows. `Release macOS` verifies the release exists before uploading, so the release must be published first (you cannot build the binaries against a draft with these triggers). This is also the moment the version shows up in followers' feeds and becomes "latest".
 
-### 9. Wait for the release workflows to upload assets
+Phase 2 verifies the published SDK again, pins
+`crates/mcp/package.json` to the exact version, regenerates the MCP lockfile,
+and refuses to continue unless those are the only two changed files. It creates
+the commit `release: pin minutes-sdk X.Y.Z for mcp` itself. Push that commit and
+wait for CI on the new exact HEAD:
+
+```bash
+git push origin main
+gh run list --branch main --limit 3
+gh run watch $(gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+Do not amend the Phase-2 commit or edit release inputs after this point. Phase 3
+will reproduce the SDK tarball from this HEAD and compare it with Phase 1.
+
+### 9. Create the GitHub release as a DRAFT
+```bash
+gh release create vX.Y.Z -t "vX.Y.Z: Short Title" -F notes-release-vX.Y.Z.md --target "$(git rev-parse HEAD)" --draft
+```
+
+This stages the notes without announcing the release. Keep it as a draft while
+the tag-triggered workflows build and attach artifacts. Creating the draft does
+not create or push the local annotated tag used by the committed release flow.
+
+### 10. Phase 3: verify provenance, create the tag, and publish `minutes-mcp`
+```bash
+node scripts/release.mjs tag X.Y.Z
+# Run the exact tag-push command printed by the script, for example:
+git push origin vX.Y.Z
+```
+
+Phase 3 requires a clean, pushed HEAD and green CI, runs
+`check_version_sync.mjs --release` to enforce the exact pin, and proves that
+`npm pack` for the SDK still matches the Phase-1 integrity. It creates an
+annotated local tag but never pushes it. Finally it publishes MCP idempotently,
+using the same registry-integrity rule as the SDK.
+
+If `gh` is unavailable, Phase 3 refuses to proceed unless
+`--skip-ci-check` is supplied explicitly. Use that escape hatch only after
+manually confirming CI is green on `git rev-parse HEAD`.
+
+Pushing the printed tag command fires the three artifact workflows. Each starts
+with a `release_readiness` job that reruns the exact-pin release policy before
+any artifact build can begin.
+
+### 11. Wait for release assets, then publish the draft
+
 ```bash
 gh run list --workflow="Release CLI Binaries" --limit 1
 gh run list --workflow="Release macOS" --limit 1
 gh run list --workflow="Release Windows Desktop" --limit 1
-```
-They attach the CLI binaries, DMG, Windows installers, updater files (`latest.json`, `Minutes.app.tar.gz`), and `SHA256SUMS.txt`. If one fails, fix on `main`, delete the tag and release (`gh release delete vX.Y.Z --cleanup-tag --yes`), and re-run from step 7 at the new commit. Because main CI was green before the tag, failures here are usually packaging or signing, not code.
 
-### 10. Build and upload .mcpb
+# After all three are green and their assets are attached:
+gh release edit vX.Y.Z --draft=false
+```
+
+The workflows attach the CLI binaries, DMG, Windows installers, updater files
+(`latest.json`, `Minutes.app.tar.gz`), and `SHA256SUMS.txt`. Publishing the draft
+is the announcement moment: it appears in followers' feeds and becomes
+"latest". If an artifact workflow fails, do not move or replace the tag; follow
+the immutable-tag recovery policy in `channels.md` and cut a new patch release.
+
+### 12. Build and upload .mcpb
 ```bash
 ./scripts/pack_mcpb.sh   # use this, not `mcpb pack .`; it swaps manifest.mcpb.json's Claude listing into the bundle
 ./scripts/check_mcpb_bundle.sh minutes.mcpb   # same guard CI runs; catches manifest drift before upload
 gh release upload vX.Y.Z minutes.mcpb --clobber
 ```
 
-### 11. Publish npm packages
-```bash
-cd crates/sdk && npm publish --access public --registry https://registry.npmjs.org
-cd crates/mcp && npm publish --access public --registry https://registry.npmjs.org
-```
-**IMPORTANT**: `crates/mcp/package.json` must depend on `"minutes-sdk": "^X.Y.Z"` (npm version), NOT `"file:../sdk"` (local path). Check before publishing. If 2FA blocks publish, use a granular access token with "Bypass 2FA" enabled.
+There are no manual npm publish commands after the tag. The three release-script
+phases own SDK-before-MCP ordering, exact dependency pinning, provenance checks,
+and idempotent retries.
 
-### 11.5. Publish independent-cadence crates (whisper-guard) if bumped
+### 13. Publish independent-cadence crates (whisper-guard) if bumped
 Skip this step if Step 1 showed no changes to `crates/whisper-guard/` since the last whisper-guard publish.
 ```bash
 cd crates/whisper-guard
@@ -115,11 +176,11 @@ sleep 30 && curl -s https://crates.io/api/v1/crates/whisper-guard | jq '.crate.m
 ```
 whisper-guard is a standalone MIT crate consumed outside this repo (currently 277+ downloads). Bump independently of the main release; do NOT couple to the Minutes version. If you skip the publish, the crates.io users miss the fix and you create silent drift between repo state and published artifact.
 
-### 11.6. Publish minutes-core and minutes-cli to crates.io
+### 14. Publish minutes-core and minutes-cli to crates.io
 
 As of #79 the workspace has no git dependencies (cpal is on crates.io 0.18.1 with `windows-core` pinned to 0.61.2; pyannote-rs is on crates.io 0.3.4), so these crates can be published again. They were last on crates.io at v0.9.4 and now publish at the main release version (currently 0.18.5).
 
-Publish in dependency order, `minutes-core` before `minutes-cli`, because `minutes-cli` depends on the crates.io version of `minutes-core`. whisper-guard (Step 11.5) must already be published at the version `minutes-core` requires.
+Publish in dependency order, `minutes-core` before `minutes-cli`, because `minutes-cli` depends on the crates.io version of `minutes-core`. whisper-guard (Step 13) must already be published at the version `minutes-core` requires.
 
 ```bash
 # core first; cli depends on it. dry-run each before the real publish.
@@ -139,9 +200,9 @@ Notes:
 - `cargo publish` reads each crate's `version =` dependency fields (not the local `path =`), which already point at the crates.io versions, so no manifest edits are needed.
 - Publishing is irreversible: you can only yank, never replace a version. Always run the `--dry-run` first.
 - This revives `cargo install minutes-cli` for users who do not use Homebrew.
-- If `minutes-core` fails to publish with a missing-dependency error, confirm whisper-guard at the required version is already indexed (Step 11.5).
+- If `minutes-core` fails to publish with a missing-dependency error, confirm whisper-guard at the required version is already indexed (Step 13).
 
-### 12. Refresh the landing page copy, then redeploy
+### 15. Refresh the landing page copy, then redeploy
 Before deploying, make sure the site matches what just shipped:
 
 1. **Regenerate the stat line** (version, tool count, CLI count, test count):
@@ -161,7 +222,7 @@ Before deploying, make sure the site matches what just shipped:
 
 **Check before deploying**: `cat .vercel/project.json` should show `"projectName": "useminutes.app"` with `"framework": "nextjs"`. If it's pointing at a different project (e.g. `rx-vip/minutes`), the build produces an empty static tree (no `index.html`, no SSR functions) and the deploy aliases return 404. Fix the link before building.
 
-### 13. Update Homebrew tap formula if CLI changed
+### 16. Update Homebrew tap formula if CLI changed
 The formula lives at `silverstein/homebrew-tap` → `Formula/minutes.rb`. Update the `tag:` to the new version:
 ```bash
 # Fetch current SHA, update via GitHub API

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,651 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const STATE_FILE = ".minutes-release-state.json";
+const SDK_DIRECTORY = "crates/sdk";
+const MCP_DIRECTORY = "crates/mcp";
+const PHASE2_FILES = ["crates/mcp/package.json", "crates/mcp/package-lock.json"];
+const DEFAULT_REGISTRY_URL = "https://registry.npmjs.org/";
+const DEFAULT_POLL_DELAYS_MS = [5_000, 10_000, 20_000, 40_000, 60_000, 60_000, 60_000, 45_000];
+const exactVersionPattern = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?$/;
+
+const toolPath = process.env.RELEASE_TOOL_PATH;
+const childEnvironment = {
+  ...process.env,
+  ...(toolPath ? { PATH: `${toolPath}${path.delimiter}${process.env.PATH ?? ""}` } : {}),
+};
+
+class CommandError extends Error {
+  constructor(command, args, code, signal, stdout, stderr) {
+    const outcome = signal ? `signal ${signal}` : `exit code ${code}`;
+    const detail = stderr.trim() || stdout.trim();
+    super(`${command} ${args.join(" ")} failed with ${outcome}${detail ? `\n${detail}` : ""}`);
+    this.name = "CommandError";
+    this.command = command;
+    this.code = code;
+    this.signal = signal;
+    this.stdout = stdout;
+    this.stderr = stderr;
+  }
+}
+
+function exec(command, args, { cwd, input, env = childEnvironment } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(new CommandError(command, args, code, signal, stdout, stderr));
+    });
+    child.stdin.end(input);
+  });
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/release.mjs phase1 <version>",
+    "  node scripts/release.mjs phase2 <version>",
+    "  node scripts/release.mjs tag <version> [--skip-ci-check]",
+    "  node scripts/release.mjs status",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  if (command === "status") {
+    if (rest.length !== 0) throw new Error("status does not accept arguments");
+    return { command };
+  }
+  if (!["phase1", "phase2", "tag"].includes(command)) {
+    throw new Error(command === undefined ? "a subcommand is required" : `unknown subcommand: ${command}`);
+  }
+
+  let version;
+  let skipCiCheck = false;
+  for (const argument of rest) {
+    if (argument === "--skip-ci-check") {
+      if (command !== "tag") throw new Error("--skip-ci-check is only valid with tag");
+      if (skipCiCheck) throw new Error("--skip-ci-check may only be specified once");
+      skipCiCheck = true;
+    } else if (argument.startsWith("-")) {
+      throw new Error(`unknown option: ${argument}`);
+    } else if (version === undefined) {
+      version = argument;
+    } else {
+      throw new Error(`unexpected argument: ${argument}`);
+    }
+  }
+  if (version === undefined) throw new Error("a version is required");
+  if (!exactVersionPattern.test(version)) {
+    throw new Error(`invalid version ${JSON.stringify(version)}; expected x.y.z or x.y.z-prerelease`);
+  }
+  return { command, version, skipCiCheck };
+}
+
+async function repositoryRoot() {
+  const { stdout } = await exec("git", ["rev-parse", "--show-toplevel"], { cwd: process.cwd() });
+  return stdout.trim();
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+async function readState(root) {
+  try {
+    return await readJson(path.join(root, STATE_FILE));
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw new Error(`cannot read ${STATE_FILE}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function writeState(root, state) {
+  await writeFile(path.join(root, STATE_FILE), `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function requireStateVersion(state, version) {
+  if (state === null) {
+    throw new Error(`phase1 state is missing for ${version}; run node scripts/release.mjs phase1 ${version}`);
+  }
+  if (state.version !== version) {
+    throw new Error(
+      `${STATE_FILE} belongs to ${state.version ?? "an unknown version"}, not ${version}; finish or remove that state deliberately`,
+    );
+  }
+  if (typeof state.sdkIntegrity !== "string" || !state.sdkIntegrity.startsWith("sha512-")) {
+    throw new Error(`${STATE_FILE} has no valid sdkIntegrity`);
+  }
+}
+
+function phase1Complete(state) {
+  return ["phase1-complete", "phase2-complete", "tag-complete"].includes(state?.phase);
+}
+
+async function assertCleanAndPushed(root, { requireMain = false } = {}) {
+  const { stdout: status } = await exec(
+    "git",
+    ["status", "--porcelain=v1", "--untracked-files=all"],
+    { cwd: root },
+  );
+  if (status !== "") throw new Error("working tree is not clean; release commands require a committed tree");
+
+  if (requireMain) {
+    const { stdout: branchOutput } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: root });
+    if (branchOutput.trim() !== "main") {
+      throw new Error(`phase1 must run on main (current branch: ${branchOutput.trim() || "unknown"})`);
+    }
+  }
+
+  const [{ stdout: headOutput }, { stdout: upstreamOutput }] = await Promise.all([
+    exec("git", ["rev-parse", "HEAD"], { cwd: root }),
+    exec("git", ["rev-parse", "@{u}"], { cwd: root }),
+  ]);
+  if (headOutput.trim() !== upstreamOutput.trim()) {
+    throw new Error("HEAD is not pushed to its upstream; push the release commit first");
+  }
+  return headOutput.trim();
+}
+
+async function runVersionCheck(root, release = false) {
+  await exec(
+    process.execPath,
+    [path.join(root, "scripts", "check_version_sync.mjs"), ...(release ? ["--release"] : [])],
+    { cwd: root },
+  );
+}
+
+async function assertTreeVersion(root, version) {
+  const sdk = await readJson(path.join(root, SDK_DIRECTORY, "package.json"));
+  if (sdk.version !== version) {
+    throw new Error(
+      `tree version is ${sdk.version ?? "missing"}, not ${version}; run bump-version.mjs and merge the bump first`,
+    );
+  }
+}
+
+async function withPackedPackage(root, directory, callback) {
+  const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "minutes-release-pack-"));
+  try {
+    // minutes-sdk builds in prepublishOnly, a lifecycle that npm pack does not
+    // run. Build explicitly so the provenance tarball contains the same dist/
+    // payload that npm publish will pack. This is also harmlessly idempotent for
+    // minutes-mcp and makes its publish artifact independent of an old dist/.
+    await exec("npm", ["run", "build"], { cwd: path.join(root, directory) });
+    await exec("npm", ["pack", "--json", "--pack-destination", temporaryDirectory], {
+      cwd: path.join(root, directory),
+    });
+    const tarballs = (await readdir(temporaryDirectory)).filter((file) => file.endsWith(".tgz"));
+    if (tarballs.length !== 1) {
+      throw new Error(`npm pack in ${directory} produced ${tarballs.length} tarballs; expected exactly one`);
+    }
+    const tarball = path.join(temporaryDirectory, tarballs[0]);
+    const bytes = await readFile(tarball);
+    const integrity = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+    return await callback({ tarball, integrity });
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function packPackage(root, directory) {
+  return withPackedPackage(root, directory, ({ integrity }) => integrity);
+}
+
+function registryUrl() {
+  const configured = process.env.RELEASE_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
+  return configured.endsWith("/") ? configured : `${configured}/`;
+}
+
+async function registryLookup(packageName, version) {
+  const url = new URL(`${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`, registryUrl());
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    return { kind: "server-error", detail: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 404) return { kind: "missing" };
+  if (response.status >= 500 && response.status <= 599) {
+    return { kind: "server-error", detail: `HTTP ${response.status}` };
+  }
+  if (!response.ok) {
+    throw new Error(`registry lookup for ${packageName}@${version} failed with HTTP ${response.status}`);
+  }
+  let metadata;
+  try {
+    metadata = await response.json();
+  } catch (error) {
+    throw new Error(
+      `registry returned invalid JSON for ${packageName}@${version}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return { kind: "found", integrity: metadata?.dist?.integrity };
+}
+
+function assertRegistryIntegrity(packageName, version, actual, expected) {
+  if (typeof actual !== "string") {
+    throw new Error(`registry metadata for ${packageName}@${version} has no dist.integrity`);
+  }
+  if (actual !== expected) {
+    throw new Error(
+      `${packageName}@${version} already exists with different integrity\n` +
+        `  registry: ${actual}\n  local:    ${expected}\nRefusing to replace published provenance.`,
+    );
+  }
+}
+
+function pollDelays() {
+  const configured = process.env.RELEASE_POLL_DELAYS_MS;
+  if (configured === undefined) return DEFAULT_POLL_DELAYS_MS;
+  const delays = configured.split(",").map((value) => Number(value));
+  if (delays.length === 0 || delays.some((value) => !Number.isFinite(value) || value < 0)) {
+    throw new Error("RELEASE_POLL_DELAYS_MS must be a comma-separated list of non-negative numbers");
+  }
+  return delays;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function pollForPackage(packageName, version, integrity) {
+  const delays = pollDelays();
+  let lastResult;
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    lastResult = await registryLookup(packageName, version);
+    if (lastResult.kind === "found") {
+      assertRegistryIntegrity(packageName, version, lastResult.integrity, integrity);
+      console.log(`Registry confirms ${packageName}@${version} (${integrity}).`);
+      return;
+    }
+    if (attempt < delays.length) {
+      const description = lastResult.kind === "missing" ? "404 (not visible yet)" : lastResult.detail;
+      console.log(`Registry poll ${attempt + 1}: ${description}; retrying in ${delays[attempt]}ms.`);
+      await sleep(delays[attempt]);
+    }
+  }
+  const lastDescription = lastResult?.kind === "missing" ? "404" : lastResult?.detail ?? "unknown error";
+  throw new Error(
+    `${packageName}@${version} did not become visible before the registry polling timeout (last result: ${lastDescription}). ` +
+      "This is the npm registry lag pattern that can leave minutes-mcp depending on an SDK version the registry cannot resolve; stop and retry phase1 later.",
+  );
+}
+
+async function publishPackage(root, directory, packageName, version, integrity, { poll = false } = {}) {
+  const firstLookup = await registryLookup(packageName, version);
+  if (firstLookup.kind === "found") {
+    assertRegistryIntegrity(packageName, version, firstLookup.integrity, integrity);
+    console.log(`${packageName}@${version} is already published with matching integrity; skipping npm publish.`);
+    if (poll) await pollForPackage(packageName, version, integrity);
+    return false;
+  }
+  if (firstLookup.kind === "server-error") {
+    throw new Error(
+      `cannot safely determine whether ${packageName}@${version} already exists (${firstLookup.detail}); refusing to publish`,
+    );
+  }
+
+  try {
+    await exec(
+      "npm",
+      ["publish", "--access", "public", "--registry", registryUrl()],
+      { cwd: path.join(root, directory) },
+    );
+  } catch (error) {
+    // A concurrent publisher can win after our 404. Verify provenance before
+    // deciding whether the failed publish is nevertheless an idempotent success.
+    const afterFailure = await registryLookup(packageName, version);
+    if (afterFailure.kind === "found") {
+      assertRegistryIntegrity(packageName, version, afterFailure.integrity, integrity);
+      console.log(`${packageName}@${version} appeared concurrently with matching integrity; continuing.`);
+      if (poll) await pollForPackage(packageName, version, integrity);
+      return false;
+    }
+    throw error;
+  }
+
+  console.log(`Published ${packageName}@${version}.`);
+  if (poll) await pollForPackage(packageName, version, integrity);
+  return true;
+}
+
+async function testMcpAgainstSdkTarball(root, tarball, sdkIntegrity) {
+  let primaryError;
+  try {
+    const bytes = await readFile(tarball);
+    const installedIntegrity = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+    if (installedIntegrity !== sdkIntegrity) throw new Error("SDK tarball changed between packing and MCP validation");
+
+    await exec("npm", ["install", tarball, "--no-save", "--package-lock=false"], {
+      cwd: path.join(root, MCP_DIRECTORY),
+    });
+    await exec("npm", ["run", "build"], { cwd: path.join(root, MCP_DIRECTORY) });
+    await exec("npx", ["tsc", "--noEmit"], { cwd: path.join(root, MCP_DIRECTORY) });
+  } catch (error) {
+    primaryError = error;
+  }
+
+  try {
+    await exec("npm", ["ci"], { cwd: path.join(root, MCP_DIRECTORY) });
+  } catch (error) {
+    if (primaryError === undefined) throw error;
+    console.error(`Additionally failed to restore MCP node_modules with npm ci: ${error.message}`);
+  }
+  if (primaryError !== undefined) throw primaryError;
+}
+
+async function phase1(root, version) {
+  await assertCleanAndPushed(root, { requireMain: true });
+  await runVersionCheck(root);
+  await assertTreeVersion(root, version);
+
+  let existingState = await readState(root);
+  if (existingState !== null && existingState.version !== version && existingState.phase === "tag-complete") {
+    console.log(`Previous release ${existingState.version} is complete; starting release ${version}.`);
+    existingState = null;
+  }
+  if (existingState !== null) requireStateVersion(existingState, version);
+
+  const sdkPackage = await readJson(path.join(root, SDK_DIRECTORY, "package.json"));
+  let state;
+  const integrity = await withPackedPackage(root, SDK_DIRECTORY, async ({ tarball, integrity: packedIntegrity }) => {
+    if (existingState?.sdkIntegrity && existingState.sdkIntegrity !== packedIntegrity) {
+      throw new Error(
+        `SDK provenance changed since phase1 began\n  state: ${existingState.sdkIntegrity}\n  local: ${packedIntegrity}`,
+      );
+    }
+    state = {
+      version,
+      phase: phase1Complete(existingState) ? existingState.phase : "phase1-started",
+      sdkPublished: existingState?.sdkPublished === true,
+      sdkIntegrity: packedIntegrity,
+      timestamps: {
+        ...(existingState?.timestamps ?? {}),
+        phase1StartedAt: existingState?.timestamps?.phase1StartedAt ?? now(),
+      },
+    };
+    await writeState(root, state);
+    if (!phase1Complete(existingState)) {
+      await testMcpAgainstSdkTarball(root, tarball, packedIntegrity);
+    }
+    return packedIntegrity;
+  });
+
+  const publishedNow = await publishPackage(
+    root,
+    SDK_DIRECTORY,
+    sdkPackage.name,
+    version,
+    integrity,
+    { poll: false },
+  );
+  state.sdkPublished = true;
+  state.timestamps.sdkPublishedAt = state.timestamps.sdkPublishedAt ?? now();
+  if (publishedNow) state.timestamps.sdkPublishCommandCompletedAt = now();
+  await writeState(root, state);
+
+  await pollForPackage(sdkPackage.name, version, integrity);
+  state.phase = phase1Complete(existingState) ? existingState.phase : "phase1-complete";
+  state.timestamps.phase1CompletedAt = state.timestamps.phase1CompletedAt ?? now();
+  await writeState(root, state);
+
+  console.log("\nPhase 1 complete. Run Phase 2 from this checkout:");
+  console.log(`  node scripts/release.mjs phase2 ${version}`);
+}
+
+async function changedFilesFromHead(root) {
+  const { stdout } = await exec("git", ["diff", "HEAD", "--name-only", "-z", "--no-ext-diff"], { cwd: root });
+  return stdout.split("\0").filter(Boolean).sort();
+}
+
+function assertOnlyPhase2Files(files, context) {
+  const unexpected = files.filter((file) => !PHASE2_FILES.includes(file));
+  if (unexpected.length > 0) {
+    throw new Error(`phase2 diff restriction failed ${context}; unexpected files: ${unexpected.join(", ")}`);
+  }
+}
+
+async function verifySdkStateOnRegistry(state) {
+  const lookup = await registryLookup("minutes-sdk", state.version);
+  if (lookup.kind !== "found") {
+    const detail = lookup.kind === "missing" ? "404 (missing)" : lookup.detail;
+    throw new Error(`minutes-sdk@${state.version} is not currently visible on the registry (${detail})`);
+  }
+  assertRegistryIntegrity("minutes-sdk", state.version, lookup.integrity, state.sdkIntegrity);
+}
+
+async function phase2(root, version) {
+  const state = await readState(root);
+  requireStateVersion(state, version);
+  if (!phase1Complete(state)) {
+    throw new Error(`phase1 is not complete for ${version} (current state: ${state.phase ?? "unknown"})`);
+  }
+  await verifySdkStateOnRegistry(state);
+
+  const preexisting = await changedFilesFromHead(root);
+  assertOnlyPhase2Files(preexisting, "before pinning");
+  if (preexisting.length > 0) {
+    throw new Error(`phase2 requires a clean committed tree; already changed: ${preexisting.join(", ")}`);
+  }
+
+  const packageFile = path.join(root, MCP_DIRECTORY, "package.json");
+  const lockFile = path.join(root, MCP_DIRECTORY, "package-lock.json");
+  const originalPackageText = await readFile(packageFile, "utf8");
+  const originalLockText = await readFile(lockFile, "utf8");
+  const packageJson = await readJson(packageFile);
+  const lockJson = JSON.parse(originalLockText);
+  if (
+    packageJson.dependencies?.["minutes-sdk"] === version &&
+    lockJson.packages?.[""]?.dependencies?.["minutes-sdk"] === version
+  ) {
+    await runVersionCheck(root, true);
+    if (state.phase !== "tag-complete") state.phase = "phase2-complete";
+    state.timestamps = { ...(state.timestamps ?? {}), phase2CompletedAt: state.timestamps?.phase2CompletedAt ?? now() };
+    await writeState(root, state);
+    console.log(`Phase 2 is already committed for ${version}; nothing to change.`);
+    printPhase3Instructions(version);
+    return;
+  }
+  if (!packageJson.dependencies || typeof packageJson.dependencies["minutes-sdk"] !== "string") {
+    throw new Error('crates/mcp/package.json is missing dependencies["minutes-sdk"]');
+  }
+  let committed = false;
+  try {
+    packageJson.dependencies["minutes-sdk"] = version;
+    await writeFile(packageFile, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+    await exec("npm", ["install", "--package-lock-only"], { cwd: path.join(root, MCP_DIRECTORY) });
+
+    const resultingLock = await readJson(lockFile);
+    if (resultingLock.packages?.[""]?.dependencies?.["minutes-sdk"] !== version) {
+      throw new Error(`npm did not regenerate package-lock.json with exact minutes-sdk ${version}`);
+    }
+    const changed = await changedFilesFromHead(root);
+    assertOnlyPhase2Files(changed, "after pinning");
+    if (changed.length === 0) throw new Error("phase2 unexpectedly produced no committed pin diff");
+    await runVersionCheck(root, true);
+    await exec("git", ["add", "--", ...PHASE2_FILES], { cwd: root });
+    await exec("git", ["commit", "-m", `release: pin minutes-sdk ${version} for mcp`], { cwd: root });
+    committed = true;
+  } catch (error) {
+    if (!committed) {
+      try {
+        await exec("git", ["restore", "--staged", "--", ...PHASE2_FILES], { cwd: root });
+        await writeFile(packageFile, originalPackageText, "utf8");
+        await writeFile(lockFile, originalLockText, "utf8");
+      } catch (rollbackError) {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}\n` +
+            `Additionally failed to roll back the Phase-2 manifest edits: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+        );
+      }
+    }
+    throw error;
+  }
+
+  state.phase = "phase2-complete";
+  state.timestamps = { ...(state.timestamps ?? {}), phase2CompletedAt: now() };
+  await writeState(root, state);
+  console.log(`Committed exact minutes-sdk ${version} pin for MCP.`);
+  printPhase3Instructions(version);
+}
+
+function printPhase3Instructions(version) {
+  console.log("\nNext, push the Phase-2 commit, wait for CI on that exact HEAD to pass, then run:");
+  console.log("  git push origin main");
+  console.log(`  node scripts/release.mjs tag ${version}`);
+}
+
+async function assertCiGreen(root, head, skipCiCheck) {
+  if (skipCiCheck) {
+    console.log("Skipping CI verification because --skip-ci-check was explicitly supplied.");
+    return;
+  }
+  let result;
+  try {
+    result = await exec(
+      "gh",
+      ["run", "list", "--commit", head, "--workflow", "CI", "--limit", "1", "--json", "status,conclusion,databaseId"],
+      { cwd: root },
+    );
+  } catch (error) {
+    throw new Error(
+      `could not verify CI with gh (${error instanceof Error ? error.message : String(error)}). ` +
+        "Install/authenticate gh, or rerun with --skip-ci-check only after manually verifying CI on this HEAD.",
+    );
+  }
+  let runs;
+  try {
+    runs = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("gh returned invalid JSON while checking CI; use --skip-ci-check only after manual verification");
+  }
+  if (!Array.isArray(runs) || runs.length === 0) {
+    throw new Error(`no CI run found for HEAD ${head}; wait for CI before tagging`);
+  }
+  if (runs[0].status !== "completed" || runs[0].conclusion !== "success") {
+    throw new Error(
+      `CI is not green for HEAD ${head} (status=${runs[0].status ?? "unknown"}, conclusion=${runs[0].conclusion ?? "unknown"})`,
+    );
+  }
+}
+
+async function ensureAnnotatedTag(root, version, head) {
+  const tag = `v${version}`;
+  try {
+    const { stdout } = await exec("git", ["rev-parse", "--verify", `${tag}^{commit}`], { cwd: root });
+    if (stdout.trim() !== head) {
+      throw new Error(`${tag} already exists at ${stdout.trim()}, not HEAD ${head}`);
+    }
+    const { stdout: typeOutput } = await exec("git", ["cat-file", "-t", `refs/tags/${tag}`], { cwd: root });
+    if (typeOutput.trim() !== "tag") {
+      throw new Error(`${tag} already exists at HEAD but is not an annotated tag`);
+    }
+    console.log(`${tag} already exists at HEAD; reusing it for this resumed release.`);
+  } catch (error) {
+    if (!(error instanceof CommandError)) throw error;
+    await exec("git", ["tag", "-a", tag, "-m", tag], { cwd: root });
+    console.log(`Created annotated tag ${tag}.`);
+  }
+  return tag;
+}
+
+async function tagRelease(root, version, skipCiCheck) {
+  const state = await readState(root);
+  requireStateVersion(state, version);
+  if (!["phase2-complete", "tag-complete"].includes(state.phase)) {
+    throw new Error(`phase2 is not complete for ${version} (current state: ${state.phase ?? "unknown"})`);
+  }
+  await verifySdkStateOnRegistry(state);
+
+  const head = await assertCleanAndPushed(root);
+  await assertCiGreen(root, head, skipCiCheck);
+  await runVersionCheck(root, true);
+  const sdkIntegrity = await packPackage(root, SDK_DIRECTORY);
+  if (sdkIntegrity !== state.sdkIntegrity) {
+    throw new Error(
+      `SDK provenance mismatch: npm pack from HEAD no longer reproduces phase1\n` +
+        `  phase1: ${state.sdkIntegrity}\n  HEAD:   ${sdkIntegrity}`,
+    );
+  }
+
+  // Build and pack MCP before creating the tag. npm publish has no MCP build
+  // lifecycle, so from the annotated tag onward every publish input is frozen.
+  const mcpPackage = await readJson(path.join(root, MCP_DIRECTORY, "package.json"));
+  const mcpIntegrity = await packPackage(root, MCP_DIRECTORY);
+
+  const tag = await ensureAnnotatedTag(root, version, head);
+  console.log(`Push it only after the draft GitHub release is ready:\n  git push origin ${tag}`);
+
+  await publishPackage(root, MCP_DIRECTORY, mcpPackage.name, version, mcpIntegrity);
+
+  state.phase = "tag-complete";
+  state.timestamps = { ...(state.timestamps ?? {}), tagCompletedAt: now() };
+  await writeState(root, state);
+  console.log(`\nRelease command flow complete for ${tag}. The local tag has not been pushed.`);
+}
+
+async function printStatus(root) {
+  const state = await readState(root);
+  if (state === null) {
+    console.log("no release in progress");
+    return;
+  }
+  console.log(`release ${state.version ?? "<unknown>"}: ${state.phase ?? "<unknown phase>"}`);
+  console.log(`sdk published: ${state.sdkPublished === true ? "yes" : "no"}`);
+  if (state.sdkIntegrity) console.log(`sdk integrity: ${state.sdkIntegrity}`);
+  if (state.timestamps && typeof state.timestamps === "object") {
+    for (const [name, value] of Object.entries(state.timestamps)) console.log(`${name}: ${value}`);
+  }
+}
+
+let options;
+try {
+  options = parseArgs(process.argv.slice(2));
+  const root = await repositoryRoot();
+  if (options.command === "status") await printStatus(root);
+  else if (options.command === "phase1") await phase1(root, options.version);
+  else if (options.command === "phase2") await phase2(root, options.version);
+  else await tagRelease(root, options.version, options.skipCiCheck);
+} catch (error) {
+  console.error(`release: ${error instanceof Error ? error.message : String(error)}`);
+  if (
+    options === undefined ||
+    (error instanceof Error && /^(?:a subcommand|a version|invalid version|unknown subcommand|unknown option|unexpected argument|--|status does not)/.test(error.message))
+  ) {
+    console.error(usage());
+    process.exitCode = 2;
+  } else {
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,374 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { existsSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const scriptsDirectory = path.dirname(process.argv[1]);
+const releaseScript = path.resolve(scriptsDirectory, "release.mjs");
+const version = "1.2.3";
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8", ...options });
+  assert.equal(result.error, undefined, result.error?.message);
+  return result;
+}
+
+function git(root, ...args) {
+  return run("git", args, { cwd: root });
+}
+
+async function writeFixture(root, file, contents) {
+  const destination = path.join(root, file);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, contents);
+}
+
+async function writeJson(root, file, value) {
+  await writeFixture(root, file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function packageBytes(name, packageVersion, variant = "original") {
+  return Buffer.from(`${name}:${packageVersion}:${variant}\n`);
+}
+
+function integrityFor(name, packageVersion, variant = "original") {
+  return `sha512-${createHash("sha512").update(packageBytes(name, packageVersion, variant)).digest("base64")}`;
+}
+
+async function installToolShims(root) {
+  const tools = path.join(root, ".release-tools");
+  await mkdir(tools, { recursive: true });
+
+  await writeFixture(
+    tools,
+    "git",
+    `#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+const result = spawnSync(process.env.RELEASE_REAL_GIT, process.argv.slice(2), { stdio: "inherit" });
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);
+`,
+  );
+  await writeFixture(
+    tools,
+    "npm",
+    `#!/usr/bin/env node
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+const args = process.argv.slice(2);
+await appendFile(process.env.RELEASE_SHIM_LOG, "npm " + args.join(" ") + " @ " + process.cwd() + "\\n");
+const packageJson = JSON.parse(await readFile(path.join(process.cwd(), "package.json"), "utf8"));
+if (args[0] === "pack") {
+  const destination = args[args.indexOf("--pack-destination") + 1];
+  await mkdir(destination, { recursive: true });
+  const variant = packageJson.name === "minutes-sdk"
+    ? (process.env.RELEASE_SHIM_SDK_VARIANT || "original")
+    : (process.env.RELEASE_SHIM_MCP_VARIANT || "original");
+  const filename = packageJson.name + "-" + packageJson.version + ".tgz";
+  await writeFile(path.join(destination, filename), packageJson.name + ":" + packageJson.version + ":" + variant + "\\n");
+  console.log(JSON.stringify([{ filename }]));
+} else if (args[0] === "publish") {
+  await writeFile(path.join(process.env.RELEASE_SHIM_MARKERS, "published-" + packageJson.name), "yes\\n");
+} else if (args[0] === "install" && args.includes("--package-lock-only")) {
+  const lockFile = path.join(process.cwd(), "package-lock.json");
+  const lock = JSON.parse(await readFile(lockFile, "utf8"));
+  lock.packages[""].dependencies["minutes-sdk"] = packageJson.dependencies["minutes-sdk"];
+  await writeFile(lockFile, JSON.stringify(lock, null, 2) + "\\n");
+}
+`,
+  );
+  await writeFixture(
+    tools,
+    "npx",
+    `#!/usr/bin/env node
+import { appendFile } from "node:fs/promises";
+await appendFile(process.env.RELEASE_SHIM_LOG, "npx " + process.argv.slice(2).join(" ") + " @ " + process.cwd() + "\\n");
+`,
+  );
+  await writeFixture(
+    tools,
+    "gh",
+    `#!/usr/bin/env node
+if (process.env.RELEASE_SHIM_GH_FAIL === "1") {
+  console.error("simulated gh failure");
+  process.exit(42);
+}
+console.log(JSON.stringify([{
+  status: process.env.RELEASE_SHIM_CI_STATUS || "completed",
+  conclusion: process.env.RELEASE_SHIM_CI_CONCLUSION || "success",
+  databaseId: 123
+}]));
+`,
+  );
+
+  for (const tool of ["git", "npm", "npx", "gh"]) await chmod(path.join(tools, tool), 0o755);
+  return tools;
+}
+
+async function startRegistry(t, root, config) {
+  const markers = path.join(root, ".release-markers");
+  await mkdir(markers, { recursive: true });
+  const server = http.createServer((request, response) => {
+    const segments = new URL(request.url, "http://fixture.invalid").pathname
+      .split("/")
+      .filter(Boolean)
+      .map(decodeURIComponent);
+    const packageName = segments[0];
+    const packageVersion = segments[1];
+    if (!packageName || packageVersion !== version) {
+      response.writeHead(404).end(JSON.stringify({ error: "not found" }));
+      return;
+    }
+
+    const sequence = config.sequences?.[packageName];
+    if (sequence?.length) {
+      const status = sequence.shift();
+      if (status !== 200) {
+        response.writeHead(status).end(JSON.stringify({ error: `fixture ${status}` }));
+        return;
+      }
+    }
+
+    let packageIntegrity = config.integrities?.[packageName];
+    if (packageIntegrity === undefined && existsSync(path.join(markers, `published-${packageName}`))) {
+      const remainingLag = config.visibilityLag?.[packageName] ?? 0;
+      if (remainingLag > 0) {
+        config.visibilityLag[packageName] = remainingLag - 1;
+        response.writeHead(404).end(JSON.stringify({ error: "not visible yet" }));
+        return;
+      }
+      packageIntegrity = config.expected[packageName];
+    }
+    if (packageIntegrity === undefined) {
+      response.writeHead(404).end(JSON.stringify({ error: "not found" }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ name: packageName, version, dist: { integrity: packageIntegrity } }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const address = server.address();
+  return { markers, url: `http://127.0.0.1:${address.port}/` };
+}
+
+async function makeRepo(t, registryConfig = {}) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minutes-release-fixture-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const remote = `${root}-remote.git`;
+  t.after(() => rm(remote, { recursive: true, force: true }));
+
+  await writeFixture(
+    root,
+    ".gitignore",
+    "/.minutes-release-state.json\n/.release-tools/\n/.release-markers/\n/.release-shim.log\n",
+  );
+  await writeJson(root, "crates/sdk/package.json", { name: "minutes-sdk", version });
+  await writeJson(root, "crates/mcp/package.json", {
+    name: "minutes-mcp",
+    version,
+    dependencies: { "minutes-sdk": "^1.0.0" },
+  });
+  await writeJson(root, "crates/mcp/package-lock.json", {
+    name: "minutes-mcp",
+    version,
+    lockfileVersion: 3,
+    packages: {
+      "": { name: "minutes-mcp", version, dependencies: { "minutes-sdk": "^1.0.0" } },
+    },
+  });
+  await writeFixture(
+    root,
+    "scripts/check_version_sync.mjs",
+    `import { readFile } from "node:fs/promises";
+if (process.argv.includes("--release") && process.env.RELEASE_CHECK_FAIL === "release") {
+  console.error("simulated --release policy failure");
+  process.exit(1);
+}
+if (process.argv.includes("--release")) {
+  const sdk = JSON.parse(await readFile("crates/sdk/package.json", "utf8"));
+  const mcp = JSON.parse(await readFile("crates/mcp/package.json", "utf8"));
+  if (mcp.dependencies["minutes-sdk"] !== sdk.version) process.exit(1);
+}
+console.log("Version sync check passed.");
+`,
+  );
+  await writeFixture(root, "extra.txt", "original\n");
+
+  assert.equal(git(root, "init", "-q", "-b", "main").status, 0);
+  assert.equal(git(root, "config", "user.email", "fixture@example.com").status, 0);
+  assert.equal(git(root, "config", "user.name", "Fixture Test").status, 0);
+  assert.equal(git(root, "add", ".").status, 0);
+  assert.equal(git(root, "commit", "-qm", "fixture").status, 0);
+  assert.equal(run("git", ["init", "--bare", "-q", remote]).status, 0);
+  assert.equal(git(root, "remote", "add", "origin", remote).status, 0);
+  assert.equal(git(root, "push", "-qu", "origin", "main").status, 0);
+
+  const tools = await installToolShims(root);
+  const log = path.join(root, ".release-shim.log");
+  await writeFile(log, "");
+  const expected = {
+    "minutes-sdk": integrityFor("minutes-sdk", version),
+    "minutes-mcp": integrityFor("minutes-mcp", version),
+  };
+  const config = {
+    expected,
+    integrities: {},
+    visibilityLag: {},
+    ...registryConfig,
+  };
+  config.expected = { ...expected, ...(registryConfig.expected ?? {}) };
+  config.integrities = { ...(registryConfig.integrities ?? {}) };
+  config.visibilityLag = { ...(registryConfig.visibilityLag ?? {}) };
+  const registry = await startRegistry(t, root, config);
+  return { root, tools, log, config, registry };
+}
+
+function runRelease(fixture, args, extraEnvironment = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [releaseScript, ...args], {
+      cwd: fixture.root,
+      env: {
+      ...process.env,
+      RELEASE_TOOL_PATH: fixture.tools,
+      RELEASE_REAL_GIT: run("which", ["git"]).stdout.trim(),
+      RELEASE_REGISTRY_URL: fixture.registry.url,
+      RELEASE_POLL_DELAYS_MS: "1,1,1",
+      RELEASE_SHIM_LOG: fixture.log,
+      RELEASE_SHIM_MARKERS: fixture.registry.markers,
+      ...extraEnvironment,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (status, signal) => resolve({ status, signal, stdout, stderr }));
+  });
+}
+
+function assertSucceeded(result) {
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+async function completePhase1(fixture, extraEnvironment = {}) {
+  const result = await runRelease(fixture, ["phase1", version], extraEnvironment);
+  assertSucceeded(result);
+  return result;
+}
+
+async function completePhase2(fixture) {
+  const result = await runRelease(fixture, ["phase2", version]);
+  assertSucceeded(result);
+  return result;
+}
+
+test("happy path completes phase1, phase2, and tag with resumable state", async (t) => {
+  const fixture = await makeRepo(t);
+  const phase1 = await completePhase1(fixture);
+  assert.match(phase1.stdout, /Phase 1 complete/);
+  const phase2 = await completePhase2(fixture);
+  assert.match(phase2.stdout, /Committed exact minutes-sdk 1\.2\.3 pin/);
+  assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
+
+  const phase3 = await runRelease(fixture, ["tag", version]);
+  assertSucceeded(phase3);
+  assert.match(phase3.stdout, /Created annotated tag v1\.2\.3/);
+  assert.match(phase3.stdout, /git push origin v1\.2\.3/);
+  assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), `v${version}`);
+
+  const mcpPackage = JSON.parse(await readFile(path.join(fixture.root, "crates/mcp/package.json"), "utf8"));
+  assert.equal(mcpPackage.dependencies["minutes-sdk"], version);
+  const state = JSON.parse(await readFile(path.join(fixture.root, ".minutes-release-state.json"), "utf8"));
+  assert.equal(state.phase, "tag-complete");
+  assert.equal(state.sdkPublished, true);
+  assert.equal(state.sdkIntegrity, integrityFor("minutes-sdk", version));
+  const log = await readFile(fixture.log, "utf8");
+  assert.match(log, /npm publish .*crates\/sdk/);
+  assert.match(log, /npm publish .*crates\/mcp/);
+});
+
+test("phase1 polls through registry 404 responses until the SDK is visible", async (t) => {
+  const fixture = await makeRepo(t, { visibilityLag: { "minutes-sdk": 2 } });
+  const result = await completePhase1(fixture);
+  assert.match(result.stdout, /404 \(not visible yet\)/);
+  assert.match(result.stdout, /Registry confirms minutes-sdk@1\.2\.3/);
+});
+
+test("phase1 polling timeout fails with the npm lag-pattern explanation", async (t) => {
+  const fixture = await makeRepo(t, { visibilityLag: { "minutes-sdk": 99 } });
+  const result = await runRelease(fixture, ["phase1", version], { RELEASE_POLL_DELAYS_MS: "1,1" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /registry lag pattern/);
+  const state = JSON.parse(await readFile(path.join(fixture.root, ".minutes-release-state.json"), "utf8"));
+  assert.equal(state.sdkPublished, true);
+  assert.equal(state.phase, "phase1-started");
+});
+
+test("phase1 skips an existing SDK version with matching integrity", async (t) => {
+  const fixture = await makeRepo(t, {
+    integrities: { "minutes-sdk": integrityFor("minutes-sdk", version) },
+  });
+  const result = await completePhase1(fixture);
+  assert.match(result.stdout, /already published with matching integrity; skipping npm publish/);
+  const log = await readFile(fixture.log, "utf8");
+  assert.doesNotMatch(log, /npm publish/);
+});
+
+test("phase1 aborts when an existing SDK version has different integrity", async (t) => {
+  const fixture = await makeRepo(t, {
+    integrities: { "minutes-sdk": "sha512-not-the-local-package" },
+  });
+  const result = await runRelease(fixture, ["phase1", version]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /already exists with different integrity/);
+  assert.match(result.stderr, /Refusing to replace published provenance/);
+});
+
+test("phase2 diff restriction aborts when another tracked file is dirty", async (t) => {
+  const fixture = await makeRepo(t);
+  await completePhase1(fixture);
+  await writeFile(path.join(fixture.root, "extra.txt"), "modified\n");
+  const result = await runRelease(fixture, ["phase2", version]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /phase2 diff restriction failed/);
+  assert.match(result.stderr, /extra\.txt/);
+});
+
+test("tag aborts when SDK tarball provenance no longer matches phase1", async (t) => {
+  const fixture = await makeRepo(t);
+  await completePhase1(fixture);
+  await completePhase2(fixture);
+  assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
+  const result = await runRelease(fixture, ["tag", version], { RELEASE_SHIM_SDK_VARIANT: "changed" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /SDK provenance mismatch/);
+  assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), "");
+});
+
+test("tag aborts when the --release version policy check fails", async (t) => {
+  const fixture = await makeRepo(t);
+  await completePhase1(fixture);
+  await completePhase2(fixture);
+  assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
+  const result = await runRelease(fixture, ["tag", version], { RELEASE_CHECK_FAIL: "release" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /simulated --release policy failure/);
+  assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), "");
+});


### PR DESCRIPTION
## What

Kills the sdk npm publish-lag class mechanically (it recurred twice; commit 2878442 literally says "matches the lag pattern from v0.19.0").

`scripts/release.mjs`, three subcommands with a resumable state file:
1. **phase1** — from a green pushed release commit: `npm pack` the sdk, install the tarball into mcp and build+test against it, publish the sdk, poll the registry for the exact version (backoff; 404-not-yet vs 5xx distinguished; timeout cites the lag pattern).
2. **phase2** — commit **only** the exact `minutes-sdk` pin + regenerated mcp lockfile (diff-restriction asserted; anything else aborts).
3. **tag** — requires CI green, `check_version_sync.mjs --release` passing (forbids tagging transitional state), and sdk **provenance**: packing the sdk from the tag must reproduce the published tarball integrity. Then publishes mcp. Publishes are idempotent (already-published detection); sdk-published/mcp-failed is an explicit resumable state.

Plus: every tag-triggered workflow (`release-cli`, `release-macos`, `release-windows-desktop`) gains a `release_readiness` job that artifact jobs `need` — a manual tag on a bad tree publishes zero artifacts. procedure.md rewritten around the three commands.

8 fixture tests via tool/registry shims: poll retry/timeout, integrity mismatch abort, phase2 diff restriction, resume-from-partial.

Part of the agent-infra hardening epic (bead `minutes-4a9r`, PR-C2). Plan reviewed adversarially by codex to SHIP 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)