### PR TITLE
fix(test): retry the relay reconnect instead of unwrapping through it (#656)

### DIFF
--- a/crates/core/src/copilot/relay.rs
+++ b/crates/core/src/copilot/relay.rs
@@ -1313,17 +1313,23 @@ mod tests {
 
         server.publish_transcript_for_test(utterance("second"));
         server.publish_nudge(nudge("nudge-2"));
-        let mut second = CaptureRelayClient::connect_from(&discovery_path, cursor).unwrap();
-        let transcript = wait_for_frame(&mut second, |frame| {
-            matches!(frame, RelayFrame::Transcript { seq: 2, .. })
-        });
-        let replayed_nudge = wait_for_frame(&mut second, |frame| {
-            matches!(frame, RelayFrame::Nudge { seq: 2, .. })
-        });
-        assert!(matches!(transcript, RelayFrame::Transcript { seq: 2, .. }));
-        assert!(matches!(replayed_nudge, RelayFrame::Nudge { seq: 2, .. }));
-        assert_eq!(second.cursor().transcript_seq, 2);
-        assert_eq!(second.cursor().nudge_seq, 2);
+
+        // Reconnect through the retrying helper rather than a bare
+        // connect + wait_for_frame. The server's retirement of the dropped
+        // client is not ordered against accepting the next one, so a freshly
+        // connected client can observe EOF immediately; on Windows named pipes
+        // that happened in 5 of 25 runs (#656).
+        //
+        // An established consumer surfacing that as an error is deliberate
+        // production behavior, established in #529 and relied on by
+        // `repeated_reconnects_replay_each_cursor_advance` directly below, so
+        // the test retries instead of the client swallowing it. Replay is
+        // cursor-based, so a retry resumes from the same cursor and the
+        // invariant under test is unchanged: some (re)connection must deliver
+        // transcript 2 and nudge 2, and only those.
+        let resumed = read_reconnect_cycle_with_retry(&discovery_path, cursor, 2);
+        assert_eq!(resumed.transcript_seq, 2);
+        assert_eq!(resumed.nudge_seq, 2);
     }
 
     #[test]

--- a/site/app/docs/errors/data.json
+++ b/site/app/docs/errors/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06",
+  "generatedAt": "2026-08-07",
   "visibleCount": 68,
   "hiddenCount": 17,
   "groups": [

--- a/site/app/docs/mcp/tools/data.json
+++ b/site/app/docs/mcp/tools/data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06",
+  "generatedAt": "2026-08-07",
   "installCommand": "npx minutes-mcp",
   "documentationUrl": "https://useminutes.app/for-agents",
   "supportUrl": "https://github.com/silverstein/minutes/discussions",

--- a/site/public/docs/errors.md
+++ b/site/public/docs/errors.md
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: crates/core thiserror definitions
-> Last generated: 2026-08-06
+> Last generated: 2026-08-07
 
 This is the generated public catalog of stable Minutes core errors. It intentionally favors actionable, user-facing errors over generic wrapper variants.
 

--- a/site/public/docs/mcp/tools.md
+++ b/site/public/docs/mcp/tools.md
@@ -3,7 +3,7 @@
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts
 > Regenerate: node scripts/generate_llms_txt.mjs
-> Last generated: 2026-08-06
+> Last generated: 2026-08-07
 
 Minutes exposes 34 tools, 11 resources, and 6 prompt templates through the MCP server.
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-08-06
+> Last generated: 2026-08-07
 
 ## Product
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Generated file. Do not edit by hand.
 > Source: manifest.json + crates/mcp/src/index.ts + site/lib/skills-catalog.json
-> Last generated: 2026-08-06
+> Last generated: 2026-08-07
 
 Minutes is the private, owned conversation-memory layer. Record meetings, voice memos, and dictation; transcribe them on your own machine; and get structured markdown in `~/meetings/` that policy-aware local tools expose to Claude Desktop, Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Pi, and MCP-compatible clients — no proprietary SDK, no API key. Restricted meetings are excluded from agent results by default; explicit access requires a trusted launch policy, a per-call request, and a durable audit record. Minutes never uploads your audio; meeting text leaves your device only when you explicitly send policy-authorized context to a connected cloud agent or summarizer. When a cloud memory tool gets acquired or subpoenaed, your recordings aren't theirs to hand over. No vendor to outlive — ten years from now, `grep` still works on your corpus.
 


### PR DESCRIPTION
Fixes #656.

## Measured, not guessed

`connect_reconnect_replays_only_after_both_cursors` is not a rare race. On a Windows 11 VM:

```
before: 5 failures in 25 runs   (20%)
after:  0 failures in 25 runs
relay suite (5 runs): 0 failures
```

It looked rare in CI only because CI runs the test once per job. At a 20% base rate, any Windows CI run had roughly a one-in-five chance of failing on this test alone, which matches how often it has been blocking unrelated PRs.

## Root cause

The panic is `try_recv().unwrap()` inside `wait_for_frame` returning `UnexpectedEof`. The server's retirement of the dropped client is not ordered against accepting the next one, so a freshly connected client can observe EOF immediately.

## Why the test, not the client

The product behavior is deliberate. From a comment left by the #529 work in this same file:

> Rapid reconnect churn can transiently close a freshly established connection mid-delivery (observed on Windows named pipes, #529). That is a legitimate reconnect scenario, not a replay failure, and an established consumer surfacing it as an error is correct production behavior — so the *test* reconnects with the same cursor and retries the cycle.

The neighbouring `repeated_reconnects_replay_each_cursor_advance` already does exactly that, and the helpers already exist: `try_wait_for_frame`, `read_reconnect_cycle`, and `read_reconnect_cycle_with_retry` with backoff.

This test was simply the last one still crossing a reconnect with the unwrapping helper. It now uses the same retry path.

## What is deliberately not changed

`wait_for_frame` stays strict. Other tests rely on it to catch a genuinely closed connection, and teaching it to swallow `UnexpectedEof` would weaken the capture-reliability invariants this suite exists to protect. The retry is scoped to the one place a reconnect is expected.

Assertions are preserved: transcript 2 and nudge 2 must still be replayed, and the resumed cursor must still be `{2, 2}`.

## Note on verification

Linux passes but never reproduced this, so a green Linux run proves only that it compiles and the logic holds. The meaningful evidence is 25 Windows runs against a known 20% baseline, which is the first time this has been checkable — the QA VM gained a Rust toolchain today.