### PR TITLE
chore: move the Coach model freshness eval to local hardware (#620)

### DIFF
--- a/.github/workflows/coach-model-eval.yml
+++ b/.github/workflows/coach-model-eval.yml
@@ -1,8 +1,11 @@
 name: Coach model freshness
 
+# Scheduled runs moved to the maintainer's Mac (scripts/coach-model-eval-local.sh
+# plus the app.minutes.coacheval LaunchAgent). A GitHub-hosted runner cannot
+# serve a 9B or 12B local model, so every candidate errored and the report
+# carried no signal (#620). Kept dispatchable for one-off runs where a hosted
+# runner is good enough.
 on:
-  schedule:
-    - cron: "17 9 1 * *"
   workflow_dispatch:
 
 permissions:

--- a/scripts/coach-model-eval-local.sh
+++ b/scripts/coach-model-eval-local.sh
@@ -18,6 +18,23 @@ cd "$repo_root"
 
 log() { printf '%s coach-eval: %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 
+# --install-agent registers the monthly LaunchAgent and exits. Idempotent: it
+# boots out any previous instance first so an edited plist actually takes.
+if [[ "${1:-}" == "--install-agent" ]]; then
+  label="app.minutes.coacheval"
+  plist="$HOME/Library/LaunchAgents/$label.plist"
+  log_path="$HOME/.minutes/coach-eval.log"
+  mkdir -p "$HOME/Library/LaunchAgents" "$HOME/.minutes"
+  sed -e "s|REPLACE_WITH_SCRIPT_PATH|$script_dir/coach-model-eval-local.sh|" \
+      -e "s|REPLACE_WITH_LOG_PATH|$log_path|" \
+      "$repo_root/tauri/src-tauri/assets/$label.plist" >"$plist"
+  launchctl bootout "gui/$(id -u)/$label" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$plist"
+  log "installed $label (1st of each month, 10:17 local; log: $log_path)"
+  log "run now with: launchctl kickstart gui/$(id -u)/$label"
+  exit 0
+fi
+
 # ── Guards ───────────────────────────────────────────────────────────────────
 # Never compete with a capture. Loading a multi-billion-parameter model pins the
 # GPU and memory, and the standing rule here is that an optional consumer must

--- a/scripts/coach-model-eval-local.sh
+++ b/scripts/coach-model-eval-local.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Run the Coach model freshness eval on this machine and file the monthly report.
+#
+# This used to run on a GitHub-hosted macOS runner. It produced nothing usable:
+# every candidate errored, mostly because a hosted runner cannot serve a 9B or
+# 12B local model (see #620). The report's question is "has a better local model
+# appeared for Coach", and that only means something measured on hardware
+# resembling where the model would actually run.
+#
+# Intended to be driven by the LaunchAgent in
+# tauri/src-tauri/assets/app.minutes.coacheval.plist, but safe to run by hand.
+
+set -euo pipefail
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir/.." rev-parse --show-toplevel)"
+cd "$repo_root"
+
+log() { printf '%s coach-eval: %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+
+# ── Guards ───────────────────────────────────────────────────────────────────
+# Never compete with a capture. Loading a multi-billion-parameter model pins the
+# GPU and memory, and the standing rule here is that an optional consumer must
+# never degrade recording. A month is a long window; skipping this run costs
+# nothing and the next one picks it up.
+if [[ -f "$HOME/.minutes/recording.pid" ]]; then
+  log "a recording is in progress; skipping this run"
+  exit 0
+fi
+
+if ! curl --fail --silent --max-time 5 http://localhost:11434/api/tags >/dev/null; then
+  log "Ollama is not serving on :11434; skipping (start Ollama.app and it will run next month)"
+  exit 0
+fi
+
+# On battery this would be both slow and rude. Only meaningful on laptops.
+if command -v pmset >/dev/null && ! pmset -g ps 2>/dev/null | grep -q "AC Power"; then
+  log "on battery; skipping this run"
+  exit 0
+fi
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+report="$repo_root/coach-model-report.md"
+
+log "building the eval CLI"
+cargo build -p minutes-cli --no-default-features --release
+
+log "evaluating small-tier candidates (this pulls models and can take a while)"
+# nice: this is background housekeeping and must yield to anything interactive.
+nice -n 10 python3 scripts/coach_model_eval.py \
+  --minutes-bin target/release/minutes \
+  --small-only \
+  --output "$report"
+
+# ── File the report ──────────────────────────────────────────────────────────
+if [[ ! -s "$report" ]]; then
+  log "no report produced; nothing to file"
+  exit 1
+fi
+
+month="$(date -u +%Y-%m)"
+title="Coach model freshness report $month"
+body="$repo_root/coach-eval-issue-body.md"
+
+python3 - "$report" "$body" <<'PY'
+import sys
+from pathlib import Path
+
+report = Path(sys.argv[1]).read_text(encoding="utf-8")
+suffix = "\n\n_Generated locally on the maintainer's Mac; see scripts/coach-model-eval-local.sh._\n"
+Path(sys.argv[2]).write_text(report[:60000] + suffix, encoding="utf-8")
+PY
+
+existing="$(gh issue list --state all --limit 100 --json number,title \
+  --jq ".[] | select(.title == \"$title\") | .number" | head -n 1)"
+
+if [[ -n "$existing" ]]; then
+  log "updating existing issue #$existing"
+  gh issue reopen "$existing" >/dev/null 2>&1 || true
+  gh issue edit "$existing" --body-file "$body"
+else
+  log "opening a new issue"
+  gh issue create --title "$title" --body-file "$body"
+fi
+
+rm -f "$body"
+log "done"

--- a/tauri/src-tauri/assets/app.minutes.coacheval.plist
+++ b/tauri/src-tauri/assets/app.minutes.coacheval.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Monthly Coach model freshness eval.
+
+  Runs on the maintainer's Mac rather than a GitHub-hosted runner, because a
+  hosted runner cannot serve a 9B or 12B local model and produced a report of
+  nothing but errors (#620). The question the report answers only means something
+  measured on hardware like the one the model would actually run on.
+
+  StartCalendarInterval fires on wake if the machine was asleep at the scheduled
+  time, so a closed laptop delays the run rather than skipping the month.
+
+  The script itself refuses to run during a recording or on battery, so the
+  schedule is a suggestion rather than a promise.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>app.minutes.coacheval</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>REPLACE_WITH_SCRIPT_PATH</string>
+    </array>
+
+    <!-- 1st of the month, 10:17 local. Same day as the old cron; the odd minute
+         keeps it clear of anything scheduled on the hour. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Day</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>10</integer>
+        <key>Minute</key>
+        <integer>17</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>REPLACE_WITH_LOG_PATH</string>
+    <key>StandardErrorPath</key>
+    <string>REPLACE_WITH_LOG_PATH</string>
+
+    <!-- Housekeeping: must never compete with a recording, a transcription, or
+         anything the user is actually doing. -->
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #620 by moving the eval off GitHub-hosted runners.

## Why

The first scheduled run produced a report of nothing but errors. All four candidates failed, for three unrelated reasons: two models failed Ollama warmup with HTTP 500, one tripped a QMD precondition that does not hold on a clean runner, and `gemma4:12b-qat` is not a real tag.

The fixable ones are not the point. A GitHub-hosted macOS runner cannot serve a 9B or 12B local model, so even a "working" run would benchmark under conditions that do not resemble the machine the model would actually run on. That is worse than no data, because it looks like data.

The report's question is "has a better local model appeared for Coach." It only means something measured on hardware like the target.

## What changes

- `scripts/coach-model-eval-local.sh` runs the same `coach_model_eval.py` locally and files or updates the same monthly issue via `gh`.
- A LaunchAgent (`app.minutes.coacheval`) schedules it for the 1st at 10:17 local. `StartCalendarInterval` fires on wake, so a closed laptop delays the run rather than skipping the month.
- The workflow keeps `workflow_dispatch` for one-off runs but loses the cron.

## Guards

Housekeeping must never degrade capture, so the script refuses to run rather than compete:

- **Active recording** — skips. Loading a multi-billion-parameter model pins GPU and memory, and a month is a long window; the next run picks it up.
- **Ollama not serving** — skips with an explanation instead of failing.
- **On battery** — skips.

Plus `nice`, `LowPriorityIO`, and `ProcessType: Background`.

## Verified on the Mac

- Recording guard fires correctly: with a `recording.pid` present it logs "a recording is in progress; skipping this run" and exits 0.
- `--install-agent` registers and `launchctl print` confirms it. Idempotent, boots out any prior instance first.
- Power and Ollama probes report accurately (AC power, serving).

Not run end to end: the machine currently has only `qwen3.5:4b`, and a real run pulls several GB of candidate models. That is the first scheduled run's job, or `launchctl kickstart` whenever convenient.

## After merge

One command on the Mac to point the agent at the real checkout:

```
./scripts/coach-model-eval-local.sh --install-agent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)