### PR TITLE
fix(vocabulary): never offer a known misspelling to the decoder (#647)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1356,9 +1356,18 @@ enum VocabularyAction {
         /// Canonical spelling to prefer
         canonical: String,
 
-        /// Alias or common misrecognition. Repeat for multiple aliases.
+        /// Spoken variant that should be spelled correctly (e.g. "Taura" for
+        /// "Taura Health"). Offered to the transcriber as a spelling to keep.
+        /// Repeat for multiple. Do NOT put known misrecognitions here: use
+        /// --misspelling, or the transcriber is taught the error (#647).
         #[arg(long = "alias")]
         aliases: Vec<String>,
+
+        /// Known wrong rendering to recognize after the fact (e.g. "patient
+        /// tricity"). Used for search and matching only, never offered to the
+        /// transcriber. Repeat for multiple.
+        #[arg(long = "misspelling")]
+        misspellings: Vec<String>,
 
         /// Output raw JSON instead of formatted text
         #[arg(long)]
@@ -4732,8 +4741,9 @@ fn cmd_vocabulary(action: VocabularyAction, config: &Config) -> Result<()> {
             kind,
             canonical,
             aliases,
+            misspellings,
             json,
-        } => cmd_vocabulary_add(&kind, &canonical, aliases, json),
+        } => cmd_vocabulary_add(&kind, &canonical, aliases, misspellings, json),
         VocabularyAction::Remove { id, json } => cmd_vocabulary_remove(&id, json),
         VocabularyAction::Suggest { meeting, json } => {
             cmd_vocabulary_suggest(&meeting, json, config)
@@ -4778,7 +4788,13 @@ fn cmd_vocabulary_list(json: bool) -> Result<()> {
     Ok(())
 }
 
-fn cmd_vocabulary_add(kind: &str, canonical: &str, aliases: Vec<String>, json: bool) -> Result<()> {
+fn cmd_vocabulary_add(
+    kind: &str,
+    canonical: &str,
+    aliases: Vec<String>,
+    misspellings: Vec<String>,
+    json: bool,
+) -> Result<()> {
     let path = minutes_core::vocabulary::default_path();
     let mut store = minutes_core::vocabulary::load().map_err(|e| anyhow::anyhow!("{}", e))?;
     let now = Local::now().to_rfc3339();
@@ -4788,6 +4804,7 @@ fn cmd_vocabulary_add(kind: &str, canonical: &str, aliases: Vec<String>, json: b
             kind: parse_vocabulary_kind(kind)?,
             canonical: canonical.to_string(),
             aliases,
+            misspellings,
             priority: minutes_core::vocabulary::VocabularyPriority::Normal,
             source: minutes_core::vocabulary::VocabularySource::Manual,
             created_at: Some(now.clone()),

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -85,7 +85,18 @@ pub struct VocabularyEntry {
     pub id: String,
     pub kind: VocabularyKind,
     pub canonical: String,
+    /// Spoken variants that may legitimately be *said* and should therefore be
+    /// spelled correctly: "Taura" for "Taura Health", "Mat" for "Mathieu".
+    /// These are offered to the decoder as terms to preserve.
     pub aliases: Vec<String>,
+    /// Known wrong renderings of this term, kept so search and matching can find
+    /// an already-written transcript that contains them.
+    ///
+    /// These are deliberately **never** offered to the decoder. Listing a
+    /// misspelling in a prompt that says "preserve spelling exactly" teaches the
+    /// decoder the error (#647).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub misspellings: Vec<String>,
     pub scope: VocabularyScope,
     pub priority: VocabularyPriority,
     pub source: VocabularySource,
@@ -101,6 +112,7 @@ impl Default for VocabularyEntry {
             kind: VocabularyKind::Term,
             canonical: String::new(),
             aliases: Vec::new(),
+            misspellings: Vec::new(),
             scope: VocabularyScope::Global,
             priority: VocabularyPriority::Normal,
             source: VocabularySource::Manual,
@@ -127,6 +139,7 @@ impl VocabularyEntry {
         }
 
         self.aliases = unique_clean_aliases(self.aliases, &self.canonical);
+        self.misspellings = unique_clean_aliases(self.misspellings, &self.canonical);
         if self.id.trim().is_empty() {
             self.id = entry_id(self.kind, &self.canonical);
         } else {
@@ -144,7 +157,19 @@ impl VocabularyEntry {
         Ok(self)
     }
 
+    /// Every written form that should *match* this entry, including known wrong
+    /// renderings. Use for search, deduplication and lookup.
     pub fn surface_forms(&self) -> Vec<String> {
+        let mut forms = vec![self.canonical.clone()];
+        forms.extend(self.aliases.iter().cloned());
+        forms.extend(self.misspellings.iter().cloned());
+        unique_clean_aliases(forms, "")
+    }
+
+    /// Forms safe to offer a speech decoder as spellings to preserve: the
+    /// canonical form and legitimate spoken variants, never a known
+    /// misspelling. See [`Self::misspellings`] and #647.
+    pub fn hint_forms(&self) -> Vec<String> {
         let mut forms = vec![self.canonical.clone()];
         forms.extend(self.aliases.iter().cloned());
         unique_clean_aliases(forms, "")
@@ -193,6 +218,7 @@ impl VocabularyStore {
             let key = (entry.kind, entry.scope, key_for(&entry.canonical));
             if let Some(existing) = merged.get_mut(&key) {
                 existing.aliases = merge_aliases(&existing.aliases, &entry.aliases);
+                existing.misspellings = merge_aliases(&existing.misspellings, &entry.misspellings);
                 existing.priority = existing.priority.max(entry.priority);
                 if existing.source != VocabularySource::Manual {
                     existing.source = entry.source;
@@ -243,7 +269,7 @@ impl VocabularyStore {
         let mut phrases = Vec::new();
         let mut seen = HashSet::new();
         for entry in entries {
-            for phrase in entry.surface_forms() {
+            for phrase in entry.hint_forms() {
                 let key = key_for(&phrase);
                 if seen.insert(key) {
                     phrases.push(phrase);
@@ -757,6 +783,50 @@ mod tests {
         assert_eq!(
             store.decode_phrases(2),
             vec!["Automattic".to_string(), "Automatic".to_string()]
+        );
+    }
+
+    #[test]
+    fn misspellings_match_but_are_never_offered_to_the_decoder() {
+        // The decoder prompt says "preserve spelling exactly", so a known wrong
+        // rendering listed there teaches the error. Observed in practice: an
+        // entry carrying "patient tricity" produced exactly that in the
+        // transcript (#647). Misspellings must still match, so that already
+        // written transcripts remain findable.
+        let store = VocabularyStore {
+            entries: vec![VocabularyEntry {
+                kind: VocabularyKind::Organization,
+                canonical: "PatientRicity".into(),
+                aliases: vec!["Taura".into()],
+                misspellings: vec!["patient tricity".into()],
+                ..VocabularyEntry::default()
+            }],
+        }
+        .normalized()
+        .expect("normalize");
+
+        let hinted = store.decode_phrases(8);
+        assert!(
+            hinted.contains(&"PatientRicity".to_string()),
+            "canonical must be hinted: {hinted:?}"
+        );
+        assert!(
+            hinted.contains(&"Taura".to_string()),
+            "a spoken variant must still be hinted: {hinted:?}"
+        );
+        assert!(
+            !hinted
+                .iter()
+                .any(|p| p.eq_ignore_ascii_case("patient tricity")),
+            "a known misspelling must never reach the decoder: {hinted:?}"
+        );
+
+        let matchable = store.entries[0].surface_forms();
+        assert!(
+            matchable
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case("patient tricity")),
+            "misspellings must still match for search: {matchable:?}"
         );
     }
 

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2654;
+export const MINUTES_TEST_COUNT = 2655;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## The bug

`decode_phrases` fed `entry.surface_forms()` — canonical **plus aliases** — into the whisper prompt built at `transcribe.rs:254`:

> "Names and terms that may appear in this audio: CMR, PatientRicity, **patient tricity**, RxVIP, SynapseRx, Taura Health, Taura. Preserve spelling exactly when heard."

The misspelling is offered to the decoder as a term to preserve exactly, next to the correct form.

## Why it happened

`aliases` was doing two incompatible jobs:

- **legitimate spoken variants** ("Taura" for "Taura Health", "Mat" for "Mathieu"), which should be hinted so they get spelled correctly
- **known misrecognitions**, added so an already-written wrong transcript stays findable, which must never be hinted

The CLI invited the second use directly: `--alias` was documented as *"Alias or common misrecognition."* The repo's own test fixture does it too, with `canonical: "Automattic"` and `aliases: ["Automatic"]`.

## Evidence

Real 4-minute meeting clip, deterministic pipeline, four vocabulary states:

| vocabulary | transcript |
|---|---|
| none | `patientricity` |
| canonical `PatienTricity` (wrong) + aliases | `PatienTricity` |
| canonical `PatientRicity` + alias `patient tricity` | `patient tricity` |
| canonical `PatientRicity`, no aliases | `patienticity` |

Row 3 is this bug: the decoder emitted the misspelling it was handed.

## Change

- `aliases` keeps its meaning and is still hinted.
- New `misspellings` field: used for search and matching, never hinted.
- `surface_forms()` returns everything (lookup, dedup, search expansion — all four existing callers want this and now get better coverage).
- `hint_forms()` returns canonical + aliases, and is what `decode_phrases` uses.
- `minutes vocabulary add --misspelling <form>`; `--alias` help now warns against recording misrecognitions there.

Backward compatible: `#[serde(default, skip_serializing_if)]` leaves existing `vocabulary.toml` files loading and serializing unchanged. The dedup/merge path carries `misspellings` through.

## Testing

New test asserts the canonical and a spoken variant are hinted, the misspelling is not, and the misspelling still matches for search. Verified by reverting `decode_phrases` to `surface_forms()` and confirming it fails.

`cargo test -p minutes-core --no-default-features vocabulary::` 15/15, clippy clean.

## Scope note

This removes a foot-gun; it does not make biasing reliable. Row 4 shows canonical-only hinting still missed the term, because `initial_prompt` is soft conditioning rather than a constraint. Measured cost of vocabulary entries that do not apply is approximately zero (95% CI −0.575 to +0.059 pp, n=12), so the feature is cheap, just not a guarantee. Details in #647.