### PR TITLE
test(resummarize): close edge coverage gaps

### DIFF
--- a/crates/core/src/resummarize.rs
+++ b/crates/core/src/resummarize.rs
@@ -1470,10 +1470,20 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_edit_aborts_apply() {
+    fn concurrent_edit_aborts_apply_without_overwriting_user_bytes() {
         let dir = TempDir::new().unwrap();
         let path = write_meeting(&dir);
         let path_clone = path.clone();
+        let user_edit = fs::read(&path)
+            .unwrap()
+            .into_iter()
+            .chain(
+                b"\n<!-- saved mid-inference; preserve every byte -->\n"
+                    .iter()
+                    .copied(),
+            )
+            .collect::<Vec<_>>();
+        let expected_user_edit = user_edit.clone();
         let err = resummarize_meeting_with(
             &path,
             &test_config(),
@@ -1483,17 +1493,14 @@ mod tests {
             },
             move |_, _, _| {
                 // The user saves their editor mid-inference.
-                let mutated = fs::read_to_string(&path_clone)
-                    .unwrap()
-                    .replace("edited hello", "edited again");
-                fs::write(&path_clone, mutated).unwrap();
+                fs::write(&path_clone, &user_edit).unwrap();
                 Some(good_summary())
             },
         )
         .unwrap_err();
         assert!(matches!(err, ResummarizeError::ConcurrentEdit));
-        // The user's mid-flight save is what survives.
-        assert!(fs::read_to_string(&path).unwrap().contains("edited again"));
+        // The user's mid-flight save is the exact byte sequence that survives.
+        assert_eq!(fs::read(&path).unwrap(), expected_user_edit);
     }
 
     #[test]

--- a/crates/core/src/resummarize.rs
+++ b/crates/core/src/resummarize.rs
@@ -1584,6 +1584,49 @@ mod tests {
     }
 
     #[test]
+    fn apply_round_trips_generated_artifact_larger_than_one_megabyte() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("large-meeting.md");
+        let large_transcript = format!(
+            "[SPEAKER_00 0:00] edited hello\\n{}",
+            "generated transcript payload ".repeat(42_500)
+        );
+        let fixture = MEETING.replace("[SPEAKER_00 0:00] edited hello", &large_transcript);
+        assert!(
+            fixture.len() > 1_000_000,
+            "fixture must exercise the >1MB path"
+        );
+        fs::write(&path, fixture).unwrap();
+
+        let expected_transcript = large_transcript.clone();
+        let report = resummarize_meeting_with(
+            &path,
+            &test_config(),
+            &ResummarizeOptions {
+                apply: true,
+                ..Default::default()
+            },
+            move |transcript, _, _| {
+                assert_eq!(transcript, expected_transcript);
+                Some(good_summary())
+            },
+        )
+        .unwrap();
+        assert!(report.applied);
+
+        let rewritten = fs::read_to_string(&path).unwrap();
+        assert!(
+            rewritten.len() > 1_000_000,
+            "resummarize must not truncate a >1MB artifact"
+        );
+        let (_, body) = markdown::split_frontmatter(&rewritten);
+        let transcript = markdown::find_unique_section(body, "Transcript")
+            .unwrap()
+            .expect("rewritten artifact must retain its transcript");
+        assert_eq!(markdown::section_text(body, transcript), large_transcript);
+    }
+
+    #[test]
     fn apply_to_crlf_artifact_keeps_uniform_line_endings() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("meeting.md");

--- a/crates/core/src/resummarize.rs
+++ b/crates/core/src/resummarize.rs
@@ -1474,15 +1474,16 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = write_meeting(&dir);
         let path_clone = path.clone();
-        let user_edit = fs::read(&path)
-            .unwrap()
-            .into_iter()
-            .chain(
-                b"\n<!-- saved mid-inference; preserve every byte -->\n"
-                    .iter()
-                    .copied(),
-            )
-            .collect::<Vec<_>>();
+        let mut user_edit = fs::read(&path).unwrap();
+        let original_bytes = b"edited hello";
+        let replacement_bytes = b"edited again";
+        assert_eq!(original_bytes.len(), replacement_bytes.len());
+        let edit_start = user_edit
+            .windows(original_bytes.len())
+            .position(|window| window == original_bytes)
+            .expect("fixture must contain the original transcript text");
+        user_edit[edit_start..edit_start + replacement_bytes.len()]
+            .copy_from_slice(replacement_bytes);
         let expected_user_edit = user_edit.clone();
         let err = resummarize_meeting_with(
             &path,
@@ -1588,14 +1589,24 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("large-meeting.md");
         let large_transcript = format!(
-            "[SPEAKER_00 0:00] edited hello\\n{}",
-            "generated transcript payload ".repeat(42_500)
+            "[SPEAKER_00 0:00] edited hello\n{}",
+            "generated transcript payload \n".repeat(42_500)
         );
         let fixture = MEETING.replace("[SPEAKER_00 0:00] edited hello", &large_transcript);
         assert!(
             fixture.len() > 1_000_000,
             "fixture must exercise the >1MB path"
         );
+        assert!(
+            fixture.lines().count() > 42_500,
+            "fixture must exercise many physical line boundaries"
+        );
+        let expected_backup = fixture.as_bytes().to_vec();
+        let (_, original_body) = markdown::split_frontmatter(&fixture);
+        let original_notes = markdown::find_unique_section(original_body, "Notes")
+            .unwrap()
+            .expect("fixture must contain user-owned Notes");
+        let expected_notes = markdown::section_text(original_body, original_notes).to_owned();
         fs::write(&path, fixture).unwrap();
 
         let expected_transcript = large_transcript.clone();
@@ -1613,6 +1624,12 @@ mod tests {
         )
         .unwrap();
         assert!(report.applied);
+        let backup = report.backup.expect("applied run must create a backup");
+        assert_eq!(
+            fs::read(&backup).unwrap(),
+            expected_backup,
+            "backup must retain every byte of the original large artifact"
+        );
 
         let rewritten = fs::read_to_string(&path).unwrap();
         assert!(
@@ -1624,6 +1641,10 @@ mod tests {
             .unwrap()
             .expect("rewritten artifact must retain its transcript");
         assert_eq!(markdown::section_text(body, transcript), large_transcript);
+        let notes = markdown::find_unique_section(body, "Notes")
+            .unwrap()
+            .expect("rewritten artifact must retain user-owned Notes");
+        assert_eq!(markdown::section_text(body, notes), expected_notes);
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -7,7 +7,7 @@ export const MINUTES_RELEASE_TAG = `v${MINUTES_RELEASE_VERSION}`;
 
 export const MINUTES_MCP_TOOL_COUNT = 37;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 1675;
+export const MINUTES_TEST_COUNT = 1676;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What

Three test-only commits against `crates/core/src/resummarize.rs`. No production code
changes.

1. **Concurrent-edit byte preservation** — strengthens the existing concurrent-edit
   test to assert the user's bytes survive verbatim when an apply aborts, rather than
   only asserting the error variant. Renamed to
   `concurrent_edit_aborts_apply_without_overwriting_user_bytes`.
2. **Large-artifact round trip** — new
   `apply_round_trips_generated_artifact_larger_than_one_megabyte`, covering an
   artifact over 1MB through a full apply and asserting the transcript section
   survives intact.
3. **Tightened assertions** — byte-length equality between original and replacement,
   and section-text preservation for notes.

## Why

`ConcurrentEdit` is the guard standing between a resummarize pass and a user's
in-flight edits, and #596 noted it was not exercised end-to-end. These close that
gap and pin the "abort must not overwrite" property, so a future change to the
guarded-rewrite path cannot silently weaken it.

## Verification

`cargo test -p minutes-core --no-default-features` → **1182 passed, 0 failed,
1 ignored** (the ignore is pre-existing and unrelated).

Includes a `chore(site)` commit bumping the embedded test count in
`site/lib/release.ts` from 1675 to 1676, since the new test moves it. Generated with
`node scripts/sync_site_release_version.mjs` — not hand-edited.

The agent-docs generator's outputs (`llms.txt`, `llms-full.txt`, and the error and
MCP tool catalogs) are deliberately not included. Re-running `generate_llms_txt.mjs`
on this branch produces a date-stamp diff and nothing else — verified line by line
across all six files it writes — and `generate_llms_txt.mjs --check` normalizes that
stamp away by design (`scripts/generate_llms_txt.mjs:753-764`). Both generated-docs
CI jobs pass on this branch as committed.
