### PR TITLE
ci: scope the Apple signing secrets to the release workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -53,6 +53,13 @@ jobs:
     name: Build signed + notarized Minutes.app
     needs: release_readiness
     runs-on: macos-latest
+    # Scopes the Apple signing secrets to this workflow instead of leaving
+    # them readable by every workflow in a public repository. The environment
+    # deliberately carries no required reviewer -- it exists to confine the
+    # credentials, not to add an approval step -- and its ref policy allows
+    # `main` and `v*` tags, which is exactly how this workflow is triggered,
+    # so release behaviour is unchanged.
+    environment: production-release
 
     steps:
       - name: Validate exact release tag input

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from "node:fs";
 // These whole-file hashes prevent dead/comment-only duplicate code from
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
-  release: "564b8401767f9390e3f3502eecd562711df7d10e4790178bbb6099eebe6c0ed5",
+  release: "15e4ea641da0c9d3000385e53451187349e0256e1154a295a183e180c0127874",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   build: "6a1933306c99ccbfc6c5cb35a577389fbe79f08333e855661dc1994f0f9718b1",
   dev: "b308c3088597f154a247cbfb299cd8b4da432378b4a41b3309fb0a2a15beff3c",


### PR DESCRIPTION
Step one of moving the six `APPLE_*` secrets off repository scope.

## Why this is needed

They are currently repository-scoped, so **every workflow in this public repository can read them** — which means the `signed-dev-acceptance` environment gate confines nothing. Adversarial review flagged this as the widest-blast-radius item in the Archive pilot work.

## Why it can't be a settings change

Environment-scoped secrets are only visible to jobs that declare that environment. `macos-release` declares none today, so moving the secrets first would make them arrive **empty** and every release would fail at signing. The workflow has to declare an environment before the values move.

## What this does

`macos-release` — the only job here that reads `APPLE_*` — now declares `production-release`.

That environment was created with:
- **no required reviewer** — the point is to confine credentials, not to add an approval step
- ref policy allowing `main` and `v*` tags, matching this workflow's actual triggers (`workflow_dispatch` and `push: tags: v*`)

**Release behaviour is unchanged.** Until the values are re-entered at environment scope, the job reads the same repository secrets it does today, so this merges safely on its own.

## Step two (owner, after this lands)

Add the six values to `production-release` and `signed-dev-acceptance`, then delete the repository-scoped copies.

`release-macos.yml` is covered by the whole-file golden hash under the `release` key in `check_graph_worker_packaging.mjs`; updated here. All three guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)