### PR TITLE
fix(mcp): install Windows CLI into a Minutes-owned directory (#657)

### DIFF
--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -2142,6 +2142,11 @@ function findMinutesBinary(): string {
   const candidates = [
     join(__dirname, "..", "..", "..", "target", "release", `minutes${ext}`),
     join(__dirname, "..", "..", "..", "target", "debug", `minutes${ext}`),
+    // Where the Windows auto-installer puts it: a Minutes-owned directory, so
+    // the MSVC runtime shipped beside the binary (#657) does not leak into a
+    // shared bin directory. Listed before ~/.cargo/bin so a fresh install wins
+    // over an older cargo-installed copy.
+    ...(isWindows ? [join(homedir(), ".minutes", "bin", `minutes${ext}`)] : []),
     join(homedir(), ".cargo", "bin", `minutes${ext}`),
     ...(isWindows
       ? []
@@ -2261,7 +2266,13 @@ function getReleaseBinaryName(): string | null {
 function getInstallDir(): string {
   const localBin = join(homedir(), ".local", "bin");
   if (process.platform === "win32") {
-    return join(homedir(), ".cargo", "bin"); // common writable dir on Windows
+    // A Minutes-owned directory, not ~/.cargo/bin. The Windows install ships
+    // the MSVC runtime beside the executable (#657), and Windows resolves an
+    // application's own directory ahead of the system path. Dropping those
+    // DLLs into the shared cargo bin directory would make every other
+    // cargo-installed tool launched from there load Minutes' pinned copies,
+    // and uninstalling would leave them behind.
+    return join(homedir(), ".minutes", "bin");
   }
   return localBin;
 }
@@ -2309,17 +2320,26 @@ async function tryAutoInstallAttempt(capabilityRepair: boolean = false): Promise
           targetPath: archivePath,
           execFileAsync,
         });
+        // Paths arrive as arguments rather than interpolated into the script
+        // text, so a home directory containing an apostrophe (C:\\Users\\O'Brien)
+        // cannot break or alter the command.
         await execFileAsync(
           "powershell",
           [
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            `Expand-Archive -Path '${archivePath}' -DestinationPath '${installDir}' -Force`,
+            "Expand-Archive -Path $args[0] -DestinationPath $args[1] -Force",
+            archivePath,
+            installDir,
           ],
           { timeout: 120000 },
         );
         await rm(archivePath, { force: true });
+        // Confirm the extraction actually produced the binary. The POSIX path
+        // gets this for free from rename(); without it a changed archive
+        // layout would report success while MINUTES_BIN points at nothing.
+        await stat(targetPath);
       } else {
         console.error(`[Minutes] Downloading ${binaryName} from latest release...`);
         // Download with curl, verify SHA256SUMS.txt, then move the verified

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2689;
+export const MINUTES_TEST_COUNT = 2690;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Follow-up to #660, from an adversarial review of it.

## The problem

#660 taught the Windows auto-installer to extract the zip into `getInstallDir()`, which on Windows returns `~/.cargo/bin`.

The zip carries the MSVC runtime. Windows resolves an application's own directory ahead of the system path, which is exactly why shipping those DLLs fixes #657 and exactly why putting them in a shared bin directory is wrong: every other cargo-installed tool launched from `~/.cargo/bin` would load Minutes' pinned copies of the CRT, and uninstalling `minutes-mcp` would leave them behind.

## Fix

Install to `~/.minutes/bin`, and add it to `findMinutesBinary`'s candidates **ahead of** `~/.cargo/bin` so a fresh install wins over an older cargo-installed copy.

That second half matters: without it the server would install the binary and then fail to find it, because the search list only knew about `~/.cargo/bin`. Changing the install directory alone would have broken auto-install outright.

## Two more defects in the same block

- **Quoting.** `Expand-Archive -Path '${archivePath}' -DestinationPath '${installDir}'` interpolated paths into a single-quoted PowerShell string, so a home directory containing an apostrophe (`C:\Users\O'Brien`) broke the command. Paths are passed as arguments now.
- **Unverified success.** The Windows branch never checked that extraction produced the binary, yet set `MINUTES_BIN`, logged "✓ Installed to ..." and returned `true`. The POSIX branch gets existence for free from `rename()`. A `stat()` now confirms it, so a changed archive layout fails loudly rather than reporting success while pointing at nothing.

`tsc` clean, `autoInstall` tests 5/5.