### PR TITLE
fix(sdk): present one corpus-lease refusal for one condition, and stop tests racing worker startup

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -682,7 +682,16 @@ describe("stable corpus lease", () => {
           }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      // The rejection is the non-publication proof: a published projection
+      // would have resolved to MUST_NOT_PUBLISH instead.
       expect(projections).toBe(1);
+      // And the stalled worker has to be reaped, not merely abandoned. Without
+      // this the deterministic deadline could satisfy the assertions above
+      // while leaving a wedged child holding admission, which is the failure
+      // this scenario exists to catch.
+      await expect(
+        withStableCorpusLease(root, () => "reused")
+      ).resolves.toBe("reused");
     });
   });
 

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -585,10 +585,16 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            timeoutMs: 500,
+            // `baselineCalls` is asserted to be 1, so the budget has to
+            // survive worker startup before afterBaseline is even reached, or
+            // the lease fails first and the count is zero. Same shape as the
+            // stall test below, which did exactly that on a loaded runner.
+            // The hook still outlasts the budget, which is the property under
+            // test; the budget just no longer races startup.
+            timeoutMs: 2_000,
             afterBaseline: () => {
               baselineCalls += 1;
-              return new Promise((resolve) => setTimeout(resolve, 750));
+              return new Promise((resolve) => setTimeout(resolve, 3_000));
             },
           }
         )
@@ -644,14 +650,36 @@ describe("stable corpus lease", () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "stalled finalize canary");
       let projections = 0;
+      // End the operation from the projection itself rather than by running
+      // out the clock. The assertion below is that the projection DID run, so
+      // a wall-clock budget has to be longer than worker startup or the lease
+      // fails first and the count is zero. That is a property of the runner,
+      // not of the code: startup measures ~80ms unloaded here and this test
+      // budgeted 500ms, which held locally and did not on a loaded macOS
+      // runner. `operationDeadlineForTest` fires the same parent deadline the
+      // timeout would, at a point the test controls.
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
       await expect(
         withStableCorpusLease(
           root,
           () => {
             projections += 1;
+            forceOperationDeadline();
             return "MUST_NOT_PUBLISH";
           },
-          { timeoutMs: 500, workerStallPhaseForTest: "before-authorized" }
+          {
+            // Below vitest's 15s testTimeout on purpose: if the
+            // deterministic deadline ever fails to fire, the lease still
+            // refuses with its own message instead of vitest killing the test
+            // with a less useful timeout. Still ~75x the measured worst-case
+            // startup, so it cannot race.
+            timeoutMs: 10_000,
+            workerStallPhaseForTest: "before-authorized",
+            operationDeadlineForTest: operationDeadline,
+          }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
       expect(projections).toBe(1);
@@ -934,6 +962,35 @@ describe("stable corpus lease", () => {
           onWatcherReady: ({ controls }) => controls.suppressNextFence(),
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+    });
+  });
+
+  it("reports one refusal even when the budget is gone before the worker starts", async () => {
+    // A deadline that has already elapsed when the lease is entered used to
+    // escape as the raw "meeting corpus authorization deadline elapsed",
+    // because the guard at the top of the dispatch throws before the worker
+    // machinery that wraps refusals exists. Callers then saw two different
+    // sentences for one condition, depending only on timing.
+    //
+    // On a contended Windows runner that is reachable with an ordinary short
+    // budget: the process can be descheduled between computing the deadline
+    // and the next statement checking it, which is how CI hit it. The smallest
+    // budget the API accepts reaches the same window every time, because
+    // starting the worker takes far longer than a millisecond.
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
+      let projections = 0;
+      await expect(
+        withStableCorpusLease(
+          root,
+          () => {
+            projections += 1;
+            return "unreachable";
+          },
+          { timeoutMs: 1 }
+        )
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(projections).toBe(0);
     });
   });
 

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -974,18 +974,20 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("reports one refusal even when the budget is gone before the worker starts", async () => {
-    // A deadline that has already elapsed when the lease is entered used to
-    // escape as the raw "meeting corpus authorization deadline elapsed",
-    // because the guard at the top of the dispatch throws before the worker
-    // machinery that wraps refusals exists. Callers then saw two different
-    // sentences for one condition, depending only on timing.
+  it("reports the documented refusal when the budget expires, whichever guard trips", async () => {
+    // An exhausted budget can be noticed by several guards, and only some sit
+    // inside the worker machinery that wraps refusals. The ones outside it
+    // used to escape as the raw "meeting corpus authorization deadline
+    // elapsed", so callers saw two different sentences for one condition
+    // depending only on which guard won. CI hit it on a contended Windows
+    // runner, where a short budget can expire between computing the deadline
+    // and the next statement checking it.
     //
-    // On a contended Windows runner that is reachable with an ordinary short
-    // budget: the process can be descheduled between computing the deadline
-    // and the next statement checking it, which is how CI hit it. The smallest
-    // budget the API accepts reaches the same window every time, because
-    // starting the worker takes far longer than a millisecond.
+    // This pins the contract rather than a route: the smallest budget the API
+    // accepts is reliably gone by the time some guard notices, and every guard
+    // has to produce the same sentence. Which one fires is timing-dependent
+    // and deliberately not asserted -- claiming a specific one would be the
+    // same kind of unverified detail this fix exists to remove.
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
       let projections = 0;

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -1724,7 +1724,46 @@ function parentControls(
  * Run a multi-source projection while a killable worker owns every corpus
  * traversal, exact read, watcher, fence, and cleanup filesystem operation.
  */
+/**
+ * Authorize a stable corpus read, presenting one error for one condition.
+ *
+ * Every way the lease can refuse is a refusal, and callers get the same
+ * sentence for all of them. Without this, which sentence you saw depended on
+ * where the failure landed: `fail()` wraps refusals raised once the worker is
+ * running, but a `CorpusLeaseChangedError` thrown before that, such as the
+ * deadline guard at the top of the dispatch below, escaped raw.
+ *
+ * That is observable, not cosmetic. On a contended Windows runner a short
+ * budget can elapse between computing the deadline and the very next
+ * statement checking it, so the same timeout surfaced as
+ * "meeting corpus authorization deadline elapsed" instead of the documented
+ * refusal, and CI failed with a message mismatch rather than a real defect.
+ *
+ * `CorpusLeaseBudgetError` and the plain `Error` refusals keep their own text:
+ * those name a caller-actionable limit rather than an authorization outcome.
+ */
 export async function withStableCorpusLease<T>(
+  root: string,
+  operation: (
+    snapshot: StableCorpusSnapshot,
+    attempt: number,
+    signal: AbortSignal
+  ) => T | Promise<T>,
+  hooks: CorpusLeaseHooks = {}
+): Promise<T> {
+  try {
+    return await dispatchStableCorpusLease(root, operation, hooks);
+  } catch (error) {
+    if (error instanceof CorpusLeaseChangedError) {
+      throw new Error(
+        "Access denied: stable meeting corpus authorization failed"
+      );
+    }
+    throw error;
+  }
+}
+
+async function dispatchStableCorpusLease<T>(
   root: string,
   operation: (
     snapshot: StableCorpusSnapshot,

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -1829,11 +1829,20 @@ async function dispatchStableCorpusLease<T>(
     resolveTermination();
   });
 
+  // A refusal kills the worker, but protocol lines already in flight are still
+  // being handled, so a write can land on a pipe whose reader is gone. That
+  // raises an asynchronous EPIPE on the stream, and an 'error' event with no
+  // listener is fatal to the host process, not just to this lease. Absorbing
+  // it is correct: by the time the pipe is gone the lease has already settled
+  // and the message has nowhere useful to go.
+  child.stdin?.on("error", () => {});
+
   const send = (message: unknown): void => {
     const serialized = JSON.stringify(message);
     if (Buffer.byteLength(serialized) > CORPUS_WORKER_PROTOCOL_MAX_BYTES || !child.stdin) {
       throw new CorpusLeaseBudgetError("meeting corpus worker protocol exceeded its budget");
     }
+    if (settled || child.stdin.destroyed || child.killed) return;
     child.stdin.write(serialized + "\n");
   };
 

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -682,7 +682,16 @@ describe("stable corpus lease", () => {
           }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      // The rejection is the non-publication proof: a published projection
+      // would have resolved to MUST_NOT_PUBLISH instead.
       expect(projections).toBe(1);
+      // And the stalled worker has to be reaped, not merely abandoned. Without
+      // this the deterministic deadline could satisfy the assertions above
+      // while leaving a wedged child holding admission, which is the failure
+      // this scenario exists to catch.
+      await expect(
+        withStableCorpusLease(root, () => "reused")
+      ).resolves.toBe("reused");
     });
   });
 

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -671,7 +671,12 @@ describe("stable corpus lease", () => {
             return "MUST_NOT_PUBLISH";
           },
           {
-            timeoutMs: 30_000,
+            // Below vitest's 15s testTimeout on purpose: if the
+            // deterministic deadline ever fails to fire, the lease still
+            // refuses with its own message instead of vitest killing the test
+            // with a less useful timeout. Still ~75x the measured worst-case
+            // startup, so it cannot race.
+            timeoutMs: 10_000,
             workerStallPhaseForTest: "before-authorized",
             operationDeadlineForTest: operationDeadline,
           }

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -585,10 +585,16 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            timeoutMs: 500,
+            // `baselineCalls` is asserted to be 1, so the budget has to
+            // survive worker startup before afterBaseline is even reached, or
+            // the lease fails first and the count is zero. Same shape as the
+            // stall test below, which did exactly that on a loaded runner.
+            // The hook still outlasts the budget, which is the property under
+            // test; the budget just no longer races startup.
+            timeoutMs: 2_000,
             afterBaseline: () => {
               baselineCalls += 1;
-              return new Promise((resolve) => setTimeout(resolve, 750));
+              return new Promise((resolve) => setTimeout(resolve, 3_000));
             },
           }
         )
@@ -644,14 +650,31 @@ describe("stable corpus lease", () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "stalled finalize canary");
       let projections = 0;
+      // End the operation from the projection itself rather than by running
+      // out the clock. The assertion below is that the projection DID run, so
+      // a wall-clock budget has to be longer than worker startup or the lease
+      // fails first and the count is zero. That is a property of the runner,
+      // not of the code: startup measures ~80ms unloaded here and this test
+      // budgeted 500ms, which held locally and did not on a loaded macOS
+      // runner. `operationDeadlineForTest` fires the same parent deadline the
+      // timeout would, at a point the test controls.
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
       await expect(
         withStableCorpusLease(
           root,
           () => {
             projections += 1;
+            forceOperationDeadline();
             return "MUST_NOT_PUBLISH";
           },
-          { timeoutMs: 500, workerStallPhaseForTest: "before-authorized" }
+          {
+            timeoutMs: 30_000,
+            workerStallPhaseForTest: "before-authorized",
+            operationDeadlineForTest: operationDeadline,
+          }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
       expect(projections).toBe(1);
@@ -934,6 +957,35 @@ describe("stable corpus lease", () => {
           onWatcherReady: ({ controls }) => controls.suppressNextFence(),
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+    });
+  });
+
+  it("reports one refusal even when the budget is gone before the worker starts", async () => {
+    // A deadline that has already elapsed when the lease is entered used to
+    // escape as the raw "meeting corpus authorization deadline elapsed",
+    // because the guard at the top of the dispatch throws before the worker
+    // machinery that wraps refusals exists. Callers then saw two different
+    // sentences for one condition, depending only on timing.
+    //
+    // On a contended Windows runner that is reachable with an ordinary short
+    // budget: the process can be descheduled between computing the deadline
+    // and the next statement checking it, which is how CI hit it. The smallest
+    // budget the API accepts reaches the same window every time, because
+    // starting the worker takes far longer than a millisecond.
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
+      let projections = 0;
+      await expect(
+        withStableCorpusLease(
+          root,
+          () => {
+            projections += 1;
+            return "unreachable";
+          },
+          { timeoutMs: 1 }
+        )
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(projections).toBe(0);
     });
   });
 

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -974,18 +974,20 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("reports one refusal even when the budget is gone before the worker starts", async () => {
-    // A deadline that has already elapsed when the lease is entered used to
-    // escape as the raw "meeting corpus authorization deadline elapsed",
-    // because the guard at the top of the dispatch throws before the worker
-    // machinery that wraps refusals exists. Callers then saw two different
-    // sentences for one condition, depending only on timing.
+  it("reports the documented refusal when the budget expires, whichever guard trips", async () => {
+    // An exhausted budget can be noticed by several guards, and only some sit
+    // inside the worker machinery that wraps refusals. The ones outside it
+    // used to escape as the raw "meeting corpus authorization deadline
+    // elapsed", so callers saw two different sentences for one condition
+    // depending only on which guard won. CI hit it on a contended Windows
+    // runner, where a short budget can expire between computing the deadline
+    // and the next statement checking it.
     //
-    // On a contended Windows runner that is reachable with an ordinary short
-    // budget: the process can be descheduled between computing the deadline
-    // and the next statement checking it, which is how CI hit it. The smallest
-    // budget the API accepts reaches the same window every time, because
-    // starting the worker takes far longer than a millisecond.
+    // This pins the contract rather than a route: the smallest budget the API
+    // accepts is reliably gone by the time some guard notices, and every guard
+    // has to produce the same sentence. Which one fires is timing-dependent
+    // and deliberately not asserted -- claiming a specific one would be the
+    // same kind of unverified detail this fix exists to remove.
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
       let projections = 0;

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -1724,7 +1724,46 @@ function parentControls(
  * Run a multi-source projection while a killable worker owns every corpus
  * traversal, exact read, watcher, fence, and cleanup filesystem operation.
  */
+/**
+ * Authorize a stable corpus read, presenting one error for one condition.
+ *
+ * Every way the lease can refuse is a refusal, and callers get the same
+ * sentence for all of them. Without this, which sentence you saw depended on
+ * where the failure landed: `fail()` wraps refusals raised once the worker is
+ * running, but a `CorpusLeaseChangedError` thrown before that, such as the
+ * deadline guard at the top of the dispatch below, escaped raw.
+ *
+ * That is observable, not cosmetic. On a contended Windows runner a short
+ * budget can elapse between computing the deadline and the very next
+ * statement checking it, so the same timeout surfaced as
+ * "meeting corpus authorization deadline elapsed" instead of the documented
+ * refusal, and CI failed with a message mismatch rather than a real defect.
+ *
+ * `CorpusLeaseBudgetError` and the plain `Error` refusals keep their own text:
+ * those name a caller-actionable limit rather than an authorization outcome.
+ */
 export async function withStableCorpusLease<T>(
+  root: string,
+  operation: (
+    snapshot: StableCorpusSnapshot,
+    attempt: number,
+    signal: AbortSignal
+  ) => T | Promise<T>,
+  hooks: CorpusLeaseHooks = {}
+): Promise<T> {
+  try {
+    return await dispatchStableCorpusLease(root, operation, hooks);
+  } catch (error) {
+    if (error instanceof CorpusLeaseChangedError) {
+      throw new Error(
+        "Access denied: stable meeting corpus authorization failed"
+      );
+    }
+    throw error;
+  }
+}
+
+async function dispatchStableCorpusLease<T>(
   root: string,
   operation: (
     snapshot: StableCorpusSnapshot,

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -1829,11 +1829,20 @@ async function dispatchStableCorpusLease<T>(
     resolveTermination();
   });
 
+  // A refusal kills the worker, but protocol lines already in flight are still
+  // being handled, so a write can land on a pipe whose reader is gone. That
+  // raises an asynchronous EPIPE on the stream, and an 'error' event with no
+  // listener is fatal to the host process, not just to this lease. Absorbing
+  // it is correct: by the time the pipe is gone the lease has already settled
+  // and the message has nowhere useful to go.
+  child.stdin?.on("error", () => {});
+
   const send = (message: unknown): void => {
     const serialized = JSON.stringify(message);
     if (Buffer.byteLength(serialized) > CORPUS_WORKER_PROTOCOL_MAX_BYTES || !child.stdin) {
       throw new CorpusLeaseBudgetError("meeting corpus worker protocol exceeded its budget");
     }
+    if (settled || child.stdin.destroyed || child.killed) return;
     child.stdin.write(serialized + "\n");
   };
 


### PR DESCRIPTION
Fixes the `corpus-lease.test.ts` flakes that have been costing a CI re-run each time. Two separate causes: one is a product defect, one is a test defect.

## 1. Product defect: two errors for one condition (the Windows failure)

The Windows CI failure was not a timeout being too tight. It was `withStableCorpusLease` reporting a different error depending only on timing:

```
Expected: "stable meeting corpus authorization failed"
Received: "meeting corpus authorization deadline elapsed"
```

`fail()` wraps refusals raised once the worker is running, but a `CorpusLeaseChangedError` thrown before that escapes raw. The dispatch computes the deadline and checks it on the very next statement:

```ts
const deadline = authorizationDeadline(hooks.timeoutMs);
const timeoutMs = remainingAuthorizationMs(deadline);   // throws raw
```

On a contended runner the process can be descheduled between those two lines, so a short budget elapses in the gap. This reaches CLI, MCP, and desktop callers, not just tests: the same failure has two different user-visible messages.

The public entry now maps every `CorpusLeaseChangedError` to the documented refusal. `CorpusLeaseBudgetError` and the plain `Error` refusals keep their own text, since those name a caller-actionable limit rather than an authorization outcome, and four tests assert them specifically.

Reproduced deterministically with the smallest accepted budget. Without the wrapper the new test fails with the exact CI text:

```
expected ... 'stable meeting corpus authorization f…'
but got 'meeting corpus authorization deadline…'
```

## 2. Test defect: asserting a positive count against a wall clock (the macOS failure)

`never publishes a projection when final authorization stalls` asserts `projections === 1` while giving the whole lease 500ms. That budget has to cover spawning a worker, arming a recursive watcher, and computing a baseline manifest before the projection runs at all. When it does not, the lease fails first and the count is 0, which is exactly what CI reported.

Measured on this machine:

| | time to reach the projection |
|---|---|
| unloaded | p50 81ms, max 87ms |
| 1.5x CPU oversubscription | p50 92ms, p90 113ms, max 132ms |

So 500ms held here with ~4x margin and did not on a loaded macOS runner.

It now ends the operation from inside the projection using `operationDeadlineForTest`, the seam already in this file for precisely this purpose, so the deadline fires at a point the test controls rather than whenever the runner gets there. It is also faster: 119ms instead of a 500ms wall-clock wait.

I hardened one latent case of the same shape, `uses one cumulative deadline across hooks and retry attempts`, which asserts `baselineCalls === 1` against a 500ms budget. Its hook still outlasts the budget, which is the property under test.

## Verification

- **0 failures in 8 full-file runs under 1.5x CPU oversubscription** (the loaded condition that reproduces CI)
- each fix confirmed to fail without its change
- SDK suite: 146 passed, 1 skipped
- MCP suite: 280 passed, 1 skipped

Before this, the same file was 0/12 in isolation locally, which is why it only ever showed up on CI.