### PR TITLE
feat(release): publish a sherpa-enabled Linux CLI archive (#645)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -116,6 +116,51 @@ jobs:
         with:
           files: ${{ matrix.asset }}
 
+      # Additive second artifact for Linux only: the same CLI plus the sherpa
+      # engine and its shared libraries, as a tarball. The bare binary above is
+      # unchanged, so existing installs and the Homebrew formula are unaffected.
+      #
+      # sherpa-onnx links dynamically on Linux, so the binary needs
+      # libsherpa-onnx-c-api.so and libonnxruntime.so beside it. `$ORIGIN`
+      # runpath makes the loader look next to the executable rather than in the
+      # build tree. Static linkage is deliberately not used here: sherpa-rs-sys
+      # demands a global `-C relocation-model=dynamic-no-pic`, which produces a
+      # non-PIE binary and loses ASLR for every Linux user (#645).
+      - name: Build sherpa-enabled Linux archive
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        env:
+          RUSTFLAGS: "-C link-arg=-Wl,-rpath,$ORIGIN"
+        run: |
+          set -euo pipefail
+          cargo build --release -p minutes-cli \
+            --features ${{ matrix.features }},engine-sherpa \
+            --target ${{ matrix.target }}
+          out="minutes-linux-x64-sherpa"
+          rm -rf "$out" && mkdir -p "$out"
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "$out/minutes"
+          # sherpa-rs-sys drops its shared libraries into the target profile dir.
+          find "target/${{ matrix.target }}/release" -maxdepth 1 -name '*.so' -exec cp {} "$out/" \;
+          test -f "$out/libsherpa-onnx-c-api.so" \
+            || { echo "sherpa shared library missing from the archive"; exit 1; }
+          # Prove it loads outside the build tree, which a build-only check
+          # cannot catch: the failure mode is loader search paths.
+          ( cd /tmp && env -u LD_LIBRARY_PATH "$GITHUB_WORKSPACE/$out/minutes" --version )
+          tar czf "$out.tar.gz" "$out"
+
+      - name: Upload sherpa archive artifact
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@v7
+        with:
+          name: minutes-linux-x64-sherpa.tar.gz
+          path: minutes-linux-x64-sherpa.tar.gz
+
+      - name: Upload sherpa archive release asset
+        uses: softprops/action-gh-release@v3
+        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'x86_64-unknown-linux-gnu'
+        with:
+          files: minutes-linux-x64-sherpa.tar.gz
+
   checksums:
     name: Publish CLI checksums
     needs: [release_readiness, build]


### PR DESCRIPTION
## Problem

Prebuilt Linux users run whisper on CPU with no way out. Release binaries build with `features: parakeet` and no GPU backend, and that is deliberate: GPU backends ship through `cargo install minutes-cli --features vulkan` source builds, because a prebuilt binary cannot assume a Vulkan or CUDA SDK (see `docs/development/gpu-acceleration.md`).

Measured on identical code, CPU vs CPU, LibriSpeech test-clean:

| engine | WER | RTF |
|---|---|---|
| sherpa parakeet-v3-int8 | 2.29% | 0.28 |
| whisper small | 3.46% | 2.86 |

## Change

Adds a **second, additive** Linux artifact: `minutes-linux-x64-sherpa.tar.gz`, containing the CLI built with `engine-sherpa` plus its shared libraries.

The existing bare `minutes-linux-x64` binary is **untouched**, so current installs, the install script and the Homebrew formula are unaffected. Users who want sherpa download the archive and unpack it.

## Why bundling and not static linkage

`sherpa-rs-sys` `build.rs` panics unless `RUSTFLAGS="-C relocation-model=dynamic-no-pic"` is set on Linux x86_64. Two problems:

1. `RUSTFLAGS` is global to the entire build, not scoped to that dependency.
2. `dynamic-no-pic` produces a **non-PIE binary, losing ASLR** for every Linux user, including everyone who never enables sherpa.

Trading address-space randomization for a transcription engine is the wrong call for this product. A `-C link-arg=-Wl,-rpath,$ORIGIN` carries no such cost, so the archive uses that and ships the `.so` files beside the binary.

## Verification

The failure mode is loader search paths, which a build-only check cannot catch, so the packaging step runs the built binary from `/tmp` with `LD_LIBRARY_PATH` unset and fails the job if it will not start.

Verified locally on this exact recipe:

```
archive contents: libonnxruntime.so libsherpa-onnx-c-api.so libsherpa-onnx-cxx-api.so minutes
$ cd /tmp && env -u LD_LIBRARY_PATH .../minutes --version
minutes 0.24.0
```

`readelf -d` confirms `RUNPATH: [$ORIGIN]`. `minutes health` reports the speech model present. Works from any cwd, confirming `$ORIGIN` resolves to the binary's directory rather than the working directory. Tarball is 25 MB.

## Not covered

Windows needs the same DLL-beside-the-exe treatment. I could not verify it on available hardware, so it is deliberately left out rather than shipped untested. #645 stays open for it.