### PR TITLE
hooks: block a push that leaves generated docs stale

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,7 +14,9 @@ node scripts/check_version_sync.mjs
 # Consistency" job fails. That has caught several PRs, including contributor
 # ones where the red check was not their fault. Check it here instead, where the
 # fix is one command away rather than a round trip through CI.
-if ! node scripts/sync_site_release_version.mjs --check >/dev/null 2>&1; then
+if [[ ! -f scripts/sync_site_release_version.mjs ]]; then
+  echo "skipping generated-docs check (scripts/sync_site_release_version.mjs not present)"
+elif ! node scripts/sync_site_release_version.mjs --check >/dev/null 2>&1; then
   echo "pre-push: generated site constants are stale." >&2
   echo "  fix: node scripts/generate_llms_txt.mjs && node scripts/sync_site_release_version.mjs" >&2
   echo "  then commit the regenerated files (site/lib/release.ts, site/public/llms*.txt, docs catalogs)." >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,6 +9,18 @@ cd "$repo_root"
 
 node scripts/check_version_sync.mjs
 
+# Generated docs embed counts (tests, CLI commands, MCP tools), so any change
+# that adds a test or command leaves them stale and CI's "Site Release Link
+# Consistency" job fails. That has caught several PRs, including contributor
+# ones where the red check was not their fault. Check it here instead, where the
+# fix is one command away rather than a round trip through CI.
+if ! node scripts/sync_site_release_version.mjs --check >/dev/null 2>&1; then
+  echo "pre-push: generated site constants are stale." >&2
+  echo "  fix: node scripts/generate_llms_txt.mjs && node scripts/sync_site_release_version.mjs" >&2
+  echo "  then commit the regenerated files (site/lib/release.ts, site/public/llms*.txt, docs catalogs)." >&2
+  exit 1
+fi
+
 if [[ -d tooling/skills/node_modules && -d tooling/skills/dist ]]; then
   npm --prefix tooling/skills run check
 else


### PR DESCRIPTION
The generated docs embed counts (tests, CLI commands, MCP tools), so any change that adds a test leaves `site/lib/release.ts` and the llms/docs catalogs stale, and CI's `Site Release Link Consistency` job fails.

That has caught several PRs this week, including contributor ones (#522, #573) where the red check was not their fault and cost a round trip plus an explanation from me. It also caught two of my own today. At that point it is a process gap rather than repeated carelessness, so it belongs in a hook rather than in everyone's memory.

The pre-push hook already runs `check_version_sync.mjs`; this adds the generated-docs check beside it, with the exact regeneration command in the failure message.

Verified both directions rather than assumed: a deliberately stale `MINUTES_TEST_COUNT` is blocked with the fix instructions, and a clean tree passes. Hooks remain optional and bypassable with `--no-verify`, and CI stays authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)