### PR TITLE
fix(parakeet): don't misreport benign helper exits as argv/#163 drift

### DIFF
--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -2729,35 +2729,76 @@ fn loud_once(gate: &AtomicBool) -> bool {
     !gate.swap(true, Ordering::Relaxed)
 }
 
+/// Classify a helper non-zero exit as either an argv/clap contract mismatch
+/// (the issue #163 failure mode) or an ordinary runtime outcome.
+///
+/// The distinction matters because the two demand opposite responses. A
+/// contract mismatch — `transcribe.rs` builds a flag the `ParakeetHelper` clap
+/// struct in `crates/cli/src/main.rs` doesn't accept — makes the helper reject
+/// *every* invocation, so the fast host-process path is silently dead and a
+/// maintainer must go re-sync the flags. clap signals this by exiting with code
+/// 2 and printing a `usage:` / `unexpected argument` / `required arguments`
+/// diagnostic. An ordinary runtime outcome — the helper parsed its args, ran,
+/// and simply produced nothing usable (silence, or a clip below the word
+/// minimum) — exits 1 with an `anyhow` `Error: ...` line and is usually benign.
+/// Only the former should send anyone hunting for flag drift.
+#[cfg(feature = "parakeet")]
+fn helper_failure_is_argv_mismatch(status: &std::process::ExitStatus, stderr: &str) -> bool {
+    if status.code() == Some(2) {
+        return true;
+    }
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("unexpected argument")
+        || lower.contains("following required arguments")
+        || lower.contains("usage:")
+}
+
 /// Log the FIRST helper-subprocess non-zero exit per process at warn level
 /// before falling back to direct invocation. Subsequent failures are
 /// silenced (debug only) to avoid log spam during a recording.
 ///
-/// The motivation is issue #163: when `transcribe.rs` and the
-/// `ParakeetHelper` clap struct in `crates/cli/src/main.rs` disagree about
-/// what flags exist, the helper rejects every invocation and the code
-/// silently falls back to spawning parakeet directly. Without this warning,
-/// that kind of regression hides for arbitrary durations because the
-/// fallback path is functional. Loud first occurrence forces the failure
-/// onto someone's screen instead of into the void.
+/// The message is tailored to the failure class (see
+/// [`helper_failure_is_argv_mismatch`]). An argv/clap contract mismatch is the
+/// issue #163 regression — the fast host-process path is dead for every
+/// utterance until the flags are re-synced — so that case points explicitly at
+/// the two structs to reconcile. A plain "ran but produced no usable transcript"
+/// exit is usually benign (silence / below word minimum) and must NOT masquerade
+/// as an argv bug, or it sends maintainers chasing a phantom flag drift. Either
+/// way the loud first occurrence forces the failure onto someone's screen
+/// instead of into the void.
 #[cfg(feature = "parakeet")]
 fn log_parakeet_helper_failure_once(status: &std::process::ExitStatus, stderr: &str) {
     static GATE: AtomicBool = AtomicBool::new(false);
     let last_line = stderr.lines().last().unwrap_or("").trim();
+    let argv_mismatch = helper_failure_is_argv_mismatch(status, stderr);
     if loud_once(&GATE) {
-        tracing::warn!(
-            exit_status = ?status,
-            stderr_tail = %last_line,
-            "parakeet-helper exited non-zero; falling back to direct subprocess. \
-             This message is logged once per process; subsequent failures will \
-             be debug-level. If you see this, check that every argv flag in \
-             transcribe::transcribe_with_parakeet is also accepted by the \
-             ParakeetHelper clap struct in crates/cli/src/main.rs (issue #163)."
-        );
+        if argv_mismatch {
+            tracing::warn!(
+                exit_status = ?status,
+                stderr_tail = %last_line,
+                "parakeet-helper rejected its arguments; falling back to direct \
+                 subprocess. This is an argv/clap contract drift: every flag built \
+                 in transcribe::transcribe_with_parakeet must be accepted by the \
+                 ParakeetHelper clap struct in crates/cli/src/main.rs (issue #163). \
+                 The fast host-process path stays dead until they are re-synced. \
+                 Logged once per process; subsequent failures are debug-level."
+            );
+        } else {
+            tracing::warn!(
+                exit_status = ?status,
+                stderr_tail = %last_line,
+                "parakeet-helper ran but returned no usable transcript; falling \
+                 back to direct subprocess. This is usually benign (silence or a \
+                 clip below the word minimum), NOT an argv mismatch. Investigate \
+                 only if it persists on audio with clear speech. Logged once per \
+                 process; subsequent failures are debug-level."
+            );
+        }
     } else {
         tracing::debug!(
             exit_status = ?status,
             stderr_tail = %last_line,
+            argv_mismatch,
             "parakeet-helper exited non-zero (suppressed; first occurrence already logged)"
         );
     }
@@ -3339,6 +3380,40 @@ pub fn warmup_parakeet(config: &Config) -> Result<ParakeetWarmupStats, Transcrib
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Exit-code classification for the parakeet helper fallback. Building a
+    /// real `ExitStatus` needs the Unix `from_raw` extension (raw wait status =
+    /// `code << 8`), so these are unix + parakeet gated.
+    #[cfg(all(unix, feature = "parakeet"))]
+    mod parakeet_helper_failure_classification {
+        use super::super::helper_failure_is_argv_mismatch;
+        use std::os::unix::process::ExitStatusExt;
+        use std::process::ExitStatus;
+
+        fn exit(code: i32) -> ExitStatus {
+            ExitStatus::from_raw(code << 8)
+        }
+
+        #[test]
+        fn clap_usage_error_code_two_is_argv_mismatch() {
+            let stderr = "error: unexpected argument '--fp16' found\n\nUsage: minutes parakeet-helper --binary <BINARY> ...";
+            assert!(helper_failure_is_argv_mismatch(&exit(2), stderr));
+        }
+
+        #[test]
+        fn missing_required_arg_is_argv_mismatch_even_if_code_is_one() {
+            // Some clap configurations surface required-arg errors on exit 1.
+            let stderr = "error: the following required arguments were not provided:\n  --model-id <MODEL_ID>";
+            assert!(helper_failure_is_argv_mismatch(&exit(1), stderr));
+        }
+
+        #[test]
+        fn no_text_runtime_error_is_not_argv_mismatch() {
+            // The helper parsed args and ran; the clip just had no usable speech.
+            let stderr = "Error: transcription produced no text (below 3 word minimum)";
+            assert!(!helper_failure_is_argv_mismatch(&exit(1), stderr));
+        }
+    }
 
     #[test]
     #[cfg(feature = "whisper")]

--- a/docs/architecture/parakeet.md
+++ b/docs/architecture/parakeet.md
@@ -503,7 +503,7 @@ parakeet_binary = "/Users/you/.local/bin/parakeet"  # Prefer an absolute path fo
 # parakeet_sidecar_enabled auto-enables when example-server (copied above) resolves; set true/false to force
 parakeet_boost_limit = 25        # Experimental: top graph-derived boost phrases (0 disables)
 parakeet_boost_score = 2.0       # Experimental tuning for parakeet.cpp --boost-score
-parakeet_fp16 = true             # Default on macOS Apple Silicon: ~35% faster transcription with lower GPU memory (see docs/designs/parakeet-perf-2026-04-14.md)
+parakeet_fp16 = true             # Default on macOS Apple Silicon: ~35% faster transcription with lower GPU memory (see docs/designs/parakeet-perf-2026-04-14.md). If fp16 crashes MPSGraph on your machine, Minutes auto-falls-back to fp32; set false to skip the retry (see Troubleshooting → fp16 MPSGraph crash)
 parakeet_vocab = "tdt-600m.tokenizer.vocab"  # Safer when multiple Parakeet models are installed
 ```
 
@@ -572,6 +572,28 @@ Only `tdt-ctc-110m` and `tdt-600m` are supported. Check your config.
 ### "Expected parakeet model in ~/.minutes/models/parakeet/"
 Run `minutes setup --parakeet` to install the recommended Parakeet model plus
 native VAD weights, or follow the manual download steps above.
+
+### fp16 MPSGraph crash on Apple Silicon (auto-handled)
+
+On some Apple Silicon + model combinations the fp16 GPU path crashes inside
+Apple's MPSGraph with an operand type-mismatch, e.g.:
+
+```
+'mps.add' op requires the same element type for all operands and results
+... original module failed verification
+```
+
+This is an upstream `parakeet.cpp` / Apple MPSGraph limitation (an fp16 kernel
+mixing f16 and f32 tensors), **not** a Minutes bug and **not** a broken machine.
+Minutes detects the crash signature, persists an fp16 blacklist fingerprint at
+`~/.minutes/parakeet-fp16-blacklist.json`, and **auto-retries in fp32** — so
+transcription keeps working with no action required (see
+`crates/core/src/parakeet_sidecar.rs`, `FP16_CRASH_SIGNATURES`).
+
+To skip the crash-and-retry on every run, set `parakeet_fp16 = false` in
+config.toml. fp32 is slightly slower and uses more GPU memory but is otherwise
+identical in output. To re-test fp16 after an OS/model update, set
+`parakeet_fp16_blacklist_reset = true` once (it clears the persisted fingerprint).
 
 ### CMake 4.x atomics error (build)
 

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 36;
 export const MINUTES_CLI_COMMAND_COUNT = 56;
-export const MINUTES_TEST_COUNT = 1556;
+export const MINUTES_TEST_COUNT = 1559;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Problem

`log_parakeet_helper_failure_once` in `crates/core/src/transcribe.rs` printed the same warning for **any** non-zero parakeet-helper exit:

> check that every argv flag in transcribe::transcribe_with_parakeet is also accepted by the ParakeetHelper clap struct in crates/cli/src/main.rs (issue #163)

But the helper also exits non-zero for ordinary runtime outcomes — e.g. `Error: transcription produced no text (below 3 word minimum)` on silent/short audio — where it parsed its args fine. That false attribution sends whoever reads the log hunting for a phantom flag drift (it happened during a fresh Parakeet setup on this machine: the warning fired on an empty test clip while the helper path was actually healthy, `host_process_first_use=true` on real audio).

## Fix

- New `helper_failure_is_argv_mismatch(status, stderr)`: clap parse failures exit with code 2 and print `usage:` / `unexpected argument` / `required arguments` diagnostics; everything else is an ordinary runtime outcome.
- The loud first-occurrence warning is now tailored: argv/clap contract drift keeps the explicit #163 guidance (fast path dead until flags re-synced); benign exits get a calm "usually benign, NOT an argv mismatch — investigate only if it persists on audio with clear speech."
- Suppressed debug-level repeats now carry an `argv_mismatch` field.
- 3 unix-gated unit tests covering: exit-2 clap usage error, required-arg error on exit 1, and the no-text runtime error.

## Docs

`docs/architecture/parakeet.md` gains a Troubleshooting entry for the fp16 MPSGraph crash on Apple Silicon (`'mps.add' op requires the same element type for all operands and results`): it's an upstream parakeet.cpp / Apple MPSGraph limitation, Minutes already auto-detects it via `FP16_CRASH_SIGNATURES` and falls back to fp32, and `parakeet_fp16 = false` skips the per-run crash-and-retry. The config-sample comment for `parakeet_fp16` points at the new entry.

## Verification

- `cargo fmt -p minutes-core -- --check` clean
- `cargo clippy -p minutes-core -p minutes-cli --features minutes-cli/parakeet -- -D warnings` clean
- `cargo test -p minutes-core --features parakeet parakeet_helper_failure_classification` — 3/3 pass
- Live-verified on this machine: real speech through `minutes transcribe` uses the fast helper path (`host_process_first_use=true`, no fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
