### PR TITLE
feat(skills): release-notes + seo-wave workflow skills

### DIFF
--- a/.agents/skills/minutes/minutes-release-notes/SKILL.md
+++ b/.agents/skills/minutes/minutes-release-notes/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: minutes-release-notes
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+---
+
+# /minutes-release-notes
+
+Draft release notes that explain why a Minutes release matters without making users decode the commit history. Produce a draft only. Do not create, edit, or publish a GitHub release unless the user explicitly asks.
+
+## Inputs
+
+Collect:
+
+- the new version, such as `v0.22.0`
+- the previous stable tag, or an explicit starting ref
+- the target ref, normally `HEAD`
+- the release channel, normally stable or preview
+- any known breaking changes, migrations, compatibility notes, or contributor credits
+
+Resolve missing refs from the repository instead of guessing:
+
+```bash
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+```
+
+When `HEAD` is already tagged, resolve the previous tag from its parent so the range does not collapse to zero commits:
+
+```bash
+git describe --tags --abbrev=0 HEAD^
+```
+
+Confirm both refs with `git rev-parse --verify` before drafting. If the version or range is ambiguous, ask one short question.
+
+## Steps
+
+### 1. Learn the current release voice
+
+Read two or three recent stable releases before writing:
+
+```bash
+gh release list --limit 5
+gh release view <recent-tag>
+```
+
+Match the current heading hierarchy, amount of detail, install wording, contributor treatment, and overall tone. Prefer concrete user outcomes, honest limitations, and short technical explanations. Do not copy stale version-specific claims.
+
+Never use em dashes in the draft. Rewrite with commas, colons, parentheses, or separate sentences. This is a repository release convention, not an optional style preference.
+
+### 2. Build the change ledger
+
+Read the full range and inspect touched files when a subject is unclear:
+
+```bash
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+git diff --stat <previous-tag>..HEAD
+git show --stat <commit>
+```
+
+Classify every relevant commit by conventional prefix:
+
+- `feat` -> **Features**
+- `fix` -> **Fixes**
+- `perf` -> **Performance**
+- `docs`, `chore`, `build`, `ci`, `test`, and uncategorized maintenance -> **Docs / Chore rollup**
+
+Treat merge commits and follow-up fixes as part of the user-visible change they complete. Deduplicate stacked or backported commits. Use file inspection to verify the affected surface: desktop, CLI, MCP and agent integrations, site, plugin, SDK, or shared engine.
+
+Drop internal-only version bumps, lockfile syncs, generated-file refreshes, formatting, test-only changes, CI churn, and release bookkeeping unless they change installation, compatibility, reliability, security, or another user-visible behavior. Do not inflate the notes with one bullet per commit.
+
+### 3. Turn the ledger into release prose
+
+Lead with one or two sentences that state why the release exists. Convert the strongest Features and Performance items into outcome-led headline sections. Roll smaller items into **Fixes**. Include Docs / Chore items only when users must act on them or will notice the result.
+
+For each claim:
+
+- say what changed and who benefits
+- distinguish defaults from opt-in or experimental behavior
+- name affected platforms when behavior differs
+- preserve important limitations and fallback behavior
+- link issue or pull request numbers when the history supports them
+- credit external contributors by verified GitHub handle
+
+Do not infer a breaking change, migration, benchmark, security property, compatibility promise, or contributor from the subject line alone. Verify it in the diff, release procedure, or repository documentation.
+
+### 4. Check release integrity
+
+Run the repository version check after the release version has been applied:
+
+```bash
+node scripts/check_version_sync.mjs --release
+```
+
+If the check fails because the requested version has not been bumped yet, report that clearly. Do not change versions as part of drafting notes unless the user asked for release preparation too.
+
+Search the range for configuration, storage, schema, feature-default, platform-support, and install-path changes. State either the required migration or that no migration is required. Never leave breaking-change status implicit.
+
+## Output format
+
+Follow the closest of the recent releases inspected in step 1. Use this current Minutes layout when those releases do not establish a more specific pattern:
+
+```markdown
+## Minutes vX.Y.Z
+
+<One short paragraph explaining why this release matters.>
+
+### <Feature or outcome headline>
+<User-facing explanation, with bullets only when they improve scanning.>
+
+### <Additional feature or performance headline, if needed>
+<User-facing explanation.>
+
+### Fixes
+- <Grouped, concrete fix>
+
+### Notes
+<Breaking change, migration, compatibility, preview, or known-issue note. Say "No migration is required" when that is the verified result.>
+
+## Install / update
+
+The desktop app updates itself: open Minutes and it pulls vX.Y.Z on next launch, or grab the DMG from the assets below.
+
+- **DMG**: download from the release assets below
+- **CLI**: `brew install silverstein/tap/minutes` or `cargo install minutes-cli`
+- **MCP**: `npx minutes-mcp` (or update the Claude Desktop extension)
+
+## Claude Code plugin
+<Include only when the plugin changed. Use the refresh commands and wording from a recent release.>
+
+---
+<Use the current release-preparation credit and contributor block only when recent releases include them and the credits are verified.>
+```
+
+Keep the install block wording and order exact unless the repository's current distribution paths changed. Omit empty feature sections, but never omit the install block or breaking-change and migration status.
+
+## Checklist
+
+Before returning the draft, verify:
+
+- [ ] The previous tag, target ref, and new version are explicit.
+- [ ] Every user-facing claim is supported by the range or repository documentation.
+- [ ] Features, Fixes, Performance, and Docs / Chore commits were classified before rollup.
+- [ ] Internal-only version bumps, lockfiles, generated syncs, and CI churn were dropped.
+- [ ] The prose matches two or three recent releases and contains no em dash characters.
+- [ ] Breaking changes, migrations, compatibility notes, preview status, and known issues are explicit.
+- [ ] `node scripts/check_version_sync.mjs --release` passes, or its version-bump blocker is reported.
+- [ ] The standard DMG, CLI, and MCP download block is present and current.
+- [ ] Plugin update instructions appear only if the plugin changed.
+- [ ] Contributor handles and issue or pull request references are verified.
+
+

--- a/.agents/skills/minutes/minutes-release-notes/agents/openai.yaml
+++ b/.agents/skills/minutes/minutes-release-notes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Minutes Release Notes"
+  short_description: "Turn a version's commit range into polished, release-ready Minutes notes."
+  default_prompt: "Draft release notes for the requested Minutes version from the real commit range and current release conventions."

--- a/.agents/skills/minutes/minutes-seo-wave/SKILL.md
+++ b/.agents/skills/minutes/minutes-seo-wave/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: minutes-seo-wave
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+---
+
+# /minutes-seo-wave
+
+Produce one coherent SEO content wave, not a pile of disconnected pages. Keep the method reusable across comparison pages, use-case or resource pages, and docs hubs.
+
+Competitive research and keyword specifics are time-sensitive. Research them fresh for each wave. Internal competitive plans may exist in gitignored documentation; never invent, reconstruct, or embed those private specifics in this skill or in repository documentation.
+
+## Inputs
+
+Collect:
+
+- the wave theme, such as comparison pages, use-case pages, a resource cluster, or a docs hub
+- target keywords and search intents
+- the intended audience and conversion action
+- the requested number of pages or the time box
+- existing pages and drafts that must not be duplicated
+- any supplied first-party research, approved claims, and source requirements
+
+If theme or keywords are missing, inspect the repository and ask only for the choice that materially changes the wave. Do not invent search volume, keyword difficulty, competitor capabilities, pricing, compliance status, or product claims.
+
+## Steps
+
+### 1. Inventory the existing site
+
+Map the current routes before proposing slugs or outlines:
+
+```bash
+rg --files site/app | rg '/page\.tsx$'
+rg --files site/public | rg '\.md$'
+sed -n '1,240p' site/app/sitemap.ts
+```
+
+Inspect relevant hubs, shared page components, adjacent pages, metadata, structured data, and markdown twins. Record pages that already satisfy the target intent, pages that should be refreshed instead of duplicated, and genuine content gaps.
+
+### 2. Perform SERP recon
+
+Research each target query with current search results. Identify:
+
+- dominant intent: comparison, informational, transactional, navigational, or mixed
+- recurring page formats and questions
+- weak, stale, or unsupported answers the wave can improve
+- primary sources required to support factual claims
+- a distinct, truthful angle Minutes can substantiate
+
+For competitor, legal, compliance, security, pricing, or product-capability claims, use current primary or official sources and record the review date. Treat search snippets and third-party summaries as discovery aids, not final evidence. For claims about Minutes, verify the current repository implementation and documentation.
+
+Do not copy competitor framing or manufacture a claim because it would make a stronger headline. Give alternatives credit where they are better. Add appropriate not-legal-advice or scope language to regulated-topic pages.
+
+### 3. Outline the wave page by page
+
+For every proposed page, specify:
+
+- route and primary keyword
+- search intent and direct answer
+- unique promise and evidence plan
+- title, description, and social metadata
+- section outline, including honest limitations or "when the alternative wins" where relevant
+- structured data only when the visible page content supports it
+- internal links in and out
+- conversion action
+- required hub, sitemap, and markdown-twin updates
+
+Use extractable structures when they serve the query: a direct answer near the top, clear headings, comparison tables, concise lists, and visible FAQs that match any FAQ schema. Avoid near-duplicate pages that merely swap a product name or keyword.
+
+### 4. Implement within `DESIGN.md`
+
+Read `DESIGN.md` and reuse established site components and nearby page patterns. Preserve the Minutes type system: Instrument Serif for display headings, Geist for body and UI, and Geist Mono for labels, evidence, and technical material.
+
+Use the repository's semantic design tokens and established utilities, including `var(--bg)`, `var(--text)`, `var(--accent)`, `font-serif`, `font-sans`, and `font-mono`. Do not introduce raw color values, ad hoc font families, off-scale spacing, gradients, glows, decorative motion, or new arbitrary literals. The design-token CI gate treats new raw literals as failures.
+
+Keep the page useful without JavaScript when practical, keyboard accessible, responsive, and consistent in light and dark modes. Metadata and structured data must describe what the rendered page actually says.
+
+### 5. Run an evidence and honesty pass
+
+Fact-check every time-sensitive or consequential statement against its recorded source. Then compare Minutes claims against code and first-party documentation. Look especially for absolute language such as "never," "always," "nothing leaves," "compliant," "offline," or "free forever" that may need a precise boundary.
+
+Check dates, plan names, pricing cadence, beta status, platform availability, default versus opt-in behavior, storage and network paths, and legal or compliance qualifiers. Remove a claim when it cannot be verified.
+
+### 6. Complete the internal-linking pass
+
+Connect the wave as a cluster:
+
+- link each page to its relevant hub, pillar, sibling pages, and product or quick-start action
+- add the new pages to the appropriate compare, resource, writing, or docs hub
+- add contextual links from existing authoritative pages when useful
+- update `site/app/sitemap.ts`
+- add or update the corresponding `site/public/**/*.md` page when the site pattern requires a markdown twin
+- verify there are no orphan pages or circular trails with no useful destination
+
+Use descriptive anchor text. Do not stuff exact-match keywords into every link.
+
+### 7. Regenerate and validate generated surfaces
+
+After page and inventory changes, regenerate the LLM-facing site text:
+
+```bash
+node scripts/generate_llms_txt.mjs
+node scripts/generate_llms_txt.mjs --check
+```
+
+Run the relevant site tests, type checks, and repository gates for the touched files. At minimum, run the design-token check when site UI changed:
+
+```bash
+node scripts/check_design_tokens.mjs
+```
+
+Do not hand-edit generated `llms.txt` files. Fix their source or generator input and regenerate.
+
+## Output format
+
+Return a page checklist followed by the shipped-wave retro. Keep routes, keywords, evidence, integrations, and validation visible:
+
+```markdown
+## Wave: <theme>
+
+### Page checklist
+
+- [ ] `/route-one` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+- [ ] `/route-two` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+
+### Wave checklist
+
+- [ ] Existing `site/app/` and `site/public/` inventory checked for overlap.
+- [ ] SERP intent and primary evidence recorded with a review date.
+- [ ] `DESIGN.md`, accessibility, metadata, and structured-data constraints met.
+- [ ] Hub, sibling, pillar, conversion, sitemap, and markdown-twin links complete.
+- [ ] LLM text regenerated and repository checks pass.
+
+## Shipped-wave retro
+
+- **Scope shipped:** <routes and page types>
+- **Why this wave:** <shared intent and evidence-backed opportunity>
+- **Evidence and honesty review:** <sources checked, claims corrected or dropped, review date>
+- **Site integration:** <hubs, internal links, sitemap, markdown twins, generated LLM text>
+- **Validation:** <commands and results>
+- **Follow-up:** <measurement or unresolved work, without inventing rankings or traffic>
+```
+
+Mark items complete only when the repository contains the work and the validation ran. The retro should follow the #435 through #438 pattern: summarize the shipped routes, the research basis, the integration work, the adversarial or honesty review, and concrete corrections. Do not claim ranking, traffic, or conversion impact before measurement exists.
+
+## Checklist
+
+Before calling the wave complete, verify:
+
+- [ ] The theme, keywords, audience, conversion action, and wave size are explicit.
+- [ ] Existing `site/app/` routes, hubs, sitemap entries, and markdown twins were inventoried.
+- [ ] Each page answers a distinct search intent and avoids thin keyword substitution.
+- [ ] Current primary sources support competitor and high-stakes claims.
+- [ ] Minutes claims match current code and first-party documentation.
+- [ ] `DESIGN.md` tokens and fonts are reused with no new raw design literals.
+- [ ] Metadata, structured data, accessibility, responsive behavior, and light and dark modes were checked.
+- [ ] Internal links connect every page to a hub, relevant siblings, a pillar, and a useful conversion action.
+- [ ] `site/app/sitemap.ts` and required `site/public/**/*.md` twins are updated.
+- [ ] `node scripts/generate_llms_txt.mjs --check` passes after regeneration.
+- [ ] Relevant site checks and `node scripts/check_design_tokens.mjs` pass.
+- [ ] The shipped-wave retro records scope, evidence, integrations, corrections, validation, and follow-up without invented outcomes.
+
+

--- a/.agents/skills/minutes/minutes-seo-wave/agents/openai.yaml
+++ b/.agents/skills/minutes/minutes-seo-wave/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Minutes SEO Wave"
+  short_description: "Ship a researched, internally linked SEO page wave without duplicating or overstating claims."
+  default_prompt: "Build one evidence-backed SEO content wave for Minutes and return the page checklist plus shipped-wave retro."

--- a/.claude/plugins/minutes/plugin.json
+++ b/.claude/plugins/minutes/plugin.json
@@ -23,7 +23,9 @@
     { "name": "minutes-graph", "path": "skills/minutes-graph/SKILL.md" },
     { "name": "minutes-video-review", "path": "skills/minutes-video-review/SKILL.md" },
     { "name": "minutes-copilot", "path": "skills/minutes-copilot/SKILL.md" },
-    { "name": "minutes-live-sidekick", "path": "skills/minutes-live-sidekick/SKILL.md" }
+    { "name": "minutes-live-sidekick", "path": "skills/minutes-live-sidekick/SKILL.md" },
+    { "name": "minutes-release-notes", "path": "skills/minutes-release-notes/SKILL.md" },
+    { "name": "minutes-seo-wave", "path": "skills/minutes-seo-wave/SKILL.md" }
   ],
   "agents": [
     { "name": "meeting-analyst", "path": "agents/meeting-analyst.md" }

--- a/.claude/plugins/minutes/skills/minutes-release-notes/SKILL.md
+++ b/.claude/plugins/minutes/skills/minutes-release-notes/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: minutes-release-notes
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+user_invocable: true
+---
+
+# /minutes-release-notes
+
+Draft release notes that explain why a Minutes release matters without making users decode the commit history. Produce a draft only. Do not create, edit, or publish a GitHub release unless the user explicitly asks.
+
+## Inputs
+
+Collect:
+
+- the new version, such as `v0.22.0`
+- the previous stable tag, or an explicit starting ref
+- the target ref, normally `HEAD`
+- the release channel, normally stable or preview
+- any known breaking changes, migrations, compatibility notes, or contributor credits
+
+Resolve missing refs from the repository instead of guessing:
+
+```bash
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+```
+
+When `HEAD` is already tagged, resolve the previous tag from its parent so the range does not collapse to zero commits:
+
+```bash
+git describe --tags --abbrev=0 HEAD^
+```
+
+Confirm both refs with `git rev-parse --verify` before drafting. If the version or range is ambiguous, ask one short question.
+
+## Steps
+
+### 1. Learn the current release voice
+
+Read two or three recent stable releases before writing:
+
+```bash
+gh release list --limit 5
+gh release view <recent-tag>
+```
+
+Match the current heading hierarchy, amount of detail, install wording, contributor treatment, and overall tone. Prefer concrete user outcomes, honest limitations, and short technical explanations. Do not copy stale version-specific claims.
+
+Never use em dashes in the draft. Rewrite with commas, colons, parentheses, or separate sentences. This is a repository release convention, not an optional style preference.
+
+### 2. Build the change ledger
+
+Read the full range and inspect touched files when a subject is unclear:
+
+```bash
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+git diff --stat <previous-tag>..HEAD
+git show --stat <commit>
+```
+
+Classify every relevant commit by conventional prefix:
+
+- `feat` -> **Features**
+- `fix` -> **Fixes**
+- `perf` -> **Performance**
+- `docs`, `chore`, `build`, `ci`, `test`, and uncategorized maintenance -> **Docs / Chore rollup**
+
+Treat merge commits and follow-up fixes as part of the user-visible change they complete. Deduplicate stacked or backported commits. Use file inspection to verify the affected surface: desktop, CLI, MCP and agent integrations, site, plugin, SDK, or shared engine.
+
+Drop internal-only version bumps, lockfile syncs, generated-file refreshes, formatting, test-only changes, CI churn, and release bookkeeping unless they change installation, compatibility, reliability, security, or another user-visible behavior. Do not inflate the notes with one bullet per commit.
+
+### 3. Turn the ledger into release prose
+
+Lead with one or two sentences that state why the release exists. Convert the strongest Features and Performance items into outcome-led headline sections. Roll smaller items into **Fixes**. Include Docs / Chore items only when users must act on them or will notice the result.
+
+For each claim:
+
+- say what changed and who benefits
+- distinguish defaults from opt-in or experimental behavior
+- name affected platforms when behavior differs
+- preserve important limitations and fallback behavior
+- link issue or pull request numbers when the history supports them
+- credit external contributors by verified GitHub handle
+
+Do not infer a breaking change, migration, benchmark, security property, compatibility promise, or contributor from the subject line alone. Verify it in the diff, release procedure, or repository documentation.
+
+### 4. Check release integrity
+
+Run the repository version check after the release version has been applied:
+
+```bash
+node scripts/check_version_sync.mjs --release
+```
+
+If the check fails because the requested version has not been bumped yet, report that clearly. Do not change versions as part of drafting notes unless the user asked for release preparation too.
+
+Search the range for configuration, storage, schema, feature-default, platform-support, and install-path changes. State either the required migration or that no migration is required. Never leave breaking-change status implicit.
+
+## Output format
+
+Follow the closest of the recent releases inspected in step 1. Use this current Minutes layout when those releases do not establish a more specific pattern:
+
+```markdown
+## Minutes vX.Y.Z
+
+<One short paragraph explaining why this release matters.>
+
+### <Feature or outcome headline>
+<User-facing explanation, with bullets only when they improve scanning.>
+
+### <Additional feature or performance headline, if needed>
+<User-facing explanation.>
+
+### Fixes
+- <Grouped, concrete fix>
+
+### Notes
+<Breaking change, migration, compatibility, preview, or known-issue note. Say "No migration is required" when that is the verified result.>
+
+## Install / update
+
+The desktop app updates itself: open Minutes and it pulls vX.Y.Z on next launch, or grab the DMG from the assets below.
+
+- **DMG**: download from the release assets below
+- **CLI**: `brew install silverstein/tap/minutes` or `cargo install minutes-cli`
+- **MCP**: `npx minutes-mcp` (or update the Claude Desktop extension)
+
+## Claude Code plugin
+<Include only when the plugin changed. Use the refresh commands and wording from a recent release.>
+
+---
+<Use the current release-preparation credit and contributor block only when recent releases include them and the credits are verified.>
+```
+
+Keep the install block wording and order exact unless the repository's current distribution paths changed. Omit empty feature sections, but never omit the install block or breaking-change and migration status.
+
+## Checklist
+
+Before returning the draft, verify:
+
+- [ ] The previous tag, target ref, and new version are explicit.
+- [ ] Every user-facing claim is supported by the range or repository documentation.
+- [ ] Features, Fixes, Performance, and Docs / Chore commits were classified before rollup.
+- [ ] Internal-only version bumps, lockfiles, generated syncs, and CI churn were dropped.
+- [ ] The prose matches two or three recent releases and contains no em dash characters.
+- [ ] Breaking changes, migrations, compatibility notes, preview status, and known issues are explicit.
+- [ ] `node scripts/check_version_sync.mjs --release` passes, or its version-bump blocker is reported.
+- [ ] The standard DMG, CLI, and MCP download block is present and current.
+- [ ] Plugin update instructions appear only if the plugin changed.
+- [ ] Contributor handles and issue or pull request references are verified.
+
+

--- a/.claude/plugins/minutes/skills/minutes-seo-wave/SKILL.md
+++ b/.claude/plugins/minutes/skills/minutes-seo-wave/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: minutes-seo-wave
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+user_invocable: true
+---
+
+# /minutes-seo-wave
+
+Produce one coherent SEO content wave, not a pile of disconnected pages. Keep the method reusable across comparison pages, use-case or resource pages, and docs hubs.
+
+Competitive research and keyword specifics are time-sensitive. Research them fresh for each wave. Internal competitive plans may exist in gitignored documentation; never invent, reconstruct, or embed those private specifics in this skill or in repository documentation.
+
+## Inputs
+
+Collect:
+
+- the wave theme, such as comparison pages, use-case pages, a resource cluster, or a docs hub
+- target keywords and search intents
+- the intended audience and conversion action
+- the requested number of pages or the time box
+- existing pages and drafts that must not be duplicated
+- any supplied first-party research, approved claims, and source requirements
+
+If theme or keywords are missing, inspect the repository and ask only for the choice that materially changes the wave. Do not invent search volume, keyword difficulty, competitor capabilities, pricing, compliance status, or product claims.
+
+## Steps
+
+### 1. Inventory the existing site
+
+Map the current routes before proposing slugs or outlines:
+
+```bash
+rg --files site/app | rg '/page\.tsx$'
+rg --files site/public | rg '\.md$'
+sed -n '1,240p' site/app/sitemap.ts
+```
+
+Inspect relevant hubs, shared page components, adjacent pages, metadata, structured data, and markdown twins. Record pages that already satisfy the target intent, pages that should be refreshed instead of duplicated, and genuine content gaps.
+
+### 2. Perform SERP recon
+
+Research each target query with current search results. Identify:
+
+- dominant intent: comparison, informational, transactional, navigational, or mixed
+- recurring page formats and questions
+- weak, stale, or unsupported answers the wave can improve
+- primary sources required to support factual claims
+- a distinct, truthful angle Minutes can substantiate
+
+For competitor, legal, compliance, security, pricing, or product-capability claims, use current primary or official sources and record the review date. Treat search snippets and third-party summaries as discovery aids, not final evidence. For claims about Minutes, verify the current repository implementation and documentation.
+
+Do not copy competitor framing or manufacture a claim because it would make a stronger headline. Give alternatives credit where they are better. Add appropriate not-legal-advice or scope language to regulated-topic pages.
+
+### 3. Outline the wave page by page
+
+For every proposed page, specify:
+
+- route and primary keyword
+- search intent and direct answer
+- unique promise and evidence plan
+- title, description, and social metadata
+- section outline, including honest limitations or "when the alternative wins" where relevant
+- structured data only when the visible page content supports it
+- internal links in and out
+- conversion action
+- required hub, sitemap, and markdown-twin updates
+
+Use extractable structures when they serve the query: a direct answer near the top, clear headings, comparison tables, concise lists, and visible FAQs that match any FAQ schema. Avoid near-duplicate pages that merely swap a product name or keyword.
+
+### 4. Implement within `DESIGN.md`
+
+Read `DESIGN.md` and reuse established site components and nearby page patterns. Preserve the Minutes type system: Instrument Serif for display headings, Geist for body and UI, and Geist Mono for labels, evidence, and technical material.
+
+Use the repository's semantic design tokens and established utilities, including `var(--bg)`, `var(--text)`, `var(--accent)`, `font-serif`, `font-sans`, and `font-mono`. Do not introduce raw color values, ad hoc font families, off-scale spacing, gradients, glows, decorative motion, or new arbitrary literals. The design-token CI gate treats new raw literals as failures.
+
+Keep the page useful without JavaScript when practical, keyboard accessible, responsive, and consistent in light and dark modes. Metadata and structured data must describe what the rendered page actually says.
+
+### 5. Run an evidence and honesty pass
+
+Fact-check every time-sensitive or consequential statement against its recorded source. Then compare Minutes claims against code and first-party documentation. Look especially for absolute language such as "never," "always," "nothing leaves," "compliant," "offline," or "free forever" that may need a precise boundary.
+
+Check dates, plan names, pricing cadence, beta status, platform availability, default versus opt-in behavior, storage and network paths, and legal or compliance qualifiers. Remove a claim when it cannot be verified.
+
+### 6. Complete the internal-linking pass
+
+Connect the wave as a cluster:
+
+- link each page to its relevant hub, pillar, sibling pages, and product or quick-start action
+- add the new pages to the appropriate compare, resource, writing, or docs hub
+- add contextual links from existing authoritative pages when useful
+- update `site/app/sitemap.ts`
+- add or update the corresponding `site/public/**/*.md` page when the site pattern requires a markdown twin
+- verify there are no orphan pages or circular trails with no useful destination
+
+Use descriptive anchor text. Do not stuff exact-match keywords into every link.
+
+### 7. Regenerate and validate generated surfaces
+
+After page and inventory changes, regenerate the LLM-facing site text:
+
+```bash
+node scripts/generate_llms_txt.mjs
+node scripts/generate_llms_txt.mjs --check
+```
+
+Run the relevant site tests, type checks, and repository gates for the touched files. At minimum, run the design-token check when site UI changed:
+
+```bash
+node scripts/check_design_tokens.mjs
+```
+
+Do not hand-edit generated `llms.txt` files. Fix their source or generator input and regenerate.
+
+## Output format
+
+Return a page checklist followed by the shipped-wave retro. Keep routes, keywords, evidence, integrations, and validation visible:
+
+```markdown
+## Wave: <theme>
+
+### Page checklist
+
+- [ ] `/route-one` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+- [ ] `/route-two` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+
+### Wave checklist
+
+- [ ] Existing `site/app/` and `site/public/` inventory checked for overlap.
+- [ ] SERP intent and primary evidence recorded with a review date.
+- [ ] `DESIGN.md`, accessibility, metadata, and structured-data constraints met.
+- [ ] Hub, sibling, pillar, conversion, sitemap, and markdown-twin links complete.
+- [ ] LLM text regenerated and repository checks pass.
+
+## Shipped-wave retro
+
+- **Scope shipped:** <routes and page types>
+- **Why this wave:** <shared intent and evidence-backed opportunity>
+- **Evidence and honesty review:** <sources checked, claims corrected or dropped, review date>
+- **Site integration:** <hubs, internal links, sitemap, markdown twins, generated LLM text>
+- **Validation:** <commands and results>
+- **Follow-up:** <measurement or unresolved work, without inventing rankings or traffic>
+```
+
+Mark items complete only when the repository contains the work and the validation ran. The retro should follow the #435 through #438 pattern: summarize the shipped routes, the research basis, the integration work, the adversarial or honesty review, and concrete corrections. Do not claim ranking, traffic, or conversion impact before measurement exists.
+
+## Checklist
+
+Before calling the wave complete, verify:
+
+- [ ] The theme, keywords, audience, conversion action, and wave size are explicit.
+- [ ] Existing `site/app/` routes, hubs, sitemap entries, and markdown twins were inventoried.
+- [ ] Each page answers a distinct search intent and avoids thin keyword substitution.
+- [ ] Current primary sources support competitor and high-stakes claims.
+- [ ] Minutes claims match current code and first-party documentation.
+- [ ] `DESIGN.md` tokens and fonts are reused with no new raw design literals.
+- [ ] Metadata, structured data, accessibility, responsive behavior, and light and dark modes were checked.
+- [ ] Internal links connect every page to a hub, relevant siblings, a pillar, and a useful conversion action.
+- [ ] `site/app/sitemap.ts` and required `site/public/**/*.md` twins are updated.
+- [ ] `node scripts/generate_llms_txt.mjs --check` passes after regeneration.
+- [ ] Relevant site checks and `node scripts/check_design_tokens.mjs` pass.
+- [ ] The shipped-wave retro records scope, evidence, integrations, corrections, validation, and follow-up without invented outcomes.
+
+

--- a/.opencode/commands/minutes-release-notes.md
+++ b/.opencode/commands/minutes-release-notes.md
@@ -1,0 +1,9 @@
+---
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+---
+
+Load the `minutes-release-notes` skill and follow it exactly for this request.
+
+User arguments: $ARGUMENTS
+
+If no arguments were provided, use the skill's normal no-argument/default flow instead of stopping to ask for input.

--- a/.opencode/commands/minutes-seo-wave.md
+++ b/.opencode/commands/minutes-seo-wave.md
@@ -1,0 +1,9 @@
+---
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+---
+
+Load the `minutes-seo-wave` skill and follow it exactly for this request.
+
+User arguments: $ARGUMENTS
+
+If no arguments were provided, use the skill's normal no-argument/default flow instead of stopping to ask for input.

--- a/.opencode/skills/minutes-release-notes/SKILL.md
+++ b/.opencode/skills/minutes-release-notes/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: minutes-release-notes
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+compatibility: opencode
+---
+
+# /minutes-release-notes
+
+Draft release notes that explain why a Minutes release matters without making users decode the commit history. Produce a draft only. Do not create, edit, or publish a GitHub release unless the user explicitly asks.
+
+## Inputs
+
+Collect:
+
+- the new version, such as `v0.22.0`
+- the previous stable tag, or an explicit starting ref
+- the target ref, normally `HEAD`
+- the release channel, normally stable or preview
+- any known breaking changes, migrations, compatibility notes, or contributor credits
+
+Resolve missing refs from the repository instead of guessing:
+
+```bash
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+```
+
+When `HEAD` is already tagged, resolve the previous tag from its parent so the range does not collapse to zero commits:
+
+```bash
+git describe --tags --abbrev=0 HEAD^
+```
+
+Confirm both refs with `git rev-parse --verify` before drafting. If the version or range is ambiguous, ask one short question.
+
+## Steps
+
+### 1. Learn the current release voice
+
+Read two or three recent stable releases before writing:
+
+```bash
+gh release list --limit 5
+gh release view <recent-tag>
+```
+
+Match the current heading hierarchy, amount of detail, install wording, contributor treatment, and overall tone. Prefer concrete user outcomes, honest limitations, and short technical explanations. Do not copy stale version-specific claims.
+
+Never use em dashes in the draft. Rewrite with commas, colons, parentheses, or separate sentences. This is a repository release convention, not an optional style preference.
+
+### 2. Build the change ledger
+
+Read the full range and inspect touched files when a subject is unclear:
+
+```bash
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+git diff --stat <previous-tag>..HEAD
+git show --stat <commit>
+```
+
+Classify every relevant commit by conventional prefix:
+
+- `feat` -> **Features**
+- `fix` -> **Fixes**
+- `perf` -> **Performance**
+- `docs`, `chore`, `build`, `ci`, `test`, and uncategorized maintenance -> **Docs / Chore rollup**
+
+Treat merge commits and follow-up fixes as part of the user-visible change they complete. Deduplicate stacked or backported commits. Use file inspection to verify the affected surface: desktop, CLI, MCP and agent integrations, site, plugin, SDK, or shared engine.
+
+Drop internal-only version bumps, lockfile syncs, generated-file refreshes, formatting, test-only changes, CI churn, and release bookkeeping unless they change installation, compatibility, reliability, security, or another user-visible behavior. Do not inflate the notes with one bullet per commit.
+
+### 3. Turn the ledger into release prose
+
+Lead with one or two sentences that state why the release exists. Convert the strongest Features and Performance items into outcome-led headline sections. Roll smaller items into **Fixes**. Include Docs / Chore items only when users must act on them or will notice the result.
+
+For each claim:
+
+- say what changed and who benefits
+- distinguish defaults from opt-in or experimental behavior
+- name affected platforms when behavior differs
+- preserve important limitations and fallback behavior
+- link issue or pull request numbers when the history supports them
+- credit external contributors by verified GitHub handle
+
+Do not infer a breaking change, migration, benchmark, security property, compatibility promise, or contributor from the subject line alone. Verify it in the diff, release procedure, or repository documentation.
+
+### 4. Check release integrity
+
+Run the repository version check after the release version has been applied:
+
+```bash
+node scripts/check_version_sync.mjs --release
+```
+
+If the check fails because the requested version has not been bumped yet, report that clearly. Do not change versions as part of drafting notes unless the user asked for release preparation too.
+
+Search the range for configuration, storage, schema, feature-default, platform-support, and install-path changes. State either the required migration or that no migration is required. Never leave breaking-change status implicit.
+
+## Output format
+
+Follow the closest of the recent releases inspected in step 1. Use this current Minutes layout when those releases do not establish a more specific pattern:
+
+```markdown
+## Minutes vX.Y.Z
+
+<One short paragraph explaining why this release matters.>
+
+### <Feature or outcome headline>
+<User-facing explanation, with bullets only when they improve scanning.>
+
+### <Additional feature or performance headline, if needed>
+<User-facing explanation.>
+
+### Fixes
+- <Grouped, concrete fix>
+
+### Notes
+<Breaking change, migration, compatibility, preview, or known-issue note. Say "No migration is required" when that is the verified result.>
+
+## Install / update
+
+The desktop app updates itself: open Minutes and it pulls vX.Y.Z on next launch, or grab the DMG from the assets below.
+
+- **DMG**: download from the release assets below
+- **CLI**: `brew install silverstein/tap/minutes` or `cargo install minutes-cli`
+- **MCP**: `npx minutes-mcp` (or update the Claude Desktop extension)
+
+## Claude Code plugin
+<Include only when the plugin changed. Use the refresh commands and wording from a recent release.>
+
+---
+<Use the current release-preparation credit and contributor block only when recent releases include them and the credits are verified.>
+```
+
+Keep the install block wording and order exact unless the repository's current distribution paths changed. Omit empty feature sections, but never omit the install block or breaking-change and migration status.
+
+## Checklist
+
+Before returning the draft, verify:
+
+- [ ] The previous tag, target ref, and new version are explicit.
+- [ ] Every user-facing claim is supported by the range or repository documentation.
+- [ ] Features, Fixes, Performance, and Docs / Chore commits were classified before rollup.
+- [ ] Internal-only version bumps, lockfiles, generated syncs, and CI churn were dropped.
+- [ ] The prose matches two or three recent releases and contains no em dash characters.
+- [ ] Breaking changes, migrations, compatibility notes, preview status, and known issues are explicit.
+- [ ] `node scripts/check_version_sync.mjs --release` passes, or its version-bump blocker is reported.
+- [ ] The standard DMG, CLI, and MCP download block is present and current.
+- [ ] Plugin update instructions appear only if the plugin changed.
+- [ ] Contributor handles and issue or pull request references are verified.
+
+

--- a/.opencode/skills/minutes-seo-wave/SKILL.md
+++ b/.opencode/skills/minutes-seo-wave/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: minutes-seo-wave
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+compatibility: opencode
+---
+
+# /minutes-seo-wave
+
+Produce one coherent SEO content wave, not a pile of disconnected pages. Keep the method reusable across comparison pages, use-case or resource pages, and docs hubs.
+
+Competitive research and keyword specifics are time-sensitive. Research them fresh for each wave. Internal competitive plans may exist in gitignored documentation; never invent, reconstruct, or embed those private specifics in this skill or in repository documentation.
+
+## Inputs
+
+Collect:
+
+- the wave theme, such as comparison pages, use-case pages, a resource cluster, or a docs hub
+- target keywords and search intents
+- the intended audience and conversion action
+- the requested number of pages or the time box
+- existing pages and drafts that must not be duplicated
+- any supplied first-party research, approved claims, and source requirements
+
+If theme or keywords are missing, inspect the repository and ask only for the choice that materially changes the wave. Do not invent search volume, keyword difficulty, competitor capabilities, pricing, compliance status, or product claims.
+
+## Steps
+
+### 1. Inventory the existing site
+
+Map the current routes before proposing slugs or outlines:
+
+```bash
+rg --files site/app | rg '/page\.tsx$'
+rg --files site/public | rg '\.md$'
+sed -n '1,240p' site/app/sitemap.ts
+```
+
+Inspect relevant hubs, shared page components, adjacent pages, metadata, structured data, and markdown twins. Record pages that already satisfy the target intent, pages that should be refreshed instead of duplicated, and genuine content gaps.
+
+### 2. Perform SERP recon
+
+Research each target query with current search results. Identify:
+
+- dominant intent: comparison, informational, transactional, navigational, or mixed
+- recurring page formats and questions
+- weak, stale, or unsupported answers the wave can improve
+- primary sources required to support factual claims
+- a distinct, truthful angle Minutes can substantiate
+
+For competitor, legal, compliance, security, pricing, or product-capability claims, use current primary or official sources and record the review date. Treat search snippets and third-party summaries as discovery aids, not final evidence. For claims about Minutes, verify the current repository implementation and documentation.
+
+Do not copy competitor framing or manufacture a claim because it would make a stronger headline. Give alternatives credit where they are better. Add appropriate not-legal-advice or scope language to regulated-topic pages.
+
+### 3. Outline the wave page by page
+
+For every proposed page, specify:
+
+- route and primary keyword
+- search intent and direct answer
+- unique promise and evidence plan
+- title, description, and social metadata
+- section outline, including honest limitations or "when the alternative wins" where relevant
+- structured data only when the visible page content supports it
+- internal links in and out
+- conversion action
+- required hub, sitemap, and markdown-twin updates
+
+Use extractable structures when they serve the query: a direct answer near the top, clear headings, comparison tables, concise lists, and visible FAQs that match any FAQ schema. Avoid near-duplicate pages that merely swap a product name or keyword.
+
+### 4. Implement within `DESIGN.md`
+
+Read `DESIGN.md` and reuse established site components and nearby page patterns. Preserve the Minutes type system: Instrument Serif for display headings, Geist for body and UI, and Geist Mono for labels, evidence, and technical material.
+
+Use the repository's semantic design tokens and established utilities, including `var(--bg)`, `var(--text)`, `var(--accent)`, `font-serif`, `font-sans`, and `font-mono`. Do not introduce raw color values, ad hoc font families, off-scale spacing, gradients, glows, decorative motion, or new arbitrary literals. The design-token CI gate treats new raw literals as failures.
+
+Keep the page useful without JavaScript when practical, keyboard accessible, responsive, and consistent in light and dark modes. Metadata and structured data must describe what the rendered page actually says.
+
+### 5. Run an evidence and honesty pass
+
+Fact-check every time-sensitive or consequential statement against its recorded source. Then compare Minutes claims against code and first-party documentation. Look especially for absolute language such as "never," "always," "nothing leaves," "compliant," "offline," or "free forever" that may need a precise boundary.
+
+Check dates, plan names, pricing cadence, beta status, platform availability, default versus opt-in behavior, storage and network paths, and legal or compliance qualifiers. Remove a claim when it cannot be verified.
+
+### 6. Complete the internal-linking pass
+
+Connect the wave as a cluster:
+
+- link each page to its relevant hub, pillar, sibling pages, and product or quick-start action
+- add the new pages to the appropriate compare, resource, writing, or docs hub
+- add contextual links from existing authoritative pages when useful
+- update `site/app/sitemap.ts`
+- add or update the corresponding `site/public/**/*.md` page when the site pattern requires a markdown twin
+- verify there are no orphan pages or circular trails with no useful destination
+
+Use descriptive anchor text. Do not stuff exact-match keywords into every link.
+
+### 7. Regenerate and validate generated surfaces
+
+After page and inventory changes, regenerate the LLM-facing site text:
+
+```bash
+node scripts/generate_llms_txt.mjs
+node scripts/generate_llms_txt.mjs --check
+```
+
+Run the relevant site tests, type checks, and repository gates for the touched files. At minimum, run the design-token check when site UI changed:
+
+```bash
+node scripts/check_design_tokens.mjs
+```
+
+Do not hand-edit generated `llms.txt` files. Fix their source or generator input and regenerate.
+
+## Output format
+
+Return a page checklist followed by the shipped-wave retro. Keep routes, keywords, evidence, integrations, and validation visible:
+
+```markdown
+## Wave: <theme>
+
+### Page checklist
+
+- [ ] `/route-one` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+- [ ] `/route-two` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+
+### Wave checklist
+
+- [ ] Existing `site/app/` and `site/public/` inventory checked for overlap.
+- [ ] SERP intent and primary evidence recorded with a review date.
+- [ ] `DESIGN.md`, accessibility, metadata, and structured-data constraints met.
+- [ ] Hub, sibling, pillar, conversion, sitemap, and markdown-twin links complete.
+- [ ] LLM text regenerated and repository checks pass.
+
+## Shipped-wave retro
+
+- **Scope shipped:** <routes and page types>
+- **Why this wave:** <shared intent and evidence-backed opportunity>
+- **Evidence and honesty review:** <sources checked, claims corrected or dropped, review date>
+- **Site integration:** <hubs, internal links, sitemap, markdown twins, generated LLM text>
+- **Validation:** <commands and results>
+- **Follow-up:** <measurement or unresolved work, without inventing rankings or traffic>
+```
+
+Mark items complete only when the repository contains the work and the validation ran. The retro should follow the #435 through #438 pattern: summarize the shipped routes, the research basis, the integration work, the adversarial or honesty review, and concrete corrections. Do not claim ranking, traffic, or conversion impact before measurement exists.
+
+## Checklist
+
+Before calling the wave complete, verify:
+
+- [ ] The theme, keywords, audience, conversion action, and wave size are explicit.
+- [ ] Existing `site/app/` routes, hubs, sitemap entries, and markdown twins were inventoried.
+- [ ] Each page answers a distinct search intent and avoids thin keyword substitution.
+- [ ] Current primary sources support competitor and high-stakes claims.
+- [ ] Minutes claims match current code and first-party documentation.
+- [ ] `DESIGN.md` tokens and fonts are reused with no new raw design literals.
+- [ ] Metadata, structured data, accessibility, responsive behavior, and light and dark modes were checked.
+- [ ] Internal links connect every page to a hub, relevant siblings, a pillar, and a useful conversion action.
+- [ ] `site/app/sitemap.ts` and required `site/public/**/*.md` twins are updated.
+- [ ] `node scripts/generate_llms_txt.mjs --check` passes after regeneration.
+- [ ] Relevant site checks and `node scripts/check_design_tokens.mjs` pass.
+- [ ] The shipped-wave retro records scope, evidence, integrations, corrections, validation, and follow-up without invented outcomes.
+
+

--- a/tooling/skills/goldens/claude/minutes-release-notes/SKILL.md
+++ b/tooling/skills/goldens/claude/minutes-release-notes/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: minutes-release-notes
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+user_invocable: true
+---
+
+# /minutes-release-notes
+
+Draft release notes that explain why a Minutes release matters without making users decode the commit history. Produce a draft only. Do not create, edit, or publish a GitHub release unless the user explicitly asks.
+
+## Inputs
+
+Collect:
+
+- the new version, such as `v0.22.0`
+- the previous stable tag, or an explicit starting ref
+- the target ref, normally `HEAD`
+- the release channel, normally stable or preview
+- any known breaking changes, migrations, compatibility notes, or contributor credits
+
+Resolve missing refs from the repository instead of guessing:
+
+```bash
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+```
+
+When `HEAD` is already tagged, resolve the previous tag from its parent so the range does not collapse to zero commits:
+
+```bash
+git describe --tags --abbrev=0 HEAD^
+```
+
+Confirm both refs with `git rev-parse --verify` before drafting. If the version or range is ambiguous, ask one short question.
+
+## Steps
+
+### 1. Learn the current release voice
+
+Read two or three recent stable releases before writing:
+
+```bash
+gh release list --limit 5
+gh release view <recent-tag>
+```
+
+Match the current heading hierarchy, amount of detail, install wording, contributor treatment, and overall tone. Prefer concrete user outcomes, honest limitations, and short technical explanations. Do not copy stale version-specific claims.
+
+Never use em dashes in the draft. Rewrite with commas, colons, parentheses, or separate sentences. This is a repository release convention, not an optional style preference.
+
+### 2. Build the change ledger
+
+Read the full range and inspect touched files when a subject is unclear:
+
+```bash
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+git diff --stat <previous-tag>..HEAD
+git show --stat <commit>
+```
+
+Classify every relevant commit by conventional prefix:
+
+- `feat` -> **Features**
+- `fix` -> **Fixes**
+- `perf` -> **Performance**
+- `docs`, `chore`, `build`, `ci`, `test`, and uncategorized maintenance -> **Docs / Chore rollup**
+
+Treat merge commits and follow-up fixes as part of the user-visible change they complete. Deduplicate stacked or backported commits. Use file inspection to verify the affected surface: desktop, CLI, MCP and agent integrations, site, plugin, SDK, or shared engine.
+
+Drop internal-only version bumps, lockfile syncs, generated-file refreshes, formatting, test-only changes, CI churn, and release bookkeeping unless they change installation, compatibility, reliability, security, or another user-visible behavior. Do not inflate the notes with one bullet per commit.
+
+### 3. Turn the ledger into release prose
+
+Lead with one or two sentences that state why the release exists. Convert the strongest Features and Performance items into outcome-led headline sections. Roll smaller items into **Fixes**. Include Docs / Chore items only when users must act on them or will notice the result.
+
+For each claim:
+
+- say what changed and who benefits
+- distinguish defaults from opt-in or experimental behavior
+- name affected platforms when behavior differs
+- preserve important limitations and fallback behavior
+- link issue or pull request numbers when the history supports them
+- credit external contributors by verified GitHub handle
+
+Do not infer a breaking change, migration, benchmark, security property, compatibility promise, or contributor from the subject line alone. Verify it in the diff, release procedure, or repository documentation.
+
+### 4. Check release integrity
+
+Run the repository version check after the release version has been applied:
+
+```bash
+node scripts/check_version_sync.mjs --release
+```
+
+If the check fails because the requested version has not been bumped yet, report that clearly. Do not change versions as part of drafting notes unless the user asked for release preparation too.
+
+Search the range for configuration, storage, schema, feature-default, platform-support, and install-path changes. State either the required migration or that no migration is required. Never leave breaking-change status implicit.
+
+## Output format
+
+Follow the closest of the recent releases inspected in step 1. Use this current Minutes layout when those releases do not establish a more specific pattern:
+
+```markdown
+## Minutes vX.Y.Z
+
+<One short paragraph explaining why this release matters.>
+
+### <Feature or outcome headline>
+<User-facing explanation, with bullets only when they improve scanning.>
+
+### <Additional feature or performance headline, if needed>
+<User-facing explanation.>
+
+### Fixes
+- <Grouped, concrete fix>
+
+### Notes
+<Breaking change, migration, compatibility, preview, or known-issue note. Say "No migration is required" when that is the verified result.>
+
+## Install / update
+
+The desktop app updates itself: open Minutes and it pulls vX.Y.Z on next launch, or grab the DMG from the assets below.
+
+- **DMG**: download from the release assets below
+- **CLI**: `brew install silverstein/tap/minutes` or `cargo install minutes-cli`
+- **MCP**: `npx minutes-mcp` (or update the Claude Desktop extension)
+
+## Claude Code plugin
+<Include only when the plugin changed. Use the refresh commands and wording from a recent release.>
+
+---
+<Use the current release-preparation credit and contributor block only when recent releases include them and the credits are verified.>
+```
+
+Keep the install block wording and order exact unless the repository's current distribution paths changed. Omit empty feature sections, but never omit the install block or breaking-change and migration status.
+
+## Checklist
+
+Before returning the draft, verify:
+
+- [ ] The previous tag, target ref, and new version are explicit.
+- [ ] Every user-facing claim is supported by the range or repository documentation.
+- [ ] Features, Fixes, Performance, and Docs / Chore commits were classified before rollup.
+- [ ] Internal-only version bumps, lockfiles, generated syncs, and CI churn were dropped.
+- [ ] The prose matches two or three recent releases and contains no em dash characters.
+- [ ] Breaking changes, migrations, compatibility notes, preview status, and known issues are explicit.
+- [ ] `node scripts/check_version_sync.mjs --release` passes, or its version-bump blocker is reported.
+- [ ] The standard DMG, CLI, and MCP download block is present and current.
+- [ ] Plugin update instructions appear only if the plugin changed.
+- [ ] Contributor handles and issue or pull request references are verified.
+
+

--- a/tooling/skills/goldens/claude/minutes-seo-wave/SKILL.md
+++ b/tooling/skills/goldens/claude/minutes-seo-wave/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: minutes-seo-wave
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+user_invocable: true
+---
+
+# /minutes-seo-wave
+
+Produce one coherent SEO content wave, not a pile of disconnected pages. Keep the method reusable across comparison pages, use-case or resource pages, and docs hubs.
+
+Competitive research and keyword specifics are time-sensitive. Research them fresh for each wave. Internal competitive plans may exist in gitignored documentation; never invent, reconstruct, or embed those private specifics in this skill or in repository documentation.
+
+## Inputs
+
+Collect:
+
+- the wave theme, such as comparison pages, use-case pages, a resource cluster, or a docs hub
+- target keywords and search intents
+- the intended audience and conversion action
+- the requested number of pages or the time box
+- existing pages and drafts that must not be duplicated
+- any supplied first-party research, approved claims, and source requirements
+
+If theme or keywords are missing, inspect the repository and ask only for the choice that materially changes the wave. Do not invent search volume, keyword difficulty, competitor capabilities, pricing, compliance status, or product claims.
+
+## Steps
+
+### 1. Inventory the existing site
+
+Map the current routes before proposing slugs or outlines:
+
+```bash
+rg --files site/app | rg '/page\.tsx$'
+rg --files site/public | rg '\.md$'
+sed -n '1,240p' site/app/sitemap.ts
+```
+
+Inspect relevant hubs, shared page components, adjacent pages, metadata, structured data, and markdown twins. Record pages that already satisfy the target intent, pages that should be refreshed instead of duplicated, and genuine content gaps.
+
+### 2. Perform SERP recon
+
+Research each target query with current search results. Identify:
+
+- dominant intent: comparison, informational, transactional, navigational, or mixed
+- recurring page formats and questions
+- weak, stale, or unsupported answers the wave can improve
+- primary sources required to support factual claims
+- a distinct, truthful angle Minutes can substantiate
+
+For competitor, legal, compliance, security, pricing, or product-capability claims, use current primary or official sources and record the review date. Treat search snippets and third-party summaries as discovery aids, not final evidence. For claims about Minutes, verify the current repository implementation and documentation.
+
+Do not copy competitor framing or manufacture a claim because it would make a stronger headline. Give alternatives credit where they are better. Add appropriate not-legal-advice or scope language to regulated-topic pages.
+
+### 3. Outline the wave page by page
+
+For every proposed page, specify:
+
+- route and primary keyword
+- search intent and direct answer
+- unique promise and evidence plan
+- title, description, and social metadata
+- section outline, including honest limitations or "when the alternative wins" where relevant
+- structured data only when the visible page content supports it
+- internal links in and out
+- conversion action
+- required hub, sitemap, and markdown-twin updates
+
+Use extractable structures when they serve the query: a direct answer near the top, clear headings, comparison tables, concise lists, and visible FAQs that match any FAQ schema. Avoid near-duplicate pages that merely swap a product name or keyword.
+
+### 4. Implement within `DESIGN.md`
+
+Read `DESIGN.md` and reuse established site components and nearby page patterns. Preserve the Minutes type system: Instrument Serif for display headings, Geist for body and UI, and Geist Mono for labels, evidence, and technical material.
+
+Use the repository's semantic design tokens and established utilities, including `var(--bg)`, `var(--text)`, `var(--accent)`, `font-serif`, `font-sans`, and `font-mono`. Do not introduce raw color values, ad hoc font families, off-scale spacing, gradients, glows, decorative motion, or new arbitrary literals. The design-token CI gate treats new raw literals as failures.
+
+Keep the page useful without JavaScript when practical, keyboard accessible, responsive, and consistent in light and dark modes. Metadata and structured data must describe what the rendered page actually says.
+
+### 5. Run an evidence and honesty pass
+
+Fact-check every time-sensitive or consequential statement against its recorded source. Then compare Minutes claims against code and first-party documentation. Look especially for absolute language such as "never," "always," "nothing leaves," "compliant," "offline," or "free forever" that may need a precise boundary.
+
+Check dates, plan names, pricing cadence, beta status, platform availability, default versus opt-in behavior, storage and network paths, and legal or compliance qualifiers. Remove a claim when it cannot be verified.
+
+### 6. Complete the internal-linking pass
+
+Connect the wave as a cluster:
+
+- link each page to its relevant hub, pillar, sibling pages, and product or quick-start action
+- add the new pages to the appropriate compare, resource, writing, or docs hub
+- add contextual links from existing authoritative pages when useful
+- update `site/app/sitemap.ts`
+- add or update the corresponding `site/public/**/*.md` page when the site pattern requires a markdown twin
+- verify there are no orphan pages or circular trails with no useful destination
+
+Use descriptive anchor text. Do not stuff exact-match keywords into every link.
+
+### 7. Regenerate and validate generated surfaces
+
+After page and inventory changes, regenerate the LLM-facing site text:
+
+```bash
+node scripts/generate_llms_txt.mjs
+node scripts/generate_llms_txt.mjs --check
+```
+
+Run the relevant site tests, type checks, and repository gates for the touched files. At minimum, run the design-token check when site UI changed:
+
+```bash
+node scripts/check_design_tokens.mjs
+```
+
+Do not hand-edit generated `llms.txt` files. Fix their source or generator input and regenerate.
+
+## Output format
+
+Return a page checklist followed by the shipped-wave retro. Keep routes, keywords, evidence, integrations, and validation visible:
+
+```markdown
+## Wave: <theme>
+
+### Page checklist
+
+- [ ] `/route-one` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+- [ ] `/route-two` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+
+### Wave checklist
+
+- [ ] Existing `site/app/` and `site/public/` inventory checked for overlap.
+- [ ] SERP intent and primary evidence recorded with a review date.
+- [ ] `DESIGN.md`, accessibility, metadata, and structured-data constraints met.
+- [ ] Hub, sibling, pillar, conversion, sitemap, and markdown-twin links complete.
+- [ ] LLM text regenerated and repository checks pass.
+
+## Shipped-wave retro
+
+- **Scope shipped:** <routes and page types>
+- **Why this wave:** <shared intent and evidence-backed opportunity>
+- **Evidence and honesty review:** <sources checked, claims corrected or dropped, review date>
+- **Site integration:** <hubs, internal links, sitemap, markdown twins, generated LLM text>
+- **Validation:** <commands and results>
+- **Follow-up:** <measurement or unresolved work, without inventing rankings or traffic>
+```
+
+Mark items complete only when the repository contains the work and the validation ran. The retro should follow the #435 through #438 pattern: summarize the shipped routes, the research basis, the integration work, the adversarial or honesty review, and concrete corrections. Do not claim ranking, traffic, or conversion impact before measurement exists.
+
+## Checklist
+
+Before calling the wave complete, verify:
+
+- [ ] The theme, keywords, audience, conversion action, and wave size are explicit.
+- [ ] Existing `site/app/` routes, hubs, sitemap entries, and markdown twins were inventoried.
+- [ ] Each page answers a distinct search intent and avoids thin keyword substitution.
+- [ ] Current primary sources support competitor and high-stakes claims.
+- [ ] Minutes claims match current code and first-party documentation.
+- [ ] `DESIGN.md` tokens and fonts are reused with no new raw design literals.
+- [ ] Metadata, structured data, accessibility, responsive behavior, and light and dark modes were checked.
+- [ ] Internal links connect every page to a hub, relevant siblings, a pillar, and a useful conversion action.
+- [ ] `site/app/sitemap.ts` and required `site/public/**/*.md` twins are updated.
+- [ ] `node scripts/generate_llms_txt.mjs --check` passes after regeneration.
+- [ ] Relevant site checks and `node scripts/check_design_tokens.mjs` pass.
+- [ ] The shipped-wave retro records scope, evidence, integrations, corrections, validation, and follow-up without invented outcomes.
+
+

--- a/tooling/skills/goldens/codex/minutes-release-notes/SKILL.md
+++ b/tooling/skills/goldens/codex/minutes-release-notes/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: minutes-release-notes
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+---
+
+# /minutes-release-notes
+
+Draft release notes that explain why a Minutes release matters without making users decode the commit history. Produce a draft only. Do not create, edit, or publish a GitHub release unless the user explicitly asks.
+
+## Inputs
+
+Collect:
+
+- the new version, such as `v0.22.0`
+- the previous stable tag, or an explicit starting ref
+- the target ref, normally `HEAD`
+- the release channel, normally stable or preview
+- any known breaking changes, migrations, compatibility notes, or contributor credits
+
+Resolve missing refs from the repository instead of guessing:
+
+```bash
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+```
+
+When `HEAD` is already tagged, resolve the previous tag from its parent so the range does not collapse to zero commits:
+
+```bash
+git describe --tags --abbrev=0 HEAD^
+```
+
+Confirm both refs with `git rev-parse --verify` before drafting. If the version or range is ambiguous, ask one short question.
+
+## Steps
+
+### 1. Learn the current release voice
+
+Read two or three recent stable releases before writing:
+
+```bash
+gh release list --limit 5
+gh release view <recent-tag>
+```
+
+Match the current heading hierarchy, amount of detail, install wording, contributor treatment, and overall tone. Prefer concrete user outcomes, honest limitations, and short technical explanations. Do not copy stale version-specific claims.
+
+Never use em dashes in the draft. Rewrite with commas, colons, parentheses, or separate sentences. This is a repository release convention, not an optional style preference.
+
+### 2. Build the change ledger
+
+Read the full range and inspect touched files when a subject is unclear:
+
+```bash
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+git diff --stat <previous-tag>..HEAD
+git show --stat <commit>
+```
+
+Classify every relevant commit by conventional prefix:
+
+- `feat` -> **Features**
+- `fix` -> **Fixes**
+- `perf` -> **Performance**
+- `docs`, `chore`, `build`, `ci`, `test`, and uncategorized maintenance -> **Docs / Chore rollup**
+
+Treat merge commits and follow-up fixes as part of the user-visible change they complete. Deduplicate stacked or backported commits. Use file inspection to verify the affected surface: desktop, CLI, MCP and agent integrations, site, plugin, SDK, or shared engine.
+
+Drop internal-only version bumps, lockfile syncs, generated-file refreshes, formatting, test-only changes, CI churn, and release bookkeeping unless they change installation, compatibility, reliability, security, or another user-visible behavior. Do not inflate the notes with one bullet per commit.
+
+### 3. Turn the ledger into release prose
+
+Lead with one or two sentences that state why the release exists. Convert the strongest Features and Performance items into outcome-led headline sections. Roll smaller items into **Fixes**. Include Docs / Chore items only when users must act on them or will notice the result.
+
+For each claim:
+
+- say what changed and who benefits
+- distinguish defaults from opt-in or experimental behavior
+- name affected platforms when behavior differs
+- preserve important limitations and fallback behavior
+- link issue or pull request numbers when the history supports them
+- credit external contributors by verified GitHub handle
+
+Do not infer a breaking change, migration, benchmark, security property, compatibility promise, or contributor from the subject line alone. Verify it in the diff, release procedure, or repository documentation.
+
+### 4. Check release integrity
+
+Run the repository version check after the release version has been applied:
+
+```bash
+node scripts/check_version_sync.mjs --release
+```
+
+If the check fails because the requested version has not been bumped yet, report that clearly. Do not change versions as part of drafting notes unless the user asked for release preparation too.
+
+Search the range for configuration, storage, schema, feature-default, platform-support, and install-path changes. State either the required migration or that no migration is required. Never leave breaking-change status implicit.
+
+## Output format
+
+Follow the closest of the recent releases inspected in step 1. Use this current Minutes layout when those releases do not establish a more specific pattern:
+
+```markdown
+## Minutes vX.Y.Z
+
+<One short paragraph explaining why this release matters.>
+
+### <Feature or outcome headline>
+<User-facing explanation, with bullets only when they improve scanning.>
+
+### <Additional feature or performance headline, if needed>
+<User-facing explanation.>
+
+### Fixes
+- <Grouped, concrete fix>
+
+### Notes
+<Breaking change, migration, compatibility, preview, or known-issue note. Say "No migration is required" when that is the verified result.>
+
+## Install / update
+
+The desktop app updates itself: open Minutes and it pulls vX.Y.Z on next launch, or grab the DMG from the assets below.
+
+- **DMG**: download from the release assets below
+- **CLI**: `brew install silverstein/tap/minutes` or `cargo install minutes-cli`
+- **MCP**: `npx minutes-mcp` (or update the Claude Desktop extension)
+
+## Claude Code plugin
+<Include only when the plugin changed. Use the refresh commands and wording from a recent release.>
+
+---
+<Use the current release-preparation credit and contributor block only when recent releases include them and the credits are verified.>
+```
+
+Keep the install block wording and order exact unless the repository's current distribution paths changed. Omit empty feature sections, but never omit the install block or breaking-change and migration status.
+
+## Checklist
+
+Before returning the draft, verify:
+
+- [ ] The previous tag, target ref, and new version are explicit.
+- [ ] Every user-facing claim is supported by the range or repository documentation.
+- [ ] Features, Fixes, Performance, and Docs / Chore commits were classified before rollup.
+- [ ] Internal-only version bumps, lockfiles, generated syncs, and CI churn were dropped.
+- [ ] The prose matches two or three recent releases and contains no em dash characters.
+- [ ] Breaking changes, migrations, compatibility notes, preview status, and known issues are explicit.
+- [ ] `node scripts/check_version_sync.mjs --release` passes, or its version-bump blocker is reported.
+- [ ] The standard DMG, CLI, and MCP download block is present and current.
+- [ ] Plugin update instructions appear only if the plugin changed.
+- [ ] Contributor handles and issue or pull request references are verified.
+
+

--- a/tooling/skills/goldens/codex/minutes-release-notes/agents/openai.yaml
+++ b/tooling/skills/goldens/codex/minutes-release-notes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Minutes Release Notes"
+  short_description: "Turn a version's commit range into polished, release-ready Minutes notes."
+  default_prompt: "Draft release notes for the requested Minutes version from the real commit range and current release conventions."

--- a/tooling/skills/goldens/codex/minutes-seo-wave/SKILL.md
+++ b/tooling/skills/goldens/codex/minutes-seo-wave/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: minutes-seo-wave
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+---
+
+# /minutes-seo-wave
+
+Produce one coherent SEO content wave, not a pile of disconnected pages. Keep the method reusable across comparison pages, use-case or resource pages, and docs hubs.
+
+Competitive research and keyword specifics are time-sensitive. Research them fresh for each wave. Internal competitive plans may exist in gitignored documentation; never invent, reconstruct, or embed those private specifics in this skill or in repository documentation.
+
+## Inputs
+
+Collect:
+
+- the wave theme, such as comparison pages, use-case pages, a resource cluster, or a docs hub
+- target keywords and search intents
+- the intended audience and conversion action
+- the requested number of pages or the time box
+- existing pages and drafts that must not be duplicated
+- any supplied first-party research, approved claims, and source requirements
+
+If theme or keywords are missing, inspect the repository and ask only for the choice that materially changes the wave. Do not invent search volume, keyword difficulty, competitor capabilities, pricing, compliance status, or product claims.
+
+## Steps
+
+### 1. Inventory the existing site
+
+Map the current routes before proposing slugs or outlines:
+
+```bash
+rg --files site/app | rg '/page\.tsx$'
+rg --files site/public | rg '\.md$'
+sed -n '1,240p' site/app/sitemap.ts
+```
+
+Inspect relevant hubs, shared page components, adjacent pages, metadata, structured data, and markdown twins. Record pages that already satisfy the target intent, pages that should be refreshed instead of duplicated, and genuine content gaps.
+
+### 2. Perform SERP recon
+
+Research each target query with current search results. Identify:
+
+- dominant intent: comparison, informational, transactional, navigational, or mixed
+- recurring page formats and questions
+- weak, stale, or unsupported answers the wave can improve
+- primary sources required to support factual claims
+- a distinct, truthful angle Minutes can substantiate
+
+For competitor, legal, compliance, security, pricing, or product-capability claims, use current primary or official sources and record the review date. Treat search snippets and third-party summaries as discovery aids, not final evidence. For claims about Minutes, verify the current repository implementation and documentation.
+
+Do not copy competitor framing or manufacture a claim because it would make a stronger headline. Give alternatives credit where they are better. Add appropriate not-legal-advice or scope language to regulated-topic pages.
+
+### 3. Outline the wave page by page
+
+For every proposed page, specify:
+
+- route and primary keyword
+- search intent and direct answer
+- unique promise and evidence plan
+- title, description, and social metadata
+- section outline, including honest limitations or "when the alternative wins" where relevant
+- structured data only when the visible page content supports it
+- internal links in and out
+- conversion action
+- required hub, sitemap, and markdown-twin updates
+
+Use extractable structures when they serve the query: a direct answer near the top, clear headings, comparison tables, concise lists, and visible FAQs that match any FAQ schema. Avoid near-duplicate pages that merely swap a product name or keyword.
+
+### 4. Implement within `DESIGN.md`
+
+Read `DESIGN.md` and reuse established site components and nearby page patterns. Preserve the Minutes type system: Instrument Serif for display headings, Geist for body and UI, and Geist Mono for labels, evidence, and technical material.
+
+Use the repository's semantic design tokens and established utilities, including `var(--bg)`, `var(--text)`, `var(--accent)`, `font-serif`, `font-sans`, and `font-mono`. Do not introduce raw color values, ad hoc font families, off-scale spacing, gradients, glows, decorative motion, or new arbitrary literals. The design-token CI gate treats new raw literals as failures.
+
+Keep the page useful without JavaScript when practical, keyboard accessible, responsive, and consistent in light and dark modes. Metadata and structured data must describe what the rendered page actually says.
+
+### 5. Run an evidence and honesty pass
+
+Fact-check every time-sensitive or consequential statement against its recorded source. Then compare Minutes claims against code and first-party documentation. Look especially for absolute language such as "never," "always," "nothing leaves," "compliant," "offline," or "free forever" that may need a precise boundary.
+
+Check dates, plan names, pricing cadence, beta status, platform availability, default versus opt-in behavior, storage and network paths, and legal or compliance qualifiers. Remove a claim when it cannot be verified.
+
+### 6. Complete the internal-linking pass
+
+Connect the wave as a cluster:
+
+- link each page to its relevant hub, pillar, sibling pages, and product or quick-start action
+- add the new pages to the appropriate compare, resource, writing, or docs hub
+- add contextual links from existing authoritative pages when useful
+- update `site/app/sitemap.ts`
+- add or update the corresponding `site/public/**/*.md` page when the site pattern requires a markdown twin
+- verify there are no orphan pages or circular trails with no useful destination
+
+Use descriptive anchor text. Do not stuff exact-match keywords into every link.
+
+### 7. Regenerate and validate generated surfaces
+
+After page and inventory changes, regenerate the LLM-facing site text:
+
+```bash
+node scripts/generate_llms_txt.mjs
+node scripts/generate_llms_txt.mjs --check
+```
+
+Run the relevant site tests, type checks, and repository gates for the touched files. At minimum, run the design-token check when site UI changed:
+
+```bash
+node scripts/check_design_tokens.mjs
+```
+
+Do not hand-edit generated `llms.txt` files. Fix their source or generator input and regenerate.
+
+## Output format
+
+Return a page checklist followed by the shipped-wave retro. Keep routes, keywords, evidence, integrations, and validation visible:
+
+```markdown
+## Wave: <theme>
+
+### Page checklist
+
+- [ ] `/route-one` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+- [ ] `/route-two` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+
+### Wave checklist
+
+- [ ] Existing `site/app/` and `site/public/` inventory checked for overlap.
+- [ ] SERP intent and primary evidence recorded with a review date.
+- [ ] `DESIGN.md`, accessibility, metadata, and structured-data constraints met.
+- [ ] Hub, sibling, pillar, conversion, sitemap, and markdown-twin links complete.
+- [ ] LLM text regenerated and repository checks pass.
+
+## Shipped-wave retro
+
+- **Scope shipped:** <routes and page types>
+- **Why this wave:** <shared intent and evidence-backed opportunity>
+- **Evidence and honesty review:** <sources checked, claims corrected or dropped, review date>
+- **Site integration:** <hubs, internal links, sitemap, markdown twins, generated LLM text>
+- **Validation:** <commands and results>
+- **Follow-up:** <measurement or unresolved work, without inventing rankings or traffic>
+```
+
+Mark items complete only when the repository contains the work and the validation ran. The retro should follow the #435 through #438 pattern: summarize the shipped routes, the research basis, the integration work, the adversarial or honesty review, and concrete corrections. Do not claim ranking, traffic, or conversion impact before measurement exists.
+
+## Checklist
+
+Before calling the wave complete, verify:
+
+- [ ] The theme, keywords, audience, conversion action, and wave size are explicit.
+- [ ] Existing `site/app/` routes, hubs, sitemap entries, and markdown twins were inventoried.
+- [ ] Each page answers a distinct search intent and avoids thin keyword substitution.
+- [ ] Current primary sources support competitor and high-stakes claims.
+- [ ] Minutes claims match current code and first-party documentation.
+- [ ] `DESIGN.md` tokens and fonts are reused with no new raw design literals.
+- [ ] Metadata, structured data, accessibility, responsive behavior, and light and dark modes were checked.
+- [ ] Internal links connect every page to a hub, relevant siblings, a pillar, and a useful conversion action.
+- [ ] `site/app/sitemap.ts` and required `site/public/**/*.md` twins are updated.
+- [ ] `node scripts/generate_llms_txt.mjs --check` passes after regeneration.
+- [ ] Relevant site checks and `node scripts/check_design_tokens.mjs` pass.
+- [ ] The shipped-wave retro records scope, evidence, integrations, corrections, validation, and follow-up without invented outcomes.
+
+

--- a/tooling/skills/goldens/codex/minutes-seo-wave/agents/openai.yaml
+++ b/tooling/skills/goldens/codex/minutes-seo-wave/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Minutes SEO Wave"
+  short_description: "Ship a researched, internally linked SEO page wave without duplicating or overstating claims."
+  default_prompt: "Build one evidence-backed SEO content wave for Minutes and return the page checklist plus shipped-wave retro."

--- a/tooling/skills/goldens/commands/minutes-release-notes.md
+++ b/tooling/skills/goldens/commands/minutes-release-notes.md
@@ -1,0 +1,9 @@
+---
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+---
+
+Load the `minutes-release-notes` skill and follow it exactly for this request.
+
+User arguments: $ARGUMENTS
+
+If no arguments were provided, use the skill's normal no-argument/default flow instead of stopping to ask for input.

--- a/tooling/skills/goldens/commands/minutes-seo-wave.md
+++ b/tooling/skills/goldens/commands/minutes-seo-wave.md
@@ -1,0 +1,9 @@
+---
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+---
+
+Load the `minutes-seo-wave` skill and follow it exactly for this request.
+
+User arguments: $ARGUMENTS
+
+If no arguments were provided, use the skill's normal no-argument/default flow instead of stopping to ask for input.

--- a/tooling/skills/goldens/opencode/minutes-release-notes/SKILL.md
+++ b/tooling/skills/goldens/opencode/minutes-release-notes/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: minutes-release-notes
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+compatibility: opencode
+---
+
+# /minutes-release-notes
+
+Draft release notes that explain why a Minutes release matters without making users decode the commit history. Produce a draft only. Do not create, edit, or publish a GitHub release unless the user explicitly asks.
+
+## Inputs
+
+Collect:
+
+- the new version, such as `v0.22.0`
+- the previous stable tag, or an explicit starting ref
+- the target ref, normally `HEAD`
+- the release channel, normally stable or preview
+- any known breaking changes, migrations, compatibility notes, or contributor credits
+
+Resolve missing refs from the repository instead of guessing:
+
+```bash
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+```
+
+When `HEAD` is already tagged, resolve the previous tag from its parent so the range does not collapse to zero commits:
+
+```bash
+git describe --tags --abbrev=0 HEAD^
+```
+
+Confirm both refs with `git rev-parse --verify` before drafting. If the version or range is ambiguous, ask one short question.
+
+## Steps
+
+### 1. Learn the current release voice
+
+Read two or three recent stable releases before writing:
+
+```bash
+gh release list --limit 5
+gh release view <recent-tag>
+```
+
+Match the current heading hierarchy, amount of detail, install wording, contributor treatment, and overall tone. Prefer concrete user outcomes, honest limitations, and short technical explanations. Do not copy stale version-specific claims.
+
+Never use em dashes in the draft. Rewrite with commas, colons, parentheses, or separate sentences. This is a repository release convention, not an optional style preference.
+
+### 2. Build the change ledger
+
+Read the full range and inspect touched files when a subject is unclear:
+
+```bash
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+git diff --stat <previous-tag>..HEAD
+git show --stat <commit>
+```
+
+Classify every relevant commit by conventional prefix:
+
+- `feat` -> **Features**
+- `fix` -> **Fixes**
+- `perf` -> **Performance**
+- `docs`, `chore`, `build`, `ci`, `test`, and uncategorized maintenance -> **Docs / Chore rollup**
+
+Treat merge commits and follow-up fixes as part of the user-visible change they complete. Deduplicate stacked or backported commits. Use file inspection to verify the affected surface: desktop, CLI, MCP and agent integrations, site, plugin, SDK, or shared engine.
+
+Drop internal-only version bumps, lockfile syncs, generated-file refreshes, formatting, test-only changes, CI churn, and release bookkeeping unless they change installation, compatibility, reliability, security, or another user-visible behavior. Do not inflate the notes with one bullet per commit.
+
+### 3. Turn the ledger into release prose
+
+Lead with one or two sentences that state why the release exists. Convert the strongest Features and Performance items into outcome-led headline sections. Roll smaller items into **Fixes**. Include Docs / Chore items only when users must act on them or will notice the result.
+
+For each claim:
+
+- say what changed and who benefits
+- distinguish defaults from opt-in or experimental behavior
+- name affected platforms when behavior differs
+- preserve important limitations and fallback behavior
+- link issue or pull request numbers when the history supports them
+- credit external contributors by verified GitHub handle
+
+Do not infer a breaking change, migration, benchmark, security property, compatibility promise, or contributor from the subject line alone. Verify it in the diff, release procedure, or repository documentation.
+
+### 4. Check release integrity
+
+Run the repository version check after the release version has been applied:
+
+```bash
+node scripts/check_version_sync.mjs --release
+```
+
+If the check fails because the requested version has not been bumped yet, report that clearly. Do not change versions as part of drafting notes unless the user asked for release preparation too.
+
+Search the range for configuration, storage, schema, feature-default, platform-support, and install-path changes. State either the required migration or that no migration is required. Never leave breaking-change status implicit.
+
+## Output format
+
+Follow the closest of the recent releases inspected in step 1. Use this current Minutes layout when those releases do not establish a more specific pattern:
+
+```markdown
+## Minutes vX.Y.Z
+
+<One short paragraph explaining why this release matters.>
+
+### <Feature or outcome headline>
+<User-facing explanation, with bullets only when they improve scanning.>
+
+### <Additional feature or performance headline, if needed>
+<User-facing explanation.>
+
+### Fixes
+- <Grouped, concrete fix>
+
+### Notes
+<Breaking change, migration, compatibility, preview, or known-issue note. Say "No migration is required" when that is the verified result.>
+
+## Install / update
+
+The desktop app updates itself: open Minutes and it pulls vX.Y.Z on next launch, or grab the DMG from the assets below.
+
+- **DMG**: download from the release assets below
+- **CLI**: `brew install silverstein/tap/minutes` or `cargo install minutes-cli`
+- **MCP**: `npx minutes-mcp` (or update the Claude Desktop extension)
+
+## Claude Code plugin
+<Include only when the plugin changed. Use the refresh commands and wording from a recent release.>
+
+---
+<Use the current release-preparation credit and contributor block only when recent releases include them and the credits are verified.>
+```
+
+Keep the install block wording and order exact unless the repository's current distribution paths changed. Omit empty feature sections, but never omit the install block or breaking-change and migration status.
+
+## Checklist
+
+Before returning the draft, verify:
+
+- [ ] The previous tag, target ref, and new version are explicit.
+- [ ] Every user-facing claim is supported by the range or repository documentation.
+- [ ] Features, Fixes, Performance, and Docs / Chore commits were classified before rollup.
+- [ ] Internal-only version bumps, lockfiles, generated syncs, and CI churn were dropped.
+- [ ] The prose matches two or three recent releases and contains no em dash characters.
+- [ ] Breaking changes, migrations, compatibility notes, preview status, and known issues are explicit.
+- [ ] `node scripts/check_version_sync.mjs --release` passes, or its version-bump blocker is reported.
+- [ ] The standard DMG, CLI, and MCP download block is present and current.
+- [ ] Plugin update instructions appear only if the plugin changed.
+- [ ] Contributor handles and issue or pull request references are verified.
+
+

--- a/tooling/skills/goldens/opencode/minutes-seo-wave/SKILL.md
+++ b/tooling/skills/goldens/opencode/minutes-seo-wave/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: minutes-seo-wave
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+compatibility: opencode
+---
+
+# /minutes-seo-wave
+
+Produce one coherent SEO content wave, not a pile of disconnected pages. Keep the method reusable across comparison pages, use-case or resource pages, and docs hubs.
+
+Competitive research and keyword specifics are time-sensitive. Research them fresh for each wave. Internal competitive plans may exist in gitignored documentation; never invent, reconstruct, or embed those private specifics in this skill or in repository documentation.
+
+## Inputs
+
+Collect:
+
+- the wave theme, such as comparison pages, use-case pages, a resource cluster, or a docs hub
+- target keywords and search intents
+- the intended audience and conversion action
+- the requested number of pages or the time box
+- existing pages and drafts that must not be duplicated
+- any supplied first-party research, approved claims, and source requirements
+
+If theme or keywords are missing, inspect the repository and ask only for the choice that materially changes the wave. Do not invent search volume, keyword difficulty, competitor capabilities, pricing, compliance status, or product claims.
+
+## Steps
+
+### 1. Inventory the existing site
+
+Map the current routes before proposing slugs or outlines:
+
+```bash
+rg --files site/app | rg '/page\.tsx$'
+rg --files site/public | rg '\.md$'
+sed -n '1,240p' site/app/sitemap.ts
+```
+
+Inspect relevant hubs, shared page components, adjacent pages, metadata, structured data, and markdown twins. Record pages that already satisfy the target intent, pages that should be refreshed instead of duplicated, and genuine content gaps.
+
+### 2. Perform SERP recon
+
+Research each target query with current search results. Identify:
+
+- dominant intent: comparison, informational, transactional, navigational, or mixed
+- recurring page formats and questions
+- weak, stale, or unsupported answers the wave can improve
+- primary sources required to support factual claims
+- a distinct, truthful angle Minutes can substantiate
+
+For competitor, legal, compliance, security, pricing, or product-capability claims, use current primary or official sources and record the review date. Treat search snippets and third-party summaries as discovery aids, not final evidence. For claims about Minutes, verify the current repository implementation and documentation.
+
+Do not copy competitor framing or manufacture a claim because it would make a stronger headline. Give alternatives credit where they are better. Add appropriate not-legal-advice or scope language to regulated-topic pages.
+
+### 3. Outline the wave page by page
+
+For every proposed page, specify:
+
+- route and primary keyword
+- search intent and direct answer
+- unique promise and evidence plan
+- title, description, and social metadata
+- section outline, including honest limitations or "when the alternative wins" where relevant
+- structured data only when the visible page content supports it
+- internal links in and out
+- conversion action
+- required hub, sitemap, and markdown-twin updates
+
+Use extractable structures when they serve the query: a direct answer near the top, clear headings, comparison tables, concise lists, and visible FAQs that match any FAQ schema. Avoid near-duplicate pages that merely swap a product name or keyword.
+
+### 4. Implement within `DESIGN.md`
+
+Read `DESIGN.md` and reuse established site components and nearby page patterns. Preserve the Minutes type system: Instrument Serif for display headings, Geist for body and UI, and Geist Mono for labels, evidence, and technical material.
+
+Use the repository's semantic design tokens and established utilities, including `var(--bg)`, `var(--text)`, `var(--accent)`, `font-serif`, `font-sans`, and `font-mono`. Do not introduce raw color values, ad hoc font families, off-scale spacing, gradients, glows, decorative motion, or new arbitrary literals. The design-token CI gate treats new raw literals as failures.
+
+Keep the page useful without JavaScript when practical, keyboard accessible, responsive, and consistent in light and dark modes. Metadata and structured data must describe what the rendered page actually says.
+
+### 5. Run an evidence and honesty pass
+
+Fact-check every time-sensitive or consequential statement against its recorded source. Then compare Minutes claims against code and first-party documentation. Look especially for absolute language such as "never," "always," "nothing leaves," "compliant," "offline," or "free forever" that may need a precise boundary.
+
+Check dates, plan names, pricing cadence, beta status, platform availability, default versus opt-in behavior, storage and network paths, and legal or compliance qualifiers. Remove a claim when it cannot be verified.
+
+### 6. Complete the internal-linking pass
+
+Connect the wave as a cluster:
+
+- link each page to its relevant hub, pillar, sibling pages, and product or quick-start action
+- add the new pages to the appropriate compare, resource, writing, or docs hub
+- add contextual links from existing authoritative pages when useful
+- update `site/app/sitemap.ts`
+- add or update the corresponding `site/public/**/*.md` page when the site pattern requires a markdown twin
+- verify there are no orphan pages or circular trails with no useful destination
+
+Use descriptive anchor text. Do not stuff exact-match keywords into every link.
+
+### 7. Regenerate and validate generated surfaces
+
+After page and inventory changes, regenerate the LLM-facing site text:
+
+```bash
+node scripts/generate_llms_txt.mjs
+node scripts/generate_llms_txt.mjs --check
+```
+
+Run the relevant site tests, type checks, and repository gates for the touched files. At minimum, run the design-token check when site UI changed:
+
+```bash
+node scripts/check_design_tokens.mjs
+```
+
+Do not hand-edit generated `llms.txt` files. Fix their source or generator input and regenerate.
+
+## Output format
+
+Return a page checklist followed by the shipped-wave retro. Keep routes, keywords, evidence, integrations, and validation visible:
+
+```markdown
+## Wave: <theme>
+
+### Page checklist
+
+- [ ] `/route-one` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+- [ ] `/route-two` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+
+### Wave checklist
+
+- [ ] Existing `site/app/` and `site/public/` inventory checked for overlap.
+- [ ] SERP intent and primary evidence recorded with a review date.
+- [ ] `DESIGN.md`, accessibility, metadata, and structured-data constraints met.
+- [ ] Hub, sibling, pillar, conversion, sitemap, and markdown-twin links complete.
+- [ ] LLM text regenerated and repository checks pass.
+
+## Shipped-wave retro
+
+- **Scope shipped:** <routes and page types>
+- **Why this wave:** <shared intent and evidence-backed opportunity>
+- **Evidence and honesty review:** <sources checked, claims corrected or dropped, review date>
+- **Site integration:** <hubs, internal links, sitemap, markdown twins, generated LLM text>
+- **Validation:** <commands and results>
+- **Follow-up:** <measurement or unresolved work, without inventing rankings or traffic>
+```
+
+Mark items complete only when the repository contains the work and the validation ran. The retro should follow the #435 through #438 pattern: summarize the shipped routes, the research basis, the integration work, the adversarial or honesty review, and concrete corrections. Do not claim ranking, traffic, or conversion impact before measurement exists.
+
+## Checklist
+
+Before calling the wave complete, verify:
+
+- [ ] The theme, keywords, audience, conversion action, and wave size are explicit.
+- [ ] Existing `site/app/` routes, hubs, sitemap entries, and markdown twins were inventoried.
+- [ ] Each page answers a distinct search intent and avoids thin keyword substitution.
+- [ ] Current primary sources support competitor and high-stakes claims.
+- [ ] Minutes claims match current code and first-party documentation.
+- [ ] `DESIGN.md` tokens and fonts are reused with no new raw design literals.
+- [ ] Metadata, structured data, accessibility, responsive behavior, and light and dark modes were checked.
+- [ ] Internal links connect every page to a hub, relevant siblings, a pillar, and a useful conversion action.
+- [ ] `site/app/sitemap.ts` and required `site/public/**/*.md` twins are updated.
+- [ ] `node scripts/generate_llms_txt.mjs --check` passes after regeneration.
+- [ ] Relevant site checks and `node scripts/check_design_tokens.mjs` pass.
+- [ ] The shipped-wave retro records scope, evidence, integrations, corrections, validation, and follow-up without invented outcomes.
+
+

--- a/tooling/skills/sources/minutes-release-notes/skill.md
+++ b/tooling/skills/sources/minutes-release-notes/skill.md
@@ -1,0 +1,178 @@
+---
+name: minutes-release-notes
+description: Draft user-facing Minutes release notes for a version from the commit range, recent GitHub releases, and the repository release checks. Use when the user asks to write, generate, prepare, revise, or review release notes or a changelog for a Minutes version.
+triggers:
+  - write release notes
+  - generate release notes
+  - prepare release notes
+  - draft release notes
+  - review release notes
+  - release notes for x
+user_invocable: true
+metadata:
+  display_name: Minutes Release Notes
+  short_description: Turn a version's commit range into polished, release-ready Minutes notes.
+  default_prompt: Draft release notes for the requested Minutes version from the real commit range and current release conventions.
+  site_category: Artifacts
+  site_example: /minutes-release-notes v0.22.0
+  site_best_for: Prepare accurate, user-facing release notes with install links and migration checks.
+  site_visible: false
+assets:
+  scripts: []
+  templates: []
+  references: []
+output:
+  claude:
+    path: .claude/plugins/minutes/skills/minutes-release-notes/SKILL.md
+  codex:
+    path: .agents/skills/minutes/minutes-release-notes/SKILL.md
+tests:
+  golden: true
+  lint_commands: true
+---
+
+# /minutes-release-notes
+
+Draft release notes that explain why a Minutes release matters without making users decode the commit history. Produce a draft only. Do not create, edit, or publish a GitHub release unless the user explicitly asks.
+
+## Inputs
+
+Collect:
+
+- the new version, such as `v0.22.0`
+- the previous stable tag, or an explicit starting ref
+- the target ref, normally `HEAD`
+- the release channel, normally stable or preview
+- any known breaking changes, migrations, compatibility notes, or contributor credits
+
+Resolve missing refs from the repository instead of guessing:
+
+```bash
+git describe --tags --abbrev=0
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+```
+
+When `HEAD` is already tagged, resolve the previous tag from its parent so the range does not collapse to zero commits:
+
+```bash
+git describe --tags --abbrev=0 HEAD^
+```
+
+Confirm both refs with `git rev-parse --verify` before drafting. If the version or range is ambiguous, ask one short question.
+
+## Steps
+
+### 1. Learn the current release voice
+
+Read two or three recent stable releases before writing:
+
+```bash
+gh release list --limit 5
+gh release view <recent-tag>
+```
+
+Match the current heading hierarchy, amount of detail, install wording, contributor treatment, and overall tone. Prefer concrete user outcomes, honest limitations, and short technical explanations. Do not copy stale version-specific claims.
+
+Never use em dashes in the draft. Rewrite with commas, colons, parentheses, or separate sentences. This is a repository release convention, not an optional style preference.
+
+### 2. Build the change ledger
+
+Read the full range and inspect touched files when a subject is unclear:
+
+```bash
+git log <previous-tag>..HEAD --pretty='%s (%h)'
+git diff --stat <previous-tag>..HEAD
+git show --stat <commit>
+```
+
+Classify every relevant commit by conventional prefix:
+
+- `feat` -> **Features**
+- `fix` -> **Fixes**
+- `perf` -> **Performance**
+- `docs`, `chore`, `build`, `ci`, `test`, and uncategorized maintenance -> **Docs / Chore rollup**
+
+Treat merge commits and follow-up fixes as part of the user-visible change they complete. Deduplicate stacked or backported commits. Use file inspection to verify the affected surface: desktop, CLI, MCP and agent integrations, site, plugin, SDK, or shared engine.
+
+Drop internal-only version bumps, lockfile syncs, generated-file refreshes, formatting, test-only changes, CI churn, and release bookkeeping unless they change installation, compatibility, reliability, security, or another user-visible behavior. Do not inflate the notes with one bullet per commit.
+
+### 3. Turn the ledger into release prose
+
+Lead with one or two sentences that state why the release exists. Convert the strongest Features and Performance items into outcome-led headline sections. Roll smaller items into **Fixes**. Include Docs / Chore items only when users must act on them or will notice the result.
+
+For each claim:
+
+- say what changed and who benefits
+- distinguish defaults from opt-in or experimental behavior
+- name affected platforms when behavior differs
+- preserve important limitations and fallback behavior
+- link issue or pull request numbers when the history supports them
+- credit external contributors by verified GitHub handle
+
+Do not infer a breaking change, migration, benchmark, security property, compatibility promise, or contributor from the subject line alone. Verify it in the diff, release procedure, or repository documentation.
+
+### 4. Check release integrity
+
+Run the repository version check after the release version has been applied:
+
+```bash
+node scripts/check_version_sync.mjs --release
+```
+
+If the check fails because the requested version has not been bumped yet, report that clearly. Do not change versions as part of drafting notes unless the user asked for release preparation too.
+
+Search the range for configuration, storage, schema, feature-default, platform-support, and install-path changes. State either the required migration or that no migration is required. Never leave breaking-change status implicit.
+
+## Output format
+
+Follow the closest of the recent releases inspected in step 1. Use this current Minutes layout when those releases do not establish a more specific pattern:
+
+```markdown
+## Minutes vX.Y.Z
+
+<One short paragraph explaining why this release matters.>
+
+### <Feature or outcome headline>
+<User-facing explanation, with bullets only when they improve scanning.>
+
+### <Additional feature or performance headline, if needed>
+<User-facing explanation.>
+
+### Fixes
+- <Grouped, concrete fix>
+
+### Notes
+<Breaking change, migration, compatibility, preview, or known-issue note. Say "No migration is required" when that is the verified result.>
+
+## Install / update
+
+The desktop app updates itself: open Minutes and it pulls vX.Y.Z on next launch, or grab the DMG from the assets below.
+
+- **DMG**: download from the release assets below
+- **CLI**: `brew install silverstein/tap/minutes` or `cargo install minutes-cli`
+- **MCP**: `npx minutes-mcp` (or update the Claude Desktop extension)
+
+## Claude Code plugin
+<Include only when the plugin changed. Use the refresh commands and wording from a recent release.>
+
+---
+<Use the current release-preparation credit and contributor block only when recent releases include them and the credits are verified.>
+```
+
+Keep the install block wording and order exact unless the repository's current distribution paths changed. Omit empty feature sections, but never omit the install block or breaking-change and migration status.
+
+## Checklist
+
+Before returning the draft, verify:
+
+- [ ] The previous tag, target ref, and new version are explicit.
+- [ ] Every user-facing claim is supported by the range or repository documentation.
+- [ ] Features, Fixes, Performance, and Docs / Chore commits were classified before rollup.
+- [ ] Internal-only version bumps, lockfiles, generated syncs, and CI churn were dropped.
+- [ ] The prose matches two or three recent releases and contains no em dash characters.
+- [ ] Breaking changes, migrations, compatibility notes, preview status, and known issues are explicit.
+- [ ] `node scripts/check_version_sync.mjs --release` passes, or its version-bump blocker is reported.
+- [ ] The standard DMG, CLI, and MCP download block is present and current.
+- [ ] Plugin update instructions appear only if the plugin changed.
+- [ ] Contributor handles and issue or pull request references are verified.
+

--- a/tooling/skills/sources/minutes-seo-wave/skill.md
+++ b/tooling/skills/sources/minutes-seo-wave/skill.md
@@ -1,0 +1,197 @@
+---
+name: minutes-seo-wave
+description: Plan, build, and review one evidence-backed SEO content wave for the Minutes site, including SERP research, page inventory, design-system compliance, internal linking, generated LLM text, and a shipped-wave retro. Use when the user asks for an SEO wave, a group of comparison or use-case pages, a docs or resource hub expansion, or a coordinated batch of search landing pages.
+triggers:
+  - create an seo wave
+  - build an seo wave
+  - plan an seo wave
+  - ship an seo wave
+  - seo content wave
+  - comparison page wave
+  - use case page wave
+  - docs hub wave
+user_invocable: true
+metadata:
+  display_name: Minutes SEO Wave
+  short_description: Ship a researched, internally linked SEO page wave without duplicating or overstating claims.
+  default_prompt: Build one evidence-backed SEO content wave for Minutes and return the page checklist plus shipped-wave retro.
+  site_category: Artifacts
+  site_example: /minutes-seo-wave comparison pages
+  site_best_for: Coordinate a researched batch of search pages, site integrations, and validation.
+  site_visible: false
+assets:
+  scripts: []
+  templates: []
+  references: []
+output:
+  claude:
+    path: .claude/plugins/minutes/skills/minutes-seo-wave/SKILL.md
+  codex:
+    path: .agents/skills/minutes/minutes-seo-wave/SKILL.md
+tests:
+  golden: true
+  lint_commands: true
+---
+
+# /minutes-seo-wave
+
+Produce one coherent SEO content wave, not a pile of disconnected pages. Keep the method reusable across comparison pages, use-case or resource pages, and docs hubs.
+
+Competitive research and keyword specifics are time-sensitive. Research them fresh for each wave. Internal competitive plans may exist in gitignored documentation; never invent, reconstruct, or embed those private specifics in this skill or in repository documentation.
+
+## Inputs
+
+Collect:
+
+- the wave theme, such as comparison pages, use-case pages, a resource cluster, or a docs hub
+- target keywords and search intents
+- the intended audience and conversion action
+- the requested number of pages or the time box
+- existing pages and drafts that must not be duplicated
+- any supplied first-party research, approved claims, and source requirements
+
+If theme or keywords are missing, inspect the repository and ask only for the choice that materially changes the wave. Do not invent search volume, keyword difficulty, competitor capabilities, pricing, compliance status, or product claims.
+
+## Steps
+
+### 1. Inventory the existing site
+
+Map the current routes before proposing slugs or outlines:
+
+```bash
+rg --files site/app | rg '/page\.tsx$'
+rg --files site/public | rg '\.md$'
+sed -n '1,240p' site/app/sitemap.ts
+```
+
+Inspect relevant hubs, shared page components, adjacent pages, metadata, structured data, and markdown twins. Record pages that already satisfy the target intent, pages that should be refreshed instead of duplicated, and genuine content gaps.
+
+### 2. Perform SERP recon
+
+Research each target query with current search results. Identify:
+
+- dominant intent: comparison, informational, transactional, navigational, or mixed
+- recurring page formats and questions
+- weak, stale, or unsupported answers the wave can improve
+- primary sources required to support factual claims
+- a distinct, truthful angle Minutes can substantiate
+
+For competitor, legal, compliance, security, pricing, or product-capability claims, use current primary or official sources and record the review date. Treat search snippets and third-party summaries as discovery aids, not final evidence. For claims about Minutes, verify the current repository implementation and documentation.
+
+Do not copy competitor framing or manufacture a claim because it would make a stronger headline. Give alternatives credit where they are better. Add appropriate not-legal-advice or scope language to regulated-topic pages.
+
+### 3. Outline the wave page by page
+
+For every proposed page, specify:
+
+- route and primary keyword
+- search intent and direct answer
+- unique promise and evidence plan
+- title, description, and social metadata
+- section outline, including honest limitations or "when the alternative wins" where relevant
+- structured data only when the visible page content supports it
+- internal links in and out
+- conversion action
+- required hub, sitemap, and markdown-twin updates
+
+Use extractable structures when they serve the query: a direct answer near the top, clear headings, comparison tables, concise lists, and visible FAQs that match any FAQ schema. Avoid near-duplicate pages that merely swap a product name or keyword.
+
+### 4. Implement within `DESIGN.md`
+
+Read `DESIGN.md` and reuse established site components and nearby page patterns. Preserve the Minutes type system: Instrument Serif for display headings, Geist for body and UI, and Geist Mono for labels, evidence, and technical material.
+
+Use the repository's semantic design tokens and established utilities, including `var(--bg)`, `var(--text)`, `var(--accent)`, `font-serif`, `font-sans`, and `font-mono`. Do not introduce raw color values, ad hoc font families, off-scale spacing, gradients, glows, decorative motion, or new arbitrary literals. The design-token CI gate treats new raw literals as failures.
+
+Keep the page useful without JavaScript when practical, keyboard accessible, responsive, and consistent in light and dark modes. Metadata and structured data must describe what the rendered page actually says.
+
+### 5. Run an evidence and honesty pass
+
+Fact-check every time-sensitive or consequential statement against its recorded source. Then compare Minutes claims against code and first-party documentation. Look especially for absolute language such as "never," "always," "nothing leaves," "compliant," "offline," or "free forever" that may need a precise boundary.
+
+Check dates, plan names, pricing cadence, beta status, platform availability, default versus opt-in behavior, storage and network paths, and legal or compliance qualifiers. Remove a claim when it cannot be verified.
+
+### 6. Complete the internal-linking pass
+
+Connect the wave as a cluster:
+
+- link each page to its relevant hub, pillar, sibling pages, and product or quick-start action
+- add the new pages to the appropriate compare, resource, writing, or docs hub
+- add contextual links from existing authoritative pages when useful
+- update `site/app/sitemap.ts`
+- add or update the corresponding `site/public/**/*.md` page when the site pattern requires a markdown twin
+- verify there are no orphan pages or circular trails with no useful destination
+
+Use descriptive anchor text. Do not stuff exact-match keywords into every link.
+
+### 7. Regenerate and validate generated surfaces
+
+After page and inventory changes, regenerate the LLM-facing site text:
+
+```bash
+node scripts/generate_llms_txt.mjs
+node scripts/generate_llms_txt.mjs --check
+```
+
+Run the relevant site tests, type checks, and repository gates for the touched files. At minimum, run the design-token check when site UI changed:
+
+```bash
+node scripts/check_design_tokens.mjs
+```
+
+Do not hand-edit generated `llms.txt` files. Fix their source or generator input and regenerate.
+
+## Output format
+
+Return a page checklist followed by the shipped-wave retro. Keep routes, keywords, evidence, integrations, and validation visible:
+
+```markdown
+## Wave: <theme>
+
+### Page checklist
+
+- [ ] `/route-one` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+- [ ] `/route-two` | `<primary keyword>` | <intent>
+  - Direct answer and distinct angle: <one line>
+  - Evidence: <primary sources or first-party repository evidence>
+  - Integrations: <hub, sibling, sitemap, markdown twin, CTA>
+
+### Wave checklist
+
+- [ ] Existing `site/app/` and `site/public/` inventory checked for overlap.
+- [ ] SERP intent and primary evidence recorded with a review date.
+- [ ] `DESIGN.md`, accessibility, metadata, and structured-data constraints met.
+- [ ] Hub, sibling, pillar, conversion, sitemap, and markdown-twin links complete.
+- [ ] LLM text regenerated and repository checks pass.
+
+## Shipped-wave retro
+
+- **Scope shipped:** <routes and page types>
+- **Why this wave:** <shared intent and evidence-backed opportunity>
+- **Evidence and honesty review:** <sources checked, claims corrected or dropped, review date>
+- **Site integration:** <hubs, internal links, sitemap, markdown twins, generated LLM text>
+- **Validation:** <commands and results>
+- **Follow-up:** <measurement or unresolved work, without inventing rankings or traffic>
+```
+
+Mark items complete only when the repository contains the work and the validation ran. The retro should follow the #435 through #438 pattern: summarize the shipped routes, the research basis, the integration work, the adversarial or honesty review, and concrete corrections. Do not claim ranking, traffic, or conversion impact before measurement exists.
+
+## Checklist
+
+Before calling the wave complete, verify:
+
+- [ ] The theme, keywords, audience, conversion action, and wave size are explicit.
+- [ ] Existing `site/app/` routes, hubs, sitemap entries, and markdown twins were inventoried.
+- [ ] Each page answers a distinct search intent and avoids thin keyword substitution.
+- [ ] Current primary sources support competitor and high-stakes claims.
+- [ ] Minutes claims match current code and first-party documentation.
+- [ ] `DESIGN.md` tokens and fonts are reused with no new raw design literals.
+- [ ] Metadata, structured data, accessibility, responsive behavior, and light and dark modes were checked.
+- [ ] Internal links connect every page to a hub, relevant siblings, a pillar, and a useful conversion action.
+- [ ] `site/app/sitemap.ts` and required `site/public/**/*.md` twins are updated.
+- [ ] `node scripts/generate_llms_txt.mjs --check` passes after regeneration.
+- [ ] Relevant site checks and `node scripts/check_design_tokens.mjs` pass.
+- [ ] The shipped-wave retro records scope, evidence, integrations, corrections, validation, and follow-up without invented outcomes.
+


### PR DESCRIPTION
## What

The last item of the agent-infra epic: the two workflows that kept being re-invented by hand become canonical skills (skill count 21 → 23, compiled to all three hosts):

- **`/minutes-release-notes`** — commit-range classification into release sections, voice matched to recent releases, the no-em-dash convention (commit 88ded28) encoded, version-sync + migration checklist. Kills the recurring release-notes ticket family.
- **`/minutes-seo-wave`** — the wave methodology from #435–#438: SERP recon, page outlines under DESIGN.md token constraints (raw literals would fail the `design_tokens` gate anyway), internal-linking pass, llms.txt regeneration. Methodology only; competitive specifics stay in gitignored internal docs.

Honest acceptance per the reviewed plan: skills are instruction documents, not deterministic generators — the gate is compilation + structure + the full compiler CI (33 tests, ownership audit, goldens for all 23 skills, `compile:dry` clean), plus one maintainer read-through of the two documents.

Part of the agent-infra hardening epic (bead `minutes-4a9r`, T3.3 — final item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)