### PR TITLE
ci(release): OIDC trusted publishing for npm + crates.io

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,345 @@
+name: Release Registry Packages
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example v0.23.0"
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+jobs:
+  release_readiness:
+    name: Release readiness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+
+      - name: Verify committed release invariants
+        run: node scripts/check_version_sync.mjs --release
+
+      - name: Verify tag and expose release version
+        id: release-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_commit="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [ "$tag_commit" != "$head_commit" ]; then
+            echo "ERROR: checkout HEAD ($head_commit) does not match ${RELEASE_TAG} ($tag_commit)" >&2
+            exit 1
+          fi
+          version="$(node -p "require('./crates/sdk/package.json').version")"
+          if [ "${RELEASE_TAG}" != "v${version}" ]; then
+            echo "ERROR: ${RELEASE_TAG} does not match the committed package version v${version}" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+  publish_npm:
+    name: Publish npm packages
+    needs: release_readiness
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Setup Node.js for npm trusted publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          registry-url: https://registry.npmjs.org
+
+      # npm 11.5.1 is the first release that supports OIDC trusted publishing.
+      # Pin it so a future npm release cannot change release behavior unexpectedly.
+      - name: Install OIDC-capable npm
+        run: npm install -g npm@11.5.1
+
+      - name: Pack and check minutes-sdk
+        id: sdk
+        working-directory: crates/sdk
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+
+          pack_json="$(mktemp)"
+          npm pack --json > "$pack_json"
+          mapfile -t pack < <(node - "$pack_json" <<'NODE'
+          const [pack] = require(process.argv[2]);
+          if (!pack?.filename || !pack?.integrity) throw new Error("npm pack did not return filename and integrity");
+          console.log(pack.filename);
+          console.log(pack.integrity);
+          NODE
+          )
+          package_name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          rm -f "${pack[0]}" "$pack_json"
+
+          {
+            echo "package_name=${package_name}"
+            echo "version=${version}"
+            echo "integrity=${pack[1]}"
+          } >> "$GITHUB_OUTPUT"
+          node ../../scripts/registry_poll.mjs npm-check "$package_name" "$version" "${pack[1]}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish minutes-sdk with npm OIDC
+        if: steps.sdk.outputs.already != 'true'
+        working-directory: crates/sdk
+        env:
+          PACKAGE_NAME: ${{ steps.sdk.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.sdk.outputs.version }}
+          PACKAGE_INTEGRITY: ${{ steps.sdk.outputs.integrity }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_log="$(mktemp)"
+          set +e
+          npm publish --access public 2>&1 | tee "$publish_log"
+          publish_status="${PIPESTATUS[0]}"
+          set -e
+          rm -f "$publish_log"
+          if [ "$publish_status" -eq 0 ]; then
+            exit 0
+          fi
+
+          # A concurrent rerun may have published after the initial 404. It is
+          # safe only when the now-visible tarball has the exact local integrity.
+          check="$(node ../../scripts/registry_poll.mjs npm-check "$PACKAGE_NAME" "$PACKAGE_VERSION" "$PACKAGE_INTEGRITY")"
+          if [ "$check" = "already=true" ]; then
+            echo "$PACKAGE_NAME@$PACKAGE_VERSION appeared concurrently with matching integrity; continuing."
+            exit 0
+          fi
+          exit "$publish_status"
+
+      - name: Wait for minutes-sdk registry visibility
+        run: >-
+          node scripts/registry_poll.mjs npm-poll
+          "${{ steps.sdk.outputs.package_name }}"
+          "${{ steps.sdk.outputs.version }}"
+          "${{ steps.sdk.outputs.integrity }}"
+
+      - name: Pack and check minutes-mcp
+        id: mcp
+        working-directory: crates/mcp
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+
+          pack_json="$(mktemp)"
+          npm pack --json > "$pack_json"
+          mapfile -t pack < <(node - "$pack_json" <<'NODE'
+          const [pack] = require(process.argv[2]);
+          if (!pack?.filename || !pack?.integrity) throw new Error("npm pack did not return filename and integrity");
+          console.log(pack.filename);
+          console.log(pack.integrity);
+          NODE
+          )
+          package_name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          rm -f "${pack[0]}" "$pack_json"
+
+          {
+            echo "package_name=${package_name}"
+            echo "version=${version}"
+            echo "integrity=${pack[1]}"
+          } >> "$GITHUB_OUTPUT"
+          node ../../scripts/registry_poll.mjs npm-check "$package_name" "$version" "${pack[1]}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish minutes-mcp with npm OIDC
+        if: steps.mcp.outputs.already != 'true'
+        working-directory: crates/mcp
+        env:
+          PACKAGE_NAME: ${{ steps.mcp.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.mcp.outputs.version }}
+          PACKAGE_INTEGRITY: ${{ steps.mcp.outputs.integrity }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_log="$(mktemp)"
+          set +e
+          npm publish --access public 2>&1 | tee "$publish_log"
+          publish_status="${PIPESTATUS[0]}"
+          set -e
+          rm -f "$publish_log"
+          if [ "$publish_status" -eq 0 ]; then
+            exit 0
+          fi
+
+          check="$(node ../../scripts/registry_poll.mjs npm-check "$PACKAGE_NAME" "$PACKAGE_VERSION" "$PACKAGE_INTEGRITY")"
+          if [ "$check" = "already=true" ]; then
+            echo "$PACKAGE_NAME@$PACKAGE_VERSION appeared concurrently with matching integrity; continuing."
+            exit 0
+          fi
+          exit "$publish_status"
+
+      - name: Wait for minutes-mcp registry visibility
+        run: >-
+          node scripts/registry_poll.mjs npm-poll
+          "${{ steps.mcp.outputs.package_name }}"
+          "${{ steps.mcp.outputs.version }}"
+          "${{ steps.mcp.outputs.integrity }}"
+
+  publish_crates:
+    name: Publish crates.io packages
+    needs: release_readiness
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev cmake
+
+      - name: Authenticate to crates.io with OIDC
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      # whisper-guard is intentionally absent: it has an independent crates.io
+      # cadence and is published only by its dedicated maintainer procedure.
+      - name: Publish minutes-core then minutes-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
+          VERSION: ${{ needs.release_readiness.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          publish_crate() {
+            local crate="$1"
+            local publish_log
+            local publish_status
+            publish_log="$(mktemp)"
+
+            set +e
+            cargo publish -p "$crate" 2>&1 | tee "$publish_log"
+            publish_status="${PIPESTATUS[0]}"
+            set -e
+
+            if [ "$publish_status" -eq 0 ]; then
+              rm -f "$publish_log"
+              return 0
+            fi
+            if grep -Fqi "already uploaded" "$publish_log"; then
+              echo "$crate@$VERSION is already uploaded; treating this rerun as successful."
+              rm -f "$publish_log"
+              return 0
+            fi
+            rm -f "$publish_log"
+            return "$publish_status"
+          }
+
+          poll_crate() {
+            local crate="$1"
+            local body
+            local curl_status
+            local delay
+            local http_status
+            local visible_version
+            body="$(mktemp)"
+
+            for delay in 0 5 10 20 40 60 60 60 45; do
+              if [ "$delay" -gt 0 ]; then
+                echo "Waiting ${delay}s for $crate@$VERSION to become visible on crates.io."
+                sleep "$delay"
+              fi
+
+              set +e
+              http_status="$(curl --silent --show-error --output "$body" --write-out '%{http_code}' \
+                --header 'User-Agent: minutes-release-publish (https://github.com/silverstein/minutes)' \
+                "https://crates.io/api/v1/crates/$crate/$VERSION")"
+              curl_status="$?"
+              set -e
+
+              if [ "$curl_status" -eq 0 ] && [ "$http_status" = "200" ]; then
+                visible_version="$(python3 - "$body" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as response:
+              print(json.load(response)["version"]["num"])
+          PY
+          )"
+                if [ "$visible_version" != "$VERSION" ]; then
+                  echo "ERROR: crates.io returned $visible_version while waiting for $crate@$VERSION" >&2
+                  rm -f "$body"
+                  return 1
+                fi
+                echo "crates.io confirms $crate@$VERSION."
+                rm -f "$body"
+                return 0
+              fi
+
+              if [ "$curl_status" -eq 0 ] && [ "$http_status" != "404" ] && [[ "$http_status" != 5* ]]; then
+                echo "ERROR: crates.io lookup for $crate@$VERSION returned HTTP $http_status" >&2
+                rm -f "$body"
+                return 1
+              fi
+            done
+
+            echo "ERROR: $crate@$VERSION did not become visible before the crates.io polling timeout" >&2
+            rm -f "$body"
+            return 1
+          }
+
+          publish_crate minutes-core
+          poll_crate minutes-core
+          publish_crate minutes-cli
+          poll_crate minutes-cli
+
+  summary:
+    name: Registry publish summary
+    needs: [publish_npm, publish_crates, release_readiness]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Write release summary
+        env:
+          VERSION: ${{ needs.release_readiness.outputs.version }}
+        run: |
+          {
+            echo "## Registry publishing complete"
+            echo
+            echo "The workflow published or integrity-verified all tag artifacts:"
+            echo
+            echo "- npm: \`minutes-sdk@$VERSION\`"
+            echo "- npm: \`minutes-mcp@$VERSION\`"
+            echo "- crates.io: \`minutes-core@$VERSION\`"
+            echo "- crates.io: \`minutes-cli@$VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -64,41 +64,34 @@ Every release shows up in followers' GitHub feeds — this is free awareness. Wr
 ### 6. Push the release commit to `main` and wait for CI to go green
 ```bash
 git push origin main
-# Phase 1 refuses to run until this exact HEAD is pushed. Watch CI before publishing.
+# The release preflight and pin step require this exact HEAD to be pushed.
 gh run list --branch main --limit 3
 gh run watch $(gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
-**Why this step exists**: Phase 1 publishes `minutes-sdk`, so the version bump must
-already be committed, pushed, and green. The release script verifies the clean
-`main` checkout, pushed HEAD, and normal version-sync policy; the maintainer
-confirms that HEAD's CI run is green before starting Phase 1.
+**Why this step exists**: registry publishing is authorized by the immutable
+release tag, so the version bump and exact dependency pin must be reviewed and
+green before that tag exists. The release script verifies the clean `main`
+checkout, pushed HEAD, and version-sync policy.
 
-### 7. Phase 1: validate and publish `minutes-sdk`
+### 7. Optional Phase 1 local pack-and-test preflight
 ```bash
-node scripts/release.mjs phase1 X.Y.Z
+node scripts/release.mjs phase1 X.Y.Z --dry-run
 ```
 
-Phase 1 packs the SDK, tests MCP against that exact tarball, and records the
-tarball's SHA-512 integrity in `.minutes-release-state.json`. It publishes the
-SDK only if the registry does not already contain the version; a retry skips an
-existing package only when its registry integrity matches. It then polls for
-exact-version visibility, avoiding the v0.19.0/v0.20 registry-lag failure where
-MCP was published before npm could resolve its SDK dependency.
-
-If polling times out, stop. The SDK-published/MCP-unpublished state is safe and
-supported: check it with `node scripts/release.mjs status`, then rerun Phase 1
-later. Do not edit package inputs or manually publish MCP.
+This credential-free preflight packs the SDK and tests MCP against that exact
+tarball. It does not publish. The tag workflow repeats the package builds and
+owns all registry mutations, so Phase 1 is useful before the irreversible tag
+but is no longer required for authentication or publish ordering.
 
 ### 8. Phase 2: commit MCP's exact SDK pin
 ```bash
 node scripts/release.mjs phase2 X.Y.Z
 ```
 
-Phase 2 verifies the published SDK again, pins
-`crates/mcp/package.json` to the exact version, regenerates the MCP lockfile,
-and refuses to continue unless those are the only two changed files. It creates
-the commit `release: pin minutes-sdk X.Y.Z for mcp` itself. Push that commit and
-wait for CI on the new exact HEAD:
+Phase 2 pins `crates/mcp/package.json` to the exact SDK version, regenerates the
+MCP lockfile, and refuses to continue unless those are the only two changed
+files. It creates the commit `release: pin minutes-sdk X.Y.Z for mcp` itself.
+Push that commit and wait for CI on the new exact HEAD:
 
 ```bash
 git push origin main
@@ -106,8 +99,9 @@ gh run list --branch main --limit 3
 gh run watch $(gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
 
-Do not amend the Phase-2 commit or edit release inputs after this point. Phase 3
-will reproduce the SDK tarball from this HEAD and compare it with Phase 1.
+Do not amend the Phase-2 commit or edit release inputs after this point. The
+tag-triggered registry workflow checks out this exact commit and reruns
+`check_version_sync.mjs --release` before either publish job can start.
 
 ### 9. Create the GitHub release as a DRAFT
 ```bash
@@ -118,42 +112,47 @@ This stages the notes without announcing the release. Keep it as a draft while
 the tag-triggered workflows build and attach artifacts. Creating the draft does
 not create or push the local annotated tag used by the committed release flow.
 
-### 10. Phase 3: verify provenance, create the tag, and publish `minutes-mcp`
+### 10. Create and push the release tag
 ```bash
 node scripts/release.mjs tag X.Y.Z
 # Run the exact tag-push command printed by the script, for example:
 git push origin vX.Y.Z
 ```
 
-Phase 3 requires a clean, pushed HEAD and green CI, runs
-`check_version_sync.mjs --release` to enforce the exact pin, and proves that
-`npm pack` for the SDK still matches the Phase-1 integrity. It creates an
-annotated local tag but never pushes it. Finally it publishes MCP idempotently,
-using the same registry-integrity rule as the SDK.
+The tag command requires a clean, pushed HEAD and green CI, enforces the exact
+pin, and creates an annotated local tag without pushing it. It has no registry
+credentials and does not publish packages.
 
 If `gh` is unavailable, Phase 3 refuses to proceed unless
 `--skip-ci-check` is supplied explicitly. Use that escape hatch only after
 manually confirming CI is green on `git rev-parse HEAD`.
 
-Pushing the printed tag command fires the three artifact workflows. Each starts
-with a `release_readiness` job that reruns the exact-pin release policy before
-any artifact build can begin.
+Pushing the printed tag command fires the three artifact workflows and
+`release-publish.yml`. The registry workflow publishes `minutes-sdk`, waits for
+its exact version and integrity to be visible, then publishes `minutes-mcp`. In
+parallel it publishes `minutes-core`, waits for its crates.io API visibility,
+then publishes `minutes-cli`. Every publish is idempotent for safe workflow
+reruns. See [Trusted publishing setup](trusted-publishing.md) for the one-time
+registry configuration.
 
-### 11. Wait for release assets, then publish the draft
+### 11. Wait for release assets and registry publishes, then publish the draft
 
 ```bash
 gh run list --workflow="Release CLI Binaries" --limit 1
 gh run list --workflow="Release macOS" --limit 1
 gh run list --workflow="Release Windows Desktop" --limit 1
+gh run list --workflow="Release Registry Packages" --limit 1
 
-# After all three are green and their assets are attached:
+# After all four are green, registry versions are visible, and assets are attached:
 gh release edit vX.Y.Z --draft=false
 ```
 
-The workflows attach the CLI binaries, DMG, Windows installers, updater files
-(`latest.json`, `Minutes.app.tar.gz`), and `SHA256SUMS.txt`. Publishing the draft
-is the announcement moment: it appears in followers' feeds and becomes
-"latest". If an artifact workflow fails, do not move or replace the tag; follow
+The artifact workflows attach the CLI binaries, DMG, Windows installers,
+updater files (`latest.json`, `Minutes.app.tar.gz`), and `SHA256SUMS.txt`. The
+registry workflow summary lists all four published or integrity-verified
+versions. Publishing the draft is the announcement moment: it appears in
+followers' feeds and becomes "latest". If any release workflow fails, do not
+move or replace the tag; rerun an idempotent job where appropriate, or follow
 the immutable-tag recovery policy in `channels.md` and cut a new patch release.
 
 ### 12. Build and upload .mcpb
@@ -163,9 +162,9 @@ the immutable-tag recovery policy in `channels.md` and cut a new patch release.
 gh release upload vX.Y.Z minutes.mcpb --clobber
 ```
 
-There are no manual npm publish commands after the tag. The three release-script
-phases own SDK-before-MCP ordering, exact dependency pinning, provenance checks,
-and idempotent retries.
+There are no manual npm publish commands. `release-publish.yml` owns
+SDK-before-MCP ordering, exact-integrity checks, OIDC provenance, and idempotent
+retries.
 
 ### 13. Publish independent-cadence crates (whisper-guard) if bumped
 Skip this step if Step 1 showed no changes to `crates/whisper-guard/` since the last whisper-guard publish.
@@ -178,31 +177,28 @@ sleep 30 && curl -s https://crates.io/api/v1/crates/whisper-guard | jq '.crate.m
 ```
 whisper-guard is a standalone MIT crate consumed outside this repo (currently 277+ downloads). Bump independently of the main release; do NOT couple to the Minutes version. If you skip the publish, the crates.io users miss the fix and you create silent drift between repo state and published artifact.
 
-### 14. Publish minutes-core and minutes-cli to crates.io
+### 14. Verify minutes-core and minutes-cli on crates.io
 
 As of #79 the workspace has no git dependencies (cpal is on crates.io 0.18.1 with `windows-core` pinned to 0.61.2; pyannote-rs is on crates.io 0.3.4), so these crates can be published again. They were last on crates.io at v0.9.4 and now publish at the main release version (currently 0.18.5).
 
-Publish in dependency order, `minutes-core` before `minutes-cli`, because `minutes-cli` depends on the crates.io version of `minutes-core`. whisper-guard (Step 13) must already be published at the version `minutes-core` requires.
+The trusted-publishing workflow publishes in dependency order,
+`minutes-core` before `minutes-cli`, because `minutes-cli` depends on the
+crates.io version of `minutes-core`. whisper-guard (Step 13) must already be
+published at the version `minutes-core` requires.
 
 ```bash
-# core first; cli depends on it. dry-run each before the real publish.
-cd crates/core
-cargo publish --dry-run
-cargo publish
-# wait for the index to pick up core so cli can resolve it
-sleep 45 && curl -s https://crates.io/api/v1/crates/minutes-core | jq '.crate.max_stable_version'
-
-cd ../cli
-cargo publish --dry-run
-cargo publish
-sleep 30 && curl -s https://crates.io/api/v1/crates/minutes-cli | jq '.crate.max_stable_version'
+gh run view $(gh run list --workflow="Release Registry Packages" --limit 1 --json databaseId --jq '.[0].databaseId')
+curl -sS -H 'User-Agent: minutes-release-verify (https://github.com/silverstein/minutes)' \
+  https://crates.io/api/v1/crates/minutes-core/X.Y.Z | jq -r '.version.num'
+curl -sS -H 'User-Agent: minutes-release-verify (https://github.com/silverstein/minutes)' \
+  https://crates.io/api/v1/crates/minutes-cli/X.Y.Z | jq -r '.version.num'
 ```
 
 Notes:
 - `cargo publish` reads each crate's `version =` dependency fields (not the local `path =`), which already point at the crates.io versions, so no manifest edits are needed.
-- Publishing is irreversible: you can only yank, never replace a version. Always run the `--dry-run` first.
+- Publishing is irreversible: you can only yank, never replace a version. Never move a failed release tag to replace published crate contents.
 - This revives `cargo install minutes-cli` for users who do not use Homebrew.
-- If `minutes-core` fails to publish with a missing-dependency error, confirm whisper-guard at the required version is already indexed (Step 13).
+- If the workflow's `minutes-core` publish fails with a missing-dependency error, confirm whisper-guard at the required version is already indexed (Step 13), then rerun `release-publish.yml` for the same tag.
 
 ### 15. Refresh the landing page copy, then redeploy
 Before deploying, make sure the site matches what just shipped:

--- a/docs/release/trusted-publishing.md
+++ b/docs/release/trusted-publishing.md
@@ -1,0 +1,76 @@
+# Trusted publishing setup
+
+The `release-publish.yml` workflow publishes `minutes-sdk`, `minutes-mcp`,
+`minutes-core`, and `minutes-cli` from a protected `v*` tag. npm and crates.io
+authenticate the workflow through GitHub's OpenID Connect (OIDC) identity, so
+the repository must not contain registry tokens or registry publishing secrets.
+
+Complete this one-time registry setup after `release-publish.yml` is present on
+the repository's default branch. The owner, repository, and workflow filename
+are security boundaries; enter them exactly as shown.
+
+## npm
+
+Configure each package separately:
+
+1. Sign in to [npmjs.com](https://www.npmjs.com/) with a maintainer account.
+2. Open `minutes-sdk` -> **Settings** -> **Trusted Publisher**.
+3. Select **GitHub Actions** and enter:
+   - Organization or user: `silverstein`
+   - Repository: `minutes`
+   - Workflow filename: `release-publish.yml`
+   - Environment name: leave empty (the workflow does not use an environment)
+   - Allowed action: enable `npm publish`
+4. Save the trusted publisher.
+5. Repeat the same click-path and values for `minutes-mcp`.
+
+The workflow deliberately does not set `NODE_AUTH_TOKEN`. npm 11.5.1 or newer
+detects the GitHub OIDC context automatically, and public trusted publishes
+include provenance automatically.
+
+After a tag run successfully publishes or verifies both packages through OIDC:
+
+1. Revoke legacy automation and granular access tokens that were used for
+   publishing these packages.
+2. For each package, return to **Settings**, set publishing access to
+   **Require two-factor authentication and disallow tokens**, and save it.
+
+Do not tighten token access before the first OIDC run succeeds; keeping the
+transition ordered preserves a recovery path if a registry-side field was
+mistyped.
+
+## crates.io
+
+Configure each crate separately:
+
+1. Sign in to [crates.io](https://crates.io/) with a crate owner account.
+2. Open `minutes-core` -> **Settings** -> **Trusted Publishing**.
+3. Add a GitHub trusted publisher with:
+   - Organization or user: `silverstein`
+   - Repository: `minutes`
+   - Workflow filename: `release-publish.yml`
+   - Environment name: leave empty
+4. Save the trusted publisher.
+5. Repeat the same click-path and values for `minutes-cli`.
+
+The workflow uses the official `rust-lang/crates-io-auth-action@v1` action to
+exchange the GitHub OIDC identity for a short-lived crates.io token. The action
+revokes that temporary token when the job finishes. No `CARGO_REGISTRY_TOKEN`
+secret should be added to GitHub.
+
+`whisper-guard` is intentionally not configured for this workflow. It has an
+independent version and publishing cadence documented in the main release
+procedure.
+
+## GitHub tag protection and rollout
+
+The repository's existing ruleset protects `v*` tags. Keep that protection in
+place: a pushed release tag authorizes all four irreversible registry
+publishes, and neither trusted publisher configuration uses a GitHub
+environment as an additional boundary.
+
+Adding the workflow does not replay past tag events. In particular, the
+already-pushed `v0.22.0` tag will not trigger `release-publish.yml`
+retroactively. `workflow_dispatch` exists only for an intentional rerun of a
+specific tag; the workflow checks out that tag, reruns release readiness, and
+requires the tag name to match the committed package version.

--- a/scripts/registry_poll.mjs
+++ b/scripts/registry_poll.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_NPM_REGISTRY_URL = "https://registry.npmjs.org/";
+const DEFAULT_POLL_DELAYS_MS = [5_000, 10_000, 20_000, 40_000, 60_000, 60_000, 60_000, 45_000];
+
+function registryUrl() {
+  const configured = process.env.NPM_REGISTRY_URL ?? DEFAULT_NPM_REGISTRY_URL;
+  return configured.endsWith("/") ? configured : `${configured}/`;
+}
+
+function pollDelays() {
+  const configured = process.env.REGISTRY_POLL_DELAYS_MS;
+  if (configured === undefined) return DEFAULT_POLL_DELAYS_MS;
+
+  const delays = configured.split(",").map((value) => Number(value));
+  if (delays.length === 0 || delays.some((value) => !Number.isFinite(value) || value < 0)) {
+    throw new Error("REGISTRY_POLL_DELAYS_MS must be a comma-separated list of non-negative numbers");
+  }
+  return delays;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export async function lookupNpmVersion(
+  packageName,
+  version,
+  { fetchImpl = fetch, npmRegistryUrl = registryUrl(), timeoutMs = 10_000 } = {},
+) {
+  const baseUrl = npmRegistryUrl.endsWith("/") ? npmRegistryUrl : `${npmRegistryUrl}/`;
+  const url = new URL(`${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`, baseUrl);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    return { kind: "temporary-error", detail: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 404) return { kind: "missing" };
+  if (response.status >= 500 && response.status <= 599) {
+    return { kind: "temporary-error", detail: `HTTP ${response.status}` };
+  }
+  if (!response.ok) {
+    throw new Error(`npm registry lookup for ${packageName}@${version} failed with HTTP ${response.status}`);
+  }
+
+  let metadata;
+  try {
+    metadata = await response.json();
+  } catch (error) {
+    throw new Error(
+      `npm registry returned invalid JSON for ${packageName}@${version}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return { kind: "found", integrity: metadata?.dist?.integrity };
+}
+
+export function assertNpmIntegrity(packageName, version, actual, expected) {
+  if (typeof actual !== "string" || actual.length === 0) {
+    throw new Error(`npm registry metadata for ${packageName}@${version} has no dist.integrity`);
+  }
+  if (actual !== expected) {
+    throw new Error(
+      `${packageName}@${version} already exists with different integrity\n` +
+        `  registry: ${actual}\n  local:    ${expected}\nRefusing to replace published provenance.`,
+    );
+  }
+}
+
+export async function checkNpmVersion(packageName, version, expectedIntegrity, options = {}) {
+  const result = await lookupNpmVersion(packageName, version, options);
+  if (result.kind === "found") {
+    assertNpmIntegrity(packageName, version, result.integrity, expectedIntegrity);
+    return true;
+  }
+  if (result.kind === "missing") return false;
+  throw new Error(
+    `cannot safely determine whether ${packageName}@${version} already exists (${result.detail}); refusing to publish`,
+  );
+}
+
+export async function pollForNpmVersion(
+  packageName,
+  version,
+  expectedIntegrity,
+  { delays = pollDelays(), logger = console.log, sleepImpl = sleep, ...lookupOptions } = {},
+) {
+  let lastResult;
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    lastResult = await lookupNpmVersion(packageName, version, lookupOptions);
+    if (lastResult.kind === "found") {
+      assertNpmIntegrity(packageName, version, lastResult.integrity, expectedIntegrity);
+      logger(`npm confirms ${packageName}@${version} (${expectedIntegrity}).`);
+      return;
+    }
+
+    if (attempt < delays.length) {
+      const description = lastResult.kind === "missing" ? "404 (not visible yet)" : lastResult.detail;
+      logger(`npm registry poll ${attempt + 1}: ${description}; retrying in ${delays[attempt]}ms.`);
+      await sleepImpl(delays[attempt]);
+    }
+  }
+
+  const lastDescription = lastResult?.kind === "missing" ? "404" : lastResult?.detail ?? "unknown error";
+  throw new Error(
+    `${packageName}@${version} did not become visible before the npm registry polling timeout ` +
+      `(last result: ${lastDescription})`,
+  );
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/registry_poll.mjs npm-check <package> <version> <sha512-integrity>",
+    "  node scripts/registry_poll.mjs npm-poll <package> <version> <sha512-integrity>",
+  ].join("\n");
+}
+
+async function main(argv) {
+  const [command, packageName, version, integrity, ...rest] = argv;
+  if (
+    !["npm-check", "npm-poll"].includes(command) ||
+    [packageName, version, integrity].some((value) => value === undefined) ||
+    rest.length > 0
+  ) {
+    throw new Error(usage());
+  }
+  if (!integrity.startsWith("sha512-")) {
+    throw new Error(`expected a sha512 integrity for ${packageName}@${version}`);
+  }
+
+  if (command === "npm-check") {
+    const alreadyPublished = await checkNpmVersion(packageName, version, integrity);
+    process.stdout.write(`already=${alreadyPublished}\n`);
+  } else {
+    await pollForNpmVersion(packageName, version, integrity);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/registry_poll.test.mjs
+++ b/scripts/registry_poll.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import {
+  assertNpmIntegrity,
+  checkNpmVersion,
+  lookupNpmVersion,
+  pollForNpmVersion,
+} from "./registry_poll.mjs";
+
+const PACKAGE_NAME = "minutes-sdk";
+const VERSION = "1.2.3";
+const INTEGRITY = "sha512-local";
+
+async function registryFixture(t, responses) {
+  let requestCount = 0;
+  const server = createServer((request, response) => {
+    assert.equal(request.url, `/${PACKAGE_NAME}/${VERSION}`);
+    const fixture = responses[Math.min(requestCount, responses.length - 1)];
+    requestCount += 1;
+    response.writeHead(fixture.status, { "content-type": "application/json" });
+    response.end(JSON.stringify(fixture.body ?? {}));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))));
+
+  const address = server.address();
+  return {
+    npmRegistryUrl: `http://127.0.0.1:${address.port}/`,
+    requestCount: () => requestCount,
+  };
+}
+
+test("lookup distinguishes a missing version from a matching published version", async (t) => {
+  const fixture = await registryFixture(t, [
+    { status: 404 },
+    { status: 200, body: { dist: { integrity: INTEGRITY } } },
+  ]);
+
+  assert.deepEqual(await lookupNpmVersion(PACKAGE_NAME, VERSION, fixture), { kind: "missing" });
+  assert.equal(await checkNpmVersion(PACKAGE_NAME, VERSION, INTEGRITY, fixture), true);
+});
+
+test("integrity mismatch refuses an idempotent skip", () => {
+  assert.throws(
+    () => assertNpmIntegrity(PACKAGE_NAME, VERSION, "sha512-registry", INTEGRITY),
+    /already exists with different integrity[\s\S]*Refusing to replace published provenance/,
+  );
+});
+
+test("check refuses to publish after a temporary registry error", async (t) => {
+  const fixture = await registryFixture(t, [{ status: 503 }]);
+
+  await assert.rejects(
+    checkNpmVersion(PACKAGE_NAME, VERSION, INTEGRITY, fixture),
+    /cannot safely determine.*HTTP 503.*refusing to publish/,
+  );
+});
+
+test("poll retries 404 and server errors until exact integrity is visible", async (t) => {
+  const fixture = await registryFixture(t, [
+    { status: 404 },
+    { status: 502 },
+    { status: 200, body: { dist: { integrity: INTEGRITY } } },
+  ]);
+  const messages = [];
+
+  await pollForNpmVersion(PACKAGE_NAME, VERSION, INTEGRITY, {
+    ...fixture,
+    delays: [0, 0],
+    logger: (message) => messages.push(message),
+    sleepImpl: async () => {},
+  });
+
+  assert.equal(fixture.requestCount(), 3);
+  assert.match(messages[0], /404 \(not visible yet\)/);
+  assert.match(messages[1], /HTTP 502/);
+  assert.match(messages[2], /npm confirms minutes-sdk@1\.2\.3/);
+});


### PR DESCRIPTION
## What

Closes the last credential surface in the release pipeline. A new tag-triggered `release-publish.yml` publishes all four packages (`minutes-sdk`, `minutes-mcp` to npm; `minutes-core`, `minutes-cli` to crates.io) using OIDC trusted publishing — no tokens stored anywhere, npm provenance included automatically.

Motivated directly by v0.22.0's release friction: npm's 2FA-bypass deprecation (changelog 2026-07-08; token publishing dies Jan 2027) forced two browser-auth dances, and cargo publishing required a key on another machine.

**Security posture:**
- Top-level `permissions: {}`; `id-token: write` granted only to the two publish jobs
- Every job needs `release_readiness` (`check_version_sync.mjs --release`) — the same invariant that gates artifact workflows, so a bad tag publishes nothing
- Idempotent: reruns detect already-published versions and verify integrity instead of failing
- crates.io auth via the official `rust-lang/crates-io-auth-action`; whisper-guard explicitly excluded (independent cadence)

**Maintainer one-time setup** (in `docs/release/trusted-publishing.md`): add the GitHub trusted-publisher config on each of the four package settings pages, then revoke the legacy npm token and Mac cargo key after the first successful OIDC release.

`procedure.md` now ends at "push the tag" — the workflow does the rest. 4 fixture tests for the registry poll helper; actionlint + runner-context checks green.

Follow-up from the v0.22.0 release retro (bead filed during the agent-infra epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)