### PR TITLE
ci: bootstrap signed Apple Speech acceptance

### DIFF
--- a/.github/workflows/signed-dev-acceptance.yml
+++ b/.github/workflows/signed-dev-acceptance.yml
@@ -89,6 +89,7 @@ jobs:
           cp -f tauri/src-tauri/entitlements.plist outer-entitlements.plist
           cp -f tauri/src-tauri/minutes-cli.entitlements cli-entitlements.plist
           cp -f tauri/src-tauri/minutes-graph-worker.entitlements graph-worker-entitlements.plist
+          cp -f tauri/src-tauri/minutes-apple-speech-worker.entitlements apple-speech-worker-entitlements.plist
 
       - name: Upload unsigned candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -101,6 +102,7 @@ jobs:
             outer-entitlements.plist
             cli-entitlements.plist
             graph-worker-entitlements.plist
+            apple-speech-worker-entitlements.plist
           if-no-files-found: error
           retention-days: 1
 
@@ -183,9 +185,14 @@ jobs:
           sidecar="$app/Contents/MacOS/minutes"
           graph_worker_bundle="$app/Contents/XPCServices/com.useminutes.graph-worker.xpc"
           graph_worker="$graph_worker_bundle/Contents/MacOS/minutes-graph-worker"
+          apple_speech_worker_bundle="$app/Contents/XPCServices/com.useminutes.apple-speech-worker.xpc"
+          apple_speech_worker="$apple_speech_worker_bundle/Contents/MacOS/minutes-apple-speech-worker"
           test -d "$graph_worker_bundle"
           test -f "$graph_worker"
           test ! -e "$app/Contents/MacOS/minutes-graph-worker"
+          test -d "$apple_speech_worker_bundle"
+          test -f "$apple_speech_worker"
+          test ! -e "$app/Contents/MacOS/minutes-apple-speech-worker"
           while IFS= read -r nested_executable; do
             if [ "$nested_executable" = "$sidecar" ]; then
               codesign --force --options runtime --timestamp \
@@ -201,6 +208,10 @@ jobs:
             --entitlements payload/graph-worker-entitlements.plist \
             --identifier com.useminutes.graph-worker \
             --sign "$MINUTES_DEV_SIGNING_IDENTITY" "$graph_worker_bundle"
+          codesign --force --options runtime --timestamp \
+            --entitlements payload/apple-speech-worker-entitlements.plist \
+            --identifier com.useminutes.apple-speech-worker \
+            --sign "$MINUTES_DEV_SIGNING_IDENTITY" "$apple_speech_worker_bundle"
           graph_worker_cdhash="$(
             codesign -dvvv "$graph_worker" 2>&1 \
               | awk -F= '/^CDHash=/{print tolower($2); exit}'
@@ -210,6 +221,14 @@ jobs:
           printf '%s\n' "$graph_worker_cdhash" \
             > "$app/Contents/Resources/minutes-graph-worker.cdhash"
           chmod 444 "$app/Contents/Resources/minutes-graph-worker.cdhash"
+          apple_speech_worker_cdhash="$(
+            codesign -dvvv "$apple_speech_worker" 2>&1 \
+              | awk -F= '/^CDHash=/{print tolower($2); exit}'
+          )"
+          [[ "$apple_speech_worker_cdhash" =~ ^[0-9a-f]{40}$ ]]
+          printf '%s\n' "$apple_speech_worker_cdhash" \
+            > "$app/Contents/Resources/minutes-apple-speech-worker.cdhash"
+          chmod 444 "$app/Contents/Resources/minutes-apple-speech-worker.cdhash"
           app_executable_name="$(
             /usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
               "$app/Contents/Info.plist"
@@ -246,6 +265,37 @@ jobs:
           if sealed.count(expected) != 1 or sealed.count(marker) != 1:
               raise SystemExit("parent graph-worker seal verification failed")
           PY
+          python3 - "$app_executable" "$apple_speech_worker_cdhash" <<'PY'
+          import os
+          import pathlib
+          import re
+          import sys
+
+          executable = pathlib.Path(sys.argv[1])
+          cdhash = sys.argv[2]
+          if re.fullmatch(r"[0-9a-f]{40}", cdhash) is None:
+              raise SystemExit("invalid Apple Speech worker CodeDirectory hash")
+          marker = b"MINUTES_APPLE_SPEECH_WORKER_CDHASH_V1="
+          expected = marker + cdhash.encode("ascii")
+          contents = executable.read_bytes()
+          if contents.count(marker) != 1:
+              raise SystemExit("ambiguous parent Apple Speech worker seal")
+          offset = contents.index(marker)
+          old = contents[offset:offset + len(marker) + 40]
+          suffix = old[len(marker):]
+          if len(suffix) != 40 or any(
+              byte not in b"0123456789abcdef" for byte in suffix
+          ):
+              raise SystemExit("invalid prior parent Apple Speech worker seal")
+          with executable.open("r+b", buffering=0) as target:
+              target.seek(offset)
+              target.write(expected)
+              target.flush()
+              os.fsync(target.fileno())
+          sealed = executable.read_bytes()
+          if sealed.count(expected) != 1 or sealed.count(marker) != 1:
+              raise SystemExit("parent Apple Speech worker seal verification failed")
+          PY
           codesign --force --options runtime --timestamp \
             --entitlements payload/outer-entitlements.plist \
             --sign "$MINUTES_DEV_SIGNING_IDENTITY" "$app"
@@ -263,8 +313,12 @@ jobs:
           test "$identifier" = "com.useminutes.desktop.dev"
           graph_worker_bundle="$app/Contents/XPCServices/com.useminutes.graph-worker.xpc"
           graph_worker="$graph_worker_bundle/Contents/MacOS/minutes-graph-worker"
+          apple_speech_worker_bundle="$app/Contents/XPCServices/com.useminutes.apple-speech-worker.xpc"
+          apple_speech_worker="$apple_speech_worker_bundle/Contents/MacOS/minutes-apple-speech-worker"
           test ! -e "$app/Contents/MacOS/minutes-graph-worker"
+          test ! -e "$app/Contents/MacOS/minutes-apple-speech-worker"
           codesign --verify --strict --verbose=4 "$graph_worker_bundle"
+          codesign --verify --strict --verbose=4 "$apple_speech_worker_bundle"
           codesign -dv --verbose=4 "$graph_worker" >graph-worker-identity.txt 2>&1
           grep -Fq "Identifier=com.useminutes.graph-worker" graph-worker-identity.txt
           grep -Fq "TeamIdentifier=63TMLKT8HN" graph-worker-identity.txt
@@ -281,6 +335,22 @@ jobs:
                   f"graph worker entitlement allowlist mismatch: {actual!r}"
               )
           PY
+          codesign -dv --verbose=4 "$apple_speech_worker" >apple-speech-worker-identity.txt 2>&1
+          grep -Fq "Identifier=com.useminutes.apple-speech-worker" apple-speech-worker-identity.txt
+          grep -Fq "TeamIdentifier=63TMLKT8HN" apple-speech-worker-identity.txt
+          codesign -d --entitlements :- "$apple_speech_worker" \
+            >apple-speech-worker-entitlements.actual.plist 2>/dev/null
+          python3 - <<'PY'
+          import plistlib
+
+          with open("apple-speech-worker-entitlements.actual.plist", "rb") as source:
+              actual = plistlib.load(source)
+          expected = {"com.apple.security.app-sandbox": True}
+          if actual != expected:
+              raise SystemExit(
+                  f"Apple Speech worker entitlement allowlist mismatch: {actual!r}"
+              )
+          PY
           expected_cdhash="$(
             tr -d '\n' < "$app/Contents/Resources/minutes-graph-worker.cdhash"
           )"
@@ -289,6 +359,14 @@ jobs:
               | awk -F= '/^CDHash=/{print tolower($2); exit}'
           )"
           test "$expected_cdhash" = "$observed_cdhash"
+          expected_apple_cdhash="$(
+            tr -d '\n' < "$app/Contents/Resources/minutes-apple-speech-worker.cdhash"
+          )"
+          observed_apple_cdhash="$(
+            codesign -dvvv "$apple_speech_worker" 2>&1 \
+              | awk -F= '/^CDHash=/{print tolower($2); exit}'
+          )"
+          test "$expected_apple_cdhash" = "$observed_apple_cdhash"
           app_executable_name="$(
             /usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
               "$app/Contents/Info.plist"
@@ -303,6 +381,19 @@ jobs:
           contents = pathlib.Path(sys.argv[1]).read_bytes()
           if contents.count(expected) != 1:
               raise SystemExit("signed parent is not bound to the exact graph worker")
+          PY
+          python3 - "$app/Contents/MacOS/$app_executable_name" \
+            "$observed_apple_cdhash" <<'PY'
+          import pathlib
+          import sys
+
+          marker = b"MINUTES_APPLE_SPEECH_WORKER_CDHASH_V1="
+          expected = marker + sys.argv[2].encode("ascii")
+          contents = pathlib.Path(sys.argv[1]).read_bytes()
+          if contents.count(expected) != 1:
+              raise SystemExit(
+                  "signed parent is not bound to the exact Apple Speech worker"
+              )
           PY
           printf 'candidate=%s\nteam_id=%s\nidentifier=%s\n' \
             "$CANDIDATE_SHA" "$team_id" "$identifier" \
@@ -326,5 +417,58 @@ jobs:
             minutes-dev-signed.zip
             minutes-dev-signed.zip.sha256
             signed-dev-provenance.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  run-signed-runtime:
+    name: Run signed Apple Speech byte-transport acceptance
+    needs:
+      - authorize-candidate
+      - sign-reviewed-artifact
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact protected acceptance harness
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: refs/tags/acceptance-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download exact signed candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: minutes-dev-signed-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          path: payload
+
+      - name: Verify and expand exact signed candidate
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize-candidate.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+          (
+            cd payload
+            shasum -a 256 -c minutes-dev-signed.zip.sha256
+          )
+          mkdir -p runtime
+          ditto -x -k payload/minutes-dev-signed.zip runtime
+          test -d "runtime/Minutes Dev.app"
+
+      - name: Exercise signed byte path under same-UID open holder
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize-candidate.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/test_apple_speech_signed_transport.py \
+            --app "runtime/Minutes Dev.app" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            | tee signed-runtime-provenance.json
+
+      - name: Upload content-free signed runtime receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: apple-speech-signed-runtime-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          path: signed-runtime-provenance.json
           if-no-files-found: error
           retention-days: 1

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -8,7 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
   release: "986432ffb8697f36a026afa6e66a5bf20cd0861de5e428029edca0129088c19d",
-  acceptance: "b5afb18dd30be29a9885331ed8dd505c8ff5ffd3a632232d328fe3b6d08b8c3f",
+  acceptance: "701960b7d3f9a8a363946a72e4e2271cc057919ea0425d4b6ad4abf25673dd13",
   build: "5f6029f8e22484a55294f08de62df299e816e08f4b45278d143a008142a47ea5",
   dev: "70f7a3aa227440c5928bc51227d64fbf85176b5f966b2fcc04a15e159bbd223e",
   packageXpc: "baebd532d240fc26188c431f571d0a44f2ce1e7240c3277284c9ea9e69c1ef82",

--- a/scripts/check_signed_acceptance_policy.mjs
+++ b/scripts/check_signed_acceptance_policy.mjs
@@ -7,9 +7,9 @@ import { readFileSync } from "node:fs";
 // boundary and secret-bearing job. Raw regex matches are intentionally not the
 // authority: these goldens make comment/dead-step duplication fail closed.
 const EXPECTED_SIGNING_JOB_SHA256 =
-  "f29213abf408b5e69a381bfbefef7db4896368c1369d8acc38f09f8442c41aad";
+  "4a5aa3f4aead6d336e57fa862085bffb594940923e93d8f58fab9cae962ef310";
 const EXPECTED_PRE_SIGNING_BOUNDARY_SHA256 =
-  "f532d4e841a4be222ccec24b029a4a8f413dcfe6f4688c621475dace9c54c2e6";
+  "c6fb10e1051bd745f737d4718ad949b9b1a01b585702bfecf354be752ff2e278";
 const EXPECTED_TRIGGER_BLOCK = `on:
   workflow_dispatch:
     inputs:
@@ -83,11 +83,45 @@ if (!signingJobFixture) {
     /signed parent is not bound to the exact graph worker/,
     "signed acceptance must verify the final parent-to-helper binding",
   );
+  requirePattern(
+    /apple_speech_worker_bundle="\$app\/Contents\/XPCServices\/com\.useminutes\.apple-speech-worker\.xpc"[\s\S]*?test ! -e "\$app\/Contents\/MacOS\/minutes-apple-speech-worker"[\s\S]*?--entitlements payload\/apple-speech-worker-entitlements\.plist[\s\S]*?--identifier com\.useminutes\.apple-speech-worker[\s\S]*?--sign "\$MINUTES_DEV_SIGNING_IDENTITY" "\$apple_speech_worker_bundle"/,
+    "the nested Apple Speech XPC service must receive only its dedicated App Sandbox identity",
+  );
+  requirePattern(
+    /apple-speech-worker-entitlements\.actual\.plist[\s\S]*?expected = \{"com\.apple\.security\.app-sandbox": True\}[\s\S]*?actual != expected/,
+    "signed acceptance must enforce the Apple Speech worker's exact one-key entitlement allowlist",
+  );
+  requirePattern(
+    /minutes-apple-speech-worker\.cdhash[\s\S]*?observed_apple_cdhash[\s\S]*?test "\$expected_apple_cdhash" = "\$observed_apple_cdhash"/,
+    "signed acceptance must seal and verify the Apple Speech worker's exact CodeDirectory hash",
+  );
+  requirePattern(
+    /MINUTES_APPLE_SPEECH_WORKER_CDHASH_V1=[\s\S]*?contents\.count\(marker\) != 1[\s\S]*?invalid prior parent Apple Speech worker seal[\s\S]*?os\.fsync/,
+    "signed acceptance must bind one exact Apple Speech worker hash into the parent before outer signing",
+  );
+  requirePattern(
+    /signed parent is not bound to the exact Apple Speech worker/,
+    "signed acceptance must verify the final parent-to-Apple-Speech-worker binding",
+  );
 }
 
-const signingJob = source.match(
-  /^  sign-reviewed-artifact:\n([\s\S]*)$/m,
-)?.[1];
+const signingJobMarker = "  sign-reviewed-artifact:\n";
+const signingJobStart = source.indexOf(signingJobMarker);
+const signingJobTail =
+  signingJobStart >= 0
+    ? source.slice(signingJobStart + signingJobMarker.length)
+    : "";
+const nextJobOffset = signingJobTail.search(/^  [a-z][a-z0-9-]*:\n/m);
+const signingJob =
+  signingJobStart < 0
+    ? undefined
+    : nextJobOffset >= 0
+      ? signingJobTail.slice(0, nextJobOffset).replace(/\n$/, "")
+      : signingJobTail;
+const afterSigningJob =
+  signingJobStart >= 0 && nextJobOffset >= 0
+    ? signingJobTail.slice(nextJobOffset)
+    : "";
 if (!signingJob) {
   errors.push("could not isolate the secret-bearing signing job");
 } else {
@@ -135,6 +169,13 @@ if (!signingJob) {
 }
 
 if (!signingJobFixture) {
+  requirePattern(
+    /^  run-signed-runtime:\n[\s\S]*?needs:\n\s+- authorize-candidate\n\s+- sign-reviewed-artifact[\s\S]*?refs\/tags\/acceptance-\$\{\{ needs\.authorize-candidate\.outputs\.candidate_sha \}\}\n\s+fetch-depth: 1\n\s+persist-credentials: false[\s\S]*?test_apple_speech_signed_transport\.py[\s\S]*?signed-runtime-provenance\.json/m,
+    "signed Apple Speech runtime acceptance must run in a no-secret successor job against the exact protected candidate",
+  );
+  if (SECRET_CONTEXT_EXPRESSION.test(afterSigningJob)) {
+    errors.push("post-signing runtime jobs must not receive signing secrets");
+  }
   const beforeSigningJob = source.split(/^  sign-reviewed-artifact:\n/m, 1)[0];
   if (SECRET_CONTEXT_EXPRESSION.test(beforeSigningJob)) {
     errors.push("signing secrets must not be exposed to candidate authorization or build jobs");

--- a/scripts/check_signed_acceptance_policy.test.mjs
+++ b/scripts/check_signed_acceptance_policy.test.mjs
@@ -73,6 +73,14 @@ const mutations = [
         "          # ref: refs/tags/acceptance-${{ needs.authorize-candidate.outputs.candidate_sha }}\n          ref: ${{ needs.authorize-candidate.outputs.candidate_sha }}",
       ),
   },
+  {
+    name: "persisted successor checkout credential",
+    expected: "signed Apple Speech runtime acceptance must run in a no-secret successor job",
+    source: workflow.replace(
+      "          persist-credentials: false",
+      "          persist-credentials: true",
+    ),
+  },
 ];
 
 try {


### PR DESCRIPTION
## What changed

- teach the trusted signed-development workflow to sign and verify the Apple Speech XPC worker
- bind the signed parent app to the exact worker CodeDirectory hash
- add a no-secret macOS successor job that runs the exact-tag byte-transport acceptance harness
- extend the fail-closed policy checker and mutation tests for the new trust boundary

## Why

Product PR #610 must remain draft, but its exact candidate SHA cannot receive a meaningful signed runtime test until the trusted workflow controller exists on `main`. GitHub deliberately exposes the Developer ID secrets only to the reviewed `main` workflow.

This PR contains only the trusted workflow controller and its policy guards. It does not contain product code, enable the Apple Speech product gate, merge PR #610, or create a release.

## Validation

- `node scripts/check_signed_acceptance_policy.mjs`
- `node scripts/check_signed_acceptance_policy.test.mjs`
- `actionlint .github/workflows/signed-dev-acceptance.yml`
- `git diff --check`