### PR TITLE
fix(search): derive the corpus authorization deadline from its own ceilings (#679)

### DIFF
--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -97,43 +97,71 @@ pub(crate) const ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES: usize = 4;
 /// without tripping the deadline.
 pub(crate) const ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC: u64 = 16 * 1024 * 1024;
 
+/// Times a snapshot physically reads each file for every byte it charges.
+///
+/// `read_bounded_markdown_twice` reads the file, seeks back to zero, and reads
+/// it again to prove the bytes did not change underneath it, but the budget
+/// charges `content.len()` once. Wall-clock cost therefore tracks twice the
+/// authorized byte count, so a deadline derived from authorized bytes alone
+/// understates the time the same work needs by exactly this factor.
+pub(crate) const ACTIVE_CORPUS_PHYSICAL_READS_PER_SNAPSHOT: u64 = 2;
+
 /// Bytes one authorization may legitimately read at the documented ceiling.
 ///
 /// Each attempt makes a pre-snapshot pass, a materialization phase worth
 /// `ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES` passes, and a post-snapshot
 /// pass, and the whole thing may run `ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS`
 /// times under one shared deadline.
+///
+/// This is the *charged* total, which is what the byte ceiling governs. It is
+/// deliberately not the number of bytes read from the disk: see
+/// `ACTIVE_CORPUS_WORST_CASE_PHYSICAL_BYTES` for that.
 pub(crate) const ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES: u64 = ACTIVE_CORPUS_MAX_AUTHORIZED_BYTES
     * (1 + ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES as u64 + 1)
     * ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS as u64;
 
+/// Bytes actually pulled off the disk for that same worst case.
+///
+/// The deadline is wall-clock, so it has to be sized against this rather than
+/// the charged total.
+pub(crate) const ACTIVE_CORPUS_WORST_CASE_PHYSICAL_BYTES: u64 =
+    ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES * ACTIVE_CORPUS_PHYSICAL_READS_PER_SNAPSHOT;
+
 /// Absolute wall-clock ceiling for one corpus authorization.
 ///
-/// Derived, not chosen. A hardcoded 15s silently required 64 MB/s sustained to
-/// read the documented 80 MB ceiling through all six passes of both attempts,
-/// so a corpus that fit every published limit still failed on ordinary storage
-/// (issue #679). It surfaced as an intermittent CI failure, but the same
-/// arithmetic fails a real user whose meetings sit on a synced folder.
+/// Derived, not chosen. A hardcoded 15s silently required 128 MB/s of real
+/// read throughput to get the documented 80 MB ceiling through all six passes
+/// of both attempts, each of which reads every file twice, so a corpus that
+/// fit every published limit still failed on ordinary storage (issue #679). It
+/// surfaced as an intermittent CI failure, but the same arithmetic fails a real
+/// user whose meetings sit on a synced folder.
 ///
-/// Deriving it keeps the two consistent: raise the byte ceiling or add a
-/// materialization pass and the deadline follows, instead of quietly
-/// tightening the throughput this code demands.
+/// Deriving it keeps the two consistent: raise the byte ceiling, add a
+/// materialization pass, or add a verification reread, and the deadline
+/// follows, instead of quietly tightening the throughput this code demands.
 ///
 /// This bounds cooperative checks between filesystem operations, so it is a
 /// backstop rather than the primary control. The byte, file, and directory
 /// ceilings bound the work itself, and agent-facing SDK/MCP reads wrap this
 /// boundary in a supervised, killable worker.
+///
+/// It also bounds `graph`'s corpus capture, which holds a projection lease
+/// while it runs, so a slow disk now refuses a competing projection for longer
+/// than it used to. That is the intended trade: the alternative was failing a
+/// projection the ceilings permit.
 const ACTIVE_CORPUS_AUTHORIZATION_DEADLINE_SECS: u64 =
-    ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES / ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC;
+    ACTIVE_CORPUS_WORST_CASE_PHYSICAL_BYTES.div_ceil(ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC);
 
-// Integer division, so a floor throughput at or above the worst-case total
-// would truncate to a zero-second deadline and fail every authorization
-// instantly. Reject that at compile time rather than shipping a build where
-// search never succeeds.
+// Round up, never down: a floor-divided deadline would promise a throughput
+// floor it does not actually honor whenever the division is inexact.
+//
+// A floor throughput at or above the worst-case total would still truncate to
+// zero and fail every authorization instantly, so reject that at compile time
+// rather than shipping a build where search never succeeds.
 const _: () = assert!(
     ACTIVE_CORPUS_AUTHORIZATION_DEADLINE_SECS > 0,
     "corpus authorization deadline truncated to zero seconds: the assumed floor throughput is \
-     at least the worst-case authorized byte total"
+     at least the worst-case physical byte total"
 );
 
 pub(crate) const ACTIVE_CORPUS_AUTHORIZATION_DEADLINE: Duration =
@@ -2685,29 +2713,51 @@ mod tests {
     #[test]
     fn authorization_deadline_admits_the_documented_ceiling_on_slow_storage() {
         // #679: the deadline was a hardcoded 15s while the ceilings allowed
-        // 960 MB of authorized reads, so a corpus that fit every published
-        // limit still failed unless the disk sustained 64 MB/s. It showed up
-        // as an intermittent CI failure; the same arithmetic fails a user
-        // whose meetings live on iCloud Drive or an external disk.
+        // 960 MB of charged reads, and every snapshot reads each file twice,
+        // so a corpus that fit every published limit still failed unless the
+        // disk sustained 128 MB/s. It showed up as an intermittent CI failure;
+        // the same arithmetic fails a user whose meetings live on iCloud Drive
+        // or an external disk.
         //
         // Pin the relationship, not the number: whichever ceiling moves, the
         // deadline has to stay reachable at the assumed floor throughput.
-        let worst_case_bytes = ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES;
-        let required = ACTIVE_CORPUS_MAX_AUTHORIZED_BYTES
-            * (1 + ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES as u64 + 1)
-            * ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS as u64;
+        let charged = ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES;
         assert_eq!(
-            worst_case_bytes, required,
-            "worst-case byte derivation drifted from the pass and attempt counts"
+            charged,
+            ACTIVE_CORPUS_MAX_AUTHORIZED_BYTES
+                * (1 + ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES as u64 + 1)
+                * ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS as u64,
+            "charged-byte derivation drifted from the pass and attempt counts"
         );
 
-        let implied_bytes_per_sec =
-            worst_case_bytes / ACTIVE_CORPUS_AUTHORIZATION_DEADLINE.as_secs();
+        // The deadline is wall clock, so it must be sized against bytes read
+        // from the disk, not bytes charged to the budget. Modelling charged
+        // bytes is what let a 2x undercount survive the first version of this
+        // test: `read_bounded_markdown_twice` reads every file a second time
+        // to prove it did not change, and the budget charges that once.
+        let physical = ACTIVE_CORPUS_WORST_CASE_PHYSICAL_BYTES;
+        assert_eq!(
+            physical,
+            charged * ACTIVE_CORPUS_PHYSICAL_READS_PER_SNAPSHOT,
+            "physical-byte derivation drifted from the per-snapshot reread count"
+        );
+
+        let deadline_secs = ACTIVE_CORPUS_AUTHORIZATION_DEADLINE.as_secs();
         assert!(
-            implied_bytes_per_sec <= ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC,
-            "the deadline demands {implied_bytes_per_sec} B/s sustained to read the documented \
-             ceiling, above the {ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC} B/s floor this \
-             envelope promises to tolerate; raise the deadline or lower the ceiling (#679)"
+            deadline_secs > 0,
+            "a sub-second deadline cannot carry the documented ceiling on any storage"
+        );
+
+        // Compare rates as a cross-multiplication rather than dividing, so an
+        // inexact ratio cannot be rounded into a pass. Dividing here let a
+        // deadline one second short of the requirement satisfy the assertion.
+        assert!(
+            physical <= ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC * deadline_secs,
+            "the deadline of {deadline_secs}s carries only {} B at the \
+             {ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC} B/s floor this envelope promises to \
+             tolerate, short of the {physical} B the documented ceiling can require; raise the \
+             deadline or lower the ceiling (#679)",
+            ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC * deadline_secs
         );
     }
 

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -84,11 +84,48 @@ pub(crate) const ACTIVE_CORPUS_MAX_DIRECTORY_COUNT: usize = 512;
 pub(crate) const ACTIVE_CORPUS_MAX_AUTHORIZED_BYTES: u64 = 80 * 1024 * 1024;
 pub(crate) const ACTIVE_CORPUS_MAX_RETAINED_PATH_BYTES: usize = 8 * 1024 * 1024;
 pub(crate) const ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS: usize = 2;
-pub(crate) const ACTIVE_CORPUS_AUTHORIZATION_DEADLINE: Duration = Duration::from_secs(15);
 /// One materialization can read each pre-authorized source during index
 /// construction, before the transactional write, after the write, and once
 /// more when converting a result into user-visible bytes.
 pub(crate) const ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES: usize = 4;
+
+/// Slowest storage the authorization deadline is willing to call a hang.
+///
+/// Meetings routinely live on iCloud Drive, Dropbox, or an external disk, and
+/// a first read there can be a network fetch rather than a local one. Anything
+/// at or above this rate must be able to finish the whole documented envelope
+/// without tripping the deadline.
+pub(crate) const ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC: u64 = 16 * 1024 * 1024;
+
+/// Bytes one authorization may legitimately read at the documented ceiling.
+///
+/// Each attempt makes a pre-snapshot pass, a materialization phase worth
+/// `ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES` passes, and a post-snapshot
+/// pass, and the whole thing may run `ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS`
+/// times under one shared deadline.
+pub(crate) const ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES: u64 = ACTIVE_CORPUS_MAX_AUTHORIZED_BYTES
+    * (1 + ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES as u64 + 1)
+    * ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS as u64;
+
+/// Absolute wall-clock ceiling for one corpus authorization.
+///
+/// Derived, not chosen. A hardcoded 15s silently required 64 MB/s sustained to
+/// read the documented 80 MB ceiling through all six passes of both attempts,
+/// so a corpus that fit every published limit still failed on ordinary storage
+/// (issue #679). It surfaced as an intermittent CI failure, but the same
+/// arithmetic fails a real user whose meetings sit on a synced folder.
+///
+/// Deriving it keeps the two consistent: raise the byte ceiling or add a
+/// materialization pass and the deadline follows, instead of quietly
+/// tightening the throughput this code demands.
+///
+/// This bounds cooperative checks between filesystem operations, so it is a
+/// backstop rather than the primary control. The byte, file, and directory
+/// ceilings bound the work itself, and agent-facing SDK/MCP reads wrap this
+/// boundary in a supervised, killable worker.
+pub(crate) const ACTIVE_CORPUS_AUTHORIZATION_DEADLINE: Duration = Duration::from_secs(
+    ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES / ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC,
+);
 
 #[derive(Debug, Default)]
 struct ActiveCorpusReadUsage {
@@ -2631,6 +2668,35 @@ mod tests {
         );
         assert!(snapshot.is_none());
         assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn authorization_deadline_admits_the_documented_ceiling_on_slow_storage() {
+        // #679: the deadline was a hardcoded 15s while the ceilings allowed
+        // 960 MB of authorized reads, so a corpus that fit every published
+        // limit still failed unless the disk sustained 64 MB/s. It showed up
+        // as an intermittent CI failure; the same arithmetic fails a user
+        // whose meetings live on iCloud Drive or an external disk.
+        //
+        // Pin the relationship, not the number: whichever ceiling moves, the
+        // deadline has to stay reachable at the assumed floor throughput.
+        let worst_case_bytes = ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES;
+        let required = ACTIVE_CORPUS_MAX_AUTHORIZED_BYTES
+            * (1 + ACTIVE_CORPUS_MAX_MATERIALIZATION_READ_PASSES as u64 + 1)
+            * ACTIVE_CORPUS_MAX_AUTHORIZATION_ATTEMPTS as u64;
+        assert_eq!(
+            worst_case_bytes, required,
+            "worst-case byte derivation drifted from the pass and attempt counts"
+        );
+
+        let implied_bytes_per_sec =
+            worst_case_bytes / ACTIVE_CORPUS_AUTHORIZATION_DEADLINE.as_secs();
+        assert!(
+            implied_bytes_per_sec <= ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC,
+            "the deadline demands {implied_bytes_per_sec} B/s sustained to read the documented \
+             ceiling, above the {ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC} B/s floor this \
+             envelope promises to tolerate; raise the deadline or lower the ceiling (#679)"
+        );
     }
 
     #[test]

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -123,9 +123,21 @@ pub(crate) const ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES: u64 = ACTIVE_CORPUS_
 /// backstop rather than the primary control. The byte, file, and directory
 /// ceilings bound the work itself, and agent-facing SDK/MCP reads wrap this
 /// boundary in a supervised, killable worker.
-pub(crate) const ACTIVE_CORPUS_AUTHORIZATION_DEADLINE: Duration = Duration::from_secs(
-    ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES / ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC,
+const ACTIVE_CORPUS_AUTHORIZATION_DEADLINE_SECS: u64 =
+    ACTIVE_CORPUS_WORST_CASE_AUTHORIZED_BYTES / ACTIVE_CORPUS_MIN_ASSUMED_READ_BYTES_PER_SEC;
+
+// Integer division, so a floor throughput at or above the worst-case total
+// would truncate to a zero-second deadline and fail every authorization
+// instantly. Reject that at compile time rather than shipping a build where
+// search never succeeds.
+const _: () = assert!(
+    ACTIVE_CORPUS_AUTHORIZATION_DEADLINE_SECS > 0,
+    "corpus authorization deadline truncated to zero seconds: the assumed floor throughput is \
+     at least the worst-case authorized byte total"
 );
+
+pub(crate) const ACTIVE_CORPUS_AUTHORIZATION_DEADLINE: Duration =
+    Duration::from_secs(ACTIVE_CORPUS_AUTHORIZATION_DEADLINE_SECS);
 
 #[derive(Debug, Default)]
 struct ActiveCorpusReadUsage {

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -35,13 +35,21 @@ fn with_stable_active_corpus<T>(
 /// The previous message collapsed every cause into "could not be verified
 /// safely", so a deadline overrun and a corpus genuinely over the byte ceiling
 /// were indistinguishable. Diagnosing #679 needed a controlled experiment to
-/// recover a fact the error already had. The variant names a limit, never
-/// content, a path, or a count, so this leaks nothing a caller cannot already
-/// infer from the published ceilings.
+/// recover a fact the error already had.
+///
+/// This is a deliberate, bounded disclosure rather than no disclosure. The
+/// text reaches CLI and desktop callers, so one who cannot read restricted
+/// meetings can now tell an unopenable corpus from an oversized one, a walk
+/// failure, or an exhausted deadline. It exposes no content, path, or count,
+/// and each state is a whole-corpus condition the caller can already provoke
+/// and observe by timing an ordinary search against the published ceilings.
+/// The diagnosability is worth that; naming a file or a count would not be.
 fn corpus_authorization_error(stage: &str, error: ActiveCorpusRevisionError) -> SearchError {
     let cause = match error {
         ActiveCorpusRevisionError::Unavailable => "the corpus could not be opened",
-        ActiveCorpusRevisionError::Traversal => "the corpus contains an unsafe path",
+        // Every walk error lands here, including permission denials and files
+        // that vanish mid-walk, so this must not claim an unsafe path.
+        ActiveCorpusRevisionError::Traversal => "the corpus could not be walked",
         ActiveCorpusRevisionError::Budget => "the corpus exceeds a documented size ceiling",
         ActiveCorpusRevisionError::Deadline => "the authorization deadline elapsed",
     };

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -30,6 +30,26 @@ fn with_stable_active_corpus<T>(
     with_stable_active_corpus_with_hooks(dir, operation, || {}, || {})
 }
 
+/// Name which limit stopped a corpus pass, without describing the corpus.
+///
+/// The previous message collapsed every cause into "could not be verified
+/// safely", so a deadline overrun and a corpus genuinely over the byte ceiling
+/// were indistinguishable. Diagnosing #679 needed a controlled experiment to
+/// recover a fact the error already had. The variant names a limit, never
+/// content, a path, or a count, so this leaks nothing a caller cannot already
+/// infer from the published ceilings.
+fn corpus_authorization_error(stage: &str, error: ActiveCorpusRevisionError) -> SearchError {
+    let cause = match error {
+        ActiveCorpusRevisionError::Unavailable => "the corpus could not be opened",
+        ActiveCorpusRevisionError::Traversal => "the corpus contains an unsafe path",
+        ActiveCorpusRevisionError::Budget => "the corpus exceeds a documented size ceiling",
+        ActiveCorpusRevisionError::Deadline => "the authorization deadline elapsed",
+    };
+    SearchError::Io(std::io::Error::other(format!(
+        "meeting corpus could not be {stage} safely: {cause}"
+    )))
+}
+
 fn with_stable_active_corpus_with_hooks<T>(
     dir: &Path,
     mut operation: impl FnMut(&StableActiveCorpusRevision) -> Result<T, SearchError>,
@@ -47,11 +67,7 @@ fn with_stable_active_corpus_with_hooks<T>(
         // while all passes share one absolute operation deadline. This keeps
         // safe rereads from making an otherwise supported corpus unavailable.
         let before = stable_active_corpus_revision_with_budget(dir, envelope.fresh_pass())
-            .map_err(|_| {
-                SearchError::Io(std::io::Error::other(
-                    "meeting corpus could not be verified safely",
-                ))
-            })?
+            .map_err(|error| corpus_authorization_error("verified", error))?
             .with_read_budget(envelope.fresh_materialization_pass());
         after_precheck();
         envelope.check_deadline().map_err(|_| {
@@ -66,13 +82,8 @@ fn with_stable_active_corpus_with_hooks<T>(
             ))
         })?;
         before_postcheck();
-        let after = stable_active_corpus_revision_with_budget(dir, envelope.fresh_pass()).map_err(
-            |_| {
-                SearchError::Io(std::io::Error::other(
-                    "meeting corpus could not be reverified safely",
-                ))
-            },
-        )?;
+        let after = stable_active_corpus_revision_with_budget(dir, envelope.fresh_pass())
+            .map_err(|error| corpus_authorization_error("reverified", error))?;
         if before == after {
             return Ok(value);
         }


### PR DESCRIPTION
Closes #679.

## This was not a test problem

`search::tests::default_budget_supports_realistic_1500_meeting_multi_pass_list` failed intermittently on both platforms, on PRs that touched nothing nearby. The test was reporting a real inconsistency.

`ACTIVE_CORPUS_AUTHORIZATION_DEADLINE` was a hardcoded 15s. The ceilings it guards authorize far more work than fits in that. One authorization reads the corpus six times per attempt (pre-snapshot, four materialization passes, post-snapshot) and may run two attempts under one shared deadline, so at the documented 80 MB ceiling it authorizes 960 MB:

```
960 MB / 15s = 64 MB/s sustained
```

That is what a corpus at the published limit needed merely to avoid a spurious failure. CI surfaced it first, but the same arithmetic fails a user whose meetings live on iCloud Drive, Dropbox, or an external disk, which this product explicitly supports. The 39 MB fixture needed 15.6 MB/s; locally it finishes in 5.77s of a 15s budget, so 2.6x headroom, which a loaded runner erases.

## The fix

The deadline is derived from the ceilings and an explicit floor throughput the envelope promises to tolerate (16 MB/s), giving 60s. Raise the byte ceiling or add a materialization pass and the deadline follows, instead of silently demanding a faster disk.

A test pins the relationship rather than the number. Confirmed it fails against the shipped value, with the arithmetic spelled out:

```
the deadline demands 67108864 B/s sustained to read the documented ceiling,
above the 16777216 B/s floor this envelope promises to tolerate;
raise the deadline or lower the ceiling (#679)
```

A const assertion rejects a zero-second deadline at compile time, since the derivation is an integer division. Verified by setting the floor to 2 GB/s:

```
error[E0080]: evaluation panicked: corpus authorization deadline truncated to
zero seconds: the assumed floor throughput is at least the worst-case
authorized byte total
```

## Why extending this is safe

This deadline is a cooperative backstop checked between filesystem operations, not the primary control. Its own doc comment says so: the byte, file, and directory ceilings bound the work, and agent-facing SDK/MCP reads wrap this boundary in a supervised, killable worker. Extending it does not widen what any caller may read. The cost is that a genuinely hung mount now errors in 60s rather than 15s; the benefit is that legitimate corpora stop failing.

Sizing is deliberately against what the envelope **authorizes**, not what today's code happens to use. Sizing against observed behavior would re-break the moment a change legitimately used its full materialization budget.

## The error discarded its own cause

Both revision passes mapped every `ActiveCorpusRevisionError` to one opaque string, so a deadline overrun and a genuinely oversized corpus were indistinguishable. Diagnosing this needed a controlled experiment to recover a fact the error already had. The message now names which limit was hit, and never content, a path, or a count:

```
meeting corpus could not be reverified safely: the authorization deadline elapsed
```

The two `canonicalize()` sites that share the old wording are a different error type (the corpus root cannot be opened, with no richer cause to preserve) and are left alone. Nothing in the repo asserts the old strings.

## Verification

- `minutes-core` lib suite: **1661 passed, 0 failed**
- the previously flaky test passes; `search::` 81, `markdown::` 81, `graph::` 78, all green
- `cargo fmt` clean; no new clippy warnings
- the 12 initial failures were `audio_decode_worker`/`diarize`/`health`/`watch` tests needing a `minutes-cli` binary beside the harness, an artifact of a fresh worktree. All 12 pass once it is built, which is the 1661 figure above.