### PR TITLE
fix(windows): repair the auto-installer and restore the app's skill bundle

### DIFF
--- a/crates/mcp/src/autoInstall.test.ts
+++ b/crates/mcp/src/autoInstall.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   downloadReleaseBinaryWithChecksum,
+  extractZipWithPowerShell,
   findSha256ForAsset,
   parseSha256Sums,
 } from "./autoInstall.js";
@@ -109,5 +110,80 @@ describe("downloadReleaseBinaryWithChecksum", () => {
       })
     ).rejects.toThrow("checksum mismatch");
     await expect(stat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("extractZipWithPowerShell", () => {
+  function capture() {
+    const calls: Array<{
+      file: string;
+      args: readonly string[];
+      options?: { timeout?: number; env?: NodeJS.ProcessEnv };
+    }> = [];
+    const execFileAsync = async (
+      file: string,
+      args: readonly string[],
+      options?: { timeout?: number; env?: NodeJS.ProcessEnv }
+    ) => {
+      calls.push({ file, args, options });
+      return undefined;
+    };
+    return { calls, execFileAsync };
+  }
+
+  it("passes both paths through the environment, not the command text", async () => {
+    const { calls, execFileAsync } = capture();
+    await extractZipWithPowerShell({
+      archivePath: "C:\\Users\\qa\\.minutes\\bin\\minutes-windows-x64.zip",
+      destDir: "C:\\Users\\qa\\.minutes\\bin",
+      execFileAsync,
+    });
+
+    expect(calls).toHaveLength(1);
+    const [call] = calls;
+    expect(call.file).toBe("powershell");
+    expect(call.options?.env?.MINUTES_ZIP_PATH).toBe(
+      "C:\\Users\\qa\\.minutes\\bin\\minutes-windows-x64.zip"
+    );
+    expect(call.options?.env?.MINUTES_ZIP_DEST).toBe("C:\\Users\\qa\\.minutes\\bin");
+  });
+
+  it("never reads $args, which -Command leaves empty", async () => {
+    const { calls, execFileAsync } = capture();
+    await extractZipWithPowerShell({
+      archivePath: "C:\\tmp\\a.zip",
+      destDir: "C:\\tmp\\out",
+      execFileAsync,
+    });
+
+    const { args } = calls[0];
+    const commandIndex = args.indexOf("-Command");
+    expect(commandIndex).toBeGreaterThanOrEqual(0);
+    const script = args[commandIndex + 1];
+
+    // `powershell -Command` appends trailing arguments to the command text and
+    // leaves $args empty; only -File binds them. Reading $args[0] made every
+    // Windows install fail with "argument is null or empty".
+    expect(script).not.toContain("$args");
+    expect(script).toContain("$env:MINUTES_ZIP_PATH");
+    expect(script).toContain("$env:MINUTES_ZIP_DEST");
+
+    // Nothing may follow the script, or it lands in the command text.
+    expect(args).toHaveLength(commandIndex + 2);
+  });
+
+  it("keeps an apostrophe home directory out of the command text", async () => {
+    const { calls, execFileAsync } = capture();
+    const home = "C:\\Users\\O'Brien\\.minutes\\bin";
+    await extractZipWithPowerShell({
+      archivePath: `${home}\\minutes-windows-x64.zip`,
+      destDir: home,
+      execFileAsync,
+    });
+
+    const { args, options } = calls[0];
+    const script = args[args.indexOf("-Command") + 1];
+    expect(script).not.toContain("O'Brien");
+    expect(options?.env?.MINUTES_ZIP_DEST).toBe(home);
   });
 });

--- a/crates/mcp/src/autoInstall.ts
+++ b/crates/mcp/src/autoInstall.ts
@@ -5,7 +5,7 @@ import { readFile, rename, rm } from "fs/promises";
 type ExecFileAsync = (
   file: string,
   args: readonly string[],
-  options?: { timeout?: number }
+  options?: { timeout?: number; env?: NodeJS.ProcessEnv }
 ) => Promise<unknown>;
 
 export type Sha256Entry = {
@@ -57,6 +57,47 @@ export async function verifyDownloadedAsset(
       `checksum mismatch: expected ${expectedSha256.toLowerCase()}, got ${actual}`
     );
   }
+}
+
+/**
+ * Extract a zip on Windows via PowerShell's Expand-Archive.
+ *
+ * The paths travel in the environment, never in the command text. Two ways to
+ * get this wrong, both of which shipped:
+ *
+ * - Interpolating into a single-quoted PowerShell string breaks on a home
+ *   directory containing an apostrophe (`C:\Users\O'Brien`).
+ * - Passing them as trailing arguments and reading `$args[0]` does not work at
+ *   all: `powershell -Command` appends trailing arguments to the command text
+ *   and leaves `$args` empty (only `-File` binds them), so `$args[0]` is
+ *   `$null` and `Expand-Archive` rejects the parameter on every machine.
+ *
+ * `$env:` lookups are read at runtime and are never parsed as script, so no
+ * value of either path can alter the command.
+ */
+export async function extractZipWithPowerShell(options: {
+  archivePath: string;
+  destDir: string;
+  execFileAsync: ExecFileAsync;
+}): Promise<void> {
+  const { archivePath, destDir, execFileAsync } = options;
+  await execFileAsync(
+    "powershell",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "Expand-Archive -Path $env:MINUTES_ZIP_PATH -DestinationPath $env:MINUTES_ZIP_DEST -Force",
+    ],
+    {
+      timeout: 120000,
+      env: {
+        ...process.env,
+        MINUTES_ZIP_PATH: archivePath,
+        MINUTES_ZIP_DEST: destDir,
+      },
+    }
+  );
 }
 
 export async function downloadReleaseBinaryWithChecksum(options: {

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -90,7 +90,10 @@ import {
   probeCapabilitiesSync,
   type CapabilityProbeResult,
 } from "./capabilities.js";
-import { downloadReleaseBinaryWithChecksum } from "./autoInstall.js";
+import {
+  downloadReleaseBinaryWithChecksum,
+  extractZipWithPowerShell,
+} from "./autoInstall.js";
 import {
   attachCaptureRelay,
   type CaptureRelayCursor,
@@ -2320,21 +2323,11 @@ async function tryAutoInstallAttempt(capabilityRepair: boolean = false): Promise
           targetPath: archivePath,
           execFileAsync,
         });
-        // Paths arrive as arguments rather than interpolated into the script
-        // text, so a home directory containing an apostrophe (C:\\Users\\O'Brien)
-        // cannot break or alter the command.
-        await execFileAsync(
-          "powershell",
-          [
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "Expand-Archive -Path $args[0] -DestinationPath $args[1] -Force",
-            archivePath,
-            installDir,
-          ],
-          { timeout: 120000 },
-        );
+        await extractZipWithPowerShell({
+          archivePath,
+          destDir: installDir,
+          execFileAsync,
+        });
         await rm(archivePath, { force: true });
         // Confirm the extraction actually produced the binary. The POSIX path
         // gets this for free from rename(); without it a changed archive

--- a/tauri/src-tauri/tauri.windows.conf.json
+++ b/tauri/src-tauri/tauri.windows.conf.json
@@ -13,6 +13,7 @@
       }
     },
     "resources": [
+      "resources/assistant-skill-bundle/**/*",
       "vcruntime140*.dll",
       "msvcp140*.dll"
     ]


### PR DESCRIPTION
Two regressions from this week's Windows work, both introduced by PRs I merged, both found by re-reviewing those PRs.

## 1. The MCP auto-installer never extracted anything (#667)

#667 changed the paths from interpolated to trailing arguments read via `$args[0]`, to protect a home directory containing an apostrophe. That does not work at all:

```
powershell -NoProfile -Command "Write-Host ('argsCount=' + $args.Count)" AAA BBB
argsCount=0
```

`powershell -Command` appends trailing arguments to the command **text**; only `-File` binds `$args`. So `$args[0]` was `$null` and `Expand-Archive` rejected the parameter. A fix for a rare case became a 100% failure of the download strategy, which then fell through to Homebrew (macOS only) and `cargo install` (needs Rust). Windows users got nothing.

Verified both directions on the Windows 11 VM, extracting into `C:\...\O'Brien\.minutes\bin`:

| form | result | extracted |
|---|---|---|
| `$args[0]` (shipped in #667) | FAILED, `Cannot validate argument on parameter 'Path'. The argument is null or empty.` | nothing |
| `$env:` (this PR) | exit 0 | `minutes.exe`, `vcruntime140.dll` |

The paths now travel in the environment. `$env:` lookups are read at runtime and never parsed as script, so no path value can alter the command, and the apostrophe case #667 targeted still works.

### Coverage

This path had none, which is why a total failure shipped. Extracted into `autoInstall.ts` behind the same injected-`execFileAsync` seam the download path already uses, with three tests. Confirmed they fail against the shipped implementation before restoring the fix:

```
× passes both paths through the environment, not the command text
× never reads $args, which -Command leaves empty
× keeps an apostrophe home directory out of the command text
Tests  3 failed | 5 passed (8)
```

## 2. The Windows app silently lost its assistant skill bundle (#663)

Tauri merges platform config using RFC 7396 JSON Merge Patch, where a non-object value replaces wholesale rather than appending. Adding a `bundle.resources` array for the runtime DLLs therefore dropped the inherited entry:

```
base    bundle.resources: ["resources/assistant-skill-bundle/**/*"]
WINDOWS effective       : ["vcruntime140*.dll", "msvcp140*.dll"]
MACOS   effective       : ["resources/assistant-skill-bundle/**/*"]
```

`tauri.macos.conf.json` re-declares the same glob, which is exactly what the Windows file should have done.

Downstream, `bundled_assistant_skill_bundle()` finds nothing and `sync_assistant_skill_mirrors` returns `Ok(())` silently, so a Windows assistant workspace gets no `.agents/skills`, `.opencode/skills` or `.opencode/commands`, with no error. CI could not have caught it: the desktop unit tests are gated on `runner.os == 'macOS'`.

`stage_assistant_skill_bundle()` runs unconditionally in `build.rs:10`, so the glob resolves on Windows and does not trip Tauri's unmatched-glob error.