### PR TITLE
chore(site): regenerate stale release constants

### DIFF
--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2685;
+export const MINUTES_TEST_COUNT = 2689;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## Main is red

`Site Release Link Consistency` has failed on main across three consecutive runs (08-06T23:20, 08-07T00:57, 08-07T02:40). Confirmed at `origin/main` directly:

```
$ node scripts/sync_site_release_version.mjs --check
target file: site/lib/release.ts
run: node scripts/sync_site_release_version.mjs
```

The committed test count drifted from the source scan as tests landed. `countRustTests` counts `#[test]` and `#[tokio::test]` attributes across the crates, so it changes whenever tests are added and has to be regenerated with them.

## Why this matters beyond the tidiness

Every open PR inherits the failure, which makes it easy to attribute to the branch under review. I nearly did exactly that on #662 and #663 before checking main. A red shared check costs more than the drift it reports.

Worth considering separately: the pre-push hook already regenerates these files, but only fires for people who have hooks installed. If this keeps drifting, having CI regenerate and fail with a diff, rather than just failing, would make the fix obvious from the log.