### PR TITLE
fix(hotkey): invalidate CGEventTap Mach port on teardown to stop system-wide tap leak (#488)

### DIFF
--- a/crates/core/src/hotkey_macos.rs
+++ b/crates/core/src/hotkey_macos.rs
@@ -88,6 +88,10 @@ mod ffi {
 
         pub fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
         pub fn CGEventTapIsEnabled(tap: CFMachPortRef) -> bool;
+        // Removes the tap's Mach port from the system event-tap table.
+        // Disabling + CFRelease alone leaves the port registered as a
+        // disabled orphan (issue #488), so this must run at teardown.
+        pub fn CFMachPortInvalidate(port: CFMachPortRef);
 
         pub fn CFMachPortCreateRunLoopSource(
             allocator: CFAllocatorRef,
@@ -433,9 +437,15 @@ fn run_event_tap(
             }
         }
 
-        // Clean up
+        // Clean up. CFMachPortInvalidate removes the tap from the system
+        // event-tap table; CGEventTapEnable(false) + CFRelease alone leaves it
+        // registered as a disabled orphan, so repeated create/teardown cycles
+        // (the input-monitoring probe, hotkey re-registration) accumulate until
+        // the 512-entry tap table is exhausted and Screen Recording /
+        // screenshots break system-wide (issue #488).
         ffi::CGEventTapEnable(tap, false);
         ffi::CFRunLoopRemoveSource(run_loop, source, ffi::kCFRunLoopCommonModes);
+        ffi::CFMachPortInvalidate(tap);
         ffi::CFRelease(source as *const std::ffi::c_void);
         ffi::CFRelease(tap as *const std::ffi::c_void);
         let _ = Box::from_raw(context_ptr as *mut TapContext);

--- a/crates/core/src/hotkey_macos.rs
+++ b/crates/core/src/hotkey_macos.rs
@@ -408,6 +408,10 @@ fn run_event_tap(
         if source.is_null() {
             let message = "Could not start native hotkey run loop.";
             tracing::error!("{}", message);
+            // The tap was already registered by CGEventTapCreate above, so
+            // invalidate it (not just CFRelease) on this error path too, or it
+            // leaks into the system tap table like the teardown case (#488).
+            ffi::CFMachPortInvalidate(tap);
             ffi::CFRelease(tap as *const std::ffi::c_void);
             let _ = Box::from_raw(context_ptr as *mut TapContext);
             status_callback(HotkeyMonitorStatus::Failed(message.to_string()));


### PR DESCRIPTION
Fixes #488 — a long-running app accumulates 512+ disabled CGEventTaps and breaks screenshots / Screen Recording system-wide.

## Root cause
`run_event_tap` (`crates/core/src/hotkey_macos.rs`) tears down with `CGEventTapEnable(false)` + `CFRelease` but never calls `CFMachPortInvalidate`. Disabling and releasing the `CFMachPort` does **not** remove a `CGEventTapCreate` port from the system's 512-entry event-tap table — the canonical teardown must invalidate the Mach port first. So each tap is left as a **disabled orphan**.

The churn comes from the permission monitor: for users who have **granted Input Monitoring**, the 15s `spawn_permission_monitor` poll runs an active tap probe (`input_monitoring_runtime_issue` → `probe_hotkey_monitor` → `CGEventTapCreate`). 512 orphans × 15s ≈ 2.1h of uptime to exhaust the table, matching the report.

## Fix
Declare `CFMachPortInvalidate` in the FFI block and call it at teardown (after `CFRunLoopRemoveSource`, before `CFRelease`). Every tap — probe, dictation monitor, and each register/unregister cycle — is now actually removed, not just dereferenced. This is a complete fix for the leak with no behavior change.

## Recommended follow-up (separate)
The passive 15s poll should not create a real tap at all — read Input Monitoring *state* via the tap-free `CGPreflightListenEventAccess()` and reserve the active "can I start a tap" probe for explicit diagnostics. That removes ~5,760 unnecessary tap create/teardown cycles/day (now harmless, but wasteful).

Reported by @jmh1313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)