### PR TITLE
fix(core): let --call auto-detect PipeWire system-audio sinks

### DIFF
--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -457,13 +457,36 @@ impl CapturePlan {
         }
     }
 
-    fn system_audio_ready(&self) -> bool {
+    /// `is_system_audio_device_name` only recognizes name patterns (BlackHole,
+    /// `.monitor`, etc). On PipeWire, a real speaker/headphone sink (including
+    /// Bluetooth A2DP sinks) is also a valid system-audio route — it has no
+    /// special name, but `categorize_device` already knows how to spot it via
+    /// the Duplex (supports_input && supports_output) shape. Without this,
+    /// `detect_loopback_device()` picks a PipeWire sink as the call route but
+    /// this check then rejects it, blocking every PipeWire call recording
+    /// that isn't routed through a virtual/monitor device.
+    fn system_audio_ready(&self, host: &cpal::Host) -> bool {
         match self {
-            Self::Single(plan) => is_system_audio_device_name(&plan.device_name),
+            Self::Single(plan) => is_system_audio_route(host, &plan.device_name),
             #[cfg(feature = "streaming")]
-            Self::Dual(plan) => is_system_audio_device_name(&plan.call_device_name),
+            Self::Dual(plan) => is_system_audio_route(host, &plan.call_device_name),
         }
     }
+}
+
+fn is_system_audio_route(host: &cpal::Host, name: &str) -> bool {
+    use cpal::traits::DeviceTrait;
+
+    if is_system_audio_device_name(name) {
+        return true;
+    }
+    if !is_pipewire_host(host.id()) {
+        return false;
+    }
+    let Some(device) = find_device_on_host(host, name) else {
+        return false;
+    };
+    device.supports_output()
 }
 
 const MISSING_DUAL_SOURCE_LOOPBACK_MESSAGE: &str =
@@ -2574,7 +2597,7 @@ pub fn preflight_recording_with_native_call_capture(
         config,
     )?;
 
-    preflight.system_audio_ready = capture_plan.system_audio_ready();
+    preflight.system_audio_ready = capture_plan.system_audio_ready(host);
     if preflight.intent == RecordingIntent::Call {
         if preflight.system_audio_ready {
             preflight.blocking_reason = None;
@@ -2973,6 +2996,30 @@ mod tests {
             mov_stems.system,
             Path::new("/tmp/meetings/2026-04-01-standup.system.wav")
         );
+    }
+
+    #[test]
+    fn is_system_audio_route_matches_known_name_regardless_of_host() {
+        // Fast path: a BlackHole-style name is recognized without needing to
+        // touch the pipewire-duplex fallback (and thus without needing a real
+        // cpal Host/device for the name to resolve on).
+        let host = cached_default_host();
+        assert!(is_system_audio_route(host, "BlackHole 2ch"));
+    }
+
+    #[test]
+    fn is_system_audio_route_rejects_unknown_name_on_non_pipewire_host() {
+        // Regression guard for the bug where a PipeWire Bluetooth/real
+        // speaker sink picked by detect_loopback_device() (via
+        // categorize_device's is_pipewire+Duplex check) was then rejected by
+        // this function because it only knew name patterns. On a host that
+        // ISN'T pipewire, an arbitrary device name must still be rejected —
+        // this function should not blanket-accept unknown names just because
+        // the pipewire fallback branch exists.
+        assert!(!is_system_audio_route(
+            cached_default_host(),
+            "__minutes_test_device_that_should_never_exist_12345__"
+        ));
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 36;
 export const MINUTES_CLI_COMMAND_COUNT = 56;
-export const MINUTES_TEST_COUNT = 1554;
+export const MINUTES_TEST_COUNT = 1556;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What

`CapturePlan::system_audio_ready()` only recognized name patterns (BlackHole, `.monitor`, Teams Audio, etc). `detect_loopback_device()` already picks a real PipeWire sink (speaker/headphones/Bluetooth A2DP) as the system-audio route via `categorize_device`'s Duplex check, but this gate then rejected it because the sink's friendly name matches none of the known patterns.

Result: `--call` / `call = "auto"` on Linux/PipeWire always fell back to mic-only, even with a correctly detected loopback device — this is the open item flagged in #62's last status update: *"the detection primitive `detect_loopback_device()` now returns the first SystemAudio-categorized device... but `[recording.sources].call = "auto"` is not wired into the runtime path yet."*

Turns out it *was* wired in — `resolve_capture_plan_with_host` calls `detect_loopback_device()` correctly — but the preflight gate downstream (`system_audio_ready()`) didn't know how to recognize what it picked.

## Fix

Add `is_system_audio_route(host, name)`:
- keep the existing name-pattern fast path (`is_system_audio_device_name`)
- add a PipeWire-Duplex fallback: look the device up on the host, check `supports_output()` — same logic `categorize_device` already uses for the same purpose

`CapturePlan::system_audio_ready()` now takes `&cpal::Host` and uses this.

## Verified on real hardware

Sony WF-1000XM5 (Bluetooth, bluez5/PipeWire), device name `sink_default`.

**Before:**
```
$ minutes record --call
Error: Minutes inferred a call capture, but 'input_default + sink_default' does not
include a recognized system-audio route. To record both sides, choose a
loopback/system-audio device like BlackHole for the call source...
```

**After:**
```
$ minutes record --call -v
[minutes] Detected system audio device: sink_default
...
INFO streaming audio capture started device=sink_default
```//`--call` now actually starts capture on the detected sink instead of blocking at preflight.

## Testing

- `cargo test -p minutes-core --no-default-features` — 1081 passed, 0 failed
- `cargo clippy -p minutes-core -- -D warnings` — clean
- `cargo fmt --check` — clean
- 2 new regression tests added: `is_system_audio_route_matches_known_name_regardless_of_host`, `is_system_audio_route_rejects_unknown_name_on_non_pipewire_host`
- Manual before/after test on real Bluetooth earbuds (see above)

Fixes #62