### PR TITLE
ci: diagnose signed XPC launch without secrets

### DIFF
--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -124,8 +124,8 @@ jobs:
           sudo "$lldb" -b -p "$worker_pid" \
             -o 'process handle -s true -n false -p false SIGBUS' \
             -o 'process continue' \
-            -o 'thread backtrace all' \
-            -o 'process kill' \
+            -k 'thread backtrace all' \
+            -k 'process kill' \
             -o 'quit'
           debugger_status=$?
           wait "$launcher_pid"

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -116,7 +116,7 @@ jobs:
             printf '%s\n' '--- scoped unified log ---'
             /usr/bin/log show --last 20s --style compact --info --debug \
               --predicate \
-              'process CONTAINS[c] "minutes" OR eventMessage CONTAINS[c] "com.useminutes.apple-speech-worker"' \
-              | tail -1200 || true
+              'process CONTAINS[c] "minutes" OR process == "launchd" OR eventMessage CONTAINS[c] "com.useminutes.apple-speech-worker"' \
+              | tail -3000 || true
             exit 1
           fi

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -1,0 +1,76 @@
+name: Temporary signed XPC launch diagnostic
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/signed-runtime-diagnostic.yml
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  launch-services-probe:
+    name: Reuse signed 0501e06a artifact through LaunchServices
+    runs-on: macos-latest
+    timeout-minutes: 10
+    env:
+      CANDIDATE_SHA: 0501e06a6e3bb559d91f6c291f1234964f5a0f36
+      SOURCE_RUN_ID: "30596190795"
+    steps:
+      - name: Download the already signed exact candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="acceptance-$CANDIDATE_SHA"
+          resolved="$(
+            git ls-remote --refs \
+              "https://github.com/${GITHUB_REPOSITORY}.git" \
+              "refs/tags/$tag" |
+              awk '{print $1}'
+          )"
+          test "$resolved" = "$CANDIDATE_SHA"
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "minutes-dev-signed-$CANDIDATE_SHA" \
+            --dir payload
+          test "$(cut -d= -f2 payload/signed-dev-provenance.txt | head -1)" = "$CANDIDATE_SHA"
+          (
+            cd payload
+            shasum -a 256 -c minutes-dev-signed.zip.sha256
+          )
+          mkdir runtime
+          ditto -x -k payload/minutes-dev-signed.zip runtime
+          codesign --verify --deep --strict --verbose=4 "runtime/Minutes Dev.app"
+
+      - name: Launch the signed app through LaunchServices
+        run: |
+          set -euo pipefail
+          stdout="$RUNNER_TEMP/minutes-acceptance.stdout"
+          stderr="$RUNNER_TEMP/minutes-acceptance.stderr"
+          isolated_tmp="$RUNNER_TEMP/minutes-acceptance-tmp"
+          mkdir -p "$isolated_tmp"
+          set +e
+          open -n -W \
+            --stdout "$stdout" \
+            --stderr "$stderr" \
+            --env "TMPDIR=$isolated_tmp" \
+            "runtime/Minutes Dev.app" \
+            --args --apple-speech-transport-acceptance
+          launch_status=$?
+          set -e
+          printf 'LaunchServices status: %s\n' "$launch_status"
+          printf '%s\n' '--- app stdout ---'
+          test ! -f "$stdout" || tail -200 "$stdout"
+          printf '%s\n' '--- app stderr ---'
+          test ! -f "$stderr" || tail -200 "$stderr"
+          if [ "$launch_status" -ne 0 ] ||
+             ! grep -Fq "apple-speech-signed-byte-transport=accepted" "$stdout"; then
+            printf '%s\n' '--- scoped unified log ---'
+            /usr/bin/log show --last 3m --style compact \
+              --predicate \
+              'process == "minutes-apple-speech-worker" OR process == "Minutes Dev" OR process == "xpcproxy"' \
+              | tail -400 || true
+            exit 1
+          fi

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -43,6 +43,18 @@ jobs:
           mkdir runtime
           ditto -x -k payload/minutes-dev-signed.zip runtime
           codesign --verify --deep --strict --verbose=4 "runtime/Minutes Dev.app"
+          app="runtime/Minutes Dev.app"
+          worker="$app/Contents/XPCServices/com.useminutes.apple-speech-worker.xpc/Contents/MacOS/minutes-apple-speech-worker"
+          worker_cdhash="$(
+            codesign -dvvv "$worker" 2>&1 |
+              awk -F= '/^CDHash=/{print tolower($2); exit}'
+          )"
+          codesign --verify --verbose=4 \
+            --test-requirement="=identifier \"com.useminutes.apple-speech-worker\" and cdhash H\"$worker_cdhash\" and anchor apple generic and certificate leaf[subject.OU] = \"63TMLKT8HN\"" \
+            "$worker"
+          codesign --verify --verbose=4 \
+            --test-requirement='=(identifier "com.useminutes.desktop" or identifier "com.useminutes.desktop.dev") and anchor apple generic and certificate leaf[subject.OU] = "63TMLKT8HN"' \
+            "$app"
 
       - name: Launch the signed app through LaunchServices
         run: |

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -115,15 +115,14 @@ jobs:
              ! grep -Fq "apple-speech-signed-byte-transport=accepted" "$stdout"; then
             sleep 3
             printf '%s\n' '--- worker crash reports ---'
-            shopt -s nullglob
-            reports=(
-              "$HOME"/Library/Logs/DiagnosticReports/*minutes-apple*
-              /Library/Logs/DiagnosticReports/*minutes-apple*
-            )
-            for report in "${reports[@]}"; do
+            while IFS= read -r report; do
               printf 'report=%s\n' "$report"
               sed -n '1,320p' "$report"
-            done
+            done < <(
+              find "$HOME/Library/Logs/DiagnosticReports" \
+                /Library/Logs/DiagnosticReports \
+                -type f -iname '*minutes-apple*' -mmin -2 -print 2>/dev/null
+            )
             printf '%s\n' '--- scoped unified log ---'
             /usr/bin/log show --last 20s --style compact --info --debug \
               --predicate \

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -90,6 +90,51 @@ jobs:
           clang -Wall -Wextra -Werror -pthread "$source_file" -o "$executable"
           "$executable"
 
+      - name: Capture the signed worker SIGBUS backtrace
+        run: |
+          set -euo pipefail
+          worker_pid_file="$RUNNER_TEMP/minutes-apple-worker.pid"
+          stdout="$RUNNER_TEMP/minutes-debug.stdout"
+          stderr="$RUNNER_TEMP/minutes-debug.stderr"
+          (
+            for _ in {1..2000}; do
+              worker_pid="$(
+                pgrep -f '/minutes-apple-speech-worker$' | head -1 || true
+              )"
+              if [ -n "$worker_pid" ]; then
+                kill -STOP "$worker_pid"
+                printf '%s\n' "$worker_pid" >"$worker_pid_file"
+                exit 0
+              fi
+              sleep 0.002
+            done
+            exit 1
+          ) &
+          watcher_pid=$!
+          open -n -W \
+            --stdout "$stdout" \
+            --stderr "$stderr" \
+            "runtime/Minutes Dev.app" \
+            --args --apple-speech-transport-acceptance &
+          launcher_pid=$!
+          wait "$watcher_pid"
+          worker_pid="$(cat "$worker_pid_file")"
+          lldb="$(xcrun -f lldb)"
+          set +e
+          sudo "$lldb" -b -p "$worker_pid" \
+            -o 'process handle -s true -n false -p false SIGBUS' \
+            -o 'process continue' \
+            -o 'thread backtrace all' \
+            -o 'process kill' \
+            -o 'quit'
+          debugger_status=$?
+          wait "$launcher_pid"
+          launcher_status=$?
+          set -e
+          printf 'debugger_status=%s launcher_status=%s\n' \
+            "$debugger_status" "$launcher_status"
+          test ! -f "$stderr" || tail -200 "$stderr"
+
       - name: Launch the signed app through LaunchServices
         run: |
           set -euo pipefail

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -68,9 +68,9 @@ jobs:
           if [ "$launch_status" -ne 0 ] ||
              ! grep -Fq "apple-speech-signed-byte-transport=accepted" "$stdout"; then
             printf '%s\n' '--- scoped unified log ---'
-            /usr/bin/log show --last 3m --style compact \
+            /usr/bin/log show --last 20s --style compact --info --debug \
               --predicate \
-              'process == "minutes-apple-speech-worker" OR process == "Minutes Dev" OR process == "xpcproxy"' \
-              | tail -400 || true
+              'process CONTAINS[c] "minutes" OR eventMessage CONTAINS[c] "com.useminutes.apple-speech-worker"' \
+              | tail -1200 || true
             exit 1
           fi

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -56,6 +56,40 @@ jobs:
             --test-requirement='=(identifier "com.useminutes.desktop" or identifier "com.useminutes.desktop.dev") and anchor apple generic and certificate leaf[subject.OU] = "63TMLKT8HN"' \
             "$app"
 
+      - name: Probe RLIMIT_NPROC compatibility with XPC worker threads
+        run: |
+          set -euo pipefail
+          source_file="$RUNNER_TEMP/rlimit-nproc-probe.c"
+          executable="$RUNNER_TEMP/rlimit-nproc-probe"
+          cat >"$source_file" <<'C'
+          #include <errno.h>
+          #include <pthread.h>
+          #include <stdio.h>
+          #include <sys/resource.h>
+
+          static void *worker(void *unused) {
+            (void)unused;
+            return NULL;
+          }
+
+          int main(void) {
+            struct rlimit limit = {1, 1};
+            errno = 0;
+            int limit_status = setrlimit(RLIMIT_NPROC, &limit);
+            int limit_errno = errno;
+            pthread_t thread;
+            int thread_status = pthread_create(&thread, NULL, worker, NULL);
+            if (thread_status == 0) {
+              pthread_join(thread, NULL);
+            }
+            printf("setrlimit_status=%d setrlimit_errno=%d pthread_create_status=%d\n",
+                   limit_status, limit_errno, thread_status);
+            return 0;
+          }
+          C
+          clang -Wall -Wextra -Werror -pthread "$source_file" -o "$executable"
+          "$executable"
+
       - name: Launch the signed app through LaunchServices
         run: |
           set -euo pipefail

--- a/.github/workflows/signed-runtime-diagnostic.yml
+++ b/.github/workflows/signed-runtime-diagnostic.yml
@@ -113,6 +113,17 @@ jobs:
           test ! -f "$stderr" || tail -200 "$stderr"
           if [ "$launch_status" -ne 0 ] ||
              ! grep -Fq "apple-speech-signed-byte-transport=accepted" "$stdout"; then
+            sleep 3
+            printf '%s\n' '--- worker crash reports ---'
+            shopt -s nullglob
+            reports=(
+              "$HOME"/Library/Logs/DiagnosticReports/*minutes-apple*
+              /Library/Logs/DiagnosticReports/*minutes-apple*
+            )
+            for report in "${reports[@]}"; do
+              printf 'report=%s\n' "$report"
+              sed -n '1,320p' "$report"
+            done
             printf '%s\n' '--- scoped unified log ---'
             /usr/bin/log show --last 20s --style compact --info --debug \
               --predicate \


### PR DESCRIPTION
Temporary no-secret diagnostic only.

- reuses the already signed artifact for exact candidate `0501e06a6e3bb559d91f6c291f1234964f5a0f36` from run `30596190795`
- verifies its protected acceptance tag and artifact checksum
- launches the signed app through LaunchServices
- emits only scoped XPC/app logs on failure

This PR must not be merged. It exists only to distinguish a harness launch defect from a product XPC defect. It has no signing-secret access and does not merge or release product code.