### PR TITLE
fix(desktop): stop the fifth action button from eating the meeting title

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -2761,6 +2761,29 @@
       gap: 8px;
       justify-content: flex-end;
       padding-right: 28px;
+      /* This row declares no `flex` shorthand, so it is `flex: 0 1 auto` and its
+         flex base size is its MAX-CONTENT width — every button on one line,
+         even though flex-wrap then wraps them onto two. Space is distributed
+         from those base sizes, so when a fifth button pushed the row's base
+         past what the header had, the header stopped handing leftovers to
+         .detail-header-copy and started shrinking it instead, until the copy
+         froze on its 16.5ch min-width while the wrapped row sat half empty.
+         Measured at the normal 762px card: 33 title characters with four
+         buttons, 21 with five.
+         max-width does not change the base size — the base is computed first,
+         then clamped — but clamping the row's hypothetical size is enough to
+         put the header back into "distribute the leftovers", and the leftovers
+         go to the title. The 22rem term is a floor on the cap, not on the row:
+         on narrow cards the row already needs more than half the header, and
+         capping it there would only force another wrapped line and a taller
+         header. So the effective rule is "half the header, but never less than
+         22rem" — above ~44rem of header the 50% term wins, below it the 22rem
+         term does. rem, not px, because UI zoom drives :root font-size.
+         Known cost, measured: at zoom >= 20 with a window wide enough that all
+         five buttons would have fitted on one line, the cap wraps them onto two
+         and the header grows 3-5px. At the default zoom there is no such width
+         — the row never fits on one line there. */
+      max-width: max(50%, 22rem);
     }
 
     .detail-scroll {
@@ -9485,7 +9508,16 @@
 
     function renderDetailSections(detail) {
       currentMeetingDetail = detail;
-      detailTitle.textContent = detail.title || 'Untitled';
+      const detailTitleText = detail.title || 'Untitled';
+      detailTitle.textContent = detailTitleText;
+      // .detail-title is `white-space: nowrap; text-overflow: ellipsis`, so a
+      // long title is only ever readable in full on hover. The native tooltip
+      // is the whole mechanism — same one .dictation-recent-text already uses
+      // for the same reason. It adds no font, colour or radius, so DESIGN.md
+      // has nothing to say about it. Set unconditionally rather than only when
+      // truncated: whether it truncates depends on the card width at the moment
+      // of measurement, and the window is resizable.
+      detailTitle.title = detailTitleText;
       detailMeta.replaceChildren();
       detailScroll.replaceChildren();
       currentMeetingPath = detail.path;


### PR DESCRIPTION
## What

#596 added a fifth button (Resummarize) to the meeting detail header. That made the
title truncate earlier than it did with four buttons, while the action row visibly
wrapped and left empty space beside it.

No header CSS changed in #596 — `.detail-header`, `.detail-header-copy`,
`.detail-title` and `.detail-actions` are byte-identical to main — so this is
intrinsic sizing, not a style regression.

`.detail-actions` declares no flex shorthand, so it is `flex: 0 1 auto` and its flex
base size is its max-content width: all five buttons on one line, even though
`flex-wrap` then wraps them onto two. Space is distributed from those base sizes, so
the fifth button pushed the row's bid past the header's width, the header stopped
handing leftovers to `.detail-header-copy`, and the copy froze on its 16.5ch
min-width.

Measured at the normal 762px card: **33 title characters with four buttons, 21 with
five, 43 with the cap.**

## Screenshots

1. Truncated title before fifth button
<img width="780" height="117" alt="Screenshot 2026-07-29 at 7 30 10 PM - old version - pre button" src="https://github.com/user-attachments/assets/e553d24e-670a-424f-b918-9d5bedcdb2d1" />


2. Truncated title with fifth button (current, e5d0113)
<img width="768" height="116" alt="Screenshot 2026-07-28 at 8 38 07 AM - resummarize button introduced" src="https://github.com/user-attachments/assets/1b75b654-6c2a-41ba-8d2b-8158c13848df" />


3. Truncated title fix (this PR)
<img width="780" height="102" alt="Screenshot 2026-07-29 at 7 32 02 PM - with button - new version w fix" src="https://github.com/user-attachments/assets/5df6d142-68bf-47a7-83fc-e6aafe5ed567" />


## Change

- `.detail-actions` gains `max-width: max(50%, 22rem)`
- the title gains a native tooltip (same mechanism `.dictation-recent-text` uses),
  since a truncated title is otherwise unreadable in full

The `22rem` term is a floor on the cap. On narrow cards the row already needs more
than half the header, and capping it there would only force another wrapped line and
a taller header. A bare `50%` does that at 90 of the 170 reachable card widths;
`max(50%, 22rem)` at none of them, and at none of the button's in-flight relabels.

## The cost, disclosed

At UI zoom 20 and above, with a window wide enough that all five buttons would have
fitted on one line, the cap wraps them onto two and the header grows 3–5px. Swept
across every zoom level × every reachable card width × every in-flight label
(3,472 samples):

| zoom | 71ch card | samples | regressions |
|---|---|---|---|
| 16 (default) | 762.3px | 340 | 0 |
| 18 | 857.5px | 436 | 14 |
| 20 | 952.8px | 532 | 38 |
| 22 | 1048.1px | 628 | 66 |
| 24 | 1143.4px | 720 | 91 |
| 26 | 1238.7px | 816 | 117 |

At the default zoom the five-button row never fits on one line at any reachable
width, so capping it can never force an extra wrap — the cap costs nothing there.
Above zoom 18 it is a permanently two-line row in that band, 3–5px taller, in
exchange for roughly double the title. It does not jitter between states.

There is no partial version of this trade — reverting the commit is the only way to
decline it.

## Verification

Click-tested in Minutes Dev on macOS 26 / Apple Silicon:

- title shows 41 of 47 characters where it showed ~21; still ellipsis-truncated, no wrap
- action row is two lines: row 1 `Create Draft` · `Discuss with Agent`; row 2
  `Resummarize` · `Open in Editor` · `Delete`, right-aligned
- `Open in Editor` opens the editor and never triggers the delete confirmation
- `Delete`'s on-screen box is pixel-identical between the `Resummarize` and
  `Confirm?` label states, so no relabel slides a button under the cursor mid-click
- narrowed to the ~460px minimum: the row wraps further, nothing is clipped and
  nothing overlaps the title; returns to two rows when widened

## Notes

- **This does not claim to fix a jitter bug.** The `Confirm?` width pin already
  exists on main (`tauri/src/index.html:8883`, from #596) and was present during the
  measurements above, so the stable geometry cannot be attributed to the cap alone.
  The cap's contribution is keeping the row at two lines in every label state.
- The tooltip is set unconditionally rather than only when truncated, because the
  window is resizable and "is it truncated" is not a stable condition. Happy to gate
  it if you would prefer.
- Frontend only; no Rust changes.
