### PR TITLE
fix(build): run tauri builds from the app crate after the Archive app joined the workspace

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -116,6 +116,51 @@ jobs:
         with:
           files: ${{ matrix.asset }}
 
+      # Additive second artifact for Linux only: the same CLI plus the sherpa
+      # engine and its shared libraries, as a tarball. The bare binary above is
+      # unchanged, so existing installs and the Homebrew formula are unaffected.
+      #
+      # sherpa-onnx links dynamically on Linux, so the binary needs
+      # libsherpa-onnx-c-api.so and libonnxruntime.so beside it. `$ORIGIN`
+      # runpath makes the loader look next to the executable rather than in the
+      # build tree. Static linkage is deliberately not used here: sherpa-rs-sys
+      # demands a global `-C relocation-model=dynamic-no-pic`, which produces a
+      # non-PIE binary and loses ASLR for every Linux user (#645).
+      - name: Build sherpa-enabled Linux archive
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        env:
+          RUSTFLAGS: "-C link-arg=-Wl,-rpath,$ORIGIN"
+        run: |
+          set -euo pipefail
+          cargo build --release -p minutes-cli \
+            --features ${{ matrix.features }},engine-sherpa \
+            --target ${{ matrix.target }}
+          out="minutes-linux-x64-sherpa"
+          rm -rf "$out" && mkdir -p "$out"
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "$out/minutes"
+          # sherpa-rs-sys drops its shared libraries into the target profile dir.
+          find "target/${{ matrix.target }}/release" -maxdepth 1 -name '*.so' -exec cp {} "$out/" \;
+          test -f "$out/libsherpa-onnx-c-api.so" \
+            || { echo "sherpa shared library missing from the archive"; exit 1; }
+          # Prove it loads outside the build tree, which a build-only check
+          # cannot catch: the failure mode is loader search paths.
+          ( cd /tmp && env -u LD_LIBRARY_PATH "$GITHUB_WORKSPACE/$out/minutes" --version )
+          tar czf "$out.tar.gz" "$out"
+
+      - name: Upload sherpa archive artifact
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@v7
+        with:
+          name: minutes-linux-x64-sherpa.tar.gz
+          path: minutes-linux-x64-sherpa.tar.gz
+
+      - name: Upload sherpa archive release asset
+        uses: softprops/action-gh-release@v3
+        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'x86_64-unknown-linux-gnu'
+        with:
+          files: minutes-linux-x64-sherpa.tar.gz
+
   checksums:
     name: Publish CLI checksums
     needs: [release_readiness, build]

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -202,6 +202,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
           MINUTES_REQUIRE_REAL_CLI_SIDECAR: "1"
+        working-directory: tauri/src-tauri
         run: cargo tauri build --features parakeet,metal,engine-sherpa --bundles app
 
       - name: Sign graph helper inside-out and notarize the final exact app

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -90,7 +90,9 @@ if [[ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]]; then
     echo "  No TAURI_SIGNING_PRIVATE_KEY configured; building updater artifacts with --no-sign."
     TAURI_BUILD_ARGS+=(--no-sign)
 fi
-"${TAURI_BUILD_ARGS[@]}"
+# Run from the app crate: with archive/src-tauri also present, the tauri CLI
+# resolves the wrong tauri.conf.json from the repo root.
+( cd "$(git rev-parse --show-toplevel)/tauri/src-tauri" && "${TAURI_BUILD_ARGS[@]}" )
 
 echo "=== Re-signing bundled CLI sidecar with its own entitlements ==="
 # The CLI sidecar needs `com.apple.security.device.audio-input` so `minutes record`

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -7,10 +7,10 @@ import { existsSync, readFileSync } from "node:fs";
 // These whole-file hashes prevent dead/comment-only duplicate code from
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
-  release: "2310494f4a559274b1204c3c1a4bc080d9d2798ea8262fbf22d5022fbb48343c",
+  release: "d63ea2ec2626b254a804e3ce12be61d0abfb0436ee7158f863e31b3e5cd1d54d",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
-  build: "6a1933306c99ccbfc6c5cb35a577389fbe79f08333e855661dc1994f0f9718b1",
-  dev: "b308c3088597f154a247cbfb299cd8b4da432378b4a41b3309fb0a2a15beff3c",
+  build: "9ca0741767b8e2fc49c4ffd200d5c5c43d13ddf0ebfd88fa2d6116d0cb3656ec",
+  dev: "3c6d77c6c92f40e646c51eb87a345d47ad66b496d18c053bf342daa844f7839a",
   packageXpc: "baebd532d240fc26188c431f571d0a44f2ce1e7240c3277284c9ea9e69c1ef82",
   tauri: "f127e92a1a2a635326d13dd766b3e6cc841655bce30ea2d01d67d9f12c15502c",
   entitlements: "7971da95784f3bdeb3ea257b5c1a31317731b513b16c47e2c4e588fc0ac40bae",

--- a/scripts/install-dev-app.sh
+++ b/scripts/install-dev-app.sh
@@ -105,7 +105,14 @@ echo "=== Building ${DEV_PRODUCT_NAME}.app ==="
 # The calendar-events Swift helper is compiled and staged into
 # tauri/src-tauri/resources/ by tauri/src-tauri/build.rs, and Tauri bundles it
 # into the .app automatically via tauri.conf.json.
-run_with_ort_retry cargo tauri build --bundles app --config "$DEV_CONFIG" --features "$MINUTES_BUILD_FEATURES" --no-sign
+# Run from the app crate, not the repo root. Two tauri.conf.json files now
+# exist (archive/src-tauri and tauri/src-tauri) and the CLI resolves the
+# first it finds, which is the archive app. From the root this builds the
+# wrong package and fails on features it does not have.
+( cd "$ROOT_DIR/tauri/src-tauri" \
+  && run_with_ort_retry cargo tauri build --bundles app \
+       --config "$ROOT_DIR/$DEV_CONFIG" \
+       --features "$MINUTES_BUILD_FEATURES" --no-sign )
 # Inside-out signing (#311): sign every nested executable FIRST (the CLI
 # sidecar with its own entitlements), then the outer bundle WITHOUT --deep.
 # --deep re-signs nested code with the outer entitlements (clobbering the

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04",
+  "generatedAt": "2026-08-05",
   "visibleCount": 68,
   "hiddenCount": 17,
   "groups": [

--- a/site/app/docs/mcp/tools/data.json
+++ b/site/app/docs/mcp/tools/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04",
+  "generatedAt": "2026-08-05",
   "installCommand": "npx minutes-mcp",
   "documentationUrl": "https://useminutes.app/for-agents",
   "supportUrl": "https://github.com/silverstein/minutes/discussions",

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: crates/core thiserror definitions
-> Last generated: 2026-08-04
+> Last generated: 2026-08-05
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 

--- a/site/public/docs/mcp/tools.md
+++ b/site/public/docs/mcp/tools.md
@@ -3,7 +3,7 @@
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts
 > Regenerate: node scripts/generate_llms_txt.mjs
-> Last generated: 2026-08-04
+> Last generated: 2026-08-05
 
 Minutes exposes 34 tools, 11 resources, and 6 prompt templates through the MCP server.
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-08-04
+> Last generated: 2026-08-05
 
 ## Product
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-08-04
+> Last generated: 2026-08-05
 
 Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that policy-aware local tools expose to Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and MCP-compatible clients — no proprietary SDK, no API key. Restricted meetings are excluded from agent results by default; explicit access requires a trusted launch policy, a per-call request, and a durable audit record. Minutes never uploads your audio; meeting text leaves your device only when you explicitly send policy-authorized context to a connected cloud agent or summarizer. When a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -9819,6 +9819,38 @@ fn recall_openai_compatible_chat_url(raw: &str) -> Result<String, String> {
     Ok(url.into())
 }
 
+/// Whether one server-sent-events line carries reasoning (chain-of-thought)
+/// rather than answer text.
+///
+/// The two local servers disagree on the key: ollama emits `reasoning`, LM
+/// Studio emits `reasoning_content`. Both are recognized. This is used only to
+/// tell the panel that the model is working, never to render as an answer:
+/// reasoning is the model's scratchpad, not its reply.
+fn openai_compatible_stream_is_reasoning(line: &str) -> bool {
+    let Some(payload) = line.strip_prefix("data:").map(str::trim) else {
+        return false;
+    };
+    if payload.is_empty() || payload == "[DONE]" {
+        return false;
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+        return false;
+    };
+    let Some(delta) = value
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("delta"))
+    else {
+        return false;
+    };
+    ["reasoning", "reasoning_content"].iter().any(|key| {
+        delta
+            .get(key)
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty())
+    })
+}
+
 /// Extract the incremental assistant text from one server-sent-events line of
 /// an OpenAI-compatible stream.
 ///
@@ -10425,12 +10457,31 @@ pub async fn cmd_recall_chat_send(
             let mut body = resp.into_body();
             let reader = BufReader::new(body.as_reader());
             let mut full_response = String::new();
+            // A reasoning model can spend hundreds of frames thinking before a
+            // single word of answer appears (observed: 504 of 508 frames). With
+            // no signal the panel looks hung, so announce once that work is
+            // happening. Announced once rather than per frame: this drives a
+            // status label, not rendered text.
+            let mut announced_thinking = false;
             for line_result in reader.lines() {
                 if cancelled.load(Ordering::Relaxed) {
                     break;
                 }
                 match line_result {
                     Ok(line) => {
+                        if !announced_thinking
+                            && full_response.is_empty()
+                            && openai_compatible_stream_is_reasoning(&line)
+                        {
+                            announced_thinking = true;
+                            app_clone
+                                .emit_to(
+                                    "main",
+                                    "recall-chat-chunk",
+                                    serde_json::json!({"type": "thinking"}),
+                                )
+                                .ok();
+                        }
                         if let Some(text) = openai_compatible_stream_delta(&line) {
                             if cancelled.load(Ordering::Relaxed) {
                                 break;
@@ -12627,6 +12678,33 @@ mod tests {
 
         // Real servers interleave blank separator lines between frames.
         assert_eq!(openai_compatible_stream_delta(""), None);
+    }
+
+    #[test]
+    fn openai_compatible_reasoning_is_detected_for_both_server_dialects() {
+        // ollama emits `reasoning`; LM Studio emits `reasoning_content`. Both
+        // observed against real servers (#650).
+        assert!(openai_compatible_stream_is_reasoning(
+            r#"data: {"choices":[{"delta":{"role":"assistant","content":"","reasoning":"Thinking"}}]}"#
+        ));
+        assert!(openai_compatible_stream_is_reasoning(
+            r#"data: {"choices":[{"delta":{"role":"assistant","reasoning_content":"*"}}]}"#
+        ));
+
+        for not_reasoning in [
+            "data: [DONE]",
+            "",
+            ": keepalive",
+            r#"data: {"choices":[{"delta":{"content":"hello"}}]}"#,
+            r#"data: {"choices":[{"delta":{"role":"assistant"}}]}"#,
+            // Present but empty carries no signal that work is happening.
+            r#"data: {"choices":[{"delta":{"reasoning":""}}]}"#,
+        ] {
+            assert!(
+                !openai_compatible_stream_is_reasoning(not_reasoning),
+                "{not_reasoning:?}"
+            );
+        }
     }
 
     #[test]

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -10452,6 +10452,23 @@ pub async fn cmd_recall_chat_send(
                 }
             }
 
+            // A reasoning model can stream its entire budget into a `reasoning`
+            // field and finish with every `content` delta empty. Observed
+            // against a real server: 3861 frames, finish_reason "stop", zero
+            // content. Without this the panel just sits blank with no
+            // explanation, which reads as a hang rather than a model choice.
+            if !cancelled.load(Ordering::Relaxed) && full_response.is_empty() {
+                app_clone
+                    .emit_to(
+                        "main",
+                        "recall-chat-error",
+                        "The local model finished without returning any answer text. Reasoning \
+                         models can spend their whole budget thinking; try a shorter question, a \
+                         larger context or token limit, or a non-reasoning model.",
+                    )
+                    .ok();
+            }
+
             if !cancelled.load(Ordering::Relaxed) && !full_response.is_empty() {
                 store_recall_history_if_still_authorized(
                     &history_arc,
@@ -12599,9 +12616,17 @@ mod tests {
             r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#,
             r#"data: {"choices":[{"delta":{"content":""}}]}"#,
             "data: not json",
+            // Seen in the wild from a reasoning model: chain-of-thought arrives
+            // in `reasoning` while `content` stays empty. Must not be emitted
+            // as answer text.
+            r#"data: {"choices":[{"delta":{"role":"assistant","content":"","reasoning":"Thinking"}}]}"#,
+            r#"data: {"choices":[{"delta":{"role":"assistant","content":""},"finish_reason":"stop"}]}"#,
         ] {
             assert_eq!(openai_compatible_stream_delta(quiet), None, "{quiet:?}");
         }
+
+        // Real servers interleave blank separator lines between frames.
+        assert_eq!(openai_compatible_stream_delta(""), None);
     }
 
     #[test]

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -9682,6 +9682,29 @@ fn reauthorize_recall_ollama_egress(
     reauthorize_recall_sources(sources, config)
 }
 
+/// Re-check an OpenAI-compatible local provider immediately before the request,
+/// mirroring [`reauthorize_recall_ollama_egress`]. Config is reloaded rather
+/// than trusted from turn start, so a provider swapped mid-turn cannot receive
+/// context authorized against the previous one.
+fn reauthorize_recall_openai_compatible_egress(
+    expected_url: &str,
+    expected_model: &str,
+    sources: &[RecallSourceBinding],
+    config: &Config,
+) -> Result<(), String> {
+    let engine = config.summarization.engine.as_str();
+    if !(engine == "openai-compatible" || engine == "openai_compatible") {
+        return Err("Recall context or local provider changed before use.".into());
+    }
+    let current_url =
+        recall_openai_compatible_chat_url(&config.summarization.openai_compatible_base_url)?;
+    if current_url != expected_url || config.summarization.openai_compatible_model != expected_model
+    {
+        return Err("Recall context or local provider changed before use.".into());
+    }
+    reauthorize_recall_sources(sources, config)
+}
+
 fn reauthorize_recall_claude_egress(
     expected_engine: &str,
     sources: &[RecallSourceBinding],
@@ -9743,6 +9766,77 @@ fn recall_ollama_chat_url(raw: &str) -> Result<String, String> {
     }
     url.set_path("/api/chat");
     Ok(url.into())
+}
+
+/// Resolve the chat-completions endpoint for an OpenAI-compatible local
+/// provider (LM Studio, llama.cpp server, vLLM) under the same local-only rule
+/// as Ollama.
+///
+/// Unlike [`recall_ollama_chat_url`] a path prefix is required rather than
+/// refused: these servers are conventionally rooted at `/v1`, so
+/// `http://localhost:1234/v1` must resolve to
+/// `http://localhost:1234/v1/chat/completions`. Credentials, query strings and
+/// fragments stay refused, and the destination must still be loopback: Recall
+/// chat never leaves the machine (#650).
+fn recall_openai_compatible_chat_url(raw: &str) -> Result<String, String> {
+    let mut url = reqwest::Url::parse(raw.trim()).map_err(|_| {
+        "Recall OpenAI-compatible URL must be a valid loopback HTTP URL.".to_string()
+    })?;
+    if url.scheme() != "http"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(
+            "Recall OpenAI-compatible URL must be a plain loopback HTTP origin with no credentials."
+                .into(),
+        );
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Recall OpenAI-compatible URL is missing a loopback host.".to_string())?;
+    let is_loopback = host.eq_ignore_ascii_case("localhost")
+        || host
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback());
+    if !is_loopback {
+        return Err(
+            "Recall OpenAI-compatible chat is local-only; remote destinations are refused.".into(),
+        );
+    }
+    // Preserve the configured prefix (usually `/v1`) and append the endpoint,
+    // tolerating a trailing slash or a base that already names the endpoint.
+    let base = url.path().trim_end_matches('/').to_string();
+    let path = if base.ends_with("/chat/completions") {
+        base
+    } else {
+        format!("{base}/chat/completions")
+    };
+    url.set_path(&path);
+    Ok(url.into())
+}
+
+/// Extract the incremental assistant text from one server-sent-events line of
+/// an OpenAI-compatible stream.
+///
+/// Returns `None` for keepalives, the `[DONE]` sentinel, and any frame without
+/// a content delta, so the caller can treat "no text" uniformly.
+fn openai_compatible_stream_delta(line: &str) -> Option<String> {
+    let payload = line.strip_prefix("data:")?.trim();
+    if payload.is_empty() || payload == "[DONE]" {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let text = value
+        .get("choices")?
+        .get(0)?
+        .get("delta")?
+        .get("content")?
+        .as_str()?;
+    (!text.is_empty()).then(|| text.to_string())
 }
 
 fn recall_ollama_agent() -> ureq::Agent {
@@ -10223,12 +10317,173 @@ pub async fn cmd_recall_chat_send(
         return Ok(());
     }
 
+    // ── OpenAI-compatible local provider path ─────────────────────────────────
+    // LM Studio, llama.cpp server and vLLM speak this shape. It was already a
+    // first-class summarization engine, so a user whose summaries worked still
+    // could not chat (#650). Same local-only rule as Ollama: loopback
+    // destinations only, no credentials, and no API key is sent.
+    let engine_name = config.summarization.engine.clone();
+    if engine_name == "openai-compatible" || engine_name == "openai_compatible" {
+        let prepared_url =
+            recall_openai_compatible_chat_url(&config.summarization.openai_compatible_base_url)?;
+        let (turn_id, cancelled) = begin_recall_chat_turn(&state)?;
+        let model = config.summarization.openai_compatible_model.clone();
+        let expected_model = model.clone();
+        let app_clone = app.clone();
+        let message_clone = message.clone();
+        let history_arc = state.recall_chat_history.clone();
+        let current_turn = state.recall_chat_turn.clone();
+        let source_bindings = egress_sources.clone();
+
+        let task_result = tauri::async_runtime::spawn_blocking(move || {
+            let mut messages: Vec<serde_json::Value> = Vec::new();
+            for turn in &history_snapshot {
+                messages.push(serde_json::json!({"role": "user", "content": turn.user_message}));
+                messages.push(serde_json::json!({"role": "assistant", "content": turn.assistant_response}));
+            }
+            messages.push(serde_json::json!({"role": "user", "content": enriched_message}));
+
+            let body = serde_json::json!({
+                "model": model,
+                "messages": messages,
+                "stream": true,
+            });
+
+            let agent = recall_ollama_agent();
+
+            let fresh_config = match Config::load_strict() {
+                Ok(config) => config,
+                Err(_) => {
+                    history_arc.lock().unwrap().clear();
+                    app_clone
+                        .emit_to(
+                            "main",
+                            "recall-chat-error",
+                            "Recall context could not be reauthorized safely. The conversation was cleared; retry the question.",
+                        )
+                        .ok();
+                    finish_recall_chat_turn(&app_clone, &current_turn, turn_id);
+                    return;
+                }
+            };
+            if reauthorize_recall_openai_compatible_egress(
+                &prepared_url,
+                &expected_model,
+                &source_bindings,
+                &fresh_config,
+            )
+            .is_err()
+            {
+                history_arc.lock().unwrap().clear();
+                app_clone
+                    .emit_to(
+                        "main",
+                        "recall-chat-error",
+                        "Recall context or local provider changed before use. The request was blocked locally.",
+                    )
+                    .ok();
+                finish_recall_chat_turn(&app_clone, &current_turn, turn_id);
+                return;
+            }
+
+            let resp = match agent
+                .post(&prepared_url)
+                .header("Content-Type", "application/json")
+                .send_json(&body)
+            {
+                Ok(r) => r,
+                Err(_) => {
+                    if !cancelled.load(Ordering::Relaxed) {
+                        app_clone
+                            .emit_to(
+                                "main",
+                                "recall-chat-error",
+                                "The local Recall provider could not be reached safely.",
+                            )
+                            .ok();
+                    }
+                    finish_recall_chat_turn(&app_clone, &current_turn, turn_id);
+                    return;
+                }
+            };
+
+            if resp.status().as_u16() >= 300 {
+                let status = resp.status().as_u16();
+                if !cancelled.load(Ordering::Relaxed) {
+                    app_clone
+                        .emit_to(
+                            "main",
+                            "recall-chat-error",
+                            format!("The local Recall provider returned HTTP {status}."),
+                        )
+                        .ok();
+                }
+                finish_recall_chat_turn(&app_clone, &current_turn, turn_id);
+                return;
+            }
+
+            let mut body = resp.into_body();
+            let reader = BufReader::new(body.as_reader());
+            let mut full_response = String::new();
+            for line_result in reader.lines() {
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
+                match line_result {
+                    Ok(line) => {
+                        if let Some(text) = openai_compatible_stream_delta(&line) {
+                            if cancelled.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            full_response.push_str(&text);
+                            app_clone
+                                .emit_to(
+                                    "main",
+                                    "recall-chat-chunk",
+                                    serde_json::json!({"type": "text", "text": text}),
+                                )
+                                .ok();
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[recall-chat/openai-compatible] read error: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            if !cancelled.load(Ordering::Relaxed) && !full_response.is_empty() {
+                store_recall_history_if_still_authorized(
+                    &history_arc,
+                    RecallChatHistoryTurn {
+                        user_message: message_clone,
+                        assistant_response: full_response,
+                        sources: source_bindings,
+                    },
+                );
+            }
+            finish_recall_chat_turn(&app_clone, &current_turn, turn_id);
+        })
+        .await;
+
+        if let Err(error) = task_result {
+            clear_recall_chat_turn_if_current(&state.recall_chat_turn, turn_id);
+            return Err(format!(
+                "Recall chat OpenAI-compatible task failed: {error}"
+            ));
+        }
+
+        return Ok(());
+    }
+
     // ── CLI agent path ─────────────────────────────────────────────────────────
     let agent_bin = minutes_core::summarize::detect_recall_chat_cli().ok_or_else(|| {
         "No safely isolated AI provider found for Recall chat. Install Claude Code (npm install -g \
-         @anthropic-ai/claude-code) — or configure \
-         Ollama ([summarization] engine = \"ollama\" in config.toml) for a fully local \
-         loopback-only option. Other agent CLIs stay disabled until their no-tools mode is verified."
+         @anthropic-ai/claude-code), or configure a local model in config.toml: \
+         [summarization] engine = \"ollama\", or engine = \"openai-compatible\" with \
+         openai_compatible_base_url pointing at a loopback server such as LM Studio \
+         (http://localhost:1234/v1). Both are fully local and loopback-only. \
+         Other agent CLIs stay disabled until their no-tools mode is verified."
             .to_string()
     })?;
 
@@ -12270,6 +12525,82 @@ mod tests {
             "not a url",
         ] {
             assert!(recall_ollama_chat_url(rejected).is_err(), "{rejected}");
+        }
+    }
+
+    #[test]
+    fn recall_openai_compatible_url_keeps_the_prefix_and_stays_local() {
+        // These servers are rooted at a prefix, so unlike Ollama a path is
+        // required rather than refused. The prefix must survive (#650).
+        for (raw, expected) in [
+            (
+                "http://localhost:1234/v1",
+                "http://localhost:1234/v1/chat/completions",
+            ),
+            (
+                "http://localhost:1234/v1/",
+                "http://localhost:1234/v1/chat/completions",
+            ),
+            (
+                "http://127.0.0.1:8080",
+                "http://127.0.0.1:8080/chat/completions",
+            ),
+            (
+                "http://[::1]:1234/v1",
+                "http://[::1]:1234/v1/chat/completions",
+            ),
+            // Already complete: must not double-append.
+            (
+                "http://localhost:1234/v1/chat/completions",
+                "http://localhost:1234/v1/chat/completions",
+            ),
+        ] {
+            assert_eq!(
+                recall_openai_compatible_chat_url(raw).unwrap(),
+                expected,
+                "{raw}"
+            );
+        }
+
+        // Local-only is the whole point: everything that could leave the
+        // machine, or smuggle credentials, stays refused.
+        for rejected in [
+            "https://localhost:1234/v1",
+            "http://localhost.example.com:1234/v1",
+            "http://192.168.1.10:1234/v1",
+            "http://0.0.0.0:1234/v1",
+            "http://user@localhost:1234/v1",
+            "http://user:pass@localhost:1234/v1",
+            "http://localhost:1234/v1?token=x",
+            "http://localhost:1234/v1#fragment",
+            "not a url",
+        ] {
+            assert!(
+                recall_openai_compatible_chat_url(rejected).is_err(),
+                "{rejected}"
+            );
+        }
+    }
+
+    #[test]
+    fn openai_compatible_stream_delta_reads_only_content_frames() {
+        assert_eq!(
+            openai_compatible_stream_delta(r#"data: {"choices":[{"delta":{"content":"hello"}}]}"#),
+            Some("hello".to_string())
+        );
+        // Keepalives, the terminator, role-only frames and finish frames carry
+        // no text and must not be emitted as chunks.
+        for quiet in [
+            "data: [DONE]",
+            "data:",
+            "",
+            ": keepalive",
+            r#"data: {"choices":[{"delta":{"role":"assistant"}}]}"#,
+            r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#,
+            r#"data: {"choices":[{"delta":{"content":""}}]}"#,
+            "data: not json",
+        ] {
+            assert_eq!(openai_compatible_stream_delta(quiet), None, "{quiet:?}");
         }
     }
 

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -13494,6 +13494,13 @@
     // the narration never overwrites a streaming reply.
     function updateRecallChatStatus(chunk) {
       if (!currentAssistantBubble || currentAssistantBubble.textContent.trim()) return;
+      // Local reasoning models can think for hundreds of stream frames before
+      // the first word of the answer (observed: 504 of 508). Without a status
+      // the panel looks hung. Emitted once per turn by the backend.
+      if (chunk && chunk.type === 'thinking') {
+        currentAssistantBubble.dataset.status = 'thinking';
+        return;
+      }
       if (!chunk || chunk.type !== 'assistant' || !chunk.message || !chunk.message.content) return;
       for (const part of chunk.message.content) {
         if (part && part.type === 'tool_use') {


### PR DESCRIPTION
## The bug

`feat(archive): ship private census app` added a second `tauri.conf.json` at `archive/src-tauri/`. The tauri CLI resolves the first config it finds from the working directory, so **any `cargo tauri build` run from the repo root now targets `minutes-archive-app` instead of `minutes-app`.**

Reproduced on a Mac against the real toolchain:

```
# from the repo root
$ cargo tauri build --bundles app --features parakeet,metal --no-sign
error: the package 'minutes-archive-app' does not contain these features: metal, parakeet

# from tauri/src-tauri
$ cargo tauri build --bundles app --features parakeet,metal --no-sign
   Compiling ...        # builds the real app
```

## Blast radius

Two CI jobs already set `working-directory: tauri/src-tauri` and were unaffected — the Windows installer in `ci.yml` and in `release-windows-desktop.yml`. That is why this did not show up as a red build.

Three call sites did not:

| site | consequence |
|---|---|
| `release-macos.yml:205` | passes `--features parakeet,metal,engine-sherpa`, so **the next macOS release would have failed at tag time** |
| `scripts/install-dev-app.sh` | fails today, blocking the dev-app workflow the repo prescribes for UI verification |
| `scripts/build.sh` | same shape |

The failure mode with `--features` is loud. **The no-features case is worse:** a root-level `cargo tauri build` with no feature flags builds the archive app and *succeeds*, silently producing the wrong bundle.

## Change

Each of the three now runs from `tauri/src-tauri`, matching what the two healthy CI jobs already do. `install-dev-app.sh` keeps its `--config` working by passing an absolute path.

## Golden hashes

`release-macos.yml`, `build.sh` and `install-dev-app.sh` are all covered by the graph-XPC packaging guard, so it fired. Reviewed before resealing: each diff is confined to the working directory of the tauri build, and none of them touch signing, entitlements, helper packaging or ordering.

## How this was found

The dev-app build failed while preparing a UI click-test for #651. It looked like the known SSH codesigning limitation at first; it was not, and reading the actual error rather than assuming the familiar cause is what surfaced it.