### PR TITLE
fix(windows): match the release CRT lookup to build.rs, stamp staged arch

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -133,9 +133,18 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $crt = Get-ChildItem 'C:\Program Files*\Microsoft Visual Studio\2022\*\VC\Redist\MSVC\*\x64\Microsoft.VC143.CRT' -Directory -ErrorAction SilentlyContinue |
-                 Sort-Object FullName -Descending | Select-Object -First 1
-          if (-not $crt) { throw 'Could not locate the VC143 CRT redistributable on the runner' }
+          # Same lookup rules as tauri/src-tauri/build.rs find_vc_redist_dir.
+          # Any VS year, any Microsoft.VC<major>.CRT, ordered by the parsed
+          # redist version rather than by path text: the edition segment sits
+          # ahead of the version in the path, so `Sort-Object FullName` picked
+          # Professional 14.29 over Community 14.44 on a box with both. Pinning
+          # '2022' and 'VC143' would also silently stop matching the next
+          # toolset.
+          $crt = Get-ChildItem 'C:\Program Files*\Microsoft Visual Studio\*\*\VC\Redist\MSVC\*\x64\Microsoft.VC*.CRT' -Directory -ErrorAction SilentlyContinue |
+                 Where-Object { $_.Parent.Parent.Name -match '^\d+(\.\d+)*$' } |
+                 Sort-Object @{ Expression = { [version]$_.Parent.Parent.Name } } -Descending |
+                 Select-Object -First 1
+          if (-not $crt) { throw 'Could not locate a VC CRT redistributable on the runner' }
           Write-Host "CRT source: $($crt.FullName)"
           $stage = 'minutes-windows-x64'
           New-Item -ItemType Directory -Force -Path $stage | Out-Null

--- a/tauri/src-tauri/.gitignore
+++ b/tauri/src-tauri/.gitignore
@@ -1,3 +1,6 @@
 # Staged by CI for Windows bundles; never committed (#657).
 vcruntime140*.dll
 msvcp140*.dll
+# Records which architecture the staged DLLs above were copied for, so an
+# x86_64 build followed by an aarch64 build re-stages instead of reusing them.
+.msvc-runtime-stage.stamp

--- a/tauri/src-tauri/build.rs
+++ b/tauri/src-tauri/build.rs
@@ -57,11 +57,24 @@ fn stage_msvc_runtime() {
         );
     }
 
-    if RUNTIME_DLLS.iter().all(|d| manifest_dir.join(d).exists()) {
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".into());
+
+    // The DLLs have fixed names and land in the manifest dir, which is shared
+    // across targets, so "the files exist" says nothing about which
+    // architecture they are. Without the stamp, building x86_64 and then
+    // aarch64 in the same checkout ships x64 CRT DLLs inside an ARM64
+    // installer, which fails exactly like #657 on the user's machine. The
+    // stamp also forces a refresh after a toolset upgrade moves the source.
+    let stamp_path = manifest_dir.join(".msvc-runtime-stage.stamp");
+    println!("cargo:rerun-if-changed={}", stamp_path.display());
+
+    let staged = RUNTIME_DLLS.iter().all(|d| manifest_dir.join(d).exists());
+    let stamp_matches = std::fs::read_to_string(&stamp_path)
+        .is_ok_and(|recorded| recorded.trim() == stage_stamp(&arch));
+    if staged && stamp_matches {
         return;
     }
 
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".into());
     let Some(redist) = find_vc_redist_dir(&arch) else {
         // Deliberately a warning, not a panic. The compiler toolset and the
         // redistributable are separate Visual Studio components, so a Build
@@ -77,15 +90,33 @@ fn stage_msvc_runtime() {
         );
         return;
     };
+    let mut staged_all = true;
     for dll in RUNTIME_DLLS {
         let src = redist.join(dll);
         if let Err(error) = std::fs::copy(&src, manifest_dir.join(dll)) {
+            staged_all = false;
             println!(
                 "cargo:warning=failed to stage {} for the Windows bundle: {error}",
                 src.display()
             );
         }
     }
+
+    // Only record the stamp once every file is in place, so a partial copy
+    // re-stages next build instead of being cached as complete.
+    if staged_all {
+        let _ = std::fs::write(&stamp_path, stage_stamp(&arch));
+    } else {
+        let _ = std::fs::remove_file(&stamp_path);
+    }
+}
+
+/// Identity of a staged runtime set: which architecture it was copied for.
+///
+/// Compared as text, so extending it later (toolset version, source path)
+/// simply invalidates every existing stamp and re-stages.
+fn stage_stamp(arch: &str) -> String {
+    format!("arch={arch}\n")
 }
 
 /// Newest `Microsoft.VC*.CRT` directory for `arch` from any installed Visual


### PR DESCRIPTION
Two leftovers from the #657 series, found by re-reviewing #663 and #668.

## 1. The release workflow kept the bug #663 fixed in Rust

`release-cli.yml` still hardcoded `\2022\` and `Microsoft.VC143.CRT`, and still did `Sort-Object FullName -Descending`. That is the exact edition-sorts-ahead-of-version bug `build.rs` was changed to avoid, 17 lines above the guard #668 added.

Reproduced on the Windows VM with two editions present:

```
TEXT SORT picks:    14.29.30133   (Professional)
VERSION SORT picks: 14.44.35112   (Community)
```

Pinning the year and `VC143` is also a slow trap: it silently stops matching once the toolset moves on, and `throw` at release time is when you'd find out. The workflow now applies `build.rs`'s rules: any VS year, any `Microsoft.VC<major>.CRT`, ordered by parsed version.

## 2. `build.rs` staging was arch-blind

The early return treated "the four DLLs exist" as proof they were staged. The names are fixed and `CARGO_MANIFEST_DIR` is shared across targets, so building `x86_64-pc-windows-msvc` and then `aarch64-pc-windows-msvc` in one checkout bundles x64 CRT DLLs into the ARM64 installer, which reproduces #657 on the user's machine while the build stays green. `find_vc_redist_dir` already maps `aarch64` to `arm64`, so the source was right and only the cache check was wrong.

A `.msvc-runtime-stage.stamp` now records the architecture the staged set was copied for. It is written only after every copy succeeds, so a partial stage re-runs next build instead of being cached as complete, and it is declared via `rerun-if-changed` alongside the DLLs. Gitignored next to them.

## Verification

On the Windows 11 VM (Build Tools 2022, 14.44.35112):

- the new glob resolves the redist directory and all four DLLs are present
- `dumpbin` is discovered at the `Hostx64\x64` path the workflow globs
- the import-table regex parses a real PE correctly: 9 imports read, `VCRUNTIME140.dll` matched by the `^(vcruntime|msvcp|concrt)` filter

That last point matters because this guard has never executed in CI. `release-cli.yml` only runs on `v*` tags, so the glob, the sort and the parse would otherwise first run at a tag push, where a mistake blocks the release. They now have one real execution behind them.

Note the VM has a single VS edition installed, so it does not reproduce the sort bug directly; the sort comparison above is a synthetic two-edition case run through the same PowerShell expression.