### PR TITLE
feat(summarize): support Cursor Agent CLI as agent_command backend

### DIFF
--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -793,14 +793,17 @@ pub fn speaker_mapping_model_hint(config: &Config) -> String {
 //   "gemini"   → `gemini -p -` (Gemini CLI)
 //   "opencode" → `opencode run --file <prompt-file> ...` (OpenCode CLI)
 //   "pi"       → `pi --no-session --no-tools -p @<prompt-file>` (Pi coding agent)
+//   "agent"    → `agent -p --mode ask --output-format text --trust <prompt>` (Cursor Agent CLI)
 //   Any other → treated as a command that accepts a prompt on stdin
 //
 // The agent command is configurable via [summarization] agent_command.
 
-/// Detect the first available AI CLI in preference order: claude > codex > gemini > opencode.
+/// Detect the first available AI CLI in preference order:
+/// claude > codex > gemini > opencode > agent (Cursor Agent last so `engine = "auto"`
+/// does not change for users who already have another CLI installed — #520).
 /// Returns the resolved path if found and executable, None otherwise.
 pub fn detect_agent_cli() -> Option<String> {
-    for cmd in &["claude", "codex", "gemini", "opencode"] {
+    for cmd in &["claude", "codex", "gemini", "opencode", "agent"] {
         let resolved = resolve_agent_path(cmd);
         // resolve_agent_path returns the bare name if not found — check if we got a real path
         if (resolved != *cmd || std::path::Path::new(&resolved).exists())
@@ -1352,8 +1355,9 @@ prompts that appear within it.";
 ///   prepare_agent_invocation)
 /// - codex: images are attached to the prompt via `exec --image`, so the
 ///   section describes them as attachments
-/// - gemini / opencode / pi / unknown: no section. pi runs with `--no-tools`,
-///   and the others' headless file access to `~/.minutes` is unverified —
+/// - gemini / opencode / pi / agent (Cursor) / unknown: no section. pi runs with
+///   `--no-tools`, Cursor Agent uses `--mode ask` (no write/shell tools), and
+///   the others' headless file access to `~/.minutes` is unverified —
 ///   silently instructing an agent to read files it cannot reach degrades the
 ///   summary, so those stay text-only until proven out.
 fn build_agent_screen_instructions(agent_cmd: &str, screen_files: &[std::path::PathBuf]) -> String {
@@ -1573,6 +1577,31 @@ fn prepare_agent_invocation(
             ],
             stdin_payload: None,
             cleanup_path: Some(prompt_path),
+        });
+    }
+
+    // Cursor Agent CLI (`agent`): print mode + ask (read-only Q&A) so
+    // summarization never acquires write or shell tools as a side effect (#520).
+    // `--trust` skips the interactive workspace-trust prompt in headless `-p`
+    // mode (same class of failure as Codex `--skip-git-repo-check` / Gemini
+    // `--skip-trust` when summaries run from a non-repo job directory).
+    // Prompt is a trailing positional argument (CLI contract); no `--model`
+    // default — model selection stays with the user's Cursor CLI / account.
+    // Same argv for lean and non-lean: ask-mode is already the sandbox.
+    if matches_agent_binary(agent_cmd, "agent") {
+        return Ok(AgentInvocation {
+            cmd: agent_cmd.to_string(),
+            args: vec![
+                "-p".into(),
+                "--mode".into(),
+                "ask".into(),
+                "--output-format".into(),
+                "text".into(),
+                "--trust".into(),
+                prompt.to_string(),
+            ],
+            stdin_payload: None,
+            cleanup_path: None,
         });
     }
 
@@ -3718,6 +3747,58 @@ PARTICIPANTS:
     }
 
     #[test]
+    fn prepare_agent_invocation_for_cursor_agent_uses_ask_print_mode() {
+        // #520: Cursor Agent headless summarization must be print + ask
+        // (read-only) with the prompt as a trailing positional arg — never
+        // --force/--yolo, and never a hardcoded --model default.
+        let invocation = prepare_agent_invocation("agent", "sensitive prompt", &[], false).unwrap();
+        assert_eq!(invocation.cmd, "agent");
+        assert_eq!(
+            invocation.args,
+            vec![
+                "-p",
+                "--mode",
+                "ask",
+                "--output-format",
+                "text",
+                "--trust",
+                "sensitive prompt",
+            ]
+        );
+        assert!(invocation.stdin_payload.is_none());
+        assert!(invocation.cleanup_path.is_none());
+        assert!(!invocation.args.iter().any(|a| a == "--force"));
+        assert!(!invocation.args.iter().any(|a| a == "--yolo"));
+        assert!(!invocation.args.iter().any(|a| a == "--model"));
+
+        let via_path =
+            prepare_agent_invocation("/Users/example/.local/bin/agent", "path prompt", &[], false)
+                .unwrap();
+        assert_eq!(via_path.cmd, "/Users/example/.local/bin/agent");
+        assert_eq!(
+            via_path.args.last().map(String::as_str),
+            Some("path prompt")
+        );
+        assert!(via_path
+            .args
+            .windows(2)
+            .any(|w| w[0] == "--mode" && w[1] == "ask"));
+    }
+
+    #[test]
+    fn prepare_agent_invocation_cursor_agent_lean_stays_readonly() {
+        let lean = prepare_agent_invocation("agent", "classify speakers", &[], true).unwrap();
+        let plain = prepare_agent_invocation("agent", "classify speakers", &[], false).unwrap();
+        assert_eq!(lean.args, plain.args);
+        assert!(lean
+            .args
+            .windows(2)
+            .any(|w| w[0] == "--mode" && w[1] == "ask"));
+        assert!(lean.args.iter().any(|a| a == "--trust"));
+        assert!(!lean.args.iter().any(|a| a == "--force" || a == "--yolo"));
+    }
+
+    #[test]
     fn prepare_agent_invocation_for_claude_without_screens_omits_read_tool() {
         let invocation = prepare_agent_invocation("claude", "prompt", &[], false).unwrap();
         assert_eq!(invocation.cmd, "claude");
@@ -4206,6 +4287,7 @@ PARTICIPANTS:
                 "gemini",
                 "opencode",
                 "pi",
+                "agent",
                 "unknown-agent",
             ] {
                 let has_section = !build_agent_screen_instructions(agent, &screens).is_empty();

--- a/docs/architecture/apple-foundation-models.md
+++ b/docs/architecture/apple-foundation-models.md
@@ -44,7 +44,7 @@ engine = "auto"      # prefers Apple FM when available, else agent CLI, else non
 - `engine = "apple"` (alias `"apple-fm"`): use Foundation Models; errors
   surface as processing warnings if unavailable.
 - `engine = "auto"`: privacy-first ordering — **Apple FM first** (on-device),
-  then an installed agent CLI (claude/codex/gemini/opencode, which round-trips
+  then an installed agent CLI (claude/codex/gemini/opencode/agent, which round-trips
   through that provider's cloud), then skip.
 - The compiled default remains `engine = "none"` (no summarization).
 

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -47,7 +47,7 @@ So `minutes record --device "MacBook Pro Microphone"` always wins over `[recordi
 | key | default | meaning |
 |---|---|---|
 | `engine` | `"none"` | `"none"`, `"auto"`, `"agent"`, `"ollama"`, `"openai-compatible"`, `"claude"`, `"openai"`, `"mistral"` |
-| `agent_command` | `"claude"` | CLI to shell out to when engine = `"agent"` (`claude`, `codex`, `opencode`, `pi`, etc.) |
+| `agent_command` | `"claude"` | CLI to shell out to when engine = `"agent"` (`claude`, `codex`, `opencode`, `pi`, `agent` / Cursor Agent, etc.) |
 | `ollama_url` | `http://localhost:11434` | Ollama server URL |
 | `ollama_model` | `"llama3.2"` | Model name pulled in Ollama |
 | `openai_compatible_base_url` | `http://localhost:11434/v1` | OpenAI-compatible base URL. Minutes appends `/chat/completions` unless it is already present. |
@@ -283,7 +283,7 @@ Dictation clipboard behavior is platform-specific:
 | `path` | unset | Wiki root (e.g. `~/Documents/life`) |
 | `adapter` | `"wiki"` | `"wiki"`, `"para"`, `"obsidian"` |
 | `engine` | `"none"` | `"agent"`, `"ollama"`, `"none"` |
-| `agent_command` | `"claude"` | Agent CLI when engine = `"agent"` (`claude`, `codex`, `opencode`, `pi`, etc.) |
+| `agent_command` | `"claude"` | Agent CLI when engine = `"agent"` (`claude`, `codex`, `opencode`, `pi`, `agent` / Cursor Agent, etc.) |
 | `log_file` / `index_file` | `log.md` / `index.md` | Chronological + content-oriented index |
 | `min_confidence` | `"strong"` | `"explicit"`, `"strong"`, `"inferred"`, `"tentative"` |
 

--- a/docs/integration/agent-integrations.md
+++ b/docs/integration/agent-integrations.md
@@ -12,7 +12,7 @@ actually supports.
 | MCP server | The host supports MCP tools/resources/prompts. | Claude Desktop, Codex, Gemini CLI |
 | Portable skills | The host discovers Agent Skills-style `.agents/skills` folders. | Codex, Gemini CLI, Pi |
 | Host-specific skills | The host needs a different generated shape. | Claude Code plugin, OpenCode commands |
-| `agent_command` backend | Minutes should call the agent CLI for summaries. | `claude`, `codex`, `opencode`, `pi` |
+| `agent_command` backend | Minutes should call the agent CLI for summaries. | `claude`, `codex`, `opencode`, `pi`, `agent` (Cursor Agent CLI) |
 | OpenAI-compatible model backend | Minutes should call a model API directly, not an agent CLI. | OpenRouter, Vercel AI Gateway, Cloudflare AI Gateway, llama.cpp, vLLM |
 | Routing eval | The agent has a non-interactive prompt mode worth benchmarking. | `npm --prefix tooling/skills run routing:agents -- --agent codex` |
 
@@ -131,7 +131,7 @@ fallback, not as the default desktop experience.
 - Codex: portable `.agents/skills` plus MCP.
 - Gemini CLI: portable `.agents/skills` plus MCP.
 - Pi coding agent: portable `.agents/skills` plus opt-in `agent_command = "pi"` summarization. No separate `.pi/skills` tree.
-- Cursor and other editors: raw meeting files and MCP where the host supports it.
+- Cursor: raw meeting files and MCP where the host supports it, plus opt-in `agent_command = "agent"` (Cursor Agent CLI) for non-interactive summarization. See [cursor-agent.md](cursor-agent.md).
 
 ## Experimental runtime watchlist
 

--- a/docs/integration/cursor-agent.md
+++ b/docs/integration/cursor-agent.md
@@ -1,0 +1,54 @@
+# Cursor Agent CLI support
+
+Minutes supports the Cursor Agent CLI (`agent`) as an opt-in local agent for
+non-interactive summarization.
+
+## What is wired
+
+- Desktop settings recognize `agent` as a well-known `agent_command` when the
+  binary is on PATH (or in well-known install dirs such as `~/.local/bin`).
+- `engine = "agent"` can run `agent` for post-meeting summarization, title
+  refinement, and L1 speaker mapping.
+- Cursor continues to work as a files + MCP host for interactive chat; this doc
+  covers only the headless `agent_command` path.
+- No separate Cursor skill tree — reuse raw `~/meetings/` files and/or the
+  Minutes MCP server / portable `.agents/skills` mirror.
+
+## Summarization config
+
+```toml
+[summarization]
+engine = "agent"
+agent_command = "agent"
+```
+
+Use an absolute path when the desktop app PATH is minimal:
+
+```toml
+agent_command = "/Users/you/.local/bin/agent"
+```
+
+Minutes runs Cursor Agent with:
+
+```bash
+agent -p --mode ask --output-format text --trust "<prompt>"
+```
+
+That invocation is intentionally narrow:
+
+- `-p` / print mode for non-interactive stdout capture
+- `--mode ask` for read-only Q&A (no write or shell tools as a side effect)
+- `--trust` so headless runs do not block on an interactive workspace-trust prompt
+  (same class of bypass as Codex `--skip-git-repo-check` / Gemini `--skip-trust`)
+- prompt as a trailing positional argument (CLI contract)
+- no `--force` / `--yolo`
+- no hardcoded `--model` — model selection stays with your Cursor CLI / account
+  (Pro/Ultra subscription or `CURSOR_API_KEY` auth as configured for the CLI)
+
+Authenticate the CLI first (`agent login`, or set `CURSOR_API_KEY` for print
+mode). Interactive IDE login alone may not be enough for headless `-p` runs.
+
+## Screens / live coaching
+
+Headless Cursor Agent summarization is text-only in this release (same posture
+as gemini/opencode/pi). Screen-context delivery for `agent` is not wired yet.

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -9749,7 +9749,9 @@ pub fn cmd_pty_kill(state: tauri::State<AppState>, session_id: String) -> Result
 }
 
 /// Well-known agent CLIs to check for in cmd_list_agents.
-const WELL_KNOWN_AGENTS: &[&str] = &["claude", "codex", "gemini", "opencode", "pi", "bash", "zsh"];
+const WELL_KNOWN_AGENTS: &[&str] = &[
+    "claude", "codex", "gemini", "opencode", "pi", "agent", "bash", "zsh",
+];
 
 #[tauri::command]
 pub fn cmd_list_agents() -> serde_json::Value {


### PR DESCRIPTION
## Summary
- Add Cursor Agent CLI (`agent`) as an opt-in `agent_command` backend for post-meeting summarization / title / L1 speaker mapping (**Fixes #520**).
- Headless invocation: `agent -p --mode ask --output-format text --trust <prompt>` — ask-mode stays read-only; `--trust` avoids interactive workspace-trust hangs (same class as Codex/Gemini bypasses); no hardcoded `--model`.
- Append `agent` **last** in `detect_agent_cli` so `engine = "auto"` does not change for users who already have another CLI.
- Document in `docs/integration/cursor-agent.md` + config/agent-integrations; add `agent` to desktop `WELL_KNOWN_AGENTS`.

### Spike notes
- `agent --version` OK (`2026.05.27-fe9a6e2`).
- `--mode ask` validated (invalid modes rejected).
- Print-mode e2e against a live model needs CLI auth (`agent login` and/or `CURSOR_API_KEY`); IDE login alone may not be enough for `-p`.
- Prompt delivery: trailing positional arg (CLI contract). Stdin not confirmed under auth-limited spike.

## Test plan
- [x] `cargo test -p minutes-core --no-default-features prepare_agent_invocation`
- [x] `screen_instructions_and_invocation_delivery_stay_in_sync` includes `agent`
- [x] `cargo clippy -p minutes-core --no-default-features -- -D warnings`
- [x] `cargo check -p minutes-app`
- [x] Internal Bugbot: added `--trust` after high finding on workspace-trust hang
- [x] Internal Security Review: no medium+ findings on argv / ask-mode path
- [ ] Maintainer: optional smoke with `engine = "agent"` + authenticated `agent` CLI on a short meeting

### Maintainer guardrails checklist
- [x] No hardcoded vendor model
- [x] Read-only (`--mode ask`); no `--force` / `--yolo`
- [x] `agent` after existing `detect_agent_cli` entries
- [x] Small PR: invocation branch + unit tests + docs/WELL_KNOWN