### PR TITLE
perf(desktop): unblock meetings-list first paint from the proactive context bundle

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -9742,14 +9742,23 @@
         await loadDocuments();
         return;
       }
+      let meetings = [];
       try {
-        await loadProactiveContextBundle();
-        const meetings = await invoke('cmd_list_meetings', { limit: 30 });
+        meetings = await invoke('cmd_list_meetings', { limit: 30 });
         renderMeetings(meetings);
       } catch (e) {
         console.error('Load:', e);
         renderMeetings([]);
+        return;
       }
+      // The proactive context bundle runs several corpus-wide scans and is only
+      // needed for the ambient-context card, not the meetings list itself. Load
+      // it in the background and re-render once it resolves, so first paint is
+      // never gated on it. (It was previously awaited *before* the list — the
+      // dominant cause of the blank window at startup.)
+      loadProactiveContextBundle()
+        .then(() => { if (!documentsViewActive) renderMeetings(meetings); })
+        .catch((e) => console.error('Proactive bundle:', e));
     }
 
     async function refreshOpenMeetingDetail() {


### PR DESCRIPTION
## Problem

On desktop launch the window appears immediately but the main view stays **blank for a few moments** before the meetings list renders.

Root cause: `loadMeetings()` (tauri/src/index.html) awaited `loadProactiveContextBundle()` **before** fetching and rendering the list. `cmd_proactive_context_bundle` runs three corpus-wide operations serially — `search("")`, `consistency_report`, and a fresh graph projection rebuild — none of which are needed to paint the meetings list. So first paint was gated behind all of it. The cost scales with corpus size (this surfaced sharply after a user's archive grew to ~800 meetings).

## Fix

Render the list as soon as `cmd_list_meetings` returns, then load the proactive bundle in the **background** and re-render once it resolves so the ambient-context card still appears. First paint is no longer gated on the bundle.

```js
// before: await loadProactiveContextBundle();  then list
// after:  render list first; loadProactiveContextBundle().then(re-render)
```

The ambient-context card behavior is preserved (it just appears a moment later, when its data is ready), and the meetings list is unchanged.

## Scope / not included

This is the low-risk, frontend-only slice. Deliberately **not** here (follow-ups):
- Parallelizing `cmd_needs_setup` with the list — the empty-state render reads `currentSetup`, so it needs a new-user re-render guard first.
- The structural wins: the in-memory FTS index is rebuilt per `search()` call (each command re-indexes the whole corpus); precomputing lifecycle badges in the index (today `cmd_list_meetings` does one `fs::read_to_string` per listed item); list virtualization + pagination so the full history can be shown without a per-row DOM/IO cost.

## Verification

Frontend-only change (`frontendDist: ../src`, no build step). Built the dev app and launched; meetings list paints immediately, ambient card fills in after. No behavior change to the list itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
