### PR TITLE
fix(sdk): mirror the corpus-lease determinism fix, and gate the mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,9 @@ jobs:
       - name: Verify version policy
         run: node scripts/check_version_sync.mjs
 
+      - name: Verify corpus lease mirror
+        run: node scripts/check_corpus_lease_mirror.mjs
+
       - name: Test version policy checker
         run: node --test scripts/check_version_sync.test.mjs
 

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -1286,18 +1286,43 @@ describe("stable corpus lease", () => {
   it("poisons admission when an asynchronous projection ignores cancellation", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "uncancellable projection canary");
-      const started = Date.now();
+      let markOperationStarted!: () => void;
+      const operationStarted = new Promise<void>((resolve) => {
+        markOperationStarted = resolve;
+      });
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
+      const lease = withStableCorpusLease(
+        root,
+        () => {
+          markOperationStarted();
+          return new Promise<never>(() => {});
+        },
+        {
+          timeoutMs: 15_000,
+          operationDeadlineForTest: operationDeadline,
+        }
+      );
+
       await expect(
-        withStableCorpusLease(
-          root,
-          () => new Promise<never>(() => {}),
-          { timeoutMs: 300 }
-        )
-      ).rejects.toThrow("stable meeting corpus authorization failed");
+        Promise.race([
+          operationStarted.then(() => true),
+          lease.then(
+            () => false,
+            () => false
+          ),
+        ])
+      ).resolves.toBe(true);
+
+      const started = Date.now();
+      forceOperationDeadline();
+      await expect(lease).rejects.toThrow("stable meeting corpus authorization failed");
       expect(Date.now() - started).toBeLessThan(2_500);
       await expect(
         withStableCorpusLease(root, () => "must not reuse")
       ).rejects.toThrow("requires a process restart");
     });
-  });
+  }, 10_000);
 });

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -167,6 +167,8 @@ export type CorpusLeaseHooks = {
     | "after-baseline"
     | "before-finalize"
     | "before-authorized";
+  /** Test-only deterministic parent deadline after the projection has started. */
+  operationDeadlineForTest?: Promise<void>;
 };
 
 type RootIdentity = {
@@ -2031,6 +2033,12 @@ export async function withStableCorpusLease<T>(
           operationTermination = new Promise<void>((resolve) => {
             resolveOperationTermination = resolve;
           });
+          if (hooks.operationDeadlineForTest) {
+            void hooks.operationDeadlineForTest.then(
+              () => fail("meeting corpus authorization deadline elapsed"),
+              () => fail("meeting corpus authorization deadline elapsed")
+            );
+          }
           try {
             operationResult = await operation(
               snapshot,

--- a/scripts/check_corpus_lease_mirror.mjs
+++ b/scripts/check_corpus_lease_mirror.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Parity gate for the files `crates/mcp/src` and `crates/sdk/src` mirror.
+ *
+ * The corpus lease exists twice, once per package, and the two copies are
+ * maintained as byte-identical mirrors: every commit that touched either one
+ * kept them the same, until a determinism fix landed in the MCP copy alone
+ * (640ad42e, then 244cc558). Nothing noticed. The SDK kept the wall-clock
+ * variant of a cancellation test, which measured elapsed time across lease
+ * setup, and it failed whenever a hosted Windows runner was slow enough --
+ * surfacing as an intermittent CI failure on branches whose diffs could not
+ * reach this code (issue #617).
+ *
+ * A drift that only shows up as a flake on one platform is expensive to
+ * diagnose and easy to misread as flaky infrastructure. Comparing the files
+ * costs nothing and names the problem exactly.
+ *
+ * Files legitimately differ where the packages differ: `index.ts` is each
+ * package's own entry point, and `secure-read.test.ts` has carried separate
+ * cases in each package for many commits. Neither is mirrored, so neither is
+ * listed here.
+ */
+
+import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIRRORED_FILES = [
+  "corpus-lease.ts",
+  "corpus-lease.test.ts",
+  "corpus-lease-worker.ts",
+  "secure-read.ts",
+];
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const digest = (contents) => createHash("sha256").update(contents).digest("hex");
+
+const drifted = [];
+for (const file of MIRRORED_FILES) {
+  const mcpPath = join(repositoryRoot, "crates", "mcp", "src", file);
+  const sdkPath = join(repositoryRoot, "crates", "sdk", "src", file);
+  // A missing file is a failure, not a skip: deleting one side is exactly the
+  // drift this gate exists to catch, and reporting "0 files checked, all
+  // identical" would be the most misleading thing it could say.
+  const [mcp, sdk] = await Promise.all([readFile(mcpPath), readFile(sdkPath)]);
+  if (!mcp.equals(sdk)) {
+    drifted.push({ file, mcp: digest(mcp).slice(0, 12), sdk: digest(sdk).slice(0, 12) });
+  }
+}
+
+if (drifted.length > 0) {
+  const detail = drifted
+    .map(({ file, mcp, sdk }) => `  ${file}\n    crates/mcp/src  ${mcp}\n    crates/sdk/src  ${sdk}`)
+    .join("\n");
+  console.error(
+    `corpus lease mirror drift in ${drifted.length} file(s):\n${detail}\n\n` +
+      "These files are byte-identical mirrors. Apply the change to both copies,\n" +
+      "or if the divergence is deliberate, remove the file from MIRRORED_FILES in\n" +
+      "scripts/check_corpus_lease_mirror.mjs and say why in the commit message.\n" +
+      "Diff them with:\n" +
+      drifted.map(({ file }) => `  diff crates/mcp/src/${file} crates/sdk/src/${file}`).join("\n")
+  );
+  process.exit(1);
+}
+
+console.log(`corpus lease mirror: ${MIRRORED_FILES.length} files identical across mcp and sdk`);


### PR DESCRIPTION
Partially addresses #617.

## What was wrong

The corpus lease exists twice, once per package, and the two copies are byte-identical mirrors. Verified against history: every commit that touched either kept them the same — until `640ad42e` landed a determinism fix in the MCP copy alone, and `244cc558` followed it. Nothing noticed, because nothing compares them.

So the SDK kept the wall-clock variant of the cancellation test:

```js
const started = Date.now();
await expect(
  withStableCorpusLease(root, () => new Promise<never>(() => {}), { timeoutMs: 300 })
).rejects.toThrow("stable meeting corpus authorization failed");
expect(Date.now() - started).toBeLessThan(2_500);
```

The clock starts **before** lease setup, so the assertion measures snapshot and baseline work rather than the cancellation it is testing. On a hosted Windows runner slow enough, that budget is spent before the operation begins.

The MCP fix makes the deadline explicit — an injected promise fired only once the projection has provably started — so the test measures cancellation and nothing else.

This matches the reported shape in #617: a *different* suite failing on each run of the same commit, Windows only, blocking merges on PRs whose diffs cannot reach this code.

## What this changes

- Both commits ported verbatim to `crates/sdk`. All four mirrored files are byte-identical again; SDK suite passes (58 passed, 1 skipped).
- `scripts/check_corpus_lease_mirror.mjs` compares the four mirrored files and fails with the drifted names and digests.

The port alone would leave the real problem in place — the next fix to either copy can drift the same way, and the symptom surfaces as one-platform flakiness that reads like bad infrastructure.

## Verification

The guard is checked against the actual history, not just against a passing tree: reverting this port makes it exit 1 and name both files.

```
corpus lease mirror drift in 2 file(s):
  corpus-lease.ts
    crates/mcp/src  cbb0a71dfeac
    crates/sdk/src  99c4f21a40bb
  corpus-lease.test.ts
    crates/mcp/src  4e306eb36a2e
    crates/sdk/src  d8bb7a31fbad
```

It runs in the ubuntu-only **Version Sync** job, which CI Gate already requires, so it costs one file comparison rather than a matrix.

`index.ts` and `secure-read.test.ts` are deliberately **not** mirrored — the first is each package's own entry point, the second has carried separate cases in each package for many commits — so neither is listed.

## What this does not fix

#617 also reports `meeting corpus retained snapshots exceeded their process budget`, a process-global budget that one suite can exhaust and preempt another's assertions. That is a separate cause and is not addressed here, so the issue should stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)