### PR TITLE
fix(ci): cover clippy.toml, stop billing TypeScript PRs for the Rust matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,25 @@ jobs:
           filters: |
             rust:
               - 'tauri/**'
-              - 'crates/**'
+              # Enumerated, not 'crates/**'. crates/mcp and crates/sdk are npm
+              # packages, not workspace members: neither has a Cargo.toml and
+              # between them they hold zero .rs files, so 'crates/**' ran
+              # test x3, install x2, the Linux full build and the Windows
+              # desktop installer on every TypeScript-only PR.
+              #
+              # Negation entries ('!crates/mcp/**') cannot do this: the action
+              # compiles each pattern separately, and a lone negated pattern
+              # matches every file outside its own subtree, which would make the
+              # filter always true. scripts/check_ci_rust_filter.mjs keeps this
+              # list in step with the workspace members instead.
+              - 'crates/core/**'
+              - 'crates/cli/**'
+              - 'crates/reader/**'
+              - 'crates/whisper-guard/**'
+              - 'crates/archive-convert/**'
+              - 'crates/archive-core/**'
+              - 'crates/archive-ocr/**'
+              - 'crates/archive-semantic/**'
               - 'archive/**'
               - 'tests/**'
               # Declared as build inputs by tauri/src-tauri/build.rs via
@@ -43,6 +61,11 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              # Workspace lint policy (disallowed-methods). `cargo clippy --all
+              # -- -D warnings` runs only inside the filtered test job, so
+              # without this a PR editing lint policy skipped every Rust job and
+              # reported green. crates/core/clippy.toml is covered by crates/**.
+              - 'clippy.toml'
               # Sets rustflags and build env per target, so it changes how every
               # Rust target compiles. Omitting it meant a change that statically
               # linked the Windows CRT skipped every Rust job and reported green
@@ -501,11 +524,17 @@ jobs:
       - name: Verify corpus lease mirror
         run: node scripts/check_corpus_lease_mirror.mjs
 
+      - name: Verify CI rust filter covers every workspace member
+        run: node scripts/check_ci_rust_filter.mjs
+
       - name: Test version policy checker
         run: node --test scripts/check_version_sync.test.mjs
 
       - name: Test optional Git hook setup
         run: node --test scripts/setup_hooks.test.mjs
+
+      - name: Test CI rust filter guard
+        run: node --test scripts/check_ci_rust_filter.test.mjs
 
       - name: Test transactional version bump
         run: node --test scripts/bump_version.test.mjs

--- a/scripts/check_ci_rust_filter.mjs
+++ b/scripts/check_ci_rust_filter.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Assert that CI's `rust` path filter covers every Cargo workspace member.
+ *
+ * The filter decides whether the Rust jobs run at all. When it drifts, a PR
+ * touching Rust skips every Rust job and reports green -- which is how a change
+ * that statically linked the Windows CRT sailed through (#657 follow-up).
+ *
+ * The obvious fix, a blanket 'crates/**', overshoots: crates/mcp and crates/sdk
+ * are npm packages with no Cargo.toml, so every TypeScript-only PR paid for
+ * test x3, install x2, a full Linux build and the Windows desktop installer.
+ * Negation entries cannot trim it back either -- the action compiles each
+ * pattern on its own, and a lone '!crates/mcp/**' matches every file outside
+ * that subtree, turning the filter always-on.
+ *
+ * So the filter enumerates, and this script is the thing that stops the
+ * enumeration going stale: add a workspace member without listing it and CI
+ * fails here rather than silently skipping the Rust jobs forever.
+ */
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Workspace member paths from the root Cargo.toml. */
+function workspaceMembers() {
+  const raw = readFileSync(join(repoRoot, "Cargo.toml"), "utf8");
+  const block = raw.match(/^\s*members\s*=\s*\[([\s\S]*?)\]/m);
+  if (!block) throw new Error("Cargo.toml has no [workspace] members array");
+  return [...block[1].matchAll(/["']([^"']+)["']/g)].map((m) => m[1]);
+}
+
+/** Patterns listed under the `rust:` filter in ci.yml. */
+function rustFilterPatterns() {
+  const raw = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  const lines = raw.split(/\r?\n/);
+  const start = lines.findIndex((l) => /^\s*rust:\s*$/.test(l));
+  if (start === -1) throw new Error("ci.yml has no `rust:` filter");
+
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const patterns = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    // Dedent to or past the `rust:` key ends the block.
+    if (line.match(/^\s*/)[0].length <= indent) break;
+    const entry = line.match(/^\s*-\s*['"]?([^'"]+)['"]?\s*$/);
+    if (entry) patterns.push(entry[1].trim());
+  }
+  if (patterns.length === 0) throw new Error("`rust:` filter is empty");
+  return patterns;
+}
+
+/**
+ * Does any pattern cover this member's files?
+ *
+ * Only prefix globs count. A pattern like 'crates/core/**' covers
+ * 'crates/core' and anything below it.
+ */
+function coveredBy(member, patterns) {
+  return patterns.some((pattern) => {
+    if (pattern.startsWith("!")) return false;
+    if (!pattern.endsWith("/**")) return pattern === `${member}/Cargo.toml`;
+    const prefix = pattern.slice(0, -3);
+    return member === prefix || member.startsWith(`${prefix}/`);
+  });
+}
+
+const members = workspaceMembers();
+const patterns = rustFilterPatterns();
+const missing = members.filter((m) => !coveredBy(m, patterns));
+
+if (missing.length > 0) {
+  console.error("CI's `rust` path filter does not cover every workspace member.");
+  console.error("");
+  for (const m of missing) console.error(`  uncovered: ${m}`);
+  console.error("");
+  console.error("A PR touching those crates would skip every Rust job and report green.");
+  console.error("Add the member to the `rust:` filter in .github/workflows/ci.yml:");
+  for (const m of missing) console.error(`  - '${m}/**'`);
+  process.exit(1);
+}
+
+console.log(
+  `CI rust filter covers all ${members.length} workspace members ` +
+    `(${patterns.length} patterns).`
+);

--- a/scripts/check_ci_rust_filter.test.mjs
+++ b/scripts/check_ci_rust_filter.test.mjs
@@ -1,0 +1,117 @@
+import { execFileSync } from "child_process";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const script = join(repoRoot, "scripts/check_ci_rust_filter.mjs");
+
+/**
+ * Run the guard against a throwaway repo whose Cargo.toml and ci.yml we control,
+ * so a test can make the filter stale without touching the real ones.
+ */
+function runAgainst({ members, patterns }) {
+  const dir = mkdtempSync(join(tmpdir(), "rust-filter-"));
+  try {
+    mkdirSync(join(dir, ".github/workflows"), { recursive: true });
+    mkdirSync(join(dir, "scripts"), { recursive: true });
+    cpSync(script, join(dir, "scripts/check_ci_rust_filter.mjs"));
+
+    const memberList = members.map((m) => `    "${m}",`).join("\n");
+    writeFileSync(
+      join(dir, "Cargo.toml"),
+      `[workspace]\nresolver = "2"\nmembers = [\n${memberList}\n]\n`
+    );
+
+    const patternList = patterns.map((p) => `              - '${p}'`).join("\n");
+    writeFileSync(
+      join(dir, ".github/workflows/ci.yml"),
+      [
+        "jobs:",
+        "  changes:",
+        "    steps:",
+        "      - uses: dorny/paths-filter@v4",
+        "        with:",
+        "          filters: |",
+        "            rust:",
+        patternList,
+        "            other:",
+        "              - 'site/**'",
+        "",
+      ].join("\n")
+    );
+
+    try {
+      const stdout = execFileSync(process.execPath, [join(dir, "scripts/check_ci_rust_filter.mjs")], {
+        cwd: dir,
+        encoding: "utf8",
+      });
+      return { code: 0, output: stdout };
+    } catch (error) {
+      return { code: error.status, output: `${error.stdout || ""}${error.stderr || ""}` };
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("passes when every member is covered", () => {
+  const result = runAgainst({
+    members: ["crates/core", "crates/cli", "tauri/src-tauri"],
+    patterns: ["crates/core/**", "crates/cli/**", "tauri/**"],
+  });
+  assert.equal(result.code, 0, result.output);
+  assert.match(result.output, /covers all 3 workspace members/);
+});
+
+test("fails and names the member when the filter goes stale", () => {
+  const result = runAgainst({
+    members: ["crates/core", "crates/cli", "crates/whisper-guard"],
+    patterns: ["crates/core/**", "crates/cli/**"],
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.output, /uncovered: crates\/whisper-guard/);
+  assert.match(result.output, /- 'crates\/whisper-guard\/\*\*'/);
+});
+
+test("a parent glob covers nested members", () => {
+  const result = runAgainst({
+    members: ["archive/src-tauri"],
+    patterns: ["archive/**"],
+  });
+  assert.equal(result.code, 0, result.output);
+});
+
+test("a negated pattern never counts as coverage", () => {
+  // The action compiles each pattern separately, so '!crates/mcp/**' matches
+  // every file outside that subtree rather than excluding it. Treating one as
+  // coverage would hide exactly the gap this guard exists to catch.
+  const result = runAgainst({
+    members: ["crates/core"],
+    patterns: ["!crates/mcp/**"],
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.output, /uncovered: crates\/core/);
+});
+
+test("the real repo satisfies the guard", () => {
+  const output = execFileSync(process.execPath, [script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.match(output, /covers all \d+ workspace members/);
+});
+
+test("the real filter does not list the npm packages", () => {
+  const ci = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  const rustBlock = ci.slice(ci.indexOf("rust:"), ci.indexOf("  test:"));
+  // crates/mcp and crates/sdk have no Cargo.toml and no .rs files; a blanket
+  // 'crates/**' made every TypeScript PR run the full Rust matrix.
+  assert.ok(
+    !/^\s*-\s*'crates\/\*\*'\s*$/m.test(rustBlock),
+    "ci.yml rust filter should enumerate Rust crates, not use a blanket crates/** glob"
+  );
+});


### PR DESCRIPTION
Two problems with the `rust` path filter, both introduced or left behind by #666.

## 1. Workspace lint policy is still a blind spot

`clippy.toml` at the repo root configures `disallowed-methods` for the whole workspace. `cargo clippy --all -- -D warnings` runs only inside the filtered `test` job, so a PR editing lint policy skipped every Rust job and reported green. That is the same class of gap #666 set out to close. `crates/core/clippy.toml` was already covered; the root one was not.

## 2. Broadening to `crates/**` overshot

`crates/mcp` and `crates/sdk` are npm packages, not workspace members:

```
crates/mcp: Cargo.toml=NO  package.json=yes  0 .rs files
crates/sdk: Cargo.toml=NO  package.json=yes  0 .rs files
```

Every TypeScript-only PR was running test x3, install x2, the Linux full build and the Windows desktop installer for nothing.

### Why not `!crates/mcp/**`

Because it does the opposite of what it looks like. The action compiles each pattern separately, so a lone negated pattern matches every file *outside* its own subtree:

```
!crates/mcp/** matches crates/core/src/lib.rs      = true
!crates/mcp/** matches crates/mcp/src/index.ts     = false
```

Dropped into an OR'd pattern list that makes the filter permanently true, which fails open and silently. I wrote the negation version first and only caught this by testing it against picomatch, so the reasoning is now a comment in the file and an assertion in the tests.

## The fix

The filter enumerates the Rust crates again, and a new guard keeps the enumeration from going stale, which was the real reason to reach for a blanket glob.

`scripts/check_ci_rust_filter.mjs` reads workspace members from `Cargo.toml`, checks each is covered by a filter pattern, and on failure names the member and prints the line to add:

```
CI's `rust` path filter does not cover every workspace member.

  uncovered: crates/whisper-guard

A PR touching those crates would skip every Rust job and report green.
Add the member to the `rust:` filter in .github/workflows/ci.yml:
  - 'crates/whisper-guard/**'
```

It runs in `version_sync`, which has no `if:` condition, so it cannot be skipped by the very filter it checks.

## Verification

Confirmed the guard fails on a stale filter by removing `crates/whisper-guard` and re-running (output above). 6 unit tests cover the pass case, the stale case, nested members like `archive/src-tauri`, the negation trap, the real repo, and a regression assert that the filter never goes back to a blanket `crates/**`.