### PR TITLE
chore(dependabot): ignore ort + ndarray (stops recurring cargo-group failure)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # ort and ndarray are intentionally pinned for pyannote-rs compat: ort rc.12
+    # switched to ndarray 0.17, which conflicts with pyannote-rs's ndarray 0.16
+    # (see crates/core/Cargo.toml). Bumping either breaks the diarize build, so
+    # the cargo-minor-patch group failed repeatedly (#545, #572, #578) until they
+    # were ignored here. Revisit when pyannote-rs supports ndarray 0.17.
+    ignore:
+      - dependency-name: "ort"
+      - dependency-name: "ndarray"
     groups:
       cargo-minor-patch:
         patterns: ["*"]


### PR DESCRIPTION
The `cargo-minor-patch` group has failed on every run (#545, #572, #578) trying to bump `ort` and `ndarray`, which are intentionally pinned for pyannote-rs compat (ort rc.12 switched to ndarray 0.17; pyannote-rs 0.3.4 needs 0.16 — see the comment in crates/core/Cargo.toml). Ignoring both stops the recurring red group. Revisit when pyannote-rs supports ndarray 0.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)