### PR TITLE
fix(vocabulary): unique id for non-ASCII canonicals (#511)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4137,7 +4137,12 @@ fn cmd_vocabulary_remove(id: &str, json: bool) -> Result<()> {
     let path = minutes_core::vocabulary::default_path();
     let mut store = minutes_core::vocabulary::load().map_err(|e| anyhow::anyhow!("{}", e))?;
     let before = store.entries.len();
-    store.entries.retain(|entry| entry.id != id);
+    // Match by id or by exact canonical, so non-Latin-script entries (whose id
+    // is a `<kind>-<hash>` derived from an empty ASCII slug) can be removed by
+    // the canonical the user typed, not just an opaque hash id. (#511)
+    store
+        .entries
+        .retain(|entry| entry.id != id && entry.canonical != id);
     let removed = store.entries.len() != before;
     let store = store.normalized().map_err(|e| anyhow::anyhow!("{}", e))?;
     minutes_core::vocabulary::save_at(&path, &store).map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -4153,7 +4158,7 @@ fn cmd_vocabulary_remove(id: &str, json: bool) -> Result<()> {
         eprintln!("Removed vocabulary entry: {}", id);
         eprintln!("Existing raw transcripts stay unchanged.");
     } else {
-        eprintln!("No vocabulary entry found with id: {}", id);
+        eprintln!("No vocabulary entry found with id or canonical: {}", id);
     }
     Ok(())
 }

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -135,7 +135,12 @@ impl VocabularyEntry {
         } else {
             self.id = slugify_id(self.id.trim());
         }
-        if self.id.is_empty() {
+        // Empty, or a bare `<kind>` id (a non-ASCII canonical whose ASCII slug
+        // collapsed to nothing, from an install predating the hash fallback):
+        // re-derive a unique, stable id from the canonical so entries cannot
+        // collide on the bare kind. This migrates existing collided installs on
+        // load. (#511)
+        if self.id.is_empty() || self.id == self.kind.label() {
             self.id = entry_id(self.kind, &self.canonical);
         }
 
@@ -400,9 +405,28 @@ fn key_for(value: &str) -> String {
 }
 
 fn entry_id(kind: VocabularyKind, canonical: &str) -> String {
-    format!("{}-{}", kind.label(), slugify_id(canonical))
-        .trim_end_matches('-')
-        .to_string()
+    let slug = slugify_id(canonical);
+    if slug.is_empty() {
+        // Canonical has no ASCII alphanumerics (e.g. Cyrillic, CJK). An ASCII
+        // slug would be empty and collapse to the bare kind, colliding across
+        // entries. Fall back to a deterministic short hash of the canonical so
+        // every entry gets a unique, stable id regardless of script. (#511)
+        format!("{}-{:x}", kind.label(), canonical_hash(canonical))
+    } else {
+        format!("{}-{}", kind.label(), slug)
+    }
+}
+
+/// Stable FNV-1a hash of a vocabulary canonical, used to build a unique id when
+/// the ASCII slug is empty. Deterministic across runs and Rust versions, so the
+/// derived id stays constant for a given canonical.
+fn canonical_hash(canonical: &str) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325; // FNV offset basis
+    for byte in canonical.trim().to_lowercase().as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3); // FNV prime
+    }
+    hash
 }
 
 fn slugify_id(value: &str) -> String {
@@ -487,6 +511,87 @@ mod tests {
         assert_eq!(entry.id, "organization-automattic");
         assert_eq!(entry.canonical, "Automattic");
         assert_eq!(entry.aliases, vec!["Automatic"]);
+    }
+
+    #[test]
+    fn non_ascii_canonical_gets_unique_hash_id_not_bare_kind() {
+        // Cyrillic canonicals: the ASCII slug is empty, so ids must fall back to
+        // unique <kind>-<hash> rather than collapsing to the bare kind. (#511)
+        let store = VocabularyStore {
+            entries: vec![
+                VocabularyEntry {
+                    kind: VocabularyKind::Term,
+                    canonical: "Пример".into(),
+                    ..VocabularyEntry::default()
+                },
+                VocabularyEntry {
+                    kind: VocabularyKind::Term,
+                    canonical: "Другой".into(),
+                    ..VocabularyEntry::default()
+                },
+            ],
+        }
+        .normalized()
+        .unwrap();
+
+        assert_eq!(store.entries.len(), 2);
+        for entry in &store.entries {
+            assert_ne!(entry.id, "term", "id must not collapse to the bare kind");
+            assert!(entry.id.starts_with("term-"));
+        }
+        assert_ne!(
+            store.entries[0].id, store.entries[1].id,
+            "two different non-ASCII canonicals must get different ids"
+        );
+    }
+
+    #[test]
+    fn non_ascii_id_is_stable_across_normalization() {
+        let build = || {
+            VocabularyStore {
+                entries: vec![VocabularyEntry {
+                    kind: VocabularyKind::Acronym,
+                    canonical: "例え".into(),
+                    ..VocabularyEntry::default()
+                }],
+            }
+            .normalized()
+            .unwrap()
+        };
+        assert_eq!(build().entries[0].id, build().entries[0].id);
+        assert!(build().entries[0].id.starts_with("acronym-"));
+    }
+
+    #[test]
+    fn bare_kind_id_is_migrated_on_normalize() {
+        // An install predating the fix persisted a bare "term" id for a Cyrillic
+        // canonical; normalizing (on every load) re-derives a unique id. (#511)
+        let store = VocabularyStore {
+            entries: vec![VocabularyEntry {
+                id: "term".into(),
+                kind: VocabularyKind::Term,
+                canonical: "Пример".into(),
+                ..VocabularyEntry::default()
+            }],
+        }
+        .normalized()
+        .unwrap();
+        assert_ne!(store.entries[0].id, "term");
+        assert!(store.entries[0].id.starts_with("term-"));
+    }
+
+    #[test]
+    fn ascii_canonical_id_is_unchanged() {
+        let store = VocabularyStore {
+            entries: vec![VocabularyEntry {
+                kind: VocabularyKind::Term,
+                canonical: "TestLatin".into(),
+                ..VocabularyEntry::default()
+            }],
+        }
+        .normalized()
+        .unwrap();
+        assert_eq!(store.entries[0].id, "term-testlatin");
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 36;
 export const MINUTES_CLI_COMMAND_COUNT = 56;
-export const MINUTES_TEST_COUNT = 1569;
+export const MINUTES_TEST_COUNT = 1573;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Fixes #511 — reported by @mishaK197.

## Problem
`vocabulary add` derives an entry `id` by ASCII-only slugification of the canonical. A canonical with no ASCII letters/digits (Cyrillic, CJK, …) produces an empty slug and collapses to the bare `<kind>` (`term` / `acronym` / `organization`). Multiple such entries share one id, making `vocabulary remove <id>` ambiguous. The reporter saw 15 of 31 entries collide onto 3 ids.

## Fix
- **`entry_id`**: when the ASCII slug is empty, fall back to a deterministic **FNV-1a hash** of the canonical (`<kind>-<hash>`) — unique + stable across runs/re-adds (unlike a positional counter, which renumbers on removal).
- **`normalize`**: re-derive any bare-`<kind>` id from the canonical, so **existing collided installs self-heal** on the next load (both `load` and `save` normalize).
- **`vocabulary remove`**: match by id **or exact canonical**, so a non-Latin entry can be removed by the term the user typed rather than an opaque hash.

## Tests
4 new `vocabulary` unit tests: non-ASCII → unique non-bare ids (two Cyrillic canonicals get different ids), hash-id stability across normalization, bare-`<kind>` id migration, ASCII ids unchanged. Full vocabulary suite + clippy + fmt green; CLI builds.

## ⚠️ Do not merge yet
Main is **frozen** for the in-flight conversation-trust integration. This PR is staged and ready; **merge after that lands** (it'll need a trivial rebase onto the new main). No overlap with the trust work — this touches only `vocabulary.rs` + the `vocabulary remove` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)