### PR TITLE
fix(archive): observe the engine's own snapshot, not the shared temp directory

### DIFF
--- a/crates/archive-semantic/tests/worker.rs
+++ b/crates/archive-semantic/tests/worker.rs
@@ -27,37 +27,26 @@ fn bound_worker_denies_network_and_personal_files_before_embedding() {
 #[test]
 fn dropping_the_engine_reclaims_its_worker_snapshot() {
     use minutes_archive_semantic::BoundedSemanticEngine;
-    use std::collections::HashSet;
     use std::path::{Path, PathBuf};
 
-    // Track the specific directory this engine creates. Counting them is
-    // racy: sibling tests in the same binary bind their own engines.
-    fn snapshots() -> HashSet<PathBuf> {
-        let Ok(entries) = std::fs::read_dir(std::env::temp_dir()) else {
-            return HashSet::new();
-        };
-        entries
-            .flatten()
-            .filter(|entry| {
-                entry
-                    .file_name()
-                    .to_string_lossy()
-                    .starts_with("minutes-archive-semantic-")
-            })
-            .map(|entry| entry.path())
-            .collect()
-    }
-
+    // Ask the engine which directory is its own rather than inspecting the
+    // shared temp directory. The previous version diffed the set of
+    // `minutes-archive-semantic-*` directories before and after binding, which
+    // only excludes ones that already existed -- a sibling test in this same
+    // binary binds its own engine concurrently, so its snapshot landed inside
+    // the diff and the count was 2. It failed on a hosted runner while passing
+    // locally, purely on scheduling. Nothing about the drop chain was wrong;
+    // the observation was.
     let executable = env!("CARGO_BIN_EXE_minutes-archive-semantic");
-    let before = snapshots();
     let engine = BoundedSemanticEngine::bind(Path::new(executable)).expect("bind");
-    let created = &snapshots() - &before;
-    assert_eq!(
-        created.len(),
-        1,
-        "binding must create exactly one private snapshot"
+    let snapshot = PathBuf::from(engine.snapshot_directory());
+    assert!(
+        snapshot.file_name().is_some_and(|name| name
+            .to_string_lossy()
+            .starts_with("minutes-archive-semantic-")),
+        "unexpected snapshot location {}",
+        snapshot.display()
     );
-    let snapshot = created.into_iter().next().expect("snapshot path");
     assert!(snapshot.exists(), "snapshot must exist while bound");
     drop(engine);
     assert!(


### PR DESCRIPTION
Unblocks the Archive pilot signing run, which failed at its unsigned build-and-gate stage — correctly, **before any credential unlocked**.

## The failure

```
dropping_the_engine_reclaims_its_worker_snapshot
assertion `left == right` failed: binding must create exactly one private snapshot
  left: 2
 right: 1
```

## Cause

The test diffed the set of `minutes-archive-semantic-*` directories in the **shared** temp directory before and after binding. That excludes directories which already existed — it does nothing about one created *concurrently*, and the sibling test in the same binary binds its own engine.

The test's own comment said counting was racy and the set difference was the mitigation. It isn't; it only moves the race.

## Fix

`BoundedSemanticEngine::snapshot_directory()` already exists, so the test asks the engine which directory is its own and never inspects a shared namespace. Deterministic regardless of scheduling.

## On proving it

Twelve repeat runs at `--test-threads=2` did **not** reproduce the failure locally on either version — the window is timing-dependent and this machine binds faster than the hosted runner. So repetition proves nothing here.

The mechanism was proved directly instead: binding two engines inside the window the old test treated as exclusive makes its set difference return **2** — exactly the observed failure. That probe was throwaway and is not committed.

Nothing about the drop chain was wrong. The assertion was measuring a shared resource and calling it private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)