### PR TITLE
fix(ci): unbreak main, and gate the release count before the tag exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
               - 'crates/archive-core/**'
               - 'crates/archive-ocr/**'
               - 'crates/archive-semantic/**'
+              # Not a workspace member and not an npm package: fixture audio
+              # read by tests and scripts. 'crates/**' used to cover it.
+              - 'crates/assets/**'
               - 'archive/**'
               - 'tests/**'
               # Declared as build inputs by tauri/src-tauri/build.rs via

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -147,11 +147,21 @@ jobs:
           # Professional 14.29 over Community 14.44 on a box with both. Pinning
           # '2022' and 'VC143' would also silently stop matching the next
           # toolset.
+          #
+          # Two details that keep this equivalent to build.rs rather than
+          # merely similar:
+          #  - require at least two version components, because [version]
+          #    rejects a bare '14' and would abort the step under
+          #    ErrorActionPreference='Stop'
+          #  - require vcruntime140.dll to be present in the candidate, so an
+          #    incomplete redist directory falls through to the next-best
+          #    version instead of being selected and then hard-throwing below
           $crt = Get-ChildItem 'C:\Program Files*\Microsoft Visual Studio\*\*\VC\Redist\MSVC\*\x64\Microsoft.VC*.CRT' -Directory -ErrorAction SilentlyContinue |
-                 Where-Object { $_.Parent.Parent.Name -match '^\d+(\.\d+)*$' } |
+                 Where-Object { $_.Parent.Parent.Name -match '^\d+(\.\d+)+$' } |
+                 Where-Object { Test-Path (Join-Path $_.FullName 'vcruntime140.dll') } |
                  Sort-Object @{ Expression = { [version]$_.Parent.Parent.Name } } -Descending |
                  Select-Object -First 1
-          if (-not $crt) { throw 'Could not locate a VC CRT redistributable on the runner' }
+          if (-not $crt) { throw 'Could not locate a complete VC CRT redistributable on the runner' }
           Write-Host "CRT source: $($crt.FullName)"
           $stage = 'minutes-windows-x64'
           New-Item -ItemType Directory -Force -Path $stage | Out-Null

--- a/scripts/check_ci_rust_filter.mjs
+++ b/scripts/check_ci_rust_filter.mjs
@@ -17,7 +17,7 @@
  * enumeration going stale: add a workspace member without listing it and CI
  * fails here rather than silently skipping the Rust jobs forever.
  */
-import { readFileSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
@@ -54,24 +54,51 @@ function rustFilterPatterns() {
 /**
  * Does any pattern cover this member's files?
  *
- * Only prefix globs count. A pattern like 'crates/core/**' covers
+ * Only recursive prefix globs count. A pattern like 'crates/core/**' covers
  * 'crates/core' and anything below it.
+ *
+ * A single-file entry such as 'crates/core/Cargo.toml' does NOT count, even
+ * though it names the member. Accepting it let the guard report full coverage
+ * for a crate whose .rs files all skipped the Rust matrix -- the same
+ * "PR touches Rust, CI reports green" gap the guard exists to close.
  */
 function coveredBy(member, patterns) {
   return patterns.some((pattern) => {
     if (pattern.startsWith("!")) return false;
-    if (!pattern.endsWith("/**")) return pattern === `${member}/Cargo.toml`;
+    if (!pattern.endsWith("/**")) return false;
     const prefix = pattern.slice(0, -3);
     return member === prefix || member.startsWith(`${prefix}/`);
   });
 }
 
+/**
+ * Directories under crates/ that are neither workspace members nor npm
+ * packages -- today that is crates/assets, which holds fixture audio.
+ *
+ * The filter used to be a blanket 'crates/**' and covered these for free.
+ * Enumerating Rust crates dropped them, and checking workspace members alone
+ * cannot notice: they are not members. So they are checked explicitly.
+ */
+function unclassifiedCrateDirs() {
+  const cratesDir = join(repoRoot, "crates");
+  if (!existsSync(cratesDir)) return [];
+  return readdirSync(cratesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `crates/${entry.name}`)
+    .filter(
+      (dir) =>
+        !existsSync(join(repoRoot, dir, "Cargo.toml")) &&
+        !existsSync(join(repoRoot, dir, "package.json")),
+    );
+}
+
 const members = workspaceMembers();
 const patterns = rustFilterPatterns();
-const missing = members.filter((m) => !coveredBy(m, patterns));
+const mustCover = [...members, ...unclassifiedCrateDirs()];
+const missing = mustCover.filter((m) => !coveredBy(m, patterns));
 
 if (missing.length > 0) {
-  console.error("CI's `rust` path filter does not cover every workspace member.");
+  console.error("CI's `rust` path filter does not cover every Rust build input.");
   console.error("");
   for (const m of missing) console.error(`  uncovered: ${m}`);
   console.error("");
@@ -83,5 +110,6 @@ if (missing.length > 0) {
 
 console.log(
   `CI rust filter covers all ${members.length} workspace members ` +
+    `and ${mustCover.length - members.length} unclassified crates/ dirs ` +
     `(${patterns.length} patterns).`
 );

--- a/scripts/check_ci_rust_filter.test.mjs
+++ b/scripts/check_ci_rust_filter.test.mjs
@@ -85,6 +85,17 @@ test("a parent glob covers nested members", () => {
   assert.equal(result.code, 0, result.output);
 });
 
+test("a Cargo.toml-only pattern does not count as covering the crate", () => {
+  // Naming the manifest is not covering the crate: every .rs file under it
+  // would still skip the Rust matrix while the guard reported green.
+  const result = runAgainst({
+    members: ["crates/foo"],
+    patterns: ["crates/foo/Cargo.toml"],
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.output, /uncovered: crates\/foo/);
+});
+
 test("a negated pattern never counts as coverage", () => {
   // The action compiles each pattern separately, so '!crates/mcp/**' matches
   // every file outside that subtree rather than excluding it. Treating one as
@@ -95,6 +106,15 @@ test("a negated pattern never counts as coverage", () => {
   });
   assert.equal(result.code, 1);
   assert.match(result.output, /uncovered: crates\/core/);
+});
+
+test("the real filter covers crates/assets, which is not a workspace member", () => {
+  // crates/assets holds fixture audio and has neither a Cargo.toml nor a
+  // package.json, so 'crates/**' covered it for free and the enumeration
+  // dropped it. Checking workspace members alone cannot see the gap.
+  const ci = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  const rustBlock = ci.slice(ci.indexOf("rust:"), ci.indexOf("  test:"));
+  assert.match(rustBlock, /-\s*'crates\/assets\/\*\*'/);
 });
 
 test("the real repo satisfies the guard", () => {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -175,6 +175,22 @@ async function runVersionCheck(root, release = false) {
     [path.join(root, "scripts", "check_version_sync.mjs"), ...(release ? ["--release"] : [])],
     { cwd: root },
   );
+  if (release) {
+    // Site constants, with the test count binding. Per-PR CI tolerates a stale
+    // count so a number that moves with every added test cannot redden
+    // unrelated checks (#666), which means nothing refreshes it on its own.
+    //
+    // This has to run here rather than only in release-cli.yml: that workflow
+    // triggers on the tag push, so a failure there arrives after the tag and
+    // the draft release already exist, and the recovery is delete-and-retag,
+    // which the immutable-tag policy forbids. Here it is a local failure with
+    // no tag created yet.
+    await exec(
+      process.execPath,
+      [path.join(root, "scripts", "sync_site_release_version.mjs"), "--check-release"],
+      { cwd: root },
+    );
+  }
 }
 
 async function assertTreeVersion(root, version) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -205,6 +205,19 @@ if (process.argv.includes("--release")) {
 console.log("Version sync check passed.");
 `,
   );
+  // The tag phase also gates on the site release constants, with the test
+  // count binding. Stubbed like check_version_sync above: the real script
+  // scans the whole repo for tests, which this fixture does not have.
+  await writeFixture(
+    root,
+    "scripts/sync_site_release_version.mjs",
+    `if (process.argv.includes("--check-release") && process.env.RELEASE_SITE_CHECK_FAIL === "1") {
+  console.error("simulated stale site release constants");
+  process.exit(1);
+}
+console.log("site release constants already match.");
+`,
+  );
   await writeFixture(root, "extra.txt", "original\n");
 
   assert.equal(git(root, "init", "-q", "-b", "main").status, 0);
@@ -370,5 +383,21 @@ test("tag aborts when the --release version policy check fails", async (t) => {
   const result = await runRelease(fixture, ["tag", version], { RELEASE_CHECK_FAIL: "release" });
   assert.equal(result.status, 1);
   assert.match(result.stderr, /simulated --release policy failure/);
+  assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), "");
+});
+
+test("tag aborts when the site release constants are stale", async (t) => {
+  // The site test count is tolerated per-PR so a number that moves with every
+  // added test cannot redden unrelated CI (#666), which means nothing refreshes
+  // it on its own. It is binding here instead. This must fail BEFORE the tag
+  // exists: release-cli.yml runs the same check, but only on the tag push, and
+  // by then the immutable-tag policy rules out simply retagging.
+  const fixture = await makeRepo(t);
+  await completePhase1(fixture);
+  await completePhase2(fixture);
+  assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
+  const result = await runRelease(fixture, ["tag", version], { RELEASE_SITE_CHECK_FAIL: "1" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /simulated stale site release constants/);
   assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), "");
 });

--- a/scripts/sync_site_release_version.test.mjs
+++ b/scripts/sync_site_release_version.test.mjs
@@ -19,6 +19,26 @@ function run(args) {
   return { code: result.status, output: `${result.stdout || ""}${result.stderr || ""}` };
 }
 
+// These tests edit a tracked file. A normal run restores it in a finally, but
+// an interrupted one (Ctrl-C, a killed pipeline, a cancelled CI job) would
+// otherwise leave the working tree modified, and the next run then fails with
+// a confusing "test edit did not change release.ts". Restore on the way out
+// too, so an abort cannot corrupt the checkout.
+const pristineReleaseTs = readFileSync(releaseTs, "utf8");
+let releaseTsDirty = false;
+function restoreReleaseTs() {
+  if (!releaseTsDirty) return;
+  writeFileSync(releaseTs, pristineReleaseTs);
+  releaseTsDirty = false;
+}
+process.on("exit", restoreReleaseTs);
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    restoreReleaseTs();
+    process.exit(1);
+  });
+}
+
 /**
  * Run `body` with release.ts temporarily edited, always restoring it.
  *
@@ -27,14 +47,14 @@ function run(args) {
  * which is how the first version of these tests reported a false result.
  */
 function withEditedReleaseTs(edit, body) {
-  const original = readFileSync(releaseTs, "utf8");
-  const edited = edit(original);
-  assert.notEqual(edited, original, "test edit did not change release.ts");
+  const edited = edit(pristineReleaseTs);
+  assert.notEqual(edited, pristineReleaseTs, "test edit did not change release.ts");
   try {
     writeFileSync(releaseTs, edited);
+    releaseTsDirty = true;
     return body();
   } finally {
-    writeFileSync(releaseTs, original);
+    restoreReleaseTs();
   }
 }
 
@@ -83,7 +103,13 @@ test("--check fails when the version and the test count both drift", () => {
   assert.match(result.output, /out of sync/);
 });
 
-test("both modes pass on a clean tree", () => {
+test("--check passes on the working tree", () => {
+  // Deliberately only --check. Asserting --check-release here would couple a
+  // unit test to live repo state: this file runs in the unfiltered version_sync
+  // job, which feeds the required CI Gate, so every PR that adds a test would
+  // redden main and every open PR. That is exactly the breakage #666 removed
+  // the exact-count comparison to stop, and the first version of this test
+  // reinstated it one layer down. Release readiness is checked where a release
+  // happens, not on every PR.
   assert.equal(run(["--check"]).code, 0);
-  assert.equal(run(["--check-release"]).code, 0);
 });

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2691;
+export const MINUTES_TEST_COUNT = 2695;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/tauri/src-tauri/build.rs
+++ b/tauri/src-tauri/build.rs
@@ -63,10 +63,21 @@ fn stage_msvc_runtime() {
     // across targets, so "the files exist" says nothing about which
     // architecture they are. Without the stamp, building x86_64 and then
     // aarch64 in the same checkout ships x64 CRT DLLs inside an ARM64
-    // installer, which fails exactly like #657 on the user's machine. The
-    // stamp also forces a refresh after a toolset upgrade moves the source.
+    // installer, which fails exactly like #657 on the user's machine.
+    //
+    // Architecture only. A VS toolset upgrade leaves the files in place and
+    // the stamp matching, so the previously staged DLLs are reused; delete
+    // them to force a refresh. Recording the source version here would fix
+    // that, at the cost of re-staging whenever the toolset moves.
+    //
+    // Deliberately NOT declared with rerun-if-changed. This build script
+    // writes the stamp, and declaring a path the script itself writes makes
+    // cargo re-run it on every single build. Measured on Windows: a warm
+    // `cargo check -p minutes-app` recompiled every time (8.6s) with the
+    // declaration, against 0 rebuilds (3.0s) without it. The DLL paths above
+    // are declared and already cover the cases that should re-trigger
+    // staging; the stamp is read, never watched.
     let stamp_path = manifest_dir.join(".msvc-runtime-stage.stamp");
-    println!("cargo:rerun-if-changed={}", stamp_path.display());
 
     let staged = RUNTIME_DLLS.iter().all(|d| manifest_dir.join(d).exists());
     let stamp_matches = std::fs::read_to_string(&stamp_path)


### PR DESCRIPTION
**main is red right now and this fixes it.** The cause is mine, from #675.

## What broke

#675 added a unit test asserting `--check-release` exits 0 against the **live working tree**. That test runs in `version_sync`, which is unfiltered and is a `needs:` of `ci_gate`, the required check.

So any PR that adds a test turns main and every open PR red. That is precisely the breakage #666 removed the exact-count comparison to stop, reinstated one layer down by the change meant to fix it. My own later PRs added four tests and tripped it, and it has been red on every commit since.

The unit test now covers only the tolerant `--check` against the live tree. Strict mode is still tested, against synthetic edits, where it belongs. Count refreshed to 2695.

## The gate was also in the wrong place

`release-cli.yml` triggers on `push: tags: v*`. Procedure Step 9 creates the draft release and Step 10 pushes the tag, so a failure there arrives **after** both exist, and recovery is delete-and-retag, which the immutable-tag policy in `channels.md` forbids. Worse, `CI Gate` green before tagging gave no warning, because `Site Release Link Consistency` runs the tolerant `--check`.

It now also runs inside `release.mjs tag`, immediately before `ensureAnnotatedTag`, where it is a local failure with no tag and no draft created. The workflow keeps it as a backstop for the publish jobs.

## Three more from the same review

**The rust-filter guard had a hole that admitted the gap it exists to close.** A `crates/foo/Cargo.toml` entry counted as covering the whole crate, so every `.rs` file under it could skip the Rust matrix while the guard reported green. Only recursive globs count now.

**`crates/assets` lost coverage.** It is neither a workspace member nor an npm package, so enumerating Rust crates in #673 dropped what `crates/**` gave it for free, and a members-only guard structurally could not notice. Added to the filter; the guard now also checks `crates/` directories that are neither.

**The release CRT lookup still diverged from `build.rs`** despite a comment claiming parity. It accepted a single-component version like `14` that `[version]` rejects, which aborts the step under `ErrorActionPreference = 'Stop'`; and it selected an incomplete redist directory and then hard-threw, where `build.rs` falls through to the next-best version. Both aligned.

## Test-suite robustness

These tests edit a tracked file. An interrupted run (Ctrl-C, a killed pipeline, a cancelled job) left it modified, and the next run failed with a confusing "test edit did not change release.ts" — which is how I found it. Restore now also runs on exit and on SIGINT/SIGTERM/SIGHUP. Verified the tree stays clean after an interrupted run.

## Verification

```
scripts/sync_site_release_version.test.mjs   5 pass, 0 fail
scripts/check_ci_rust_filter.test.mjs        8 pass, 0 fail
check_ci_rust_filter.mjs   covers 10 workspace members + 1 unclassified crates/ dir
check_version_sync.mjs     ok
```

## Note on one claim I did not take at face value

The review also argued that #674's staging stamp cannot cause a rebuild loop, reasoning that cargo writes the build-script output file after the script exits. I measured the opposite on the Windows VM, with a control that isolates the stamp from every other change in the batch:

| commit | stamp | skill-bundle resources | warm `cargo check` |
|---|---|---|---|
| `bd368e5c` | yes | no | recompiles every time |
| `fcad33a4` | no | no | 0 rebuilds |

That fix is in this PR too: the stamp stays (it is what keeps an x64 CRT out of an ARM64 bundle) but is no longer declared with `rerun-if-changed`, since declaring a path the build script itself writes is what caused the loop.