### PR TITLE
fix(permissions): probe Input Monitoring once per process, not every 15s (#488)

### DIFF
--- a/crates/core/src/macos_permissions.rs
+++ b/crates/core/src/macos_permissions.rs
@@ -329,15 +329,27 @@ mod platform {
     }
 
     pub fn input_monitoring_runtime_issue() -> Option<&'static str> {
-        let probe = crate::hotkey_macos::probe_hotkey_monitor(
-            crate::hotkey_macos::KEYCODE_FN,
-            Duration::from_millis(250),
-        );
-        if probe.status == "active" {
-            None
-        } else {
-            Some("macOS reports Input Monitoring as granted, but this running process could not start the native event tap. Restart Minutes and confirm the enabled System Settings entry matches this app copy.")
-        }
+        // Probe once per process, then cache. Whether this running app copy can
+        // start an event tap is fixed for the process lifetime (a "granted but
+        // unusable" state is only cleared by restarting Minutes), so there is
+        // no reason to re-probe. Re-probing meant the 15s permission monitor
+        // created and tore down a real kCGHIDEventTap every 15 seconds; before
+        // #488's teardown fix that leaked taps until the system tap table was
+        // exhausted and keyboard/mouse input froze system-wide. Probing once
+        // preserves the diagnostic while removing the churn entirely.
+        static RUNTIME_ISSUE: std::sync::OnceLock<Option<&'static str>> =
+            std::sync::OnceLock::new();
+        *RUNTIME_ISSUE.get_or_init(|| {
+            let probe = crate::hotkey_macos::probe_hotkey_monitor(
+                crate::hotkey_macos::KEYCODE_FN,
+                Duration::from_millis(250),
+            );
+            if probe.status == "active" {
+                None
+            } else {
+                Some("macOS reports Input Monitoring as granted, but this running process could not start the native event tap. Restart Minutes and confirm the enabled System Settings entry matches this app copy.")
+            }
+        })
     }
 
     pub fn accessibility_status() -> MacPermissionStatus {


### PR DESCRIPTION
Follow-up to #499. The `CFMachPortInvalidate` teardown fix stopped the tap *leak*; this stops the *churn* that fed it.

## What
`input_monitoring_runtime_issue()` created and tore down a real `kCGHIDEventTap` on **every 15s permission-monitor poll** (for users who granted Input Monitoring) to detect a "granted but unusable" state. That state is fixed for the process lifetime — it's only cleared by restarting the app — so re-probing is pointless churn on the system-wide input event path (~5,760 tap create/teardown cycles/day). Before #499's teardown fix, this churn is what leaked taps until the 512-entry table exhausted and keyboard/mouse froze system-wide (with WindowServer crashes).

Memoize the probe (`OnceLock`) so it runs **once per launch**, preserving the diagnostic with zero ongoing churn.

## Why this matters
This is the long-standing "Minutes left open overnight makes the whole machine laggy/frozen; quitting Minutes instantly fixes it; SSH stays fine" report — the taps are on `kCGHIDEventTap`, the system-wide HID path. #499 + this fix together fully resolve it.

Related: #488, #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)