### PR TITLE
fix(ci): restore the rust path filter and stop test-count drift reddening main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,25 @@ jobs:
           filters: |
             rust:
               - 'tauri/**'
-              - 'crates/core/**'
-              - 'crates/cli/**'
-              - 'crates/reader/**'
-              - 'crates/whisper-guard/**'
+              - 'crates/**'
+              - 'archive/**'
+              - 'tests/**'
+              # Declared as build inputs by tauri/src-tauri/build.rs via
+              # cargo:rerun-if-changed and copied into the shipped bundle, so a
+              # change here really is a Rust build change.
+              - '.agents/skills/**'
+              - '.opencode/skills/**'
+              - '.opencode/commands/**'
+              - 'scripts/calendar-events.swift'
+              - 'scripts/calendar-helper-Info.plist'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              # Sets rustflags and build env per target, so it changes how every
+              # Rust target compiles. Omitting it meant a change that statically
+              # linked the Windows CRT skipped every Rust job and reported green
+              # (#657 follow-up).
+              - '.cargo/**'
               - '.github/workflows/ci.yml'
 
   test:

--- a/scripts/sync_site_release_version.mjs
+++ b/scripts/sync_site_release_version.mjs
@@ -187,6 +187,26 @@ if (currentContent === nextContent) {
 }
 
 if (checkOnly) {
+  // The test count is derived by scanning for #[test]/#[tokio::test], so it
+  // moves whenever anyone adds a test. Comparing it for exact equality made a
+  // shared, required check go red on main every time tests landed, and every
+  // open PR then inherited a failure it did not cause. That happened twice in
+  // two days (#664 and again the next morning).
+  //
+  // Release *links* are what this job is named for and what must be exact:
+  // version, and the tool/resource/prompt/command counts that appear in
+  // documented URLs. A slightly stale test count on a marketing page is not
+  // worth reddening everyone's CI, and the pre-push hook still refreshes it.
+  const staleOnlyByTestCount =
+    currentContent.replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 0") ===
+    nextContent.replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 0");
+  if (staleOnlyByTestCount) {
+    console.warn(
+      `site release constants match except the test count (committed differs from ${totalTestCount}). ` +
+        "Not failing: run scripts/sync_site_release_version.mjs to refresh it.",
+    );
+    process.exit(0);
+  }
   console.error(
     [
       "site release constants are out of sync with source",

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2689;
+export const MINUTES_TEST_COUNT = 2690;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Two defects found by an adversarial review of yesterday's work. Both make CI lie.

## 1. The rust path filter fix was discarded with a closed PR

`33f892d4` added `.cargo/**` to the `rust` filter after a change that alters how every Rust target compiles skipped every Rust job and still reported 14 green checks. That commit existed **only** on the branch of PR #659, which I closed when static linking proved unworkable. An unrelated, still-valid CI fix went with it.

```
git merge-base --is-ancestor 33f892d4 origin/main   -> not an ancestor
git branch -a --contains 33f892d4                   -> fix/windows-static-crt only
```

It was also incomplete. The filter enumerated crates by name, so it missed four workspace members (`archive-convert`, `archive-core`, `archive-ocr`, `archive-semantic`), plus `crates/assets` and `tests/integration`. It also omitted five paths that `tauri/src-tauri/build.rs` declares as build inputs via `cargo:rerun-if-changed` and copies into the shipped bundle. A PR touching only those paths gets no clippy, no fmt and no compilation, while the CI gate reports green by design.

Now: `crates/**`, `archive/**`, `tests/**`, and the declared build inputs.

## 2. The test count reddens main every time anyone adds a test

#664 regenerated the committed count yesterday. Four commits later it drifted 2689 → 2690 and main went red again, so every open PR inherited a failure it did not cause. I fixed the value; the value was not the problem.

The job is named Site Release **Link** Consistency. What must be exact is the version and the counts that appear in documented URLs. A number derived by scanning for `#[test]` attributes changes with every test anyone writes.

Check mode now warns instead of failing **only** when the test count is the sole difference:

```
test-count drift -> exit=0, "match except the test count ... run sync to refresh"
version drift    -> exit=1
```

Verified both directions. The pre-push hook still refreshes the value, so it stays accurate for anyone with hooks installed.

## Why this matters more than it looks

A required check that is red on main for reasons unrelated to the branch under review trains everyone to ignore red. That is exactly how a 20% flake and a completely broken Windows artifact both survived in this repo.