### PR TITLE
fix(summarize): support Apple engine for speaker mapping (#487)

### DIFF
--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -2879,6 +2879,10 @@ fn run_speaker_mapping_prompt(
                 .map(|s| s.to_string())
                 .ok_or_else(|| "No text in response".into())
         }
+        "apple" | "apple-fm" => crate::apple_fm::generate(
+            "You map anonymous speaker labels to attendee names.",
+            prompt,
+        ),
         other => Err(format!("Unknown engine: {}", other).into()),
     }
 }


### PR DESCRIPTION
Fixes #487 — with `summarization.engine = "apple"`, speaker mapping fails with `Unknown engine: apple` even though summarization itself works.

## Root cause
#439 threaded the `"apple" | "apple-fm"` engine arm through summarization (`summarize.rs:168`), title refinement (`:2467`), and even the `speaker_mapping_model_hint` metadata (`:769`) — but not the actual speaker-mapping executor `run_speaker_mapping_prompt` (`:2800`). So `engine = "apple"` fell through to the `Unknown engine` catch-all, and the hint claimed apple works while dispatch rejected it.

## Fix
Add the missing arm, routing to the same `crate::apple_fm::generate` provider the other apple arms already use. Speaker mapping is a plain system+user→text call (no multimodal), so no new capability is needed; macOS gating and graceful degrade already work (`map_speakers` logs-and-continues on any engine error).

Reported by @jmh1313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)