### PR TITLE
Stabilize Windows leader-retirement timing assertion

### DIFF
--- a/crates/core/src/bounded_child.rs
+++ b/crates/core/src/bounded_child.rs
@@ -2946,23 +2946,46 @@ mod windows_tests {
     fn successful_windows_leader_exit_retires_grandchild_and_preserves_status() {
         let directory = tempfile::TempDir::new().unwrap();
         let pid_path = directory.path().join("successful-grandchild.pid");
-        let script =
-            child_and_grandchild_script(&pid_path, "[Console]::Out.Write('leader-output'); exit 7");
-        let started = Instant::now();
+        let ready_path = directory.path().join("successful-leader-ready");
+        let leader_tail = format!(
+            "[IO.File]::WriteAllText('{}', 'ready'); \
+             [Console]::Out.Write('leader-output'); exit 7",
+            quote_powershell_literal(&ready_path)
+        );
+        let script = child_and_grandchild_script(&pid_path, &leader_tail);
 
-        let run = run(
-            &mut powershell(&script),
-            None,
-            StdoutTarget::Capture { max_bytes: 1024 },
-            budget(15_000),
-        )
-        .unwrap();
-        let elapsed = started.elapsed();
+        // Hosted PowerShell cold-start can consume most of a wall-clock
+        // budget under runner contention. Measure the ordering contract from
+        // the leader's pre-exit marker instead: tree retirement and pipe drain
+        // must be prompt once the leader is ready to exit.
+        let runner = std::thread::spawn(move || {
+            run(
+                &mut powershell(&script),
+                None,
+                StdoutTarget::Capture { max_bytes: 1024 },
+                budget(30_000),
+            )
+        });
+        let ready_deadline = Instant::now() + Duration::from_secs(30);
+        while !ready_path.exists() && !runner.is_finished() && Instant::now() < ready_deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let ready_observed = ready_path.exists();
+        let retirement_started = Instant::now();
+        let run = runner
+            .join()
+            .expect("supervisor thread must not panic")
+            .unwrap();
+        let retirement_elapsed = retirement_started.elapsed();
 
+        assert!(
+            ready_observed,
+            "successful leader must publish its pre-exit marker"
+        );
         assert!(!run.timed_out);
         assert!(
-            elapsed < Duration::from_secs(10),
-            "successful leader retirement took {elapsed:?}"
+            retirement_elapsed < Duration::from_secs(10),
+            "successful leader retirement took {retirement_elapsed:?} after its pre-exit marker"
         );
         assert_eq!(run.output.status.code(), Some(7));
         assert_eq!(run.output.stdout, b"leader-output");


### PR DESCRIPTION
## Post-merge Windows CI repair — DO NOT RELEASE

PR #604 merged as `70ebfbcf8fd2346ec03bc06497651df824c0da24`. Its post-merge Windows job in CI run `30567482470` exposed that the strengthened timing assertion included PowerShell cold-start and runner scheduling: the successful leader path completed without a supervisor timeout, but the test measured `12.9342239s` from process launch.

This test-only follow-up preserves the production fix and changes the Windows regression fixture to:

- emit a unique readiness marker immediately before the successful leader writes stdout and exits;
- measure the retirement/drain interval from that marker instead of from PowerShell process launch;
- keep the strict under-10-second post-marker assertion;
- retain the exact exit code, stdout, no-supervisor-timeout, and grandchild-retirement checks;
- allow up to 30 seconds only for Windows runner and PowerShell cold-start variability before readiness.

## Exact scope

- Base: `70ebfbcf8fd2346ec03bc06497651df824c0da24`
- Head: `1adefefa5c924e32770d99b1b51da314e0e04c52`
- Production code is unchanged; the diff is confined to the Windows-only regression test in `crates/core/src/bounded_child.rs`.

## Local evidence on the exact head

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p minutes-core --no-default-features --lib -- -D warnings`
- serial `minutes-core`: `1649 passed; 0 failed; 1 ignored`
- Windows GNU no-run cross-compile completed (known cfg warnings only)
- push hooks, version guards, and generated-skill checks passed

## Exact hosted evidence

- [Lint run 30569355341](https://github.com/silverstein/minutes/actions/runs/30569355341): success.
- [Full CI run 30569355334](https://github.com/silverstein/minutes/actions/runs/30569355334): first-attempt success, 20/20 jobs, exact head `1adefefa5c924e32770d99b1b51da314e0e04c52`.
  - [Windows job 90961866372](https://github.com/silverstein/minutes/actions/runs/30569355334/job/90961866372): success; the named retirement test passed and the suite reported `1505 passed; 0 failed; 5 ignored`.
- [Guarded validation run 30569367918](https://github.com/silverstein/minutes/actions/runs/30569367918): success on the exact head; focused memory test `1 passed; 0 failed`; read-only contents; release-readiness and Windows-installer jobs skipped; zero release artifacts or effects.

## Independent reviews

Three independent read-only reviews evaluated the exact base/head pair:

- Windows security: **ACCEPT**, P0/P1/P2 = 0/0/0. The marker is emitted only after the grandchild is spawned and its PID is recorded, immediately before leader output/exit; the temporary path is unique; the old inherited-pipe ordering still fails.
- Test integrity: **ACCEPT**, P0/P1/P2 = 0/0/0. Premature completion, missing readiness, a supervisor timeout, delayed pipe closure, a wrong exit, wrong output, or a surviving grandchild still fails the test.
- Workflow safety: technical **ACCEPT**, P0/P1 = 0/0; its sole P2 was to record these hosted receipts and review verdicts in this PR body. This update satisfies that delivery-record condition without changing the reviewed head.

## Authorization boundary

Merge of this repair is authorized as part of completing PR #604. Tagging, signing, publishing, deployment, and release remain explicitly unauthorized.
