### PR TITLE
fix(windows): verify imports, and stop pointing users at broken artifacts

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -145,9 +145,21 @@ jobs:
             if (-not (Test-Path $src)) { throw "missing $dll in $($crt.FullName)" }
             Copy-Item $src $stage -Force
           }
-          # Fail the job rather than publish an archive that repeats the bug.
-          $have = (Get-ChildItem "$stage\*.dll").Count
-          if ($have -ne 4) { throw "expected 4 DLLs beside minutes.exe, found $have" }
+          # Derive the requirement from the binary rather than a hardcoded
+          # list. Counting the four files we just copied only validated our own
+          # copy loop: a dependency adding an import such as MSVCP140_2.dll
+          # (C++17 special math) or MSVCP140_ATOMIC_WAIT.dll (C++20 atomic
+          # wait) would reproduce #657 with a green job.
+          $dumpbin = Get-ChildItem 'C:\Program Files*\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $dumpbin) { throw 'dumpbin.exe not found; cannot verify the import table' }
+          $imports = & $dumpbin.FullName /dependents "$stage\minutes.exe" |
+                     Select-String -Pattern '^\s+(\S+\.dll)$' |
+                     ForEach-Object { $_.Matches[0].Groups[1].Value }
+          $needed = $imports | Where-Object { $_ -match '^(vcruntime|msvcp|concrt)' }
+          Write-Host "runtime imports: $($needed -join ', ')"
+          if (-not $needed) { throw 'no VC runtime imports detected; the import scan is probably broken' }
+          $missing = $needed | Where-Object { -not (Test-Path (Join-Path $stage $_)) }
+          if ($missing) { throw "minutes.exe imports runtime DLLs missing from the archive: $($missing -join ', '). Stage them too (#657)." }
           Compress-Archive -Path "$stage\*" -DestinationPath 'minutes-windows-x64.zip' -Force
           Write-Host ("archive MB: {0:N2}" -f ((Get-Item 'minutes-windows-x64.zip').Length/1MB))
 

--- a/.github/workflows/release-windows-desktop.yml
+++ b/.github/workflows/release-windows-desktop.yml
@@ -125,6 +125,25 @@ jobs:
         shell: bash
         run: cp -f target/release/minutes-app.exe minutes-desktop-windows-x64.exe
 
+      # The raw exe imports the Visual C++ runtime, which Windows does not
+      # include, so on a clean PC it exits 0xC0000135 printing nothing (#657).
+      # The NSIS installer carries the runtime via bundle.resources; anyone
+      # taking the bare binary gets nothing. Publish a zip that carries it too,
+      # and keep the bare exe for existing links.
+      - name: Package the raw desktop binary with its runtime
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $stage = 'minutes-desktop-windows-x64'
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item 'minutes-desktop-windows-x64.exe' (Join-Path $stage 'minutes-app.exe') -Force
+          # build.rs already staged these next to the crate for the bundle.
+          $staged = Get-ChildItem 'tauri/src-tauri/vcruntime140*.dll','tauri/src-tauri/msvcp140*.dll' -ErrorAction SilentlyContinue
+          if (-not $staged) { throw 'build.rs staged no runtime DLLs; the desktop zip would repeat #657' }
+          $staged | ForEach-Object { Copy-Item $_.FullName $stage -Force }
+          Compress-Archive -Path "$stage/*" -DestinationPath 'minutes-desktop-windows-x64.zip' -Force
+          Write-Host ("desktop zip MB: {0:N2}" -f ((Get-Item 'minutes-desktop-windows-x64.zip').Length/1MB))
+
       - name: Rename NSIS installer
         shell: bash
         run: |
@@ -141,6 +160,7 @@ jobs:
           name: minutes-desktop-windows-x64
           path: |
             minutes-desktop-windows-x64.exe
+            minutes-desktop-windows-x64.zip
             minutes-desktop-windows-x64-setup.exe
           if-no-files-found: error
 
@@ -150,4 +170,5 @@ jobs:
         with:
           files: |
             minutes-desktop-windows-x64.exe
+            minutes-desktop-windows-x64.zip
             minutes-desktop-windows-x64-setup.exe

--- a/README.md
+++ b/README.md
@@ -787,8 +787,20 @@ cargo install --path crates/cli
 
 ### Windows
 
+Download **`minutes-windows-x64.zip`** from the
+[latest release](https://github.com/silverstein/minutes/releases/latest), unzip
+it, and run `minutes.exe` from the unzipped folder.
+
+Use the zip rather than the bare `minutes-windows-x64.exe`. Minutes is built
+with MSVC and imports the Visual C++ runtime, which is not part of Windows. On
+a PC that has never had the Visual C++ Redistributable installed the bare
+executable exits immediately and prints nothing at all. The zip carries those
+runtime files beside the executable, so it works on a fresh machine with no
+install step and no admin rights. Keep the DLLs next to `minutes.exe` when you
+move it.
+
 ```powershell
-# Download pre-built binary from GitHub releases, or build from source:
+# Or build from source:
 # Requires: Rust, cmake, MSVC build tools, LLVM (for libclang)
 
 # Install LLVM (needed by whisper-rs bindgen):
@@ -1069,6 +1081,8 @@ cargo tauri build --ci --bundles nsis --no-sign
 ```
 
 Tagged GitHub releases can include both a Windows NSIS installer as `minutes-desktop-windows-x64-setup.exe` and a raw desktop binary as `minutes-desktop-windows-x64.exe`. The installer is currently unsigned, so treat it as an advanced-user / preview distribution surface until Windows signing is added.
+
+**Use the installer, not the raw binary.** The desktop app imports the Visual C++ runtime, which Windows does not include. The installer places those runtime files beside the executable; the raw `.exe` does not carry them, so on a PC without the Visual C++ Redistributable it exits immediately with no message (#657).
 
 The desktop app adds a system tray icon, recording controls, audio visualizer, Recall, and a meeting list window. The current Windows desktop build covers recording, transcription, search, settings, and Recall. Calendar suggestions, call detection, tray copy/paste automation, and the native dictation hotkey remain macOS-only for now.
 

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2689;
+export const MINUTES_TEST_COUNT = 2690;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Three gaps left by #660, all found by adversarial review.

## 1. The DLL guard validated its own copy loop

```powershell
$have = (Get-ChildItem "$stage\*.dll").Count
if ($have -ne 4) { throw ... }
```

That counts the four files the step just copied. It never inspects the binary. The four names were derived empirically from one build, so any dependency adding an import — `MSVCP140_2.dll` (C++17 special math), `MSVCP140_ATOMIC_WAIT.dll` (C++20 atomic wait), both routine for a C++ toolchain like ggml/whisper.cpp — reproduces #657 with a green job and a green guard.

Now it runs `dumpbin /dependents` on the staged binary, selects every import the redistributable supplies (`vcruntime*`, `msvcp*`, `concrt*`), and fails naming any that are missing from the archive. It also fails if the scan finds **no** runtime imports, so a broken parse cannot pass silently.

## 2. The README sent Windows users to the binary that does not work

`README.md:791` said "Download pre-built binary from GitHub releases". The only prebuilt CLI there was `minutes-windows-x64.exe` — the artifact that exits `0xC0000135` printing nothing on a clean PC. #660 shipped the zip but changed no user-facing docs, so every human following the README still got the broken one.

Now points at `minutes-windows-x64.zip`, explains why in plain terms, and tells people to keep the DLLs beside the executable when moving it.

## 3. The raw desktop exe still shipped with no runtime

#663 fixes the NSIS installer, but `release-windows-desktop.yml` also publishes `minutes-desktop-windows-x64.exe` — which is the exact artifact I used to demonstrate the bug in that PR's own description.

Adds `minutes-desktop-windows-x64.zip` carrying the runtime, keeps the bare exe so existing links do not break, and documents which to use. The packaging step throws if `build.rs` staged nothing, rather than shipping a zip that repeats the bug.

## Note

The desktop zip depends on #663's `build.rs` staging, so merge that first.