### PR TITLE
fix(desktop): make Recall/chat panel text selectable + copyable (#490)

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -579,6 +579,9 @@
       display: flex;
       flex-direction: column;
       gap: 10px;
+      /* Recall/chat content must be selectable + copyable (overrides body user-select: none) */
+      -webkit-user-select: text;
+      user-select: text;
     }
 
     /* "Jump to latest" pill — shown only when the user has scrolled up and new


### PR DESCRIPTION
## Problem

Issue #490: text in the Recall chat panel can't be selected or copied. The `.chat-messages` container inherits `user-select: none` from the global body rule, so assistant answers and transcript snippets are locked.

## Fix

Add an explicit `user-select: text` (with `-webkit-` prefix for the WKWebView) scoped to `.chat-messages`. One-line CSS override, no behavior change elsewhere.

## Test

Manual: dev app → Recall panel → select an answer → ⌘C copies it. (UI-only CSS; no unit test surface.)

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)