### PR TITLE
test: make HOME isolation reachable from integration tests (#588)

### DIFF
--- a/crates/core/src/context_store.rs
+++ b/crates/core/src/context_store.rs
@@ -1610,7 +1610,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
-        let _lock = crate::test_home_env_lock();
+        let _lock = crate::test_support::home_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let original_home = std::env::var_os("HOME");
         #[cfg(windows)]

--- a/crates/core/src/copilot/battle_card.rs
+++ b/crates/core/src/copilot/battle_card.rs
@@ -249,30 +249,8 @@ mod tests {
         CopilotRequest, CopilotUtterance, MeetingMode, StrategyRefreshReason, StrategyRequest,
         StrategyState, TranscriptUpdateKind,
     };
-    use std::ffi::OsString;
-    use std::path::Path;
 
-    struct HomeOverride {
-        previous: Option<OsString>,
-    }
-
-    impl HomeOverride {
-        fn set(path: &Path) -> Self {
-            let previous = std::env::var_os("HOME");
-            std::env::set_var("HOME", path);
-            Self { previous }
-        }
-    }
-
-    impl Drop for HomeOverride {
-        fn drop(&mut self) {
-            if let Some(previous) = &self.previous {
-                std::env::set_var("HOME", previous);
-            } else {
-                std::env::remove_var("HOME");
-            }
-        }
-    }
+    use crate::test_support::HomeOverride;
 
     fn meeting(title: &str, person: &str, secret: &str, restricted: bool) -> String {
         let sensitivity = if restricted {
@@ -287,7 +265,7 @@ mod tests {
 
     #[test]
     fn assembly_excludes_restricted_history_from_graph_structured_and_fts_sources() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let temp = tempfile::tempdir().unwrap();
         let _home = HomeOverride::set(temp.path());
         let meetings = temp.path().join("meetings");

--- a/crates/core/src/desktop_context.rs
+++ b/crates/core/src/desktop_context.rs
@@ -881,7 +881,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
-        let _lock = crate::test_home_env_lock();
+        let _lock = crate::test_support::home_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let original_home = std::env::var_os("HOME");
         #[cfg(windows)]

--- a/crates/core/src/desktop_control.rs
+++ b/crates/core/src/desktop_control.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn claim_pending_requests_is_single_claim() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let original_home = std::env::var_os("HOME");
         #[cfg(windows)]
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn desktop_app_owns_pid_requires_recent_matching_heartbeat() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let original_home = std::env::var_os("HOME");
         #[cfg(windows)]

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -1309,7 +1309,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         let original_home = std::env::var_os("HOME");
         let original_userprofile = std::env::var_os("USERPROFILE");

--- a/crates/core/src/ffmpeg.rs
+++ b/crates/core/src/ffmpeg.rs
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn env_override_wins_over_path_and_known_locations() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let env_dir = tempfile::TempDir::new().unwrap();
         let path_dir = tempfile::TempDir::new().unwrap();
         let known_dir = tempfile::TempDir::new().unwrap();
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn errors_clearly_when_no_candidate_resolves() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let empty_path = tempfile::TempDir::new().unwrap();
         let missing_dir = tempfile::TempDir::new().unwrap();
         let old_override = std::env::var_os(FFMPEG_ENV_VAR);

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -1665,7 +1665,7 @@ mod tests {
     use crate::markdown::{Frontmatter, WriteResult};
 
     fn with_temp_home<T>(f: impl FnOnce(&tempfile::TempDir) -> T) -> T {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = tempfile::tempdir().unwrap();
         // Set HOME (Unix) and USERPROFILE (Windows) so dirs::home_dir() resolves to temp
         let original_home = std::env::var_os("HOME");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -74,6 +74,9 @@ pub mod streaming_diarize;
 pub mod summarize;
 pub mod system_audio_backend;
 pub mod template;
+/// Test scaffolding shared by unit and integration tests. Not public API.
+#[doc(hidden)]
+pub mod test_support;
 pub mod transcribe;
 pub mod transcription_coordinator;
 pub mod vault;
@@ -160,14 +163,4 @@ pub use vad::{Vad, VadEngine, VadResult};
 pub fn install_whisper_logging_hooks() {
     #[cfg(feature = "whisper")]
     whisper_rs::install_logging_hooks();
-}
-
-#[cfg(test)]
-pub(crate) fn test_home_env_lock() -> std::sync::MutexGuard<'static, ()> {
-    use std::sync::{Mutex, OnceLock};
-
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -2904,7 +2904,7 @@ mod tests {
     use tempfile::{tempdir, NamedTempFile};
 
     fn with_temp_home<T>(f: impl FnOnce() -> T) -> T {
-        let _lock = crate::test_home_env_lock();
+        let _lock = crate::test_support::home_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let original_home = std::env::var_os("HOME");
         #[cfg(windows)]

--- a/crates/core/src/notes.rs
+++ b/crates/core/src/notes.rs
@@ -309,7 +309,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn with_temp_home<T>(f: impl FnOnce(&Path) -> T) -> T {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         let previous_home = std::env::var_os("HOME");
         std::env::set_var("HOME", dir.path());

--- a/crates/core/src/parakeet.rs
+++ b/crates/core/src/parakeet.rs
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn resolve_parakeet_binary_prefers_working_configured_path() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let dir = tempfile::TempDir::new().unwrap();
         let binary_path = dir.path().join(fake_parakeet_filename());
         write_fake_parakeet_binary(&binary_path);
@@ -569,7 +569,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn resolve_parakeet_binary_auto_finds_homebrew_candidate() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let home = tempfile::TempDir::new().unwrap();
         let homebrew_prefix = tempfile::TempDir::new().unwrap();
         let empty_path = tempfile::TempDir::new().unwrap();
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn resolve_parakeet_binary_errors_when_nothing_is_available() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let home = tempfile::TempDir::new().unwrap();
         let homebrew_prefix = tempfile::TempDir::new().unwrap();
         let empty_path = tempfile::TempDir::new().unwrap();
@@ -616,7 +616,7 @@ mod tests {
 
     #[test]
     fn resolve_parakeet_binary_can_fail_strictly_for_broken_config() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let home = tempfile::TempDir::new().unwrap();
         let homebrew_prefix = tempfile::TempDir::new().unwrap();
         let empty_path = tempfile::TempDir::new().unwrap();
@@ -642,7 +642,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn resolve_parakeet_binary_falls_back_from_broken_config_when_alternative_exists() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let home = tempfile::TempDir::new().unwrap();
         let homebrew_prefix = tempfile::TempDir::new().unwrap();
         let empty_path = tempfile::TempDir::new().unwrap();
@@ -671,7 +671,7 @@ mod tests {
 
     #[test]
     fn resolve_parakeet_binary_combines_error_when_fallback_also_fails() {
-        let _env_lock = crate::test_home_env_lock();
+        let _env_lock = crate::test_support::home_env_lock();
         let home = tempfile::TempDir::new().unwrap();
         let homebrew_prefix = tempfile::TempDir::new().unwrap();
         let empty_path = tempfile::TempDir::new().unwrap();

--- a/crates/core/src/pid.rs
+++ b/crates/core/src/pid.rs
@@ -760,20 +760,20 @@ mod tests {
 
     #[test]
     fn is_process_alive_detects_current_process() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         assert!(is_process_alive(std::process::id()));
     }
 
     #[test]
     fn is_process_alive_returns_false_for_dead_pid() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         // PID 99999999 almost certainly doesn't exist
         assert!(!is_process_alive(99_999_999));
     }
 
     #[test]
     fn processing_status_round_trip() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         set_processing_status(
             Some("Transcribing audio"),
             Some(CaptureMode::QuickThought),
@@ -795,7 +795,7 @@ mod tests {
 
     #[test]
     fn recording_metadata_round_trip() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         write_recording_metadata(CaptureMode::QuickThought).unwrap();
         let metadata = read_recording_metadata().unwrap();
         assert_eq!(metadata.mode, CaptureMode::QuickThought);
@@ -808,7 +808,7 @@ mod tests {
         // count and summary fields off the passed-in slice instead of going
         // back to disk. Important — this is what removes 2 of the 3 directory
         // walks per UI status poll.
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let job = crate::jobs::ProcessingJob {
             id: "job-status-check".into(),
             mode: CaptureMode::Meeting,
@@ -862,7 +862,7 @@ mod tests {
         // Locks in that the function trusts caller-provided ordering.
         // active_jobs() returns active < queued < terminal then created_at
         // desc; the active in-flight job must surface as the summary.
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let mk = |id: &str, state: crate::jobs::JobState, title: &str| crate::jobs::ProcessingJob {
             id: id.into(),
             mode: CaptureMode::Meeting,
@@ -902,7 +902,7 @@ mod tests {
 
     #[test]
     fn sentinel_lifecycle() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         // Ensure clean state
         let _ = std::fs::remove_file(stop_sentinel_path());
         assert!(!stop_sentinel_path().exists());
@@ -921,7 +921,7 @@ mod tests {
 
     #[test]
     fn sentinel_write_and_clear() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         // Write a sentinel and verify check_and_clear removes it
         write_stop_sentinel().unwrap();
         assert!(stop_sentinel_path().exists());
@@ -933,7 +933,7 @@ mod tests {
 
     #[test]
     fn check_and_clear_sentinel_returns_false_when_absent() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         // Ensure no sentinel exists
         let _ = std::fs::remove_file(stop_sentinel_path());
         assert!(!check_and_clear_sentinel());
@@ -941,7 +941,7 @@ mod tests {
 
     #[test]
     fn create_pid_file_writes_using_locked_handle_without_reopen() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let tempdir = tempfile::tempdir().unwrap();
         let pid_path = tempdir.path().join("recording.pid");
 

--- a/crates/core/src/retention.rs
+++ b/crates/core/src/retention.rs
@@ -275,7 +275,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let original_home = std::env::var_os("HOME");
         let original_userprofile = std::env::var_os("USERPROFILE");

--- a/crates/core/src/screen.rs
+++ b/crates/core/src/screen.rs
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn current_session_breadcrumb_is_metadata_only_and_requires_image_inspection() {
-        let _lock = crate::test_home_env_lock();
+        let _lock = crate::test_support::home_env_lock();
         let home = tempfile::tempdir().unwrap();
         let original_home = std::env::var_os("HOME");
         #[cfg(windows)]

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -1456,7 +1456,7 @@ mod tests {
         // Search hits the HOME-derived sqlite index; serialize with the
         // crate HOME-env lock or a concurrently HOME-swapping test yanks
         // the index mid-write (sqlite disk I/O error).
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1485,7 +1485,7 @@ mod tests {
 
     #[test]
     fn search_returns_empty_for_no_match() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1513,7 +1513,7 @@ mod tests {
 
     #[test]
     fn search_is_case_insensitive() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1541,7 +1541,7 @@ mod tests {
 
     #[test]
     fn search_expands_vocabulary_aliases_with_provenance() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let home = TempDir::new().unwrap();
         unsafe {
             std::env::set_var("HOME", home.path());
@@ -1589,7 +1589,7 @@ mod tests {
         // Search hits the HOME-derived sqlite index; serialize with the
         // crate HOME-env lock or a concurrently HOME-swapping test yanks
         // the index mid-write (sqlite disk I/O error).
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1630,7 +1630,7 @@ mod tests {
 
     #[test]
     fn search_empty_directory() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         let config = Config {
             output_dir: dir.path().to_path_buf(),
@@ -1652,7 +1652,7 @@ mod tests {
 
     #[test]
     fn split_frontmatter_works() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let content = "---\ntitle: Test\ndate: 2026-03-17\n---\n\nBody text here.";
         let (fm, body) = split_frontmatter(content);
         assert!(fm.contains("title: Test"));
@@ -1661,7 +1661,7 @@ mod tests {
 
     #[test]
     fn extract_field_finds_value() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let fm = "title: My Meeting\ndate: 2026-03-17\ntype: meeting";
         assert_eq!(extract_field(fm, "title"), Some("My Meeting".into()));
         assert_eq!(extract_field(fm, "type"), Some("meeting".into()));
@@ -1670,7 +1670,7 @@ mod tests {
 
     #[test]
     fn search_intents_returns_matching_structured_records() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1708,7 +1708,7 @@ mod tests {
 
     #[test]
     fn search_intents_filters_by_kind_and_owner() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1741,7 +1741,7 @@ mod tests {
 
     #[test]
     fn search_intents_filters_owner_through_speaker_overlay() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         let meeting = dir.path().join("2026-03-17-test.md");
         create_test_file(
@@ -1787,7 +1787,7 @@ mod tests {
 
     #[test]
     fn search_intents_filter_by_recorded_by() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1835,7 +1835,7 @@ mod tests {
 
     #[test]
     fn consistency_report_flags_conflicts_and_stale_commitments() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1896,7 +1896,7 @@ mod tests {
 
     #[test]
     fn consistency_report_resolves_stale_owner_through_speaker_overlay() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         let meeting = dir.path().join("2020-03-01-a.md");
         create_test_file(
@@ -1931,7 +1931,7 @@ mod tests {
 
     #[test]
     fn consistency_report_marks_conflict_resolved_when_supersedes_is_set() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1961,7 +1961,7 @@ mod tests {
 
     #[test]
     fn consistency_report_leaves_resolution_none_without_supersedes() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -1987,7 +1987,7 @@ mod tests {
 
     #[test]
     fn consistency_report_does_not_mark_resolution_when_other_conflicts_remain() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -2019,7 +2019,7 @@ mod tests {
 
     #[test]
     fn consistency_report_requires_supersedes_to_reference_the_prior_decision() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -2044,7 +2044,7 @@ mod tests {
 
     #[test]
     fn consistency_report_ignores_near_duplicate_decisions() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -2068,7 +2068,7 @@ mod tests {
 
     #[test]
     fn person_profile_aggregates_recent_meetings_topics_and_open_intents() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -2099,7 +2099,7 @@ mod tests {
 
     #[test]
     fn person_profile_matches_linked_people_entities() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -2119,7 +2119,7 @@ mod tests {
 
     #[test]
     fn cross_meeting_research_collects_decisions_intents_and_meetings() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -2160,7 +2160,7 @@ mod tests {
 
     #[test]
     fn find_open_actions_parses_frontmatter() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         create_test_file(
             dir.path(),
@@ -2198,7 +2198,7 @@ mod tests {
 
     #[test]
     fn search_excludes_restricted_meetings_by_default() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = restricted_test_dir();
         let config = Config {
             output_dir: dir.path().to_path_buf(),
@@ -2226,7 +2226,7 @@ mod tests {
 
     #[test]
     fn search_intents_excludes_restricted_meetings_by_default() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = restricted_test_dir();
         let config = Config {
             output_dir: dir.path().to_path_buf(),
@@ -2252,7 +2252,7 @@ mod tests {
 
     #[test]
     fn find_open_actions_excludes_restricted_meetings_by_default() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = restricted_test_dir();
         let config = Config {
             output_dir: dir.path().to_path_buf(),
@@ -2272,7 +2272,7 @@ mod tests {
 
     #[test]
     fn cross_meeting_research_excludes_restricted_meetings_by_default() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = restricted_test_dir();
         let config = Config {
             output_dir: dir.path().to_path_buf(),
@@ -2306,7 +2306,7 @@ mod tests {
 
     #[test]
     fn person_profile_always_excludes_restricted_meetings() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = restricted_test_dir();
         let config = Config {
             output_dir: dir.path().to_path_buf(),
@@ -2323,7 +2323,7 @@ mod tests {
 
     #[test]
     fn consistency_report_always_excludes_restricted_meetings() {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = restricted_test_dir();
         let config = Config {
             output_dir: dir.path().to_path_buf(),

--- a/crates/core/src/sensitive.rs
+++ b/crates/core/src/sensitive.rs
@@ -402,7 +402,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn with_temp_home<T>(f: impl FnOnce(&Config) -> T) -> T {
-        let _guard = crate::test_home_env_lock();
+        let _guard = crate::test_support::home_env_lock();
         let dir = TempDir::new().unwrap();
         let meetings = dir.path().join("meetings");
         let previous_home = std::env::var_os("HOME");

--- a/crates/core/src/summarize.rs
+++ b/crates/core/src/summarize.rs
@@ -3079,7 +3079,6 @@ fn parse_speaker_mapping(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::path::Path;
@@ -3091,7 +3090,7 @@ mod tests {
     /// private mutex here raced with crate::test_home_env_lock users and
     /// flaked parallel runs).
     fn home_env_lock_guard() -> std::sync::MutexGuard<'static, ()> {
-        crate::test_home_env_lock()
+        crate::test_support::home_env_lock()
     }
 
     fn api_env_lock() -> &'static Mutex<()> {
@@ -3099,27 +3098,7 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    struct HomeOverride {
-        previous: Option<OsString>,
-    }
-
-    impl HomeOverride {
-        fn set(path: &Path) -> Self {
-            let previous = std::env::var_os("HOME");
-            std::env::set_var("HOME", path);
-            Self { previous }
-        }
-    }
-
-    impl Drop for HomeOverride {
-        fn drop(&mut self) {
-            if let Some(previous) = &self.previous {
-                std::env::set_var("HOME", previous);
-            } else {
-                std::env::remove_var("HOME");
-            }
-        }
-    }
+    use crate::test_support::HomeOverride;
 
     fn with_temp_home<T>(f: impl FnOnce(&Path) -> T) -> T {
         let _guard = home_env_lock_guard();

--- a/crates/core/src/test_support.rs
+++ b/crates/core/src/test_support.rs
@@ -1,0 +1,67 @@
+//! Test scaffolding shared by unit and integration tests.
+//!
+//! Not part of the public API and exempt from semver. It is compiled
+//! unconditionally rather than behind `#[cfg(test)]` because integration tests
+//! in `tests/` link against this crate as an external consumer and therefore
+//! cannot see `#[cfg(test)]` items. That gap is what let an integration test
+//! overwrite the developer's real `~/.minutes/search.db` (#588): the one test
+//! that reached global state was the one with no way to isolate it.
+//!
+//! Several paths are resolved from the home directory rather than from
+//! [`crate::config::Config`], notably `search.db` and `graph.db`. A test that
+//! isolates only `output_dir` therefore still writes to real user state. Wrap
+//! any such test in [`with_temp_home`].
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+/// Serialize tests that mutate the `HOME` environment variable.
+///
+/// The environment is process-global, so concurrent tests would otherwise
+/// observe each other's overrides. Poisoning is ignored: a panicking test
+/// leaves the lock poisoned but the guard itself is still sound to hand out.
+pub fn home_env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Sets `HOME` for as long as it is held, restoring the previous value on drop.
+///
+/// Take [`home_env_lock`] first. Prefer [`with_temp_home`], which does both.
+pub struct HomeOverride {
+    previous: Option<OsString>,
+}
+
+impl HomeOverride {
+    pub fn set(path: &Path) -> Self {
+        let previous = std::env::var_os("HOME");
+        std::env::set_var("HOME", path);
+        Self { previous }
+    }
+}
+
+impl Drop for HomeOverride {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var("HOME", previous);
+        } else {
+            std::env::remove_var("HOME");
+        }
+    }
+}
+
+/// Run `f` with `HOME` pointed at a fresh temporary directory.
+///
+/// Anything the body resolves from the home directory (`search.db`, `graph.db`,
+/// `~/.minutes/...`) lands in that directory and is discarded afterwards, so the
+/// developer's real state is never touched. The lock is held for the duration,
+/// so tests using this run one at a time.
+pub fn with_temp_home<T>(f: impl FnOnce(&Path) -> T) -> T {
+    let _guard = home_env_lock();
+    let temp = tempfile::tempdir().expect("temp home");
+    let _home = HomeOverride::set(temp.path());
+    f(temp.path())
+}

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28",
+  "generatedAt": "2026-07-29",
   "visibleCount": 67,
   "hiddenCount": 17,
   "groups": [

--- a/site/app/docs/mcp/tools/data.json
+++ b/site/app/docs/mcp/tools/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28",
+  "generatedAt": "2026-07-29",
   "installCommand": "npx minutes-mcp",
   "documentationUrl": "https://useminutes.app/for-agents",
   "supportUrl": "https://github.com/silverstein/minutes/discussions",

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: crates/core thiserror definitions
-> Last generated: 2026-07-28
+> Last generated: 2026-07-29
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 

--- a/site/public/docs/mcp/tools.md
+++ b/site/public/docs/mcp/tools.md
@@ -3,7 +3,7 @@
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts
 > Regenerate: node scripts/generate_llms_txt.mjs
-> Last generated: 2026-07-28
+> Last generated: 2026-07-29
 
 Minutes exposes 37 tools, 8 resources, and 6 prompt templates through the MCP server.
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-07-28
+> Last generated: 2026-07-29
 
 ## Product
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-07-28
+> Last generated: 2026-07-29
 
 Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and any MCP-compatible client read from the same folder — no proprietary SDK, no API key. Nothing is uploaded: when a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.
 

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -151,6 +151,17 @@ fn filename_collision_appends_suffix() {
 
 #[test]
 fn search_filters_by_content_type() {
+    // The search index lives at ~/.minutes/search.db, resolved from the home
+    // directory rather than from `config`, so isolating `output_dir` alone is
+    // not enough: this test used to replace the developer's real index with its
+    // own fixture rows (#588). Redirect HOME so the index it builds is thrown
+    // away with the temp dir.
+    minutes_core::test_support::with_temp_home(|_home| {
+        search_filters_by_content_type_inner();
+    });
+}
+
+fn search_filters_by_content_type_inner() {
     let dir = TempDir::new().unwrap();
     let config = test_config(dir.path().join("output"));
 


### PR DESCRIPTION
Fixes #588, reported by @rymalia.

## The problem

`cargo test -p minutes-core` replaced the developer's real `~/.minutes/search.db` with two fixture rows pointing into a `TempDir`. Nothing in the test was wrong: `search.db` and `graph.db` resolve from the home directory rather than from `Config`, so isolating `output_dir` never reaches them.

The reporter's sharper framing is the one I acted on: the isolation pattern already existed, but was **unreachable from integration tests**. The lock was `#[cfg(test)] pub(crate)`, and `HomeOverride` was duplicated privately inside two unit-test modules. Tests in `tests/` link against this crate as an external consumer and can see none of that. So the single test that touched global state was the one with no way to isolate itself. That gap, rather than anything specific to the search index, is the actual bug.

## Fix

- New doc-hidden `test_support` module with one `HomeOverride`, the shared lock, and `with_temp_home`. Compiled unconditionally rather than under `#[cfg(test)]`, because that is precisely what integration tests cannot see.
- Both private copies deleted, and the 14 callers of the old `test_home_env_lock` moved to the shared helper, so there is one implementation instead of three.
- The offending test wrapped in `with_temp_home`.

Deliberately not done: inferring "this is a test" from the config. Indexing a temporary `output_dir` is legitimate user configuration, as the issue notes.

## Verification, both directions

With a sentinel row in a real `search.db`:

```
BEFORE:            1 row   /sentinel/real-user-row.md
unfixed (main):    2 rows  /tmp/.tmpthohMs/output/2026-07-29-meeting-one.md   <- clobbered
fixed (this PR):   1 row   /sentinel/real-user-row.md                          <- intact
```

Core lib suite 1172 passed, integration 8 passed, CI-scope clippy and fmt clean.

One observation while testing: `summarize::tests::summarize_with_agent_drains_stderr_while_waiting` failed once while a concurrent cargo command shared the target dir, then passed 5/5 on this branch and 5/5 on main under clean conditions. Load-sensitive like #591 rather than related to this change, but worth recording.

## Note on the wider exposure

`graph.db` has the same shape, with ~22 `rebuild_index` callers, and `rebuild_index_at` clears every row before repopulating. Only the sandboxed `battle_card` test reaches it today and nothing enforces that. This PR makes the guard available to any test that needs it, which is the precondition for closing that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)