### PR TITLE
fix: correct dead repo URLs in Cowork manifest and stale skill count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ minutes/
 │       └── ui/                # Interactive dashboard (vanilla TS, builds to single-file HTML)
 ├── site/                      # Landing page (Next.js + Remotion demo player)
 ├── tauri/                     # Tauri v2 menu bar app + singleton AI Assistant
-├── .claude/plugins/minutes/   # Claude Code plugin — 18 skills + 1 agent + 2 hooks
+├── .claude/plugins/minutes/   # Claude Code plugin — 23 skills + 1 agent + 2 hooks
 ├── .agents/skills/minutes/    # Portable skills mirror (Codex, Gemini, other AGENTS-aware agents)
 ├── .opencode/skills/          # OpenCode-native flattened skills mirror + runtime helpers
 ├── .opencode/commands/        # OpenCode /minutes-* slash-command wrappers
@@ -316,12 +316,12 @@ node test/mcp_tools_test.mjs                        # 8 MCP integration tests
 ## Claude Ecosystem Integration
 
 - **MCP Server**: 35 tools + 8 resources for Claude Desktop / Cowork / Dispatch (`npx minutes-mcp` for zero-install)
-- **Claude Code Plugin**: 18 skills (7 capture + 1 search + 4 lifecycle + 2 coaching + 3 knowledge + 1 intelligence) + meeting-analyst agent + SessionStart + PostToolUse hooks
+- **Claude Code Plugin**: 23 skills + meeting-analyst agent + SessionStart + PostToolUse hooks
 - **Interactive meeting lifecycle**: `/minutes-brief` → `/minutes-prep` → record → `/minutes-tag` → `/minutes-debrief` → `/minutes-mirror` → `/minutes-weekly` with skill chaining via `.brief.md` / `.prep.md` files; `/minutes-graph` for cross-meeting entity queries
 - **Conversational summarization**: Claude reads transcripts via MCP, no API key needed
 - **Auto-tagging + alerts**: PostToolUse hook tags meetings with git repo, checks for decision conflicts, surfaces overdue action items, nudges `/minutes-debrief` + `/minutes-tag`
 - **Proactive reminders**: SessionStart hook checks calendar for upcoming meetings and recommends `/minutes-brief` (fast) or `/minutes-prep` (goal-setting) based on time-to-meeting
-- **Portable skills**: `.agents/skills/minutes/` mirrors all 18 skills for Codex, Gemini, and other AGENTS-aware agents, while `.opencode/skills/` + `.opencode/commands/` gives OpenCode native skill discovery and `/minutes-*` slash commands. Both use `$MINUTES_SKILLS_ROOT` instead of `${CLAUDE_PLUGIN_ROOT}` and keep CLI-only speaker confirmation (no desktop app references). Runtime helpers at `_runtime/hooks/lib/` must stay in sync with `.claude/plugins/minutes/hooks/lib/`.
+- **Portable skills**: `.agents/skills/minutes/` mirrors all 23 skills for Codex, Gemini, and other AGENTS-aware agents, while `.opencode/skills/` + `.opencode/commands/` gives OpenCode native skill discovery and `/minutes-*` slash commands. Both use `$MINUTES_SKILLS_ROOT` instead of `${CLAUDE_PLUGIN_ROOT}` and keep CLI-only speaker confirmation (no desktop app references). Runtime helpers at `_runtime/hooks/lib/` must stay in sync with `.claude/plugins/minutes/hooks/lib/`.
 - **Desktop assistant**: Tauri AI Assistant is a singleton session that can switch focus into a selected meeting without spawning parallel assistant workspaces
 - **Live coaching**: Tauri Live Mode toggle starts real-time transcription; the assistant workspace `CLAUDE.md` and `AGENTS.md` auto-update so the connected Recall session, Claude Desktop/Code, or any other agent can read the live JSONL file and coach mid-meeting. There is no dedicated transcript/coaching panel in Tauri v1; the coaching happens through the assistant chat surface.
 

--- a/integrations/claude-cowork-extension/manifest.json
+++ b/integrations/claude-cowork-extension/manifest.json
@@ -7,14 +7,14 @@
   "long_description": "Minutes gives Claude a local-first conversation memory layer. Record meetings and quick thoughts, search transcripts, inspect structured intents, run consistency reports, profile people across meetings, register your notes with QMD, and research a topic across past conversations without uploading your artifacts to a separate cloud app.",
   "author": {
     "name": "Mat Silverstein",
-    "url": "https://github.com/matsilverstein/minutes"
+    "url": "https://github.com/silverstein/minutes"
   },
-  "homepage": "https://github.com/matsilverstein/minutes",
-  "documentation": "https://github.com/matsilverstein/minutes/tree/main/integrations/claude-cowork-extension",
-  "support": "https://github.com/matsilverstein/minutes/issues",
+  "homepage": "https://github.com/silverstein/minutes",
+  "documentation": "https://github.com/silverstein/minutes/tree/main/integrations/claude-cowork-extension",
+  "support": "https://github.com/silverstein/minutes/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/matsilverstein/minutes.git"
+    "url": "https://github.com/silverstein/minutes.git"
   },
   "license": "MIT",
   "server": {


### PR DESCRIPTION
Two small correctness fixes found while auditing the repo.

## 1. Dead repo URLs in the Cowork extension manifest

`integrations/claude-cowork-extension/manifest.json` pointed at
`github.com/matsilverstein/minutes` in **five** fields: `author.url`,
`homepage`, `documentation`, `support`, and `repository.url`.

That repo returns 404. The canonical repo is `silverstein/minutes`, so
anyone installing the Cowork extension and clicking through hit a dead
link. Pure string substitution; the `server` block is untouched and the
JSON still parses.

## 2. Stale skill count in CLAUDE.md

CLAUDE.md claimed **18** plugin skills in three places. There are **23**
`SKILL.md` files under `.claude/plugins/minutes/skills/`.

I dropped the category breakdown (`7 capture + 1 search + 4 lifecycle +
2 coaching + 3 knowledge + 1 intelligence`) rather than guess which
buckets the five newer skills belong to, since an invented breakdown
would just go stale differently. Agent and hook counts were verified as
still accurate at 1 and 2.

Historical release notes referencing 18 skills were deliberately left
alone, since they describe what shipped at the time.

## Validation

`scripts/check_cowork_extension.sh` needs a full npm build and exits 127
in a bare worktree, so I could not run it locally. Relying on CI here,
which is why this is a PR rather than a direct push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)