### PR TITLE
Stabilize Windows MCP cancellation-poison timing test

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -1286,18 +1286,43 @@ describe("stable corpus lease", () => {
   it("poisons admission when an asynchronous projection ignores cancellation", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "uncancellable projection canary");
-      const started = Date.now();
+      let markOperationStarted!: () => void;
+      const operationStarted = new Promise<void>((resolve) => {
+        markOperationStarted = resolve;
+      });
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
+      const lease = withStableCorpusLease(
+        root,
+        () => {
+          markOperationStarted();
+          return new Promise<never>(() => {});
+        },
+        {
+          timeoutMs: 5_000,
+          operationDeadlineForTest: operationDeadline,
+        }
+      );
+
       await expect(
-        withStableCorpusLease(
-          root,
-          () => new Promise<never>(() => {}),
-          { timeoutMs: 300 }
-        )
-      ).rejects.toThrow("stable meeting corpus authorization failed");
+        Promise.race([
+          operationStarted.then(() => true),
+          lease.then(
+            () => false,
+            () => false
+          ),
+        ])
+      ).resolves.toBe(true);
+
+      const started = Date.now();
+      forceOperationDeadline();
+      await expect(lease).rejects.toThrow("stable meeting corpus authorization failed");
       expect(Date.now() - started).toBeLessThan(2_500);
       await expect(
         withStableCorpusLease(root, () => "must not reuse")
       ).rejects.toThrow("requires a process restart");
     });
-  });
+  }, 10_000);
 });

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -1301,7 +1301,7 @@ describe("stable corpus lease", () => {
           return new Promise<never>(() => {});
         },
         {
-          timeoutMs: 5_000,
+          timeoutMs: 15_000,
           operationDeadlineForTest: operationDeadline,
         }
       );

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -167,6 +167,8 @@ export type CorpusLeaseHooks = {
     | "after-baseline"
     | "before-finalize"
     | "before-authorized";
+  /** Test-only deterministic parent deadline after the projection has started. */
+  operationDeadlineForTest?: Promise<void>;
 };
 
 type RootIdentity = {
@@ -2031,6 +2033,12 @@ export async function withStableCorpusLease<T>(
           operationTermination = new Promise<void>((resolve) => {
             resolveOperationTermination = resolve;
           });
+          if (hooks.operationDeadlineForTest) {
+            void hooks.operationDeadlineForTest.then(
+              () => fail("meeting corpus authorization deadline elapsed"),
+              () => fail("meeting corpus authorization deadline elapsed")
+            );
+          }
           try {
             operationResult = await operation(
               snapshot,


### PR DESCRIPTION
## Windows MCP timing repair — DO NOT RELEASE

Main CI run `30572209716` attempt 1 exposed a fixture race in `poisons admission when an asynchronous projection ignores cancellation`: the 300 ms authorization deadline could expire during Windows worker cold start before the uncancellable operation began. The test then expected process poisoning even though no active operation had ignored cancellation. The identical tree passed on the isolated rerun.

This change keeps the production invariant and makes the test causal:

- wait for an explicit operation-entry signal;
- inject the existing parent deadline path only after the projection is active;
- require prompt failure and permanent `requires a process restart` poisoning;
- retain the existing control proving a pre-operation worker timeout remains reusable;
- place the ordinary 15-second authorization deadline beyond the test's 10-second ceiling, so a disconnected injection cannot be rescued by the fallback timer.

## Exact scope

- Base: `d9a738d9546fb555b141917647c2eea04886b4a3`
- Head: `244cc558bb90e712872a388357821798b8d3d5a0`
- Two MCP files; one inert test-only hook plus a deterministic fixture. No release, version, product UI, workflow, or deployment changes.

## Local evidence

- Focused pre-operation reuse control plus operation-poison test: 10/10 consecutive runs green.
- Full MCP Vitest: `276 passed; 0 failed; 1 skipped`.
- MCP build: TypeScript and Vite green.
- MCP integration: `13 passed; 0 failed`; Copilot contract green.
- MCPB bundle guard and handshake green: 26 tools, 7 resources.
- Mutation checks:
  - disconnecting the injected deadline fails at the 10-second Vitest ceiling, before the ordinary 15-second deadline;
  - removing the poison assignment fails the exact required-restart assertion.
- `git diff --check`, version sync, skill compiler/check/routing/surface audit green.

## Exact hosted evidence

- [Lint run 30578452410](https://github.com/silverstein/minutes/actions/runs/30578452410): first-attempt success.
- [CI run 30578452406](https://github.com/silverstein/minutes/actions/runs/30578452406): first-attempt success on the exact head; 13 applicable jobs and CI Gate passed, with four unrelated path-filtered jobs skipped.
- [Native Windows job 90992439512](https://github.com/silverstein/minutes/actions/runs/30578452406/job/90992439512): success.
  - The named cancellation-poison regression passed in both relevant suites.
  - SDK corpus lane: `58 passed; 0 failed; 1 skipped`.
  - MCP corpus lane: `202 passed; 0 failed; 31 skipped`.
- The exact-head CI run produced zero artifacts. Only lint and CI ran; no release workflow or release effect ran.

## Independent exact-head reviews

Three independent read-only reviews evaluated base `d9a738d9…` against head `244cc558…`:

- Test integrity: **ACCEPT**, P0/P1/P2 = 0/0/0. The operation-entry handshake is causal, the disconnected-hook mutation cannot be rescued by the fallback deadline, permanent poisoning is required, and pre-operation timeout reuse remains covered.
- Windows security: **ACCEPT**, P0/P1/P2 = 0/0/0. Normal production callers omit the hook; the real deadline is unchanged; injection uses the same fail/abort/kill/poison path only after operation state is established.
- Workflow/release safety: technical **ACCEPT**, P0/P1 = 0/0. Its sole P2 was to replace the stale head and record these final hosted and review receipts; this body-only correction satisfies that condition without changing the reviewed head.

## Authorization boundary

Merge of this exact accepted repair is authorized as part of completing `minutes-by0e`. Tagging, signing, publishing, deployment, and release remain explicitly unauthorized.
