### PR TITLE
ci: resolve acceptance tags by exact ref and support annotated tags

### DIFF
--- a/.github/workflows/signed-dev-acceptance.yml
+++ b/.github/workflows/signed-dev-acceptance.yml
@@ -41,7 +41,38 @@ jobs:
           fi
           tag="acceptance-$CANDIDATE_SHA"
           remote="https://github.com/${GITHUB_REPOSITORY}.git"
-          resolved="$(git ls-remote --refs "$remote" "refs/tags/$tag" | awk '{print $1}')"
+          # `git ls-remote` patterns tail-match across ref namespaces, so a
+          # pattern of "refs/tags/<tag>" also matches a branch literally named
+          # "refs/tags/<tag>" (full ref refs/heads/refs/tags/<tag>). Restrict
+          # to the tag namespace and assert the full ref name exactly, so only
+          # a real, admin-protected tag can authorize a candidate.
+          #
+          # Both patterns are required: "refs/tags/<tag>" does not match the
+          # peeled "refs/tags/<tag>^{}" line that annotated tags carry, and
+          # without it an annotated tag resolves to its tag-object SHA and can
+          # never equal the candidate commit.
+          refs="$(
+            git ls-remote --tags "$remote" \
+              "refs/tags/$tag" "refs/tags/$tag^{}" || true
+          )"
+          exact="$(
+            printf '%s\n' "$refs" | awk -v t="refs/tags/$tag" '$2 == t {print $1}'
+          )"
+          peeled="$(
+            printf '%s\n' "$refs" |
+              awk -v t="refs/tags/$tag^{}" '$2 == t {print $1}'
+          )"
+          if [ "$(printf '%s\n' "$exact" | grep -c .)" -ne 1 ]; then
+            echo "Protected tag $tag must resolve to exactly one refs/tags ref" >&2
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$peeled" | grep -c .)" -gt 1 ]; then
+            echo "Protected tag $tag has ambiguous peeled refs" >&2
+            exit 1
+          fi
+          # Annotated tag -> the peeled line is the commit.
+          # Lightweight tag -> the ref itself is the commit.
+          resolved="${peeled:-$exact}"
           if [ "$resolved" != "$CANDIDATE_SHA" ]; then
             echo "Protected tag $tag does not resolve exactly to $CANDIDATE_SHA" >&2
             exit 1

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -8,7 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
   release: "986432ffb8697f36a026afa6e66a5bf20cd0861de5e428029edca0129088c19d",
-  acceptance: "94b1a57515357bcd229ca57095f7cc10736d22e9a271b58994945ba8651de158",
+  acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   build: "5f6029f8e22484a55294f08de62df299e816e08f4b45278d143a008142a47ea5",
   dev: "70f7a3aa227440c5928bc51227d64fbf85176b5f966b2fcc04a15e159bbd223e",
   packageXpc: "baebd532d240fc26188c431f571d0a44f2ce1e7240c3277284c9ea9e69c1ef82",

--- a/scripts/check_signed_acceptance_policy.mjs
+++ b/scripts/check_signed_acceptance_policy.mjs
@@ -9,7 +9,7 @@ import { readFileSync } from "node:fs";
 const EXPECTED_SIGNING_JOB_SHA256 =
   "903c7c962b5eac067fbe423699943969b0405cec732306299366f172f5037894";
 const EXPECTED_PRE_SIGNING_BOUNDARY_SHA256 =
-  "c6fb10e1051bd745f737d4718ad949b9b1a01b585702bfecf354be752ff2e278";
+  "1ddf57258d26c54dab346639d179a4cce64e6d3e333bb92982b38706ac7fe333";
 const EXPECTED_TRIGGER_BLOCK = `on:
   workflow_dispatch:
     inputs:

--- a/scripts/check_signed_acceptance_policy.test.mjs
+++ b/scripts/check_signed_acceptance_policy.test.mjs
@@ -65,8 +65,8 @@ const mutations = [
     expected: "complete trigger, authorization, and unsigned-build boundary changed",
     source: workflow
       .replace(
-        '          resolved="$(git ls-remote --refs "$remote" "refs/tags/$tag" | awk \'{print $1}\')"',
-        '          # resolved="$(git ls-remote --refs "$remote" "refs/tags/$tag" | awk \'{print $1}\')"\n          resolved="$CANDIDATE_SHA"',
+        '          resolved="${peeled:-$exact}"',
+        '          # resolved="${peeled:-$exact}"\n          resolved="$CANDIDATE_SHA"',
       )
       .replace(
         "          ref: refs/tags/acceptance-${{ needs.authorize-candidate.outputs.candidate_sha }}",


### PR DESCRIPTION
## Summary

Hardens how `signed-dev-acceptance.yml` resolves an `acceptance-<sha>` tag, and adds annotated-tag support.

The previous resolution used:

```sh
git ls-remote --refs "$remote" "refs/tags/$tag"
```

Two problems:

1. **Resolution was not confined to the tag namespace it named.** `git ls-remote` patterns tail-match across ref namespaces, so the check was looser than intended.
2. **Annotated tags could never match.** `--refs` suppresses the peeled `^{}` line, so an annotated tag resolves to its *tag object* SHA rather than the commit. Every acceptance tag on the remote today is lightweight, so this path was never exercised — but the Archive pilot runbook on `feat/minutes-archive-discovery` uses `git tag -a`, and would have hit it.

## Change

Resolve within `--tags`, assert the full ref name matches exactly, require exactly one matching ref, and read the peeled line when present — so annotated and lightweight tags both resolve to their commit.

## Blast radius

The secret-bearing job (`sign-reviewed-artifact`) is untouched — byte-identical, golden hash unchanged (`903c7c96…`). The post-signing region is byte-identical too. Two goldens covering this file move:

- `check_signed_acceptance_policy.mjs` — authorization-boundary hash
- `check_graph_worker_packaging.mjs` — whole-file `acceptance` entry

## Verification

The step's shell was extracted from the YAML with a parser and exercised against local remotes:

| case | result |
|---|---|
| lightweight tag on candidate | accept |
| annotated tag on candidate | accept |
| tag on a different commit | reject |
| no tag present | reject |
| ambiguous / non-tag ref | reject |

Fails closed on network error. `actionlint` (with shellcheck) clean; `check_signed_acceptance_policy.mjs`, its mutation suite, and `check_graph_worker_packaging.mjs` all pass.

Also retargets the "comment-only protected tag binding" mutation onto the new resolution line — its first prong matched a string this change deletes and had silently become a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)