### PR TITLE
fix(build): run build.sh's tauri build from the app crate

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -90,7 +90,9 @@ if [[ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]]; then
     echo "  No TAURI_SIGNING_PRIVATE_KEY configured; building updater artifacts with --no-sign."
     TAURI_BUILD_ARGS+=(--no-sign)
 fi
-"${TAURI_BUILD_ARGS[@]}"
+# Run from the app crate: with archive/src-tauri also present, the tauri CLI
+# resolves the wrong tauri.conf.json from the repo root.
+( cd "$(git rev-parse --show-toplevel)/tauri/src-tauri" && "${TAURI_BUILD_ARGS[@]}" )
 
 echo "=== Re-signing bundled CLI sidecar with its own entitlements ==="
 # The CLI sidecar needs `com.apple.security.device.audio-input` so `minutes record`

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -9,7 +9,7 @@ import { existsSync, readFileSync } from "node:fs";
 const EXPECTED_SOURCE_SHA256 = {
   release: "70ec47bcb544362e3858abdf026010f83668f55c9945b824eaaf9fdf4158bc43",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
-  build: "6a1933306c99ccbfc6c5cb35a577389fbe79f08333e855661dc1994f0f9718b1",
+  build: "9ca0741767b8e2fc49c4ffd200d5c5c43d13ddf0ebfd88fa2d6116d0cb3656ec",
   dev: "6a1d680b57f6914bbcadda4b83ad4c1bc56c0d0f50bee11a9f9ebb294cbb029b",
   packageXpc: "baebd532d240fc26188c431f571d0a44f2ce1e7240c3277284c9ea9e69c1ef82",
   tauri: "f127e92a1a2a635326d13dd766b3e6cc841655bce30ea2d01d67d9f12c15502c",


### PR DESCRIPTION
Follow-on to 6c1017cf, which fixed two of the three call sites.

## What is still broken

After the Archive crates joined the workspace, a root-level `cargo tauri build` resolves `--features` against every workspace member and fails:

```
error: the package 'minutes-archive-app' does not contain these features: metal, parakeet
```

`6c1017cf` pinned `scripts/install-dev-app.sh` and `.github/workflows/release-macos.yml` to `tauri/src-tauri`. **`scripts/build.sh` has the same shape and was missed.** It passes `--features "$MINUTES_BUILD_FEATURES"`, so the full-build path documented in CLAUDE.md (`./scripts/build.sh`) fails today.

## Verification

On a Mac against the real toolchain:

```
# repo root
$ cargo tauri build --bundles app --features parakeet,metal --no-sign
error: the package 'minutes-archive-app' does not contain these features: metal, parakeet

# tauri/src-tauri
$ cargo tauri build --bundles app --features parakeet,metal --no-sign
   Compiling ...        # builds the real app
```

## Note

The loud failure is the good case. A root-level `cargo tauri build` with **no** `--features` builds the archive app and *succeeds*, silently producing the wrong bundle. Two CI jobs escaped only because they already set `working-directory: tauri/src-tauri`.

Golden hash for `build.sh` resealed after review; the diff is confined to the tauri build's working directory and touches no signing, entitlements or packaging order.

Supersedes #654, which I opened from the wrong base and which duplicated unrelated work.