### PR TITLE
fix(windows): ship the MSVC runtime beside the CLI (#657)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -116,6 +116,54 @@ jobs:
         with:
           files: ${{ matrix.asset }}
 
+      # Windows needs the MSVC runtime beside the executable. Nothing ships it
+      # today, so on a PC that has never had the Visual C++ Redistributable the
+      # binary exits 0xC0000135 (STATUS_DLL_NOT_FOUND) printing nothing at all
+      # (#657). Static linking is not available: ort-sys ships prebuilt ONNX
+      # Runtime against the dynamic CRT and will not link (#659).
+      #
+      # Verified on a clean Windows 11 VM: the same binary fails bare and runs
+      # with these four files beside it. Windows resolves the application
+      # directory ahead of the system path, so no install step is needed.
+      #
+      # The bare .exe is still published so already-installed MCP servers keep
+      # resolving it, but the zip is what a clean machine needs.
+      - name: Package Windows CLI with the MSVC runtime
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $crt = Get-ChildItem 'C:\Program Files*\Microsoft Visual Studio\2022\*\VC\Redist\MSVC\*\x64\Microsoft.VC143.CRT' -Directory -ErrorAction SilentlyContinue |
+                 Sort-Object FullName -Descending | Select-Object -First 1
+          if (-not $crt) { throw 'Could not locate the VC143 CRT redistributable on the runner' }
+          Write-Host "CRT source: $($crt.FullName)"
+          $stage = 'minutes-windows-x64'
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item '${{ matrix.asset }}' (Join-Path $stage 'minutes.exe') -Force
+          foreach ($dll in 'vcruntime140.dll','vcruntime140_1.dll','msvcp140.dll','msvcp140_1.dll') {
+            $src = Join-Path $crt.FullName $dll
+            if (-not (Test-Path $src)) { throw "missing $dll in $($crt.FullName)" }
+            Copy-Item $src $stage -Force
+          }
+          # Fail the job rather than publish an archive that repeats the bug.
+          $have = (Get-ChildItem "$stage\*.dll").Count
+          if ($have -ne 4) { throw "expected 4 DLLs beside minutes.exe, found $have" }
+          Compress-Archive -Path "$stage\*" -DestinationPath 'minutes-windows-x64.zip' -Force
+          Write-Host ("archive MB: {0:N2}" -f ((Get-Item 'minutes-windows-x64.zip').Length/1MB))
+
+      - name: Upload Windows zip artifact
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        uses: actions/upload-artifact@v7
+        with:
+          name: minutes-windows-x64.zip
+          path: minutes-windows-x64.zip
+
+      - name: Upload Windows zip release asset
+        uses: softprops/action-gh-release@v3
+        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'x86_64-pc-windows-msvc'
+        with:
+          files: minutes-windows-x64.zip
+
       # Additive second artifact for Linux only: the same CLI plus the sherpa
       # engine and its shared libraries, as a tarball. The bare binary above is
       # unchanged, so existing installs and the Homebrew formula are unaffected.

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -2287,21 +2287,48 @@ async function tryAutoInstallAttempt(capabilityRepair: boolean = false): Promise
       const targetName = isWindows ? "minutes.exe" : "minutes";
       const targetPath = join(installDir, targetName);
 
-      console.error(`[Minutes] Downloading ${binaryName} from latest release...`);
-
       // Ensure install directory exists
       await mkdir(installDir, { recursive: true });
 
-      // Download with curl (available on macOS, Linux, and modern Windows),
-      // verify SHA256SUMS.txt, then move the verified binary into place.
-      await downloadReleaseBinaryWithChecksum({
-        binaryName,
-        targetPath,
-        execFileAsync,
-      });
-
-      // Make executable (not needed on Windows)
-      if (!isWindows) {
+      if (isWindows) {
+        // The Windows binary imports the MSVC runtime (VCRUNTIME140.dll,
+        // MSVCP140.dll and friends), which is not part of Windows. On a PC
+        // that has never had the Visual C++ Redistributable, the bare .exe
+        // exits 0xC0000135 (STATUS_DLL_NOT_FOUND) printing nothing at all, so
+        // the user sees the command silently do nothing (#657).
+        //
+        // The zip carries those four files beside minutes.exe. Windows
+        // resolves the application's own directory ahead of the system path,
+        // so extracting them next to the executable is sufficient and needs no
+        // installer and no admin rights. Verified on a clean Windows 11 VM.
+        const archiveName = "minutes-windows-x64.zip";
+        const archivePath = join(installDir, archiveName);
+        console.error(`[Minutes] Downloading ${archiveName} from latest release...`);
+        await downloadReleaseBinaryWithChecksum({
+          binaryName: archiveName,
+          targetPath: archivePath,
+          execFileAsync,
+        });
+        await execFileAsync(
+          "powershell",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `Expand-Archive -Path '${archivePath}' -DestinationPath '${installDir}' -Force`,
+          ],
+          { timeout: 120000 },
+        );
+        await rm(archivePath, { force: true });
+      } else {
+        console.error(`[Minutes] Downloading ${binaryName} from latest release...`);
+        // Download with curl, verify SHA256SUMS.txt, then move the verified
+        // binary into place.
+        await downloadReleaseBinaryWithChecksum({
+          binaryName,
+          targetPath,
+          execFileAsync,
+        });
         await execFileAsync("chmod", ["+x", targetPath], { timeout: 5000 });
       }
 

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04",
+  "generatedAt": "2026-08-06",
   "visibleCount": 68,
   "hiddenCount": 17,
   "groups": [

--- a/site/app/docs/mcp/tools/data.json
+++ b/site/app/docs/mcp/tools/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04",
+  "generatedAt": "2026-08-06",
   "installCommand": "npx minutes-mcp",
   "documentationUrl": "https://useminutes.app/for-agents",
   "supportUrl": "https://github.com/silverstein/minutes/discussions",

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: crates/core thiserror definitions
-> Last generated: 2026-08-04
+> Last generated: 2026-08-06
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 

--- a/site/public/docs/mcp/tools.md
+++ b/site/public/docs/mcp/tools.md
@@ -3,7 +3,7 @@
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts
 > Regenerate: node scripts/generate_llms_txt.mjs
-> Last generated: 2026-08-04
+> Last generated: 2026-08-06
 
 Minutes exposes 34 tools, 11 resources, and 6 prompt templates through the MCP server.
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-08-04
+> Last generated: 2026-08-06
 
 ## Product
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-08-04
+> Last generated: 2026-08-06
 
 Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that policy-aware local tools expose to Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and MCP-compatible clients — no proprietary SDK, no API key. Restricted meetings are excluded from agent results by default; explicit access requires a trusted launch policy, a per-call request, and a durable audit record. Minutes never uploads your audio; meeting text leaves your device only when you explicitly send policy-authorized context to a connected cloud agent or summarizer. When a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.
 


### PR DESCRIPTION
Fixes #657.

## The bug

Every published Windows artifact imports `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll`, `MSVCP140.dll` and `MSVCP140_1.dll`. Those ship in the Visual C++ Redistributable, **not** in Windows. On a PC that has never had it installed, the binary exits `0xC0000135` (`STATUS_DLL_NOT_FOUND`) and prints **nothing at all**. No window, no error, no exit message. A user downloads Minutes, runs it, and nothing happens.

There is no error text to search for, so it is close to unreportable from the user's side. The absence of bug reports says nothing about how many people hit it.

## Verified, not inferred

Controlled experiment on a clean Windows 11 VM with no runtime installed, same released binary, same session:

```
--- CONTROL: bare exe ---
  exit=-1073741515      # 0xC0000135
  out=

--- TEST: exe with the four DLLs beside it ---
  exit=0
  out=minutes 0.24.0
```

The only variable is 724 KB of runtime files in the same directory. Windows resolves the application's own directory ahead of the system path, so app-local copies satisfy the imports with no installer and no admin rights. Microsoft permits redistributing these specific files.

## Why not static linking

Tried first, in #659, and it does not work. `ort-sys` ships **prebuilt** ONNX Runtime linked against the dynamic CRT, so `+crt-static` fails at link with 38 unresolved `__imp_*` symbols. `ort` arrives through `diarize`, which is a default feature, so the shipped configuration cannot use it. whisper.cpp was fine; `cc` propagates `crt-static` to `/MT` correctly.

## What changes

- Release publishes **`minutes-windows-x64.zip`** containing `minutes.exe` plus the four DLLs.
- The bare `.exe` is **still published**, so already-installed MCP servers that resolve it by name keep working.
- The **MCP auto-installer** now prefers the zip on Windows and expands it into the install directory. That path matters: it is how the reporter in #633 obtained their CLI, and it is where the failure is most silent.
- The packaging step **fails the job** if fewer than four DLLs are staged, rather than quietly publishing an archive that reproduces the bug.

## Verification gap worth knowing

**CI cannot prove this works.** Every GitHub `windows-latest` runner has the redistributable installed, so the packaging passes identically with or without the DLLs. The only real check is running the packaged artifact on a machine that lacks the runtime, which is what the QA VM's `clean-no-vcredist` snapshot is for.

I will run the built artifact against that snapshot once this produces one. Until then, treat green CI here as "it built", not "it works".

Follow-up not in this PR: the desktop app has the same dependency, and its NSIS installer already lays down a directory, so the four files can go in beside the executable with no user-visible change at all.