### PR TITLE
fix(dictation): stop double insert/paste in accumulate mode

### DIFF
--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -912,7 +912,16 @@ fn handle_utterance<G>(
 
     if config.dictation.accumulate {
         accumulated_results.push(result.clone());
-        on_result(result);
+        // Stream the per-utterance result only for stdout. Single-shot
+        // destinations (insert/clipboard/file/command) receive exactly one
+        // combined result from `flush_accumulated_results` at session end;
+        // emitting the per-utterance result here as well delivered twice, which
+        // for `destination = "insert"` pasted the dictation into the focused
+        // field twice. This mirrors the stdout special-case in
+        // `flush_accumulated_results`.
+        if config.dictation.destination == "stdout" {
+            on_result(result);
+        }
         return;
     }
 
@@ -1609,5 +1618,54 @@ mod tests {
         assert!(note.contains("- first sentence. second sentence."));
         assert!(!note.contains("- first sentence.\n"));
         assert!(!note.contains("- second sentence.\n"));
+    }
+
+    #[test]
+    fn accumulate_insert_defers_delivery_to_flush_not_per_utterance() {
+        // Regression: with accumulate on, a single-shot destination must receive
+        // exactly one combined result from the flush, never a per-utterance emit
+        // that (for destination = "insert") pasted into the focused field twice.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config(dir.path());
+        config.dictation.accumulate = true;
+
+        config.dictation.destination = "insert".into();
+        let mut accumulated = Vec::new();
+        let mut delivered = 0usize;
+        {
+            let mut on_result = |_result: DictationResult| delivered += 1;
+            handle_utterance(
+                "hello world",
+                1.0,
+                &config,
+                &mut accumulated,
+                &mut on_result,
+            );
+        }
+        assert_eq!(
+            delivered, 0,
+            "accumulate + insert must not deliver per-utterance"
+        );
+        assert_eq!(
+            accumulated.len(),
+            1,
+            "the utterance is still accumulated for the flush"
+        );
+
+        // stdout keeps its live per-utterance stream.
+        config.dictation.destination = "stdout".into();
+        let mut accumulated_stdout = Vec::new();
+        let mut streamed = 0usize;
+        {
+            let mut on_result = |_result: DictationResult| streamed += 1;
+            handle_utterance(
+                "hello world",
+                1.0,
+                &config,
+                &mut accumulated_stdout,
+                &mut on_result,
+            );
+        }
+        assert_eq!(streamed, 1, "stdout still streams per-utterance");
     }
 }

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-25",
+  "generatedAt": "2026-07-27",
   "visibleCount": 67,
   "hiddenCount": 17,
   "groups": [

--- a/site/app/docs/mcp/tools/data.json
+++ b/site/app/docs/mcp/tools/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-25",
+  "generatedAt": "2026-07-27",
   "installCommand": "npx minutes-mcp",
   "documentationUrl": "https://useminutes.app/for-agents",
   "supportUrl": "https://github.com/silverstein/minutes/discussions",

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 36;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 1660;
+export const MINUTES_TEST_COUNT = 1661;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: crates/core thiserror definitions
-> Last generated: 2026-07-25
+> Last generated: 2026-07-27
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 

--- a/site/public/docs/mcp/tools.md
+++ b/site/public/docs/mcp/tools.md
@@ -3,7 +3,7 @@
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts
 > Regenerate: node scripts/generate_llms_txt.mjs
-> Last generated: 2026-07-25
+> Last generated: 2026-07-27
 
 Minutes exposes 36 tools, 8 resources, and 6 prompt templates through the MCP server.
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-07-25
+> Last generated: 2026-07-27
 
 ## Product
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-07-25
+> Last generated: 2026-07-27
 
 Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.
 


### PR DESCRIPTION
## The bug
`fn` dictation pastes the transcription into the focused field **twice**. Reproduced from a live dictation log: two `dictation_insert` events per utterance, ~1s apart — one per-utterance (no file) and one combined (with the note file).

Root cause in `crates/core/src/dictation.rs`: with `dictation.accumulate = true` (the **compiled default**), `handle_utterance` both accumulates the utterance **and** calls `on_result` for it, while `flush_accumulated_results` then delivers the combined result too. For a single-shot destination that is two deliveries per session; for `destination = "insert"` (also the default) it pastes twice.

It was masked until Accessibility was granted, because the paste keystroke silently no-ops without it — so fixing a TCC grant "revealed" this latent double-paste.

## Scope
`accumulate: true` + `destination: "insert"` are both defaults, so this affects every default `fn`-dictation user whose Accessibility works. Recommend a **0.23.1 patch**.

## Fix
In accumulate mode, only stream the per-utterance result for `stdout`; single-shot destinations (insert/clipboard/file/command) receive exactly one combined result from the flush. Mirrors the `stdout` special-case already in `flush_accumulated_results`. Adds a regression test: insert delivers zero per-utterance, stdout still streams.

Verified: dictation suite 29/29, clippy `-D warnings`, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)