### PR TITLE
fix(mcp): put ~/.minutes/bin on the child PATH, document the desktop zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,9 +1080,11 @@ cd tauri/src-tauri
 cargo tauri build --ci --bundles nsis --no-sign
 ```
 
-Tagged GitHub releases can include both a Windows NSIS installer as `minutes-desktop-windows-x64-setup.exe` and a raw desktop binary as `minutes-desktop-windows-x64.exe`. The installer is currently unsigned, so treat it as an advanced-user / preview distribution surface until Windows signing is added.
+Tagged GitHub releases can include three Windows desktop assets: an NSIS installer as `minutes-desktop-windows-x64-setup.exe`, a portable archive as `minutes-desktop-windows-x64.zip`, and a raw desktop binary as `minutes-desktop-windows-x64.exe`. The installer is currently unsigned, so treat it as an advanced-user / preview distribution surface until Windows signing is added.
 
-**Use the installer, not the raw binary.** The desktop app imports the Visual C++ runtime, which Windows does not include. The installer places those runtime files beside the executable; the raw `.exe` does not carry them, so on a PC without the Visual C++ Redistributable it exits immediately with no message (#657).
+**Use the installer or the zip, not the raw binary.** The desktop app imports the Visual C++ runtime, which Windows does not include. The installer and the zip both place those runtime files beside the executable; the raw `.exe` does not carry them, so on a PC without the Visual C++ Redistributable it exits immediately with no message (#657).
+
+The zip is the no-install option: unpack it anywhere and run `minutes-app.exe` from the extracted folder. Keep the runtime DLLs alongside it, since Windows resolves the application's own directory ahead of the system path and that is the whole reason the archive works.
 
 The desktop app adds a system tray icon, recording controls, audio visualizer, Recall, and a meeting list window. The current Windows desktop build covers recording, transcription, search, settings, and Recall. Calendar suggestions, call detection, tray copy/paste automation, and the native dictation hotkey remain macOS-only for now.
 

--- a/crates/mcp/src/index.test.ts
+++ b/crates/mcp/src/index.test.ts
@@ -20,8 +20,8 @@ import {
   utimesSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -643,6 +643,15 @@ describe.runIf(process.platform !== "win32")(
       )
     ).toBe(false);
     expect(canonicalPathWireEquals("normal.md", drive)).toBe(false);
+  });
+
+  it("puts the Minutes-owned install directory on the child PATH", () => {
+    // The Windows auto-installer targets ~/.minutes/bin (#657). This server
+    // uses the absolute path, but plugin skills shell out to a bare `minutes`,
+    // so the directory has to reach child processes or those fail immediately
+    // after a successful install.
+    const parts = (mcpCliChildEnv().PATH || "").split(delimiter);
+    expect(parts).toContain(join(homedir(), ".minutes", "bin"));
   });
 
   it("forces the CLI deny policy after ambient and call-site overrides", () => {

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -2353,6 +2353,17 @@ async function tryAutoInstallAttempt(capabilityRepair: boolean = false): Promise
       }
 
       console.error(`[Minutes] ✓ Installed to ${targetPath}`);
+      // Everything this server runs uses the absolute path, and child
+      // processes get the directory prepended via mcpCliChildEnv. A terminal
+      // is a different matter: nothing adds this directory to the user's own
+      // PATH, so say so rather than leaving `minutes: command not found` as
+      // the first thing they see.
+      if (process.platform === "win32") {
+        console.error(
+          `[Minutes] To run 'minutes' in your own terminal, add ${installDir} to PATH:\n` +
+            `[Minutes]   setx PATH "%PATH%;${installDir}"   (new terminals only)`,
+        );
+      }
       MINUTES_BIN = targetPath;
       return true;
     } catch (e: any) {
@@ -2687,7 +2698,13 @@ const CLI_INSTALL_MSG =
   `  sudo ln -s /opt/homebrew/bin/minutes /usr/local/bin/minutes`;
 
 // Common binary locations that may not be in Claude Desktop's restricted PATH.
+//
+// ~/.minutes/bin is where the Windows auto-installer puts the CLI (#657). The
+// MCP server resolves it absolutely via MINUTES_BIN, but plugin skills shell
+// out to a bare `minutes`, so without this entry those fail right after an
+// otherwise successful install.
 const EXTRA_PATH_DIRS = [
+  join(homedir(), ".minutes", "bin"),
   join(homedir(), ".local", "bin"),
   join(homedir(), ".cargo", "bin"),
   "/opt/homebrew/bin",

--- a/docs/release/channels.md
+++ b/docs/release/channels.md
@@ -66,7 +66,7 @@ The release note does not need to be long, but it must be explicit.
 Examples of acceptable cross-surface phrasing:
 
 - `Desktop: adds signed Minutes.app with notarized dmg`
-- `Desktop (Windows): adds experimental NSIS installer as minutes-desktop-windows-x64-setup.exe and raw fallback binary`
+- `Desktop (Windows): adds experimental NSIS installer as minutes-desktop-windows-x64-setup.exe, portable minutes-desktop-windows-x64.zip, and raw fallback binary`
 - `CLI: no command changes in this release`
 - `MCP: new quick-thought mode available through start_recording(mode=...)`
 


### PR DESCRIPTION
Two smaller gaps from this week's Windows work.

## 1. The new install directory was on nobody's PATH

#667 moved the Windows auto-installer to `~/.minutes/bin`, which is the right place, but nothing put that directory on any PATH. The MCP server itself is unaffected since it resolves `MINUTES_BIN` absolutely. Plugin skills are not: they shell out to a bare `minutes` (8 call sites in `minutes-brief/SKILL.md` alone), so they broke immediately after an otherwise successful install.

Added to `EXTRA_PATH_DIRS`, ahead of the other candidates. Confirmed the new test fails without it:

```
× puts the Minutes-owned install directory on the child PATH
```

The install message also now tells Windows users how to get it onto their own PATH. Nothing does that for them, and the success line was just `✓ Installed to <path>`, so `minutes: command not found` in a terminal was the next thing they'd see.

## 2. The desktop zip was published and never mentioned

#668 started publishing `minutes-desktop-windows-x64.zip`, and `rg` found zero references to it outside the workflow that uploads it. Worse, the README section added by the same commit says "Use the installer, not the raw binary" and never mentions the zip at all, so the one asset that actually solves the no-install case was invisible. `docs/release/channels.md` still listed only the setup exe and the raw fallback.

Both now cover it, including two things a user cannot guess: the executable inside is named `minutes-app.exe`, and the runtime DLLs have to stay in the same folder, since the application directory taking precedence over the system path is the entire reason the archive works.

## Verification

Full MCP suite: 277 passed, 1 skipped.