### PR TITLE
docs(parakeet): fix broken desktop-app build recipe (dead TAURI_FEATURES env var)

### DIFF
--- a/docs/architecture/parakeet.md
+++ b/docs/architecture/parakeet.md
@@ -531,10 +531,7 @@ The `parakeet` Cargo feature must be enabled at build time:
 cargo build --release -p minutes-cli --features parakeet
 
 # Tauri desktop app
-TAURI_FEATURES="parakeet" cargo tauri build --bundles app
-
-# Or use the build script (add parakeet feature)
-cargo build --release -p minutes-cli --features parakeet
+cargo tauri build --bundles app --features parakeet
 ```
 
 For local macOS builds in this repo, prefer the helper scripts because they keep the CLI and desktop app aligned on the same feature set:


### PR DESCRIPTION
I found a stale reference in the parakeet.md file: The build section still tells desktop users to run:

```bash
TAURI_FEATURES="parakeet" cargo tauri build --bundles app
```

`TAURI_FEATURES` isn't consumed anywhere in the codebase — the build scripts use `MINUTES_BUILD_FEATURES`, and a direct `cargo tauri build` takes `--features`. So this recipe silently builds the app **without** parakeet, and a contributor following it would hit "engine not compiled in" with no hint why.

This PR replaces it with the working direct invocation (`cargo tauri build --bundles app --features parakeet`, the same form `scripts/build.sh` uses internally) and removes the "Or use the build script" alternative that was actually a duplicate of the CLI command — the paragraph immediately below already documents the helper-script path with `MINUTES_BUILD_FEATURES`.

Doc-only change, no code touched. Verified with a repo-wide grep that this was the last remaining `TAURI_FEATURES` reference.
