### PR TITLE
fix(windows): statically link the MSVC runtime so binaries start on a clean PC

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,22 @@
 # The cc crate defaults to 10.13 for some targets, causing build failures.
 # Setting this ensures the correct -mmacosx-version-min flag. (See #14)
 MACOSX_DEPLOYMENT_TARGET = { value = "11.0", force = true }
+
+# Statically link the MSVC C and C++ runtimes on Windows.
+#
+# Without this, every published Windows artifact imports VCRUNTIME140.dll,
+# VCRUNTIME140_1.dll, MSVCP140.dll and MSVCP140_1.dll, which ship in the Visual
+# C++ Redistributable rather than in Windows. On a machine that has never had
+# it, the process fails to start with STATUS_DLL_NOT_FOUND and prints nothing
+# at all: no window, no error, no exit message. Verified on a clean Windows 11
+# 26100 VM against the released v0.24.0 CLI and desktop binaries (#657).
+#
+# CI never caught it because GitHub's windows runners ship the redistributable.
+#
+# The C++ side has to agree: a /MT Rust runtime against a /MD whisper.cpp is a
+# link-time mismatch. The `cc` crate reads crt-static from
+# CARGO_CFG_TARGET_FEATURE and switches to /MT, and `cmake` inherits its flags,
+# so this should propagate to the bundled whisper.cpp build. That propagation
+# is the risky part of this change and is what the Windows CI jobs verify.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,15 @@ jobs:
               - 'crates/cli/**'
               - 'crates/reader/**'
               - 'crates/whisper-guard/**'
+              - 'archive/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              # Sets rustflags and build env per target, so it changes how every
+              # Rust target compiles. Omitting it meant a change that statically
+              # linked the Windows CRT skipped every Rust job and reported green
+              # (#657 follow-up).
+              - '.cargo/**'
               - '.github/workflows/ci.yml'
 
   test:


### PR DESCRIPTION
Fixes #657.

## The problem

Every published Windows artifact imports `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll`, `MSVCP140.dll` and `MSVCP140_1.dll`. Those come from the Visual C++ Redistributable, which is **not** part of Windows.

Verified against the released v0.24.0 artifacts on a clean Windows 11 (26100) VM with no VC++ runtime present:

```
minutes-windows-x64.exe --version         -> exit -1073741515 (0xC0000135), no output
minutes-desktop-windows-x64.exe --version -> exit -1073741515 (0xC0000135), no output
```

No window, no error, no message. A user downloads Minutes, runs it, and nothing happens.

CI is green and will stay green: GitHub's `windows-latest` runners ship the redistributable. The failure only exists on end-user machines, and produces no text to search for, so its absence from the issue tracker means nothing.

## Why static linking rather than shipping the DLLs

It keeps the single self-contained binary. Bundling would have to be solved twice, once for the bare CLI download and once for the NSIS installer, and the installer runs `installMode: currentUser` so it cannot install a machine-wide runtime anyway.

## The risk in this change

The C++ side has to use the same runtime or the link fails with a runtime-library mismatch. `cc` reads `crt-static` from `CARGO_CFG_TARGET_FEATURE` and switches to `/MT` (`cc/src/lib.rs:2098`), and `cmake` inherits its flags, so this should propagate to the bundled whisper.cpp. **That propagation is the thing to watch.** The Windows CI jobs (`Test`, `Install CLI`, `Desktop App Installer`) all compile the C++ and will fail loudly if the runtimes disagree.

macOS and Linux are untouched: the setting is scoped to `x86_64-pc-windows-msvc`.

## Verification plan

CI proving it builds is necessary but not sufficient, because the whole point is behaviour on a machine CI does not resemble. After it goes green I will trigger `release-cli.yml` via `workflow_dispatch`, revert the QA VM to its clean snapshot, and run the artifact there. Merging before that check would be repeating the mistake that let this ship.

Binary size impact will be reported from the built artifact rather than estimated.