### PR TITLE
fix(release): make the site test count binding at tag time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,9 @@ jobs:
       - name: Test committed release flow
         run: node --test scripts/release.test.mjs
 
+      - name: Test site release constant sync modes
+        run: node --test scripts/sync_site_release_version.test.mjs
+
   design_tokens:
     name: Design Tokens
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Verify committed release invariants
         run: node scripts/check_version_sync.mjs --release
 
+      # Per-PR CI tolerates a stale test count so a number that moves whenever
+      # anyone adds a test cannot redden everyone's checks (#666). Nothing
+      # refreshes it automatically though, so it is binding here instead: a
+      # release should not publish a figure that has been drifting for weeks.
+      - name: Verify site release constants including the test count
+        run: node scripts/sync_site_release_version.mjs --check-release
+
   build:
     name: Build (${{ matrix.target }})
     needs: release_readiness

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -35,6 +35,11 @@ git log "$LAST_PUBLISH_COMMIT"..HEAD -- crates/whisper-guard/   # any commits �
 - Tools in `manifest.json` match tools registered in `crates/mcp/src/index.ts`
 - `long_description` reflects current capabilities
 - `keywords` are current
+- Regenerate the site constants and commit the result:
+  ```bash
+  node scripts/sync_site_release_version.mjs
+  ```
+  Per-PR CI tolerates a stale `MINUTES_TEST_COUNT` so a number that moves with every added test cannot redden unrelated checks (#666), but `release_readiness` runs `--check-release` at tag push and that tolerance does not apply. Do this before Step 10 or the tag fails. Step 15 refreshes the prose after publishing; this is the numbers, before tagging.
 
 ### 3. MCP runtime deps
 All `import` statements in `crates/mcp/src/index.ts` must have their packages in `dependencies` (not `devDependencies`) in `package.json`. Smoke-test: `node -e "require('./crates/mcp/dist/index.js')"`
@@ -207,7 +212,7 @@ Before deploying, make sure the site matches what just shipped:
    ```bash
    node scripts/sync_site_release_version.mjs
    ```
-   The `Site Release Link Consistency` CI job runs this with `--check` on every push, so forgetting this step also blocks CI — but running it locally first saves a round-trip and surfaces drift before tagging.
+   The `Site Release Link Consistency` CI job runs this with `--check` on every push, which allows a stale test count through so unrelated PRs do not go red (#666). `release_readiness` runs `--check-release` at tag push and does not, so the numbers should already be current from Step 2; this step is for anything that changed since.
 2. **Hand-update the prose** — the changelog strip and headline feature blurb in `site/app/page.tsx`, plus `docs/architecture/frontmatter-schema.md`'s "corresponds to" footer if the schema row moved. The sync script handles numbers; it cannot rewrite copy that references last release's headline features.
 3. **Refresh social proof + comparison freshness** — update `site/lib/proof.ts` (stars/forks/contributors from the GitHub API, npm monthly downloads from `api.npmjs.org`) and spot-check the homepage comparison table cells plus `/compare/*` pages against competitors' current public docs. Competitor capabilities drift; stale cells cost more credibility than they buy.
 4. **Build the exact static artifact**:

--- a/scripts/sync_site_release_version.mjs
+++ b/scripts/sync_site_release_version.mjs
@@ -13,6 +13,11 @@ const cliMainPath = path.join(repoRoot, "crates", "cli", "src", "main.rs");
 const mcpSourcePath = path.join(repoRoot, "crates", "mcp", "src", "index.ts");
 const cratesDir = path.join(repoRoot, "crates");
 const checkOnly = process.argv.includes("--check");
+// Release gate: like --check, but the test count is binding too. Ordinary PRs
+// should not go red over a number that moves whenever anyone adds a test; a
+// release that publishes the wrong number is a different matter, and tagging
+// is deliberate and infrequent, so the fix is one command at the right moment.
+const strict = process.argv.includes("--check-release");
 
 const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 const version = manifest.version;
@@ -186,7 +191,7 @@ if (currentContent === nextContent) {
   process.exit(0);
 }
 
-if (checkOnly) {
+if (checkOnly || strict) {
   // The test count is derived by scanning for #[test]/#[tokio::test], so it
   // moves whenever anyone adds a test. Comparing it for exact equality made a
   // shared, required check go red on main every time tests landed, and every
@@ -196,10 +201,17 @@ if (checkOnly) {
   // Release *links* are what this job is named for and what must be exact:
   // version, and the tool/resource/prompt/command counts that appear in
   // documented URLs. A slightly stale test count on a marketing page is not
-  // worth reddening everyone's CI, and the pre-push hook still refreshes it.
+  // worth reddening everyone's CI.
+  //
+  // Tolerating it per-PR does mean nothing refreshes it on its own: the
+  // pre-push hook only runs this same --check and never wrote the value, so
+  // after #666 the count could drift indefinitely with every gate green. So
+  // --check-release makes it binding at tag time, where the number actually
+  // gets published and one command fixes it.
   const staleOnlyByTestCount =
+    !strict &&
     currentContent.replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 0") ===
-    nextContent.replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 0");
+      nextContent.replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 0");
   if (staleOnlyByTestCount) {
     console.warn(
       `site release constants match except the test count (committed differs from ${totalTestCount}). ` +

--- a/scripts/sync_site_release_version.test.mjs
+++ b/scripts/sync_site_release_version.test.mjs
@@ -1,0 +1,89 @@
+import { spawnSync } from "child_process";
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const script = join(repoRoot, "scripts/sync_site_release_version.mjs");
+const releaseTs = join(repoRoot, "site/lib/release.ts");
+
+function run(args) {
+  // spawnSync, not execFileSync: the tolerated-drift path exits 0 and writes
+  // its warning to stderr, which execFileSync discards on success.
+  const result = spawnSync(process.execPath, [script, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return { code: result.status, output: `${result.stdout || ""}${result.stderr || ""}` };
+}
+
+/**
+ * Run `body` with release.ts temporarily edited, always restoring it.
+ *
+ * `edit` must actually change the file. A regex that quietly fails to match
+ * leaves the tree clean and the assertion then passes for the wrong reason,
+ * which is how the first version of these tests reported a false result.
+ */
+function withEditedReleaseTs(edit, body) {
+  const original = readFileSync(releaseTs, "utf8");
+  const edited = edit(original);
+  assert.notEqual(edited, original, "test edit did not change release.ts");
+  try {
+    writeFileSync(releaseTs, edited);
+    return body();
+  } finally {
+    writeFileSync(releaseTs, original);
+  }
+}
+
+test("--check tolerates a stale test count", () => {
+  const result = withEditedReleaseTs(
+    (s) => s.replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 1"),
+    () => run(["--check"]),
+  );
+  // A count that moves whenever anyone adds a test must not redden shared CI
+  // and every open PR with it (#664, #666).
+  assert.equal(result.code, 0, result.output);
+  assert.match(result.output, /except the test count/);
+});
+
+test("--check-release does not tolerate a stale test count", () => {
+  const result = withEditedReleaseTs(
+    (s) => s.replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 1"),
+    () => run(["--check-release"]),
+  );
+  // Nothing refreshes the count automatically, so without a binding gate
+  // somewhere it drifts indefinitely. Tag time is where it gets published.
+  assert.equal(result.code, 1);
+  assert.match(result.output, /out of sync/);
+});
+
+test("--check still fails when a release link constant drifts", () => {
+  const result = withEditedReleaseTs(
+    (s) => s.replace(/MINUTES_MCP_TOOL_COUNT = \d+/, "MINUTES_MCP_TOOL_COUNT = 999"),
+    () => run(["--check"]),
+  );
+  assert.equal(result.code, 1);
+  assert.match(result.output, /out of sync/);
+});
+
+test("--check fails when the version and the test count both drift", () => {
+  // The tolerance keys off "everything except the count is identical", so a
+  // combined change must not slip through on the count exemption.
+  const result = withEditedReleaseTs(
+    (s) =>
+      s
+        .replace(/MINUTES_TEST_COUNT = \d+/, "MINUTES_TEST_COUNT = 1")
+        .replace(/MINUTES_RELEASE_VERSION = "[^"]+"/, 'MINUTES_RELEASE_VERSION = "0.0.1"'),
+    () => run(["--check"]),
+  );
+  assert.equal(result.code, 1);
+  assert.match(result.output, /out of sync/);
+});
+
+test("both modes pass on a clean tree", () => {
+  assert.equal(run(["--check"]).code, 0);
+  assert.equal(run(["--check-release"]).code, 0);
+});

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2690;
+export const MINUTES_TEST_COUNT = 2691;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
Follow-up to #666, found by re-reviewing it.

## The gap

#666 stopped `--check` failing when only `MINUTES_TEST_COUNT` drifted, so a number that moves whenever anyone adds a test could not redden main and every open PR with it. That part was right and stays.

The compensating control is what did not exist. The commit said "the pre-push hook continues to refresh the value", and the code comment said the same. The hook only ever ran `--check` and printed a hint. It never wrote anything. After #666 that check returns 0 on count-only drift, so the hook went silent as well and nothing refreshes the number at all.

It had already drifted on main:

```
$ node scripts/sync_site_release_version.mjs --check
site release constants match except the test count (committed differs from 2691)...
EXIT=0                       # site/lib/release.ts said 2690
```

`check_version_sync.mjs --release`, the release gate, never looks at `release.ts` or the test count either. So the figure published on the landing page drifts indefinitely with every gate green.

## The fix

Keep the per-PR tolerance, drop it at the one moment the number gets published. `--check-release` behaves like `--check` except the test count is binding, and `release_readiness` in `release-cli.yml` runs it at tag push. Tagging is deliberate and infrequent, and the fix is one command.

```
--check          EXIT=0    site release constants match except the test count
--check-release  EXIT=1    site release constants are out of sync with source
```

Also in here: the count refreshed to 2691, the false claim corrected in the code comment, and the ordering documented in the release procedure. Step 15 refreshes site copy *after* publishing, so a note there alone would fire too late; Step 2 now regenerates the constants before tagging.

## Tests

This script had none. Five now:

- `--check` tolerates a count-only change
- `--check-release` does not
- `--check` still fails on a release link constant (`MINUTES_MCP_TOOL_COUNT`)
- neither tolerates a combined version + count change, so the exemption cannot be used as a carrier
- both pass on a clean tree

The harness asserts its own edit actually changed the file. The first version of these tests used `MINUTES_VERSION`, which does not exist (it is `MINUTES_RELEASE_VERSION`), so the regex silently matched nothing and the combined-drift test passed for the wrong reason.