### PR TITLE
CI: gated signing and notarization for Archive pilot

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           node scripts/check_signed_acceptance_policy.mjs
           node scripts/check_signed_acceptance_policy.test.mjs
+          node scripts/check_signed_archive_acceptance_policy.mjs
+          node scripts/check_signed_archive_acceptance_policy.test.mjs
 
       - name: Check graph worker packaging parity
         run: |

--- a/.github/workflows/signed-archive-acceptance.yml
+++ b/.github/workflows/signed-archive-acceptance.yml
@@ -1,0 +1,316 @@
+name: Signed Archive Pilot Acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Full SHA protected by the matching acceptance-<sha> tag
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: signed-archive-acceptance
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: "2"
+  TAURI_CLI_VERSION: "2.10.1"
+
+jobs:
+  authorize-candidate:
+    name: Authorize exact protected Archive candidate
+    if: github.ref == 'refs/heads/main' && github.actor == 'silverstein'
+    runs-on: ubuntu-latest
+    outputs:
+      candidate_sha: ${{ steps.authorize.outputs.candidate_sha }}
+    steps:
+      - name: Bind the request to its protected acceptance tag
+        id: authorize
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "candidate_sha must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          tag="acceptance-$CANDIDATE_SHA"
+          remote="https://github.com/${GITHUB_REPOSITORY}.git"
+          resolved="$(git ls-remote --refs "$remote" "refs/tags/$tag" | awk '{print $1}')"
+          if [ "$resolved" != "$CANDIDATE_SHA" ]; then
+            echo "Protected tag $tag does not resolve exactly to $CANDIDATE_SHA" >&2
+            exit 1
+          fi
+          echo "candidate_sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
+
+  build-unsigned:
+    name: Build and exercise Archive without signing secrets
+    needs: authorize-candidate
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out exact protected candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: refs/tags/acceptance-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          fetch-depth: 1
+
+      - name: Verify exact candidate checkout
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize-candidate.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+          printf '%s\n' "$CANDIDATE_SHA" > candidate-sha.txt
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
+
+      - name: Test bounded Archive implementation
+        run: |
+          set -euo pipefail
+          cargo fmt --all -- --check
+          cargo test \
+            -p minutes-archive-semantic \
+            -p minutes-archive-convert \
+            -p minutes-archive-core \
+            -p minutes-archive-app
+          cargo clippy \
+            -p minutes-archive-semantic \
+            -p minutes-archive-convert \
+            -p minutes-archive-core \
+            -p minutes-archive-app \
+            --all-targets -- -D warnings
+
+      - name: Build isolated production Archive app without signing
+        run: |
+          set -euo pipefail
+          (
+            cd archive/src-tauri
+            cargo tauri build --bundles app --no-sign
+          )
+
+      - name: Exercise exact unsigned app executable
+        run: |
+          set -euo pipefail
+          app="target/release/bundle/macos/Minutes Archive.app"
+          executable="$app/Contents/MacOS/minutes-archive-app"
+          test -d "$app"
+          test -x "$executable"
+          test "$(
+            /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+              "$app/Contents/Info.plist"
+          )" = "com.useminutes.archive"
+          if find "$app" -type l -print -quit | grep -q .; then
+            echo "Unsigned Archive app contains a symbolic link; refusing candidate" >&2
+            exit 1
+          fi
+          cargo run -p minutes-archive-core --example document_vault_smoke -- \
+            "$executable"
+          scripts/archive-native-lifecycle-smoke.sh "$app"
+
+      - name: Package unsigned candidate and provenance
+        run: |
+          set -euo pipefail
+          app="target/release/bundle/macos/Minutes Archive.app"
+          ditto -c -k --sequesterRsrc --keepParent \
+            "$app" minutes-archive-unsigned.zip
+          shasum -a 256 minutes-archive-unsigned.zip \
+            > minutes-archive-unsigned.zip.sha256
+
+      - name: Upload unsigned Archive candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: minutes-archive-unsigned-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          path: |
+            minutes-archive-unsigned.zip
+            minutes-archive-unsigned.zip.sha256
+            candidate-sha.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  sign-and-notarize:
+    name: Sign and notarize reviewed inert Archive app
+    needs:
+      - authorize-candidate
+      - build-unsigned
+    runs-on: macos-latest
+    timeout-minutes: 30
+    environment: signed-dev-acceptance
+    steps:
+      - name: Download exact unsigned Archive candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: minutes-archive-unsigned-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          path: payload
+
+      - name: Verify provenance before unlocking credentials
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize-candidate.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          test "$(cat payload/candidate-sha.txt)" = "$CANDIDATE_SHA"
+          (cd payload && shasum -a 256 -c minutes-archive-unsigned.zip.sha256)
+          mkdir signed
+          ditto -x -k payload/minutes-archive-unsigned.zip signed
+          app="signed/Minutes Archive.app"
+          test -d "$app"
+          if find "$app" -type l -print -quit | grep -q .; then
+            echo "Unsigned Archive app contains a symbolic link; refusing to sign" >&2
+            exit 1
+          fi
+          test "$(
+            /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+              "$app/Contents/Info.plist"
+          )" = "com.useminutes.archive"
+
+      - name: Import Developer ID identity into an ephemeral keychain
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          set -euo pipefail
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required signing secret: ${name}" >&2
+              exit 1
+            fi
+          done
+          case "$APPLE_SIGNING_IDENTITY" in
+            "Developer ID Application:"*) ;;
+            *)
+              echo "Archive distribution requires a Developer ID Application identity" >&2
+              exit 1
+              ;;
+          esac
+          keychain="$RUNNER_TEMP/minutes-archive-acceptance.keychain-db"
+          certificate="$RUNNER_TEMP/minutes-archive-acceptance.p12"
+          keychain_password="$(openssl rand -hex 24)"
+          python3 - "$certificate" <<'PY'
+          import base64
+          import os
+          import pathlib
+          import sys
+
+          pathlib.Path(sys.argv[1]).write_bytes(
+              base64.b64decode(os.environ["APPLE_CERTIFICATE"], validate=True)
+          )
+          PY
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" -k "$keychain" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain"
+          security find-identity -v -p codesigning "$keychain" \
+            | grep -Fq "$APPLE_SIGNING_IDENTITY"
+          {
+            echo "ARCHIVE_ACCEPTANCE_KEYCHAIN=$keychain"
+            echo "ARCHIVE_SIGNING_IDENTITY=$APPLE_SIGNING_IDENTITY"
+          } >> "$GITHUB_ENV"
+
+      - name: Materialize App Store Connect key
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          for name in APPLE_API_ISSUER APPLE_API_KEY APPLE_API_PRIVATE_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required notarization secret: ${name}" >&2
+              exit 1
+            fi
+          done
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          {
+            echo "ARCHIVE_API_KEY_PATH=$key_path"
+            echo "ARCHIVE_API_KEY=$APPLE_API_KEY"
+            echo "ARCHIVE_API_ISSUER=$APPLE_API_ISSUER"
+          } >> "$GITHUB_ENV"
+
+      # Candidate code is never executed after the signing identity is
+      # unlocked. This fixed workflow signs and notarizes only the reviewed,
+      # provenance-bound inert app artifact.
+      - name: Sign Archive inside-out
+        run: |
+          set -euo pipefail
+          app="signed/Minutes Archive.app"
+          while IFS= read -r nested_executable; do
+            codesign --force --options runtime --timestamp \
+              --sign "$ARCHIVE_SIGNING_IDENTITY" "$nested_executable"
+          done < <(
+            find "$app/Contents/MacOS" -maxdepth 1 -type f \
+              \( -perm -100 -o -perm -010 -o -perm -001 \)
+          )
+          codesign --force --options runtime --timestamp \
+            --sign "$ARCHIVE_SIGNING_IDENTITY" "$app"
+          codesign --verify --deep --strict --verbose=4 "$app"
+
+      - name: Verify identity, notarize, and staple exact app
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize-candidate.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          app="signed/Minutes Archive.app"
+          identity="$(codesign -dv --verbose=4 "$app" 2>&1)"
+          team_id="$(awk -F= '/^TeamIdentifier=/{print $2}' <<<"$identity")"
+          identifier="$(awk -F= '/^Identifier=/{print $2}' <<<"$identity")"
+          test "$team_id" = "63TMLKT8HN"
+          test "$identifier" = "com.useminutes.archive"
+
+          notary_zip="$RUNNER_TEMP/Minutes-Archive-notary.zip"
+          ditto -c -k --sequesterRsrc --keepParent "$app" "$notary_zip"
+          xcrun notarytool submit "$notary_zip" \
+            --key "$ARCHIVE_API_KEY_PATH" \
+            --key-id "$ARCHIVE_API_KEY" \
+            --issuer "$ARCHIVE_API_ISSUER" \
+            --wait
+          xcrun stapler staple "$app"
+          xcrun stapler validate "$app"
+          codesign --verify --deep --strict --verbose=4 "$app"
+          spctl --assess --type execute --verbose=4 "$app"
+
+          executable="$app/Contents/MacOS/minutes-archive-app"
+          executable_sha="$(shasum -a 256 "$executable" | awk '{print $1}')"
+          printf 'candidate=%s\nteam_id=%s\nidentifier=%s\nexecutable_sha256=%s\nnotarized=true\nstapled=true\n' \
+            "$CANDIDATE_SHA" "$team_id" "$identifier" "$executable_sha" \
+            > signed-archive-provenance.txt
+          ditto -c -k --sequesterRsrc --keepParent \
+            "$app" minutes-archive-pilot-notarized.zip
+          shasum -a 256 minutes-archive-pilot-notarized.zip \
+            > minutes-archive-pilot-notarized.zip.sha256
+
+      - name: Remove ephemeral signing material
+        if: always()
+        run: |
+          if [ -n "${ARCHIVE_ACCEPTANCE_KEYCHAIN:-}" ]; then
+            security delete-keychain "$ARCHIVE_ACCEPTANCE_KEYCHAIN" || true
+          fi
+          rm -f \
+            "$RUNNER_TEMP/minutes-archive-acceptance.p12" \
+            "${ARCHIVE_API_KEY_PATH:-}" \
+            "$RUNNER_TEMP/Minutes-Archive-notary.zip"
+
+      - name: Upload short-lived notarized Archive pilot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: minutes-archive-pilot-notarized-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          path: |
+            minutes-archive-pilot-notarized.zip
+            minutes-archive-pilot-notarized.zip.sha256
+            signed-archive-provenance.txt
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/signed-archive-acceptance.yml
+++ b/.github/workflows/signed-archive-acceptance.yml
@@ -89,6 +89,9 @@ jobs:
             -p minutes-archive-app \
             --all-targets -- -D warnings
 
+      - name: Validate client-free human QA fixtures
+        run: scripts/make-archive-qa-fixtures.test.sh
+
       - name: Build isolated production Archive app without signing
         run: |
           set -euo pipefail

--- a/scripts/check_signed_archive_acceptance_policy.mjs
+++ b/scripts/check_signed_archive_acceptance_policy.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+// Updated only after a line-by-line review of the complete unsigned-build
+// boundary and secret-bearing signing/notarization job.
+const EXPECTED_PRE_SIGNING_BOUNDARY_SHA256 =
+  "4a0e63562ee562d1eb9129550c7abc636e15b76ee06265663d214f6431e437e8";
+const EXPECTED_SIGNING_JOB_SHA256 =
+  "fa048e38bc4a3c51f45bbf8933df9986635e0dda16b33a182800335fdee6ccdb";
+const EXPECTED_TRIGGER_BLOCK = `on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Full SHA protected by the matching acceptance-<sha> tag
+        required: true
+        type: string
+`;
+const SECRET_CONTEXT_EXPRESSION =
+  /\$\{\{(?:(?!\}\})[\s\S])*?\bsecrets\b(?:(?!\}\})[\s\S])*?\}\}/i;
+
+const workflowPath =
+  process.argv[2] ?? ".github/workflows/signed-archive-acceptance.yml";
+const source = readFileSync(workflowPath, "utf8");
+const errors = [];
+
+function requirePattern(pattern, message) {
+  if (!pattern.test(source)) errors.push(message);
+}
+
+const triggerBlock = source.match(/^on:\n[\s\S]*?(?=\npermissions:)/m)?.[0];
+if (triggerBlock !== EXPECTED_TRIGGER_BLOCK) {
+  errors.push(
+    "signed Archive acceptance must expose only the exact reviewed workflow_dispatch trigger",
+  );
+}
+
+const signingJobMarker = "  sign-and-notarize:\n";
+const signingJobStart = source.indexOf(signingJobMarker);
+const preSigningBoundary =
+  signingJobStart >= 0 ? source.slice(0, signingJobStart) : source;
+const signingJobTail =
+  signingJobStart >= 0
+    ? source.slice(signingJobStart + signingJobMarker.length)
+    : "";
+const nextJobOffset = signingJobTail.search(/^  [a-z][a-z0-9-]*:\n/m);
+const signingJob =
+  signingJobStart < 0
+    ? undefined
+    : nextJobOffset >= 0
+      ? signingJobTail.slice(0, nextJobOffset).replace(/\n$/, "")
+      : signingJobTail;
+const afterSigningJob =
+  signingJobStart >= 0 && nextJobOffset >= 0
+    ? signingJobTail.slice(nextJobOffset)
+    : "";
+
+const preSigningBoundaryHash = createHash("sha256")
+  .update(preSigningBoundary)
+  .digest("hex");
+if (preSigningBoundaryHash !== EXPECTED_PRE_SIGNING_BOUNDARY_SHA256) {
+  errors.push(
+    "the complete Archive trigger, authorization, and unsigned-build boundary changed; review it and update its golden hash",
+  );
+}
+
+requirePattern(
+  /if: github\.ref == 'refs\/heads\/main' && github\.actor == 'silverstein'/,
+  "Archive candidate authorization must run only from protected main under the repository owner",
+);
+requirePattern(
+  /refs\/tags\/acceptance-\$\{\{ needs\.authorize-candidate\.outputs\.candidate_sha \}\}/,
+  "Archive candidate checkout must be bound to its protected acceptance-<sha> tag",
+);
+requirePattern(
+  /^  sign-and-notarize:[\s\S]*?^    environment: signed-dev-acceptance$/m,
+  "the Archive secret-bearing job must use the reviewer-gated environment",
+);
+requirePattern(
+  /^  build-unsigned:[\s\S]*?^  sign-and-notarize:/m,
+  "Archive candidate code must build and run in a separate no-secret job",
+);
+requirePattern(
+  /scripts\/archive-native-lifecycle-smoke\.sh "\$app"/,
+  "the unsigned Archive candidate must prove native visible-window close-to-purge behavior",
+);
+requirePattern(
+  /document_vault_smoke -- \\\n\s+"\$executable"/,
+  "the unsigned Archive candidate must exercise its exact document and worker executable",
+);
+
+if (!signingJob) {
+  errors.push("could not isolate the Archive secret-bearing signing job");
+} else {
+  if (!SECRET_CONTEXT_EXPRESSION.test(signingJob)) {
+    errors.push("Archive signing job no longer consumes the protected secrets");
+  }
+  if (/uses:\s*actions\/checkout@/.test(signingJob)) {
+    errors.push("the Archive secret-bearing job must never check out candidate source");
+  }
+  if (/^\s*uses:\s*\.\//m.test(signingJob)) {
+    errors.push(
+      "the Archive secret-bearing job must never execute a repository-local action",
+    );
+  }
+  if (
+    /^\s*(?:run:\s*)?(?:bash|sh|source|\.)\s+["']?(?:payload|signed)\//m.test(
+      signingJob,
+    ) ||
+    /^\s*run:\s*["']?(?:payload|signed)\//m.test(signingJob)
+  ) {
+    errors.push(
+      "the Archive secret-bearing job must never execute candidate-artifact content",
+    );
+  }
+
+  const expectedSigningSteps = [
+    "Download exact unsigned Archive candidate",
+    "Verify provenance before unlocking credentials",
+    "Import Developer ID identity into an ephemeral keychain",
+    "Materialize App Store Connect key",
+    "Sign Archive inside-out",
+    "Verify identity, notarize, and staple exact app",
+    "Remove ephemeral signing material",
+    "Upload short-lived notarized Archive pilot",
+  ];
+  const signingSteps = [...signingJob.matchAll(/^      - name:\s*(.+)$/gm)].map(
+    (match) => match[1].trim(),
+  );
+  if (JSON.stringify(signingSteps) !== JSON.stringify(expectedSigningSteps)) {
+    errors.push("the Archive secret-bearing job step allowlist changed");
+  }
+
+  const signingJobHash = createHash("sha256").update(signingJob).digest("hex");
+  if (signingJobHash !== EXPECTED_SIGNING_JOB_SHA256) {
+    errors.push(
+      "the complete Archive secret-bearing job changed; review it and update its golden hash",
+    );
+  }
+}
+
+if (SECRET_CONTEXT_EXPRESSION.test(preSigningBoundary)) {
+  errors.push(
+    "Archive signing secrets must not be exposed to candidate authorization or build jobs",
+  );
+}
+if (SECRET_CONTEXT_EXPRESSION.test(afterSigningJob)) {
+  errors.push("post-signing Archive jobs must not receive signing secrets");
+}
+
+requirePattern(
+  /case "\$APPLE_SIGNING_IDENTITY" in[\s\S]*?"Developer ID Application:"\*/,
+  "Archive distribution must require a Developer ID Application identity",
+);
+requirePattern(
+  /test "\$team_id" = "63TMLKT8HN"/,
+  "Archive signing must verify the exact Developer Team identity",
+);
+requirePattern(
+  /test "\$identifier" = "com\.useminutes\.archive"/,
+  "Archive signing must verify the production bundle identifier",
+);
+requirePattern(
+  /xcrun notarytool submit[\s\S]*?--key "\$ARCHIVE_API_KEY_PATH"[\s\S]*?--wait/,
+  "Archive signing must submit the exact app to Apple notarization and wait",
+);
+requirePattern(
+  /xcrun stapler staple "\$app"[\s\S]*?xcrun stapler validate "\$app"[\s\S]*?spctl --assess --type execute/,
+  "Archive signing must staple, validate, and pass Gatekeeper assessment",
+);
+requirePattern(
+  /notarized=true\\nstapled=true/,
+  "Archive provenance must record notarization and stapling",
+);
+
+for (const match of source.matchAll(/^\s*-?\s*uses:\s*([^\s#]+).*$/gm)) {
+  const reference = match[1];
+  if (!/@[0-9a-f]{40}$/.test(reference)) {
+    errors.push(`Archive action is not pinned to a full commit SHA: ${reference}`);
+  }
+}
+
+if (errors.length) {
+  for (const error of errors) console.error(`${workflowPath}: ${error}`);
+  process.exitCode = 1;
+}

--- a/scripts/check_signed_archive_acceptance_policy.mjs
+++ b/scripts/check_signed_archive_acceptance_policy.mjs
@@ -6,7 +6,7 @@ import { readFileSync } from "node:fs";
 // Updated only after a line-by-line review of the complete unsigned-build
 // boundary and secret-bearing signing/notarization job.
 const EXPECTED_PRE_SIGNING_BOUNDARY_SHA256 =
-  "4a0e63562ee562d1eb9129550c7abc636e15b76ee06265663d214f6431e437e8";
+  "784c49efcd1bf04c8e7cc4912d9d6fd4098c59c430706ffb0bdd8dac62bce37a";
 const EXPECTED_SIGNING_JOB_SHA256 =
   "fa048e38bc4a3c51f45bbf8933df9986635e0dda16b33a182800335fdee6ccdb";
 const EXPECTED_TRIGGER_BLOCK = `on:
@@ -88,6 +88,10 @@ requirePattern(
 requirePattern(
   /document_vault_smoke -- \\\n\s+"\$executable"/,
   "the unsigned Archive candidate must exercise its exact document and worker executable",
+);
+requirePattern(
+  /name: Validate client-free human QA fixtures\n\s+run: scripts\/make-archive-qa-fixtures\.test\.sh/,
+  "the unsigned Archive candidate must validate the client-free human QA fixture kit",
 );
 
 if (!signingJob) {

--- a/scripts/check_signed_archive_acceptance_policy.test.mjs
+++ b/scripts/check_signed_archive_acceptance_policy.test.mjs
@@ -53,6 +53,14 @@ const mutations = [
     ),
   },
   {
+    name: "human QA fixture validation removed",
+    expected: "complete Archive trigger, authorization, and unsigned-build boundary changed",
+    source: workflow.replace(
+      "      - name: Validate client-free human QA fixtures\n        run: scripts/make-archive-qa-fixtures.test.sh\n\n",
+      "",
+    ),
+  },
+  {
     name: "notarization removed",
     expected: "complete Archive secret-bearing job changed",
     source: workflow.replace(

--- a/scripts/check_signed_archive_acceptance_policy.test.mjs
+++ b/scripts/check_signed_archive_acceptance_policy.test.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const workflow = readFileSync(
+  ".github/workflows/signed-archive-acceptance.yml",
+  "utf8",
+);
+const directory = mkdtempSync(join(tmpdir(), "minutes-archive-signing-policy-"));
+
+const mutations = [
+  {
+    name: "extra signing step",
+    expected: "complete Archive secret-bearing job changed",
+    source: workflow.replace(
+      "      - name: Upload short-lived notarized Archive pilot",
+      "      - run: env\n\n      - name: Upload short-lived notarized Archive pilot",
+    ),
+  },
+  {
+    name: "candidate execution after credential unlock",
+    expected: "complete Archive secret-bearing job changed",
+    source: workflow.replace(
+      "          app=\"signed/Minutes Archive.app\"\n          while IFS=",
+      "          app=\"signed/Minutes Archive.app\"\n          bash payload/candidate-controlled.sh\n          while IFS=",
+    ),
+  },
+  {
+    name: "secret before signing",
+    expected: "Archive signing secrets must not be exposed",
+    source: workflow.replace(
+      "          CANDIDATE_SHA: ${{ inputs.candidate_sha }}",
+      "          CANDIDATE_SHA: ${{ inputs.candidate_sha }}\n          STOLEN_CERT: ${{ secrets.APPLE_CERTIFICATE }}",
+    ),
+  },
+  {
+    name: "additional workflow trigger",
+    expected: "only the exact reviewed workflow_dispatch trigger",
+    source: workflow.replace(
+      "\npermissions:\n",
+      "\n  workflow_call:\n\npermissions:\n",
+    ),
+  },
+  {
+    name: "owner authorization removed",
+    expected: "complete Archive trigger, authorization, and unsigned-build boundary changed",
+    source: workflow.replace(
+      "    if: github.ref == 'refs/heads/main' && github.actor == 'silverstein'",
+      "    if: always()",
+    ),
+  },
+  {
+    name: "notarization removed",
+    expected: "complete Archive secret-bearing job changed",
+    source: workflow.replace(
+      "          xcrun notarytool submit \"$notary_zip\" \\",
+      "          echo skip-notarization \"$notary_zip\" \\",
+    ),
+  },
+];
+
+try {
+  for (const mutation of mutations) {
+    if (mutation.source === workflow) {
+      throw new Error(`fixture mutation did not apply: ${mutation.name}`);
+    }
+    const fixture = join(directory, `${mutation.name.replaceAll(" ", "-")}.yml`);
+    writeFileSync(fixture, mutation.source);
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/check_signed_archive_acceptance_policy.mjs", fixture],
+      { encoding: "utf8" },
+    );
+    if (result.status === 0) {
+      throw new Error(`Archive policy accepted ${mutation.name}`);
+    }
+    if (!result.stderr.includes(mutation.expected)) {
+      throw new Error(
+        `Archive policy rejected ${mutation.name} for the wrong reason:\n${result.stderr}`,
+      );
+    }
+  }
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Outcome

Adds the fixed, reviewer-gated signing service needed to produce a Developer ID signed and Apple-notarized `Minutes Archive.app` from an exact Archive candidate without merging that candidate first.

## Trust boundary

- manual dispatch only, from `main`, by repository owner `silverstein`
- requires a protected `acceptance-<full-sha>` tag resolving exactly to the requested candidate
- candidate checkout, tests, production bundle build, document-worker smoke, and native close-to-purge smoke happen in a no-secret job
- the unsigned app is hashed and transferred as an inert artifact
- the secret-bearing job is behind the existing `signed-dev-acceptance` reviewer environment
- it never checks out candidate source or executes candidate code after credentials unlock
- requires a `Developer ID Application` identity and exact Team ID `63TMLKT8HN`
- signs inside-out, submits to Apple notarization, staples, validates, runs Gatekeeper assessment, and emits a seven-day provenance-bound zip
- no public release, tag creation, deployment, or updater publication

## Policy enforcement

A dedicated checker golden-hashes the complete pre-secret boundary and secret-bearing job. Dynamic negative tests prove CI rejects extra signing steps, candidate execution after unlock, early secret access, extra triggers, removed owner binding, or removed notarization. All action references are required to be full-SHA pinned.

## Verification

- `actionlint`
- `node scripts/check_signed_archive_acceptance_policy.mjs`
- `node scripts/check_signed_archive_acceptance_policy.test.mjs`
- `git diff --check`

This PR intentionally contains only the fixed signing infrastructure. After review and merge, it can notarize the exact still-unmerged Archive candidate from PR #612.