### PR TITLE
feat(resummarize): refresh derived views after an applied AI pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,10 +1032,13 @@ minutes redo-speaker-mapping <meeting> --json                   # machine-readab
 minutes resummarize <meeting>                    # preview: show the regenerated summary + merge decisions
 minutes resummarize <meeting> --apply            # splice the regenerated content into the file
 minutes resummarize <meeting> --engine apple     # override the engine for this run
+minutes resummarize <meeting> --apply --ingest   # also re-ingest into the knowledge base
 minutes resummarize <meeting> --json             # machine-readable output
 ```
 
 `<meeting>` is a path or a search term (memos and `minutes import text` files work too — for imported archives this is their first AI pass). The preview **does invoke the model** (on cloud engines the transcript leaves the machine), it just doesn't write. Only the AI-owned sections (`## Summary`, `## Decisions`, `## Action Items`, `## Open Questions`, `## Commitments`) and derived frontmatter are replaced — `## Notes`, `## Transcript`, `speaker_map`, and capture/consent metadata are never touched. Action items and decisions keep user-curated state (`status: done`, due dates, decision authority) by exact-identity matching; anything ambiguous is surfaced in the preview instead of silently resolved. A failed run (engine `none`, provider error, empty output) never modifies the file, and the previous version is backed up to a hidden `.<name>.pre-resummarize.<unix-secs>.bak` sibling on every apply; the newest 3 backups per artifact are kept. One redaction caveat: editing the transcript never touches the retained WAV — for true audio redaction, delete or re-record the audio (`minutes cleanup` / retention settings).
+
+Because an apply rewrites summary-derived frontmatter, everything computed from it goes stale. A successful `--apply` therefore refreshes the derived views the same way the recording pipeline does: the relationship graph index is rebuilt, the vault copy re-synced (`strategy = "copy"` only), and the QMD collection reindexed if one is configured. Knowledge-base ingestion is **not** automatic — its chronological log is append-only, so re-ingesting the same meeting would add a duplicate entry every run; pass `--ingest` when you want it. All of this is best-effort: a refresh that fails warns and leaves the derived view stale, but never undoes a write that already succeeded.
 
 **Privacy**: Voice enrollment is self-only (no enrolling others). Level 3 confirmed profiles require explicit opt-in per person. Voice embeddings are stored locally in `~/.minutes/voices.db` with 0600 permissions. Nothing leaves your machine.
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -784,6 +784,10 @@ enum Commands {
         #[arg(long)]
         template: Option<String>,
 
+        /// With --apply, also re-ingest into the knowledge base (adds a new entry to its append-only log)
+        #[arg(long)]
+        ingest: bool,
+
         /// Emit machine-readable JSON instead of human output
         #[arg(long)]
         json: bool,
@@ -1920,8 +1924,9 @@ fn main() -> Result<()> {
             apply,
             engine,
             template,
+            ingest,
             json,
-        } => cmd_resummarize(&meeting, apply, engine, template, json, &config),
+        } => cmd_resummarize(&meeting, apply, engine, template, ingest, json, &config),
         Commands::Process {
             path,
             content_type,
@@ -5137,6 +5142,7 @@ fn cmd_resummarize(
     apply: bool,
     engine: Option<String>,
     template: Option<String>,
+    ingest: bool,
     json: bool,
     config: &Config,
 ) -> Result<()> {
@@ -5173,6 +5179,12 @@ fn cmd_resummarize(
         cfg.summarization.engine = e.clone();
     }
 
+    if ingest && !apply && !json {
+        // A refresh only ever follows a real write, so --ingest is inert in
+        // preview mode. Say so rather than letting it look like it ran.
+        eprintln!("Note: --ingest has no effect without --apply (preview writes nothing).");
+    }
+
     if !json {
         // Cost/privacy transparency: preview still runs the model (M3).
         eprintln!(
@@ -5189,6 +5201,9 @@ fn cmd_resummarize(
     let opts = minutes_core::resummarize::ResummarizeOptions {
         apply,
         template_override: template,
+        refresh: minutes_core::derived::RefreshOptions {
+            ingest_knowledge: ingest,
+        },
     };
     let report = match minutes_core::resummarize::resummarize_meeting(&path, &cfg, &opts) {
         Ok(report) => report,
@@ -5224,6 +5239,17 @@ fn cmd_resummarize(
             "decisions": report.decisions,
             "new_ai_body": report.new_ai_body,
             "backup": report.backup.as_ref().map(|p| p.display().to_string()),
+            "derived_views": report.refresh.as_ref().map(|refresh| {
+                serde_json::json!({
+                    "graph_rebuilt": refresh.graph.is_some(),
+                    "meetings_indexed": refresh.graph.as_ref().map(|g| g.meeting_count),
+                    "vault_path": refresh.vault.as_ref().map(|p| p.display().to_string()),
+                    "qmd_refreshed": refresh.qmd_refreshed,
+                    "knowledge_ingested": refresh.knowledge.is_some(),
+                    "facts_written": refresh.knowledge.as_ref().map(|k| k.facts_written),
+                    "warnings": refresh.warnings,
+                })
+            }),
         });
         println!(
             "{}",
@@ -5273,6 +5299,39 @@ fn cmd_resummarize(
                 path.display(),
                 backup.display()
             );
+        }
+        if let Some(refresh) = report.refresh.as_ref() {
+            let mut refreshed: Vec<String> = Vec::new();
+            if let Some(stats) = refresh.graph.as_ref() {
+                refreshed.push(format!("graph ({} meetings)", stats.meeting_count));
+            }
+            if refresh.search_indexed {
+                refreshed.push("search".into());
+            }
+            if refresh.vault.is_some() {
+                refreshed.push("vault".into());
+            }
+            if refresh.qmd_refreshed {
+                refreshed.push("qmd".into());
+            }
+            if let Some(update) = refresh.knowledge.as_ref() {
+                refreshed.push(format!("knowledge ({} facts)", update.facts_written));
+            }
+            if !refreshed.is_empty() {
+                println!("  refreshed: {}", refreshed.join(", "));
+            }
+            if !refresh.warnings.is_empty() {
+                // Deliberately generic: these cover both genuine failures and
+                // policy exclusions (a `sensitivity: restricted` artifact is
+                // refused by knowledge ingest by design, not stale).
+                eprintln!("  the artifact was written; some derived views were not updated:");
+                for warning in &refresh.warnings {
+                    eprintln!("    - {warning}");
+                }
+            }
+            if !ingest && config.knowledge.enabled {
+                println!("  knowledge base not re-ingested — pass --ingest to include it.");
+            }
         }
     } else {
         println!("  preview only — the model WAS invoked, but nothing was written.");
@@ -8246,11 +8305,29 @@ life (qmd://life/)
                 "apple",
                 "--template",
                 "standup",
+                "--ingest",
                 "--json",
             ],
         ] {
             let parsed = Cli::try_parse_from(args).expect("resummarize must parse");
             assert!(matches!(parsed.command, Commands::Resummarize { .. }));
+        }
+    }
+
+    #[test]
+    fn resummarize_ingest_flag_defaults_off_and_parses_on() {
+        // The knowledge log is append-only, so ingestion must never be
+        // implied by --apply.
+        let default = Cli::try_parse_from(["minutes", "resummarize", "m.md", "--apply"]).unwrap();
+        match default.command {
+            Commands::Resummarize { ingest, .. } => assert!(!ingest),
+            _ => panic!("expected a Resummarize command"),
+        }
+        let opted =
+            Cli::try_parse_from(["minutes", "resummarize", "m.md", "--apply", "--ingest"]).unwrap();
+        match opted.command {
+            Commands::Resummarize { ingest, .. } => assert!(ingest),
+            _ => panic!("expected a Resummarize command"),
         }
     }
 

--- a/crates/core/src/derived.rs
+++ b/crates/core/src/derived.rs
@@ -1,0 +1,482 @@
+//! Derived-view refresh — the single owner of "this artifact changed on disk,
+//! so everything computed from it is now stale."
+//!
+//! Minutes keeps markdown as the canonical store, but several consumers cache
+//! views derived from it:
+//!
+//! | View | Refresh | Idempotent? |
+//! |---|---|---|
+//! | `graph.db` (people, meetings, topics, commitments) | [`crate::graph::rebuild_index`] | yes — full rebuild from files |
+//! | `search.db` (full-text index) | [`crate::search_index::SearchIndex::upsert_file`] | yes — unconditional per-file reindex |
+//! | Vault copy (`strategy = "copy"` only) | [`crate::vault::sync_file`] | yes — overwrite |
+//! | QMD collection index | `qmd update -c <collection>` | yes — reindex |
+//! | Knowledge base (wiki/PARA/Obsidian) | [`crate::knowledge::ingest_file`] | **no** — facts dedup, but the chronological log always appends |
+//!
+//! The search index earns its place despite syncing lazily on read: that sync
+//! (`SyncMode::Auto`) compares only **mtime and size**, and the enum's own
+//! docs note that `SyncMode::Force` exists to catch "mtime-collision edge
+//! cases". A regenerated summary of identical byte length, written within the
+//! filesystem's mtime granularity of the last sync, would therefore stay
+//! stale. `upsert_file` re-reads and reindexes unconditionally, which closes
+//! that window for the one file we know just changed — without paying for a
+//! whole-corpus re-walk.
+//!
+//! MCP and QMD document reads go straight to the markdown and need nothing.
+//!
+//! The first four run automatically after any write that changes
+//! summary-derived frontmatter. Knowledge ingestion is opt-in
+//! ([`RefreshOptions::ingest_knowledge`]) precisely because it is not
+//! idempotent: re-ingesting the same meeting writes a second entry into the
+//! user's append-only knowledge log even when no fact changed.
+//!
+//! Every step is **best-effort**. A stale derived view is a nuisance; a failed
+//! refresh must never fail an artifact write that already succeeded, so this
+//! module has no error return — failures land in [`RefreshReport::warnings`]
+//! and the tracing log.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+use crate::graph::GraphStats;
+use crate::knowledge::UpdateResult;
+
+/// Which derived views a refresh should touch.
+#[derive(Debug, Clone, Default)]
+pub struct RefreshOptions {
+    /// Re-run knowledge-base ingestion for this artifact.
+    ///
+    /// Off by default. [`crate::knowledge::update_from_meeting`] deduplicates
+    /// facts, but always appends a chronological log entry, so an automatic
+    /// re-ingest on every rewrite would accumulate duplicate lines in a
+    /// user-owned file. Callers expose this as an explicit opt-in
+    /// (`minutes resummarize --ingest`).
+    pub ingest_knowledge: bool,
+}
+
+/// Outcome of a QMD collection reindex.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QmdRefresh {
+    /// No `search.qmd_collection` configured — the common case.
+    NotConfigured,
+    /// `qmd update` ran and exited successfully.
+    Refreshed,
+    /// `qmd` could not be spawned, or exited non-zero. The index is stale.
+    Failed(String),
+}
+
+/// What a refresh actually managed to do.
+///
+/// Fields are `None`/`false` both when a view is not configured (no vault, no
+/// QMD collection, knowledge disabled) and when its refresh failed — the
+/// distinction is in [`RefreshReport::warnings`], which is populated only on
+/// failure.
+#[derive(Debug, Default)]
+pub struct RefreshReport {
+    /// Graph rebuild stats, when the rebuild succeeded.
+    pub graph: Option<GraphStats>,
+    /// Whether the artifact was reindexed into the full-text search index.
+    pub search_indexed: bool,
+    /// Destination path, when a vault copy was written (`strategy = "copy"`).
+    pub vault: Option<PathBuf>,
+    /// Whether a QMD collection reindex ran and succeeded.
+    pub qmd_refreshed: bool,
+    /// Knowledge-base result, when `ingest_knowledge` was requested and the
+    /// knowledge base is actually enabled. A disabled knowledge base leaves
+    /// this `None` and records a warning — never a zero-fact "success".
+    pub knowledge: Option<UpdateResult>,
+    /// Human-readable failures. Empty on a fully clean refresh.
+    pub warnings: Vec<String>,
+}
+
+impl RefreshReport {
+    /// Did every attempted step succeed?
+    pub fn is_clean(&self) -> bool {
+        self.warnings.is_empty()
+    }
+}
+
+/// Refresh every derived view that depends on `path`, best-effort.
+///
+/// Call this after any write that changes an artifact's summary-derived
+/// frontmatter (`entities`, `people`, `intents`, `action_items`, `decisions`)
+/// or its AI-owned body sections. It never fails: each step records a warning
+/// and the rest continue.
+///
+/// The graph rebuild is whole-corpus, not per-file —
+/// [`crate::graph::rebuild_index`] clears the tables and rewalks every
+/// markdown file under `config.output_dir`. That is the existing pipeline
+/// convention (`jobs.rs`, `watch.rs`), it is what makes the refresh inherently
+/// idempotent, and it is accepted here as a deliberate trade-off: a corpus of
+/// ~90 meetings rebuilds in well under a second.
+pub fn refresh_derived_views(path: &Path, config: &Config, opts: &RefreshOptions) -> RefreshReport {
+    refresh_derived_views_at(
+        path,
+        config,
+        opts,
+        &crate::graph::db_path(),
+        &crate::search_index::SearchIndex::default_db_path(),
+    )
+}
+
+/// [`refresh_derived_views`] against explicit database paths.
+///
+/// Crate-private and mirroring [`crate::graph::rebuild_index_at`]: the public
+/// entry point always targets the real `~/.minutes/{graph,search}.db`, while
+/// tests point at temporary files. Without this seam a unit test that merely
+/// sets `config.output_dir` to a `TempDir` would still clear the developer's
+/// real indexes and repopulate them from the fixture corpus — both db paths
+/// are global, not derived from the config.
+pub(crate) fn refresh_derived_views_at(
+    path: &Path,
+    config: &Config,
+    opts: &RefreshOptions,
+    graph_db: &Path,
+    search_db: &Path,
+) -> RefreshReport {
+    let mut report = RefreshReport::default();
+
+    match crate::graph::rebuild_index_at(config, graph_db) {
+        Ok(stats) => report.graph = Some(stats),
+        Err(error) => {
+            tracing::warn!(error = %error, artifact = %path.display(), "graph index rebuild failed");
+            report
+                .warnings
+                .push(format!("graph index rebuild: {error}"));
+        }
+    }
+
+    match crate::search_index::SearchIndex::open_at(search_db, config)
+        .and_then(|index| index.upsert_file(path))
+    {
+        Ok(()) => report.search_indexed = true,
+        Err(error) => {
+            tracing::warn!(error = %error, artifact = %path.display(), "search index upsert failed");
+            report.warnings.push(format!("search index: {error}"));
+        }
+    }
+
+    match crate::vault::sync_file(path, config) {
+        Ok(Some(vault_path)) => {
+            crate::events::append_event(crate::events::MinutesEvent::VaultSynced {
+                source_path: path.display().to_string(),
+                vault_path: vault_path.display().to_string(),
+                strategy: config.vault.strategy.clone(),
+            });
+            report.vault = Some(vault_path);
+        }
+        Ok(None) => {}
+        Err(error) => {
+            tracing::warn!(error = %error, artifact = %path.display(), "vault sync failed");
+            report.warnings.push(format!("vault sync: {error}"));
+        }
+    }
+
+    match refresh_qmd_collection(config) {
+        QmdRefresh::Refreshed => report.qmd_refreshed = true,
+        QmdRefresh::NotConfigured => {}
+        QmdRefresh::Failed(reason) => {
+            report.warnings.push(format!("qmd reindex: {reason}"));
+        }
+    }
+
+    if opts.ingest_knowledge {
+        refresh_knowledge(path, config, &mut report);
+    }
+
+    report
+}
+
+/// Re-ingest `path` into the knowledge base, recording the outcome.
+///
+/// A disabled or unconfigured knowledge base is reported as a warning rather
+/// than a zero-fact success: [`crate::knowledge::update_from_meeting`] returns
+/// `Ok` with empty counts in that case, which is indistinguishable from a real
+/// run that found nothing.
+fn refresh_knowledge(path: &Path, config: &Config, report: &mut RefreshReport) {
+    if !config.knowledge.enabled || config.knowledge.path.as_os_str().is_empty() {
+        report.warnings.push(
+            "knowledge ingest requested, but the knowledge base is not enabled \
+             (set `knowledge.enabled` and `knowledge.path` in config.toml)"
+                .to_string(),
+        );
+        return;
+    }
+
+    match crate::knowledge::ingest_file(path, config) {
+        Ok(update) => {
+            if update.facts_written > 0 {
+                crate::events::append_event(crate::events::MinutesEvent::KnowledgeUpdated {
+                    meeting_path: path.display().to_string(),
+                    facts_written: update.facts_written,
+                    facts_skipped: update.facts_skipped,
+                    people_updated: update.people_updated.clone(),
+                });
+            }
+            report.knowledge = Some(update);
+        }
+        Err(error) => {
+            // Two distinct cases arrive here, both correctly non-fatal:
+            // the deliberate loud refusal for `sensitivity: restricted`
+            // artifacts (a policy exclusion, not a failure), and a genuine
+            // partial write — `update_from_meeting` writes person files and
+            // always appends its chronological log *before* returning this
+            // error, so a retry adds a second log entry.
+            tracing::warn!(error = %error, artifact = %path.display(), "knowledge ingest failed");
+            report.warnings.push(format!("knowledge ingest: {error}"));
+        }
+    }
+}
+
+/// Ask QMD to reindex the configured collection.
+pub fn refresh_qmd_collection(config: &Config) -> QmdRefresh {
+    refresh_qmd_collection_with(config, "qmd")
+}
+
+/// [`refresh_qmd_collection`] against an explicit program name, so the
+/// spawn-failure branch is testable on machines where `qmd` *is* installed.
+///
+/// Note that a wrong collection name is not detectable here: `qmd update -c
+/// <unknown>` exits 0, so only a genuine spawn failure or non-zero exit is
+/// reported.
+fn refresh_qmd_collection_with(config: &Config, program: &str) -> QmdRefresh {
+    let Some(collection) = config.search.qmd_collection.as_ref() else {
+        return QmdRefresh::NotConfigured;
+    };
+    let status = crate::engine_process::command(program)
+        .args(["update", "-c", collection])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    match status {
+        Ok(status) if status.success() => QmdRefresh::Refreshed,
+        // A non-zero exit means the collection did not reindex. Reporting it
+        // as success would let the CLI claim a fresh index over a stale one.
+        Ok(status) => QmdRefresh::Failed(format!(
+            "`{program} update -c {collection}` exited {status}"
+        )),
+        Err(error) => {
+            tracing::debug!(error = %error, collection = %collection, "qmd update skipped");
+            QmdRefresh::Failed(format!(
+                "could not run `{program}` for `{collection}`: {error}"
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// A config whose meetings live in `dir`, plus the temp graph and search
+    /// db paths that keep the real `~/.minutes/*.db` out of the test.
+    fn fixture(dir: &TempDir) -> (Config, PathBuf, PathBuf) {
+        let mut config = Config::default();
+        config.output_dir = dir.path().to_path_buf();
+        (
+            config,
+            dir.path().join("graph.db"),
+            dir.path().join("search.db"),
+        )
+    }
+
+    fn write_meeting(dir: &TempDir, name: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(
+            &path,
+            "---\ntitle: Test\ntype: meeting\ndate: 2026-07-26\n---\n\n## Summary\n\nhi\n",
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn refresh_options_default_leaves_knowledge_opt_in() {
+        // The append-only knowledge log makes ingestion non-idempotent, so it
+        // must never be the default.
+        assert!(!RefreshOptions::default().ingest_knowledge);
+    }
+
+    #[test]
+    fn qmd_refresh_is_skipped_when_no_collection_configured() {
+        let dir = TempDir::new().unwrap();
+        let (config, _, _) = fixture(&dir);
+        assert!(config.search.qmd_collection.is_none());
+        assert_eq!(refresh_qmd_collection(&config), QmdRefresh::NotConfigured);
+    }
+
+    #[test]
+    fn qmd_refresh_reports_failure_when_the_binary_cannot_be_spawned() {
+        let dir = TempDir::new().unwrap();
+        let (mut config, _, _) = fixture(&dir);
+        config.search.qmd_collection = Some("meetings".into());
+
+        // Pin the program name rather than relying on `qmd` being absent: it
+        // is installed on plenty of dev machines, and `qmd update -c <bogus>`
+        // exits 0 there — so a collection-name-based test would assert nothing
+        // and would pass for opposite reasons on different machines.
+        let result = refresh_qmd_collection_with(&config, "minutes-no-such-binary-qmd");
+
+        match result {
+            QmdRefresh::Failed(reason) => {
+                assert!(
+                    reason.contains("minutes-no-such-binary-qmd"),
+                    "failure should name the program, got {reason:?}"
+                );
+            }
+            other => panic!("expected a spawn failure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn search_index_upsert_targets_the_given_db_and_never_the_global_one() {
+        // Same regression class as the graph db: `SearchIndex::default_db_path`
+        // is global, so a test that only redirects `output_dir` would rebuild
+        // the developer's real ~/.minutes/search.db.
+        let dir = TempDir::new().unwrap();
+        let (config, graph_db, search_db) = fixture(&dir);
+        let artifact = write_meeting(&dir, "meeting.md");
+
+        let report = refresh_derived_views_at(
+            &artifact,
+            &config,
+            &RefreshOptions::default(),
+            &graph_db,
+            &search_db,
+        );
+
+        assert!(report.search_indexed, "warnings: {:?}", report.warnings);
+        assert!(
+            search_db.exists(),
+            "the injected search db path must be the target"
+        );
+    }
+
+    #[test]
+    fn graph_rebuild_targets_the_given_db_and_never_the_global_one() {
+        // Regression guard: `graph::db_path()` is global, so a test that only
+        // redirects `output_dir` would wipe the developer's real graph index.
+        let dir = TempDir::new().unwrap();
+        let (config, graph_db, search_db) = fixture(&dir);
+        let artifact = write_meeting(&dir, "meeting.md");
+
+        let report = refresh_derived_views_at(
+            &artifact,
+            &config,
+            &RefreshOptions::default(),
+            &graph_db,
+            &search_db,
+        );
+
+        assert!(report.graph.is_some(), "graph should rebuild");
+        assert!(graph_db.exists(), "the injected db path must be the target");
+    }
+
+    #[test]
+    fn missing_output_dir_warns_instead_of_failing() {
+        // Best-effort contract: a graph rebuild that cannot run must not be
+        // able to fail a write that already succeeded.
+        let dir = TempDir::new().unwrap();
+        let (mut config, graph_db, search_db) = fixture(&dir);
+        config.output_dir = dir.path().join("does-not-exist");
+        let artifact = dir.path().join("meeting.md");
+
+        let report = refresh_derived_views_at(
+            &artifact,
+            &config,
+            &RefreshOptions::default(),
+            &graph_db,
+            &search_db,
+        );
+
+        assert!(report.graph.is_none());
+        assert!(!report.is_clean());
+        assert!(
+            report.warnings.iter().any(|w| w.contains("graph index")),
+            "expected a graph warning, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn clean_refresh_reports_no_warnings_and_skips_unconfigured_views() {
+        let dir = TempDir::new().unwrap();
+        let (config, graph_db, search_db) = fixture(&dir);
+        let artifact = write_meeting(&dir, "meeting.md");
+
+        let report = refresh_derived_views_at(
+            &artifact,
+            &config,
+            &RefreshOptions::default(),
+            &graph_db,
+            &search_db,
+        );
+
+        assert!(
+            report.is_clean(),
+            "unexpected warnings: {:?}",
+            report.warnings
+        );
+        assert!(report.graph.is_some());
+        // Vault and QMD are unconfigured by default; knowledge was not opted in.
+        assert!(report.vault.is_none());
+        assert!(!report.qmd_refreshed);
+        assert!(report.knowledge.is_none());
+    }
+
+    #[test]
+    fn ingest_on_a_disabled_knowledge_base_warns_instead_of_faking_success() {
+        // `update_from_meeting` returns Ok with zero counts when knowledge is
+        // disabled, which is indistinguishable from "ran, found nothing".
+        let dir = TempDir::new().unwrap();
+        let (config, graph_db, search_db) = fixture(&dir);
+        let artifact = write_meeting(&dir, "meeting.md");
+        assert!(!config.knowledge.enabled);
+
+        let opts = RefreshOptions {
+            ingest_knowledge: true,
+        };
+        let report = refresh_derived_views_at(&artifact, &config, &opts, &graph_db, &search_db);
+
+        assert!(
+            report.knowledge.is_none(),
+            "a disabled knowledge base must not report a zero-fact success"
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("knowledge base is not enabled")),
+            "expected a disabled-knowledge warning, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn restricted_artifacts_are_refused_by_knowledge_ingest() {
+        let dir = TempDir::new().unwrap();
+        let knowledge_dir = TempDir::new().unwrap();
+        let (mut config, graph_db, search_db) = fixture(&dir);
+        config.knowledge.enabled = true;
+        config.knowledge.path = knowledge_dir.path().to_path_buf();
+
+        let artifact = dir.path().join("restricted.md");
+        std::fs::write(
+            &artifact,
+            "---\ntitle: Private\ntype: meeting\ndate: 2026-07-26\nsensitivity: restricted\n---\n\n## Summary\n\nhi\n",
+        )
+        .unwrap();
+
+        let opts = RefreshOptions {
+            ingest_knowledge: true,
+        };
+        let report = refresh_derived_views_at(&artifact, &config, &opts, &graph_db, &search_db);
+
+        assert!(report.knowledge.is_none());
+        assert!(
+            report.warnings.iter().any(|w| w.contains("restricted")),
+            "expected the restricted refusal to surface, got {:?}",
+            report.warnings
+        );
+    }
+}

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -1350,20 +1350,6 @@ fn recording_duration(job: &ProcessingJob) -> String {
     }
 }
 
-fn refresh_qmd_collection(config: &Config) {
-    let Some(collection) = config.search.qmd_collection.as_ref() else {
-        return;
-    };
-    let status = crate::engine_process::command("qmd")
-        .args(["update", "-c", collection])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-    if let Err(error) = status {
-        tracing::debug!(error = %error, collection = %collection, "qmd update skipped");
-    }
-}
-
 fn job_context(job: &ProcessingJob) -> BackgroundPipelineContext {
     let template = job.template_slug.as_deref().and_then(|slug| {
         match crate::template::TemplateResolver::new().resolve(slug) {
@@ -1551,7 +1537,7 @@ fn process_pending_jobs_with_transcriber(
             if let Err(error) = crate::graph::rebuild_index(config) {
                 tracing::warn!(error = %error, "graph index rebuild failed after queued job");
             }
-            refresh_qmd_collection(config);
+            let _ = crate::derived::refresh_qmd_collection(config);
             sync_processing_status();
             on_job_update(&review_job);
             continue;
@@ -1638,7 +1624,7 @@ fn process_pending_jobs_with_transcriber(
                 if let Err(error) = crate::graph::rebuild_index(config) {
                     tracing::warn!(error = %error, "graph index rebuild failed after queued job");
                 }
-                refresh_qmd_collection(config);
+                let _ = crate::derived::refresh_qmd_collection(config);
                 // Run post_record hook (async, non-blocking)
                 pipeline::run_post_record_hook(config, &result.path);
                 if completed_job.state == JobState::Complete {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod context_store;
 pub mod copilot;
 pub mod daily_notes;
+pub mod derived;
 pub mod desktop_context;
 pub mod desktop_control;
 pub mod device_monitor;

--- a/crates/core/src/resummarize.rs
+++ b/crates/core/src/resummarize.rs
@@ -55,6 +55,9 @@ pub struct ResummarizeOptions {
     /// the artifact's frontmatter; if that recorded template no longer
     /// resolves, the run fails visibly rather than silently switching shape.
     pub template_override: Option<String>,
+    /// Which derived views to refresh after a successful apply. Ignored in
+    /// preview mode — nothing was written, so nothing is stale.
+    pub refresh: crate::derived::RefreshOptions,
 }
 
 /// How a previous action item / decision fared in the merge.
@@ -120,6 +123,10 @@ pub struct ResummarizeReport {
     pub decisions: Vec<Decision>,
     /// Wall-clock of the summarize stage in milliseconds.
     pub duration_ms: u64,
+    /// Outcome of the post-write derived-view refresh (graph, vault, QMD, and
+    /// optional knowledge ingest). `None` in preview mode and whenever the
+    /// write did not happen — a refresh only ever follows a real write.
+    pub refresh: Option<crate::derived::RefreshReport>,
 }
 
 /// Normalized identity for exact matching: lowercase, whitespace collapsed,
@@ -658,21 +665,46 @@ pub fn splice_ai_sections(
 /// | `entities`, `people`, `intents` | **recomputed** from the merged state |
 /// | `action_items`, `decisions` | **merge-derived** (exact-identity carry-forward, see [`merge_action_items`] / [`merge_decisions`]) |
 /// | `template`, `summarization`, `status`, `processing_warnings` | **recorded**: template slug used, run health block, summarize-scoped warnings removed and status re-derived |
+///
+/// ## Derived views
+///
+/// A successful apply rewrites summary-derived frontmatter, which invalidates
+/// every cached view built from it. This function therefore calls
+/// [`crate::derived::refresh_derived_views`] after — and only after — a real
+/// write: the graph index, vault copy, and QMD collection refresh
+/// automatically, while knowledge-base ingestion stays opt-in via
+/// [`ResummarizeOptions::refresh`] (its log is append-only, so re-ingesting is
+/// not idempotent). The refresh is best-effort and reported in
+/// [`ResummarizeReport::refresh`]; it can never fail a completed write.
 pub fn resummarize_meeting(
     path: &Path,
     config: &Config,
     opts: &ResummarizeOptions,
 ) -> Result<ResummarizeReport, ResummarizeError> {
-    resummarize_meeting_with(path, config, opts, |transcript, notes, template| {
-        summarize::summarize_with_template(
-            transcript,
-            notes,
-            &[], // v1 is text-only: no screenshot re-feed
+    let mut report =
+        resummarize_meeting_with(path, config, opts, |transcript, notes, template| {
+            summarize::summarize_with_template(
+                transcript,
+                notes,
+                &[], // v1 is text-only: no screenshot re-feed
+                config,
+                template,
+                None,
+            )
+        })?;
+
+    // A rewrite invalidates everything derived from this artifact. Refresh
+    // only after a real write, and never let a stale-view refresh turn an
+    // already-successful write into a failure.
+    if report.applied {
+        report.refresh = Some(crate::derived::refresh_derived_views(
+            path,
             config,
-            template,
-            None,
-        )
-    })
+            &opts.refresh,
+        ));
+    }
+
+    Ok(report)
 }
 
 /// [`resummarize_meeting`] with an injectable summarize stage, so the
@@ -786,6 +818,7 @@ where
         action_items: merged_actions.clone(),
         decisions: merged_decisions.clone(),
         duration_ms,
+        refresh: None,
     };
 
     if !opts.apply {

--- a/crates/core/src/search_index.rs
+++ b/crates/core/src/search_index.rs
@@ -97,7 +97,18 @@ impl SearchIndex {
     /// Open or create the index. Validates schema, rebuilds if corrupted,
     /// triggers a full rebuild if `output_dir` has changed since last open.
     pub fn open(config: &Config) -> Result<Self, SearchIndexError> {
-        let db_path = Self::default_db_path();
+        Self::open_at(&Self::default_db_path(), config)
+    }
+
+    /// [`SearchIndex::open`] against an explicit database path.
+    ///
+    /// [`SearchIndex::default_db_path`] is global (`~/.minutes/search.db`) and
+    /// independent of `config.output_dir`, so a caller that only redirects
+    /// `output_dir` — a test using a `TempDir`, say — would still hit the real
+    /// index and trigger its output-dir-changed full rebuild. Tests point this
+    /// at a temporary file instead.
+    pub fn open_at(db_path: &Path, config: &Config) -> Result<Self, SearchIndexError> {
+        let db_path = db_path.to_path_buf();
         let mut conn = schema::open_db(&db_path)?;
 
         // Ensure schema exists. Idempotent on existing DBs.

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 36;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 1660;
+export const MINUTES_TEST_COUNT = 1670;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
**Title:** feat(resummarize): refresh derived views after an applied AI pass

**Body:**

Follow-up to #526 — the graph/index invalidation item from the plan's Phase 4, which that PR deferred.

## The gap

A successful `resummarize --apply` rewrites summary-derived frontmatter — `entities`, `people`, `intents`, `action_items`, `decisions` — which invalidates every cached view computed from it. Nothing refreshed them, so `graph.db` went silently stale after every edit-and-resummarize cycle. `minutes people` and `minutes commitments` would answer from pre-edit data with no indication anything was out of date.

## Approach

Adds `minutes-core::derived` as a single owner of "this artifact changed, so its derived views are stale", rather than a 13th copy of `graph::rebuild_index`. This is the same doctrine you asked for on engine resolution in #523 (M1) applied to invalidation: one choke point, no parallel logic.

| View | Refresh | Automatic? |
|---|---|---|
| `graph.db` | full rebuild | yes |
| `search.db` | per-file `upsert_file` | yes |
| Vault copy (`strategy = "copy"`) | `sync_file` | yes |
| QMD collection | `qmd update -c` | yes, when configured |
| Knowledge base | `ingest_file` | **no** — `--ingest` |

**Knowledge ingestion is opt-in on purpose.** `update_from_meeting` deduplicates facts, but `append_log` appends a chronological entry unconditionally — so an automatic re-ingest would add a duplicate line to a user-owned append-only file on every resummarize. A disabled knowledge base now also reports a warning rather than the zero-fact "success" that `update_from_meeting` returns in that case, which was indistinguishable from a real run that found nothing.

**The search index is included despite syncing lazily on read.** `SyncMode::Auto` compares only mtime and size, and `SyncMode::Force`'s own doc comment says it exists to catch "mtime-collision edge cases" — so a regenerated summary of identical byte length, written within the filesystem's mtime granularity of the last sync, could stay stale. `upsert_file` reindexes unconditionally, closing that window for the one file we know changed without paying for a whole-corpus re-walk.

**Best-effort by construction.** `refresh_derived_views` has no error return: failures land in `RefreshReport::warnings` and the tracing log. A stale derived view is a nuisance; failing a write that already landed is not acceptable. The refresh runs from the public `resummarize_meeting` only after a real apply, so the crate-private `resummarize_meeting_with` test path stays free of side effects — and Phase 3's desktop button inherits the refresh for free.

## A hazard this surfaced

`graph::db_path()` and `SearchIndex::default_db_path()` are both global (`~/.minutes/*.db`) and independent of `config.output_dir`. A test that redirects only `output_dir` still hits the real database — my first draft's unit test cleared my own graph index and repopulated it from a `TempDir` fixture before I caught it.

So `refresh_derived_views_at` takes both paths explicitly, mirroring the existing `graph::rebuild_index_at` precedent, and this PR adds `SearchIndex::open_at` for the same reason. Two regression tests assert the injected paths are the targets.

This is a pre-existing repo-wide trap, not one this PR introduces — any test calling `rebuild_index` has always had it, and there is already evidence of it happening to `search.db` (I saw `output_dir changed; rebuilding index old=/var/folders/…/tmp…` on a fresh checkout). Happy to file that separately if you'd like it tracked.

## Findings I declined

Two items from review that I deliberately did not act on:

1. **`dirs::home_dir()` panics in `graph::db_path()`**, so a missing home directory would panic *after* the markdown write and make a completed apply look like a failure. Declined: it is pre-existing and shared by all ~13 existing `rebuild_index` callers, so fixing it here would be inconsistent and partial, and wrapping this one call in `catch_unwind` is worse than the disease. Better as its own change if you want it.

2. **The graph rebuild is whole-corpus on every single-file apply.** Accepted rather than optimized: it matches what the pipeline already does after every recording, and it is what makes the refresh inherently idempotent. Measured on an M3 Air at 92 meeting files: **93–142 ms**. If that becomes a problem at larger corpus sizes it argues for an incremental `rebuild_index`, which would benefit every caller, not just this one.

One known limitation worth recording: a *wrong* QMD collection name is undetectable here, because `qmd update -c <unknown>` exits 0. Only a spawn failure or non-zero exit is reported.

## Testing

- 9 new tests in `minutes-core::derived` (1168 → 1177 core unit tests), plus CLI flag coverage (80 → 81).
- `cargo clippy --all --no-default-features -- -D warnings` and `cargo fmt --all --check` clean; `check:llms` reports generated agent docs up to date.
- Verified end-to-end against a real meeting file (on a copy): apply printed `refreshed: graph (31 meetings), search`, the graph row count moved 30 → 31, and the row landed in `search.db` with the correct title. Confirmed the global databases are untouched by a full `cargo test` run.
- Rebased onto current `main` (`7037253b`) so the generated site constants regenerate against the released tree, per your note on #526.
