### PR TITLE
test(desktop): take the HOME guard in list_documents test (#591)

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -14531,19 +14531,16 @@ mod tests {
         assert_eq!(text_file_kind(Path::new("/tmp/test.txt")), Some("text"));
     }
 
-    /// Pin a file's mtime to `secs_ago` before now, so recency assertions do
-    /// not depend on sleep timing or filesystem timestamp granularity (#591).
-    fn set_test_mtime(path: &std::path::Path, secs_ago: u64) {
-        let when = SystemTime::now() - Duration::from_secs(secs_ago);
-        let file = std::fs::File::options()
-            .write(true)
-            .open(path)
-            .expect("open for mtime");
-        file.set_modified(when).expect("set mtime");
-    }
-
     #[test]
     fn list_documents_merges_assistant_and_meeting_sources_by_recency() {
+        // This test resolves HOME and builds its fixture inside it, so it must
+        // hold the same guard the HOME-mutating helpers take. Without it,
+        // with_temp_home() can repoint HOME and then recursively delete that
+        // directory while this test is still writing into it, which showed up
+        // as a NotFound partway through setup (#591). Deterministic on macOS,
+        // invisible on Linux, and never caught because CI does not run this
+        // suite at all.
+        let _guard = test_guard();
         let home = dirs::home_dir().expect("home dir");
         let temp = tempfile::Builder::new()
             .prefix("minutes-documents-test-")
@@ -14556,23 +14553,16 @@ mod tests {
         std::fs::create_dir_all(&assistant_artifacts).unwrap();
         std::fs::create_dir_all(&meetings).unwrap();
 
-        // Recency ordering is asserted below, so set each mtime explicitly
-        // rather than relying on short sleeps between writes. Sleeps only
-        // separate the timestamps if the sleep exceeds the filesystem's
-        // timestamp granularity and the process is not descheduled, which is
-        // why this test passed alone and failed under load (#591).
         let older = assistant.join("prep.md");
         std::fs::write(&older, "# Prep").unwrap();
-        set_test_mtime(&older, 40);
-        let instructions = assistant.join("CLAUDE.md");
-        std::fs::write(&instructions, "# Instructions").unwrap();
-        set_test_mtime(&instructions, 30);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(assistant.join("CLAUDE.md"), "# Instructions").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
         let nested = assistant_artifacts.join("debrief.txt");
         std::fs::write(&nested, "Debrief").unwrap();
-        set_test_mtime(&nested, 20);
+        std::thread::sleep(std::time::Duration::from_millis(5));
         let meeting = meetings.join("2026-07-02-product-review.md");
         std::fs::write(&meeting, "# Meeting artifact").unwrap();
-        set_test_mtime(&meeting, 10);
         let outside = temp.path().join("outside-secret.md");
         std::fs::write(&outside, "# Outside").unwrap();
         #[cfg(unix)]

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -14531,6 +14531,17 @@ mod tests {
         assert_eq!(text_file_kind(Path::new("/tmp/test.txt")), Some("text"));
     }
 
+    /// Pin a file's mtime to `secs_ago` before now, so recency assertions do
+    /// not depend on sleep timing or filesystem timestamp granularity (#591).
+    fn set_test_mtime(path: &std::path::Path, secs_ago: u64) {
+        let when = SystemTime::now() - Duration::from_secs(secs_ago);
+        let file = std::fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open for mtime");
+        file.set_modified(when).expect("set mtime");
+    }
+
     #[test]
     fn list_documents_merges_assistant_and_meeting_sources_by_recency() {
         let home = dirs::home_dir().expect("home dir");
@@ -14545,16 +14556,23 @@ mod tests {
         std::fs::create_dir_all(&assistant_artifacts).unwrap();
         std::fs::create_dir_all(&meetings).unwrap();
 
+        // Recency ordering is asserted below, so set each mtime explicitly
+        // rather than relying on short sleeps between writes. Sleeps only
+        // separate the timestamps if the sleep exceeds the filesystem's
+        // timestamp granularity and the process is not descheduled, which is
+        // why this test passed alone and failed under load (#591).
         let older = assistant.join("prep.md");
         std::fs::write(&older, "# Prep").unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        std::fs::write(assistant.join("CLAUDE.md"), "# Instructions").unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(5));
+        set_test_mtime(&older, 40);
+        let instructions = assistant.join("CLAUDE.md");
+        std::fs::write(&instructions, "# Instructions").unwrap();
+        set_test_mtime(&instructions, 30);
         let nested = assistant_artifacts.join("debrief.txt");
         std::fs::write(&nested, "Debrief").unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(5));
+        set_test_mtime(&nested, 20);
         let meeting = meetings.join("2026-07-02-product-review.md");
         std::fs::write(&meeting, "# Meeting artifact").unwrap();
+        set_test_mtime(&meeting, 10);
         let outside = temp.path().join("outside-secret.md");
         std::fs::write(&outside, "# Outside").unwrap();
         #[cfg(unix)]


### PR DESCRIPTION
Fixes #591. The framing in that issue was wrong and this PR corrects it.

## Not a flake

`list_documents_merges_assistant_and_meeting_sources_by_recency` fails **100% of the time** on macOS main, not intermittently. Measured on an Apple Silicon Mac:

| Build | Full-suite runs | Result |
|---|---|---|
| origin/main | 5 | 5 failed |
| main before #596 | 3 | 3 failed |
| this PR | 5 | **0 failed** (274 passed) |

It passes on Linux, which is why it looked intermittent from the VM.

## Cause

The test resolves `dirs::home_dir()` and builds its fixture inside the real home directory, but never takes the `test_guard()` mutex that the HOME-mutating helpers hold. `with_temp_home()` repoints HOME to a temp dir and recursively deletes it afterwards, so when the two overlap, that cleanup removes the directory this test is still writing into. The symptom is a `NotFound` partway through setup, at the `CLAUDE.md` write, rather than the recency assertion the issue guessed at.

Fix: take the same guard. One line plus a comment explaining why.

## The larger finding

**CI has never run this test suite.** Every workflow runs `cargo check -p minutes-app --tests`, which compiles them; nothing runs `cargo test -p minutes-app`. All 274 Tauri desktop tests compile and never execute, on any platform. That is why a deterministic macOS failure sat unnoticed, and it means the desktop app has had no test enforcement while CLAUDE.md counts these tests as coverage.

Adding `cargo test -p minutes-app` to CI is deliberately **not** in this PR. Turning on a suite that has never run is likely to surface more than this one failure, and it deserves its own change rather than being smuggled in behind a one-line fix. Filed as a follow-up.

## Note on my first attempt

The initial commit on this branch replaced the test's 5ms sleeps with explicit mtimes, on the theory that timestamp granularity was collapsing the recency ordering under load. That theory was wrong: the failing assertion is a `NotFound` during setup, not an ordering check. That change is discarded rather than kept as an unrelated improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)