### PR TITLE
ci: allow signer to reseal worker hashes

### DIFF
--- a/.github/workflows/signed-dev-acceptance.yml
+++ b/.github/workflows/signed-dev-acceptance.yml
@@ -218,17 +218,23 @@ jobs:
           )"
           [[ "$graph_worker_cdhash" =~ ^[0-9a-f]{40}$ ]]
           mkdir -p "$app/Contents/Resources"
+          graph_worker_cdhash_file="$app/Contents/Resources/minutes-graph-worker.cdhash"
+          test -f "$graph_worker_cdhash_file"
+          chmod u+w "$graph_worker_cdhash_file"
           printf '%s\n' "$graph_worker_cdhash" \
-            > "$app/Contents/Resources/minutes-graph-worker.cdhash"
-          chmod 444 "$app/Contents/Resources/minutes-graph-worker.cdhash"
+            > "$graph_worker_cdhash_file"
+          chmod 444 "$graph_worker_cdhash_file"
           apple_speech_worker_cdhash="$(
             codesign -dvvv "$apple_speech_worker" 2>&1 \
               | awk -F= '/^CDHash=/{print tolower($2); exit}'
           )"
           [[ "$apple_speech_worker_cdhash" =~ ^[0-9a-f]{40}$ ]]
+          apple_speech_worker_cdhash_file="$app/Contents/Resources/minutes-apple-speech-worker.cdhash"
+          test -f "$apple_speech_worker_cdhash_file"
+          chmod u+w "$apple_speech_worker_cdhash_file"
           printf '%s\n' "$apple_speech_worker_cdhash" \
-            > "$app/Contents/Resources/minutes-apple-speech-worker.cdhash"
-          chmod 444 "$app/Contents/Resources/minutes-apple-speech-worker.cdhash"
+            > "$apple_speech_worker_cdhash_file"
+          chmod 444 "$apple_speech_worker_cdhash_file"
           app_executable_name="$(
             /usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
               "$app/Contents/Info.plist"

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -8,7 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
   release: "986432ffb8697f36a026afa6e66a5bf20cd0861de5e428029edca0129088c19d",
-  acceptance: "701960b7d3f9a8a363946a72e4e2271cc057919ea0425d4b6ad4abf25673dd13",
+  acceptance: "94b1a57515357bcd229ca57095f7cc10736d22e9a271b58994945ba8651de158",
   build: "5f6029f8e22484a55294f08de62df299e816e08f4b45278d143a008142a47ea5",
   dev: "70f7a3aa227440c5928bc51227d64fbf85176b5f966b2fcc04a15e159bbd223e",
   packageXpc: "baebd532d240fc26188c431f571d0a44f2ce1e7240c3277284c9ea9e69c1ef82",

--- a/scripts/check_signed_acceptance_policy.mjs
+++ b/scripts/check_signed_acceptance_policy.mjs
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 // boundary and secret-bearing job. Raw regex matches are intentionally not the
 // authority: these goldens make comment/dead-step duplication fail closed.
 const EXPECTED_SIGNING_JOB_SHA256 =
-  "4a5aa3f4aead6d336e57fa862085bffb594940923e93d8f58fab9cae962ef310";
+  "903c7c962b5eac067fbe423699943969b0405cec732306299366f172f5037894";
 const EXPECTED_PRE_SIGNING_BOUNDARY_SHA256 =
   "c6fb10e1051bd745f737d4718ad949b9b1a01b585702bfecf354be752ff2e278";
 const EXPECTED_TRIGGER_BLOCK = `on:


### PR DESCRIPTION
## What changed

- make the two verified worker-CDHash placeholders owner-writable immediately before resealing
- write the observed Developer ID-signed worker hashes
- restore both resources to read-only mode `0444` before signing the parent app
- update the reviewed whole-workflow and whole-signing-job policy goldens

## Root cause

Signed acceptance run 30594448902 proved the candidate build and artifact provenance, then failed before parent sealing because the unsigned app correctly carried a read-only graph-worker CDHash placeholder. The signing controller attempted to redirect over that `0444` file without temporarily adding owner write permission. Ephemeral signing material was removed successfully and the runtime job did not run.

## Scope

Trusted workflow infrastructure only. This does not change product code, candidate SHA `0501e06a6e3bb559d91f6c291f1234964f5a0f36`, PR #610, the product gate, or any release path.

## Validation

- `actionlint .github/workflows/*.yml`
- `node scripts/check_workflow_runner_context.mjs`
- `node scripts/check_signed_acceptance_policy.mjs`
- `node scripts/check_signed_acceptance_policy.test.mjs`
- `node scripts/check_graph_worker_packaging.mjs`
- `node scripts/check_graph_worker_packaging.mjs --self-test`
- `python3 scripts/seal_graph_worker_hash.py --self-test`
- `git diff --check`