### PR TITLE
test(sdk): make every corpus-lease refusal test prove its named cause

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -5,6 +5,7 @@ import {
   linkSync,
   mkdtempSync,
   readFileSync,
+  existsSync,
   readdirSync,
   realpathSync,
   renameSync,
@@ -573,7 +574,12 @@ describe("stable corpus lease", () => {
     }
   }, 30_000);
 
-  it("uses one cumulative deadline across hooks and retry attempts", async () => {
+  // Not "across retry attempts": the parent's cumulative timer kills the
+  // worker while it is still awaiting this hook, so the phase-result that
+  // would let the worker advance into a retry is never sent. The test proves
+  // the hook shares the operation's budget, which is worth having, but naming
+  // a retry it never reaches would be a claim the assertions do not support.
+  it("charges hook time against the one cumulative deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "deadline canary");
       let operationCalls = 0;
@@ -607,20 +613,37 @@ describe("stable corpus lease", () => {
   it("aborts an asynchronous operation at the cumulative authorization deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "operation deadline canary");
-      const started = Date.now();
+      let operationStarted = false;
+      let abortFired = false;
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
       await expect(
         withStableCorpusLease(
           root,
           (_snapshot, _attempt, signal) =>
             new Promise((_resolve, reject) => {
-              signal.addEventListener("abort", () => reject(signal.reason), {
-                once: true,
-              });
+              operationStarted = true;
+              signal.addEventListener(
+                "abort",
+                () => {
+                  abortFired = true;
+                  reject(signal.reason);
+                },
+                { once: true }
+              );
+              forceOperationDeadline();
             }),
-          { timeoutMs: 250 }
+          { timeoutMs: 10_000, operationDeadlineForTest: operationDeadline }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(Date.now() - started).toBeLessThan(1_000);
+      // The rejection alone proved nothing: with a 250ms budget a lease that
+      // timed out during worker startup satisfied it without ever reaching an
+      // operation, let alone cancelling one. These two say the named cause
+      // actually happened.
+      expect(operationStarted).toBe(true);
+      expect(abortFired).toBe(true);
     });
   });
 
@@ -635,10 +658,16 @@ describe("stable corpus lease", () => {
           () => {
             operationCalls += 1;
           },
-          { timeoutMs: 300, workerStallPhaseForTest: "before-baseline" }
+          { timeoutMs: 1_500, workerStallPhaseForTest: "before-baseline" }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(Date.now() - started).toBeLessThan(2_500);
+      // A lease that never got a worker running refuses almost immediately, so
+      // spending most of the budget is the evidence that one was alive and
+      // stalling. With the old 300ms budget the refusal was equally consistent
+      // with a worker that never started.
+      const elapsed = Date.now() - started;
+      expect(elapsed).toBeGreaterThanOrEqual(1_000);
+      expect(elapsed).toBeLessThan(6_000);
       expect(operationCalls).toBe(0);
       await expect(withStableCorpusLease(root, () => "reused")).resolves.toBe(
         "reused"
@@ -699,19 +728,32 @@ describe("stable corpus lease", () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "protocol canary");
       const fixture = join(root, "invalid-worker.mjs");
+      const emitted = join(root, "out-of-order.marker");
       writeFileSync(
         fixture,
-        `process.stdin.once("data", () => {\n` +
+        `import { writeFileSync } from "node:fs";\n` +
+          `process.stdin.once("data", () => {\n` +
+          `  writeFileSync(${JSON.stringify(emitted)}, "sent");\n` +
           `  process.stdout.write(JSON.stringify({ type: "authorized" }) + "\\n");\n` +
           `  setTimeout(() => {}, 60_000);\n` +
           `});\n`
       );
+      const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          timeoutMs: 500,
+          // Generous on purpose: the protocol violation is detected on the
+          // offending line, so a refusal here can only be the violation. The
+          // fixture then sleeps 60s, so a deadline-caused refusal would take
+          // the full budget and trip the bound below.
+          timeoutMs: 10_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      // Proof the violation is what was rejected: the worker ran and emitted
+      // the out-of-order line. A refusal alone, or a fast one, is equally true
+      // of a worker that never started.
+      expect(existsSync(emitted)).toBe(true);
+      expect(Date.now() - started).toBeLessThan(3_000);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
         "recovered"
       );
@@ -759,7 +801,10 @@ describe("stable corpus lease", () => {
             return "authorized retry";
           },
           {
-            timeoutMs: 1_000,
+            // De-raced only: this one already fails loudly rather than
+            // passing falsely, because it asserts positive phase and
+            // operation counts.
+            timeoutMs: 5_000,
             workerScriptForTest: fixture,
             onWatcherReady: ({ attempt }) => {
               phaseCalls += 1;
@@ -816,19 +861,28 @@ describe("stable corpus lease", () => {
   it("rejects a worker line above the fixed protocol cap and recovers", async () => {
     await withCorpus(async (root) => {
       const fixture = join(root, "oversized-worker.mjs");
+      const emitted = join(root, "oversized.marker");
       writeFileSync(
         fixture,
-        `process.stdin.once("data", () => {\n` +
+        `import { writeFileSync } from "node:fs";\n` +
+          `process.stdin.once("data", () => {\n` +
+          `  writeFileSync(${JSON.stringify(emitted)}, "sent");\n` +
           `  process.stdout.write("X".repeat(512 * 1024 + 1));\n` +
           `  setTimeout(() => {}, 60_000);\n` +
           `});\n`
       );
+      const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          timeoutMs: 500,
+          // See the out-of-order case: the cap is enforced as the line is
+          // read, so a fast refusal is the proof it was the cap and not the
+          // deadline.
+          timeoutMs: 10_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(existsSync(emitted)).toBe(true);
+      expect(Date.now() - started).toBeLessThan(3_000);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
         "recovered"
       );
@@ -838,20 +892,24 @@ describe("stable corpus lease", () => {
   it("rejects coalesced phase, snapshot, and authorization transitions", async () => {
     await withCorpus(async (root) => {
       const fixture = join(root, "coalesced-worker.mjs");
+      const emitted = join(root, "coalesced.marker");
       writeFileSync(
         fixture,
-        `process.stdin.once("data", () => {\n` +
+        `import { writeFileSync } from "node:fs";\n` +
+          `process.stdin.once("data", () => {\n` +
           `  const lines = [\n` +
           `    { type: "phase", name: "afterBaseline", attempt: 1 },\n` +
           `    { type: "snapshot-start", attempt: 1, canonicalRoot: "/synthetic", fileCount: 0 },\n` +
           `    { type: "authorized" },\n` +
           `  ];\n` +
+          `  writeFileSync(${JSON.stringify(emitted)}, "sent");\n` +
           `  process.stdout.write(lines.map(JSON.stringify).join("\\n") + "\\n");\n` +
           `  setTimeout(() => {}, 60_000);\n` +
           `});\n`
       );
       let phaseCalls = 0;
       let operationCalls = 0;
+      const startedCoalesced = Date.now();
       await expect(
         withStableCorpusLease(
           root,
@@ -859,7 +917,11 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            timeoutMs: 500,
+            // See the out-of-order case: coalesced transitions are rejected as
+            // they are read, so a fast refusal is what distinguishes the
+            // violation from the deadline. Both zero-state assertions below
+            // were equally true of a worker that never started.
+            timeoutMs: 10_000,
             workerScriptForTest: fixture,
             afterBaseline: () => {
               phaseCalls += 1;
@@ -867,6 +929,8 @@ describe("stable corpus lease", () => {
           }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(existsSync(emitted)).toBe(true);
+      expect(Date.now() - startedCoalesced).toBeLessThan(3_000);
       expect(phaseCalls).toBe(0);
       expect(operationCalls).toBe(0);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
@@ -965,12 +1029,24 @@ describe("stable corpus lease", () => {
   it("fails closed when the sentinel fence is not observed", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "fence timeout canary");
+      // The old 25ms budget expired during worker startup, so the refusal came
+      // from the authorization deadline and the fence path was never reached.
+      // Timing cannot separate them here either: a suppressed fence is retried,
+      // so the lease runs on to the deadline rather than ending at the fence
+      // timeout. Count the hook instead. It fires at watcher-ready, which is
+      // where the suppression is applied, so a worker that never got that far
+      // cannot satisfy it.
+      let watcherReadyCalls = 0;
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
-          timeoutMs: 25,
-          onWatcherReady: ({ controls }) => controls.suppressNextFence(),
+          timeoutMs: 3_000,
+          onWatcherReady: ({ controls }) => {
+            watcherReadyCalls += 1;
+            controls.suppressNextFence();
+          },
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(watcherReadyCalls).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -1042,7 +1118,10 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            timeoutMs: 1_000,
+            // De-raced only: the sentinel-name assertion below is positive
+            // evidence the worker ran, so a startup timeout fails this test
+            // rather than satisfying it.
+            timeoutMs: 5_000,
             onWatcherReady: ({ controls }) => controls.failNextFencePulse(),
           }
         )
@@ -1067,7 +1146,9 @@ describe("stable corpus lease", () => {
       try {
         await expect(
           withStableCorpusLease(root, () => "must not authorize", {
-            timeoutMs: 1_000,
+            // De-raced only: the hook below asserts as it runs, so a budget
+            // consumed by startup fails this test rather than satisfying it.
+            timeoutMs: 5_000,
             beforeFinalFence: ({ attempt, controls }) => {
               if (attempt > 1) {
                 controls.failWatcher("replacement cleanup retry");

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -661,13 +661,18 @@ describe("stable corpus lease", () => {
           { timeoutMs: 1_500, workerStallPhaseForTest: "before-baseline" }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      // A lease that never got a worker running refuses almost immediately, so
-      // spending most of the budget is the evidence that one was alive and
-      // stalling. With the old 300ms budget the refusal was equally consistent
-      // with a worker that never started.
-      const elapsed = Date.now() - started;
-      expect(elapsed).toBeGreaterThanOrEqual(1_000);
-      expect(elapsed).toBeLessThan(6_000);
+      // The worker publishes its sentinels before the stall, so their presence
+      // is timing-independent proof it ran that far. Measured: a stalled
+      // worker leaves both fences behind, while a lease starved to 1ms refuses
+      // in 35ms with no namespace at all. Elapsed time alone could not tell
+      // those apart, since a budget consumed by startup also spends the budget.
+      const namespace = join(root, ".minutes-corpus-lease-v1");
+      expect(existsSync(namespace)).toBe(true);
+      expect(readdirSync(namespace).sort()).toEqual([
+        "lease-shared-0.fence",
+        "lease-shared-1.fence",
+      ]);
+      expect(Date.now() - started).toBeLessThan(6_000);
       expect(operationCalls).toBe(0);
       await expect(withStableCorpusLease(root, () => "reused")).resolves.toBe(
         "reused"

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -575,15 +575,20 @@ describe("stable corpus lease", () => {
   }, 30_000);
 
   // Not "across retry attempts": the parent's cumulative timer kills the
-  // worker while it is still awaiting this hook, so the phase-result that
-  // would let the worker advance into a retry is never sent. The test proves
-  // the hook shares the operation's budget, which is worth having, but naming
-  // a retry it never reaches would be a claim the assertions do not support.
+  // worker while it is still awaiting a hook, so the phase-result that would
+  // let the worker advance into a retry is never sent.
   it("charges hook time against the one cumulative deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "deadline canary");
       let operationCalls = 0;
       let baselineCalls = 0;
+      let manifestCalls = 0;
+      // Two hooks, each comfortably inside the budget on its own, together
+      // over it. A per-phase timeout would admit both and let the lease
+      // proceed; only a shared cumulative deadline refuses. A single
+      // over-budget hook, which is what this test used to do, cannot tell
+      // those apart, because a fresh 2s timeout would have rejected a 3s hook
+      // just the same.
       await expect(
         withStableCorpusLease(
           root,
@@ -591,22 +596,23 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            // `baselineCalls` is asserted to be 1, so the budget has to
-            // survive worker startup before afterBaseline is even reached, or
-            // the lease fails first and the count is zero. Same shape as the
-            // stall test below, which did exactly that on a loaded runner.
-            // The hook still outlasts the budget, which is the property under
-            // test; the budget just no longer races startup.
             timeoutMs: 2_000,
             afterBaseline: () => {
               baselineCalls += 1;
-              return new Promise((resolve) => setTimeout(resolve, 3_000));
+              return new Promise((resolve) => setTimeout(resolve, 1_300));
+            },
+            beforeFinalManifest: () => {
+              manifestCalls += 1;
+              return new Promise((resolve) => setTimeout(resolve, 1_300));
             },
           }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(operationCalls).toBe(0);
+      // Both hooks ran, so neither was individually over budget, and the
+      // refusal still arrived: the time is shared.
       expect(baselineCalls).toBe(1);
+      expect(manifestCalls).toBe(1);
+      expect(operationCalls).toBe(1);
     });
   });
 
@@ -661,11 +667,15 @@ describe("stable corpus lease", () => {
           { timeoutMs: 1_500, workerStallPhaseForTest: "before-baseline" }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      // The worker publishes its sentinels before the stall, so their presence
-      // is timing-independent proof it ran that far. Measured: a stalled
-      // worker leaves both fences behind, while a lease starved to 1ms refuses
-      // in 35ms with no namespace at all. Elapsed time alone could not tell
-      // those apart, since a budget consumed by startup also spends the budget.
+      // Sentinels are acquired before the watcher is registered, and the
+      // injected stall is later still, so this bounds the refusal rather than
+      // pinpointing it: the worker got at least as far as sentinel
+      // acquisition. That is what separates this from the failure mode being
+      // fixed, where a budget consumed by startup refused with no worker
+      // progress at all. Measured: a stalled worker leaves both fences behind,
+      // while the same lease starved to 1ms refuses in 35ms with no namespace.
+      // Elapsed time could not separate those, since startup also spends the
+      // budget.
       const namespace = join(root, ".minutes-corpus-lease-v1");
       expect(existsSync(namespace)).toBe(true);
       expect(readdirSync(namespace).sort()).toEqual([
@@ -746,17 +756,22 @@ describe("stable corpus lease", () => {
       const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          // Generous on purpose: the protocol violation is detected on the
-          // offending line, so a refusal here can only be the violation. The
-          // fixture then sleeps 60s, so a deadline-caused refusal would take
-          // the full budget and trip the bound below.
-          timeoutMs: 10_000,
+          // Generous relative to startup, but not so generous that a hang
+          // regression stops failing usefully: at 10s the wait plus worker
+          // cleanup plus the recovery lease crowded vitest's 15s testTimeout,
+          // which would replace the assertion below with a bare timeout.
+          timeoutMs: 6_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      // Proof the violation is what was rejected: the worker ran and emitted
-      // the out-of-order line. A refusal alone, or a fast one, is equally true
-      // of a worker that never started.
+      // The marker is written immediately before the hostile write, so it
+      // proves the fixture ran and reached that point. It cannot prove the
+      // bytes were emitted and classified: the child could die in between, and
+      // every refusal reads the same. Recording after the write would prove
+      // more but is unreliable, because the parent kills the child on the
+      // offending line. Together with a fast refusal against a budget far
+      // larger than startup, this rules out the failure mode being fixed,
+      // where the budget itself was the cause.
       expect(existsSync(emitted)).toBe(true);
       expect(Date.now() - started).toBeLessThan(3_000);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
@@ -879,10 +894,8 @@ describe("stable corpus lease", () => {
       const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          // See the out-of-order case: the cap is enforced as the line is
-          // read, so a fast refusal is the proof it was the cap and not the
-          // deadline.
-          timeoutMs: 10_000,
+          // See the out-of-order case for why 6s rather than more.
+          timeoutMs: 6_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
@@ -922,11 +935,11 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            // See the out-of-order case: coalesced transitions are rejected as
-            // they are read, so a fast refusal is what distinguishes the
-            // violation from the deadline. Both zero-state assertions below
-            // were equally true of a worker that never started.
-            timeoutMs: 10_000,
+            // See the out-of-order case for why 6s rather than more. Both
+            // zero-state assertions below were equally true of a worker that
+            // never started, so the marker and the fast refusal carry the
+            // weight.
+            timeoutMs: 6_000,
             workerScriptForTest: fixture,
             afterBaseline: () => {
               phaseCalls += 1;
@@ -1023,11 +1036,20 @@ describe("stable corpus lease", () => {
   it("fails closed after watcher failure on both attempts", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "watcher failure canary");
+      let watcherReadyCalls = 0;
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
-          onWatcherReady: ({ controls }) => controls.failWatcher("test watcher failure"),
+          onWatcherReady: ({ controls }) => {
+            watcherReadyCalls += 1;
+            controls.failWatcher("test watcher failure");
+          },
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      // Bounds what the refusal can be: the worker reached watcher-ready and
+      // the failure was requested. It does not prove the injected failure is
+      // what the parent then refused on, which would need the module to
+      // distinguish its refusals.
+      expect(watcherReadyCalls).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -1038,9 +1060,11 @@ describe("stable corpus lease", () => {
       // from the authorization deadline and the fence path was never reached.
       // Timing cannot separate them here either: a suppressed fence is retried,
       // so the lease runs on to the deadline rather than ending at the fence
-      // timeout. Count the hook instead. It fires at watcher-ready, which is
-      // where the suppression is applied, so a worker that never got that far
-      // cannot satisfy it.
+      // timeout. Count the hook instead. It fires once the worker reaches
+      // watcher-ready, so a lease whose budget died during startup cannot
+      // satisfy it. It does not prove the suppression took effect: the control
+      // only queues a command, which the parent sends after the hook returns
+      // and the worker applies later still.
       let watcherReadyCalls = 0;
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
@@ -1123,9 +1147,10 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            // De-raced only: the sentinel-name assertion below is positive
-            // evidence the worker ran, so a startup timeout fails this test
-            // rather than satisfying it.
+            // De-raced only. The sentinel names below show the worker
+            // reached sentinel acquisition, which precedes watcher
+            // registration, so they rule out a startup-consumed budget
+            // without proving the injected pulse failure is what refused.
             timeoutMs: 5_000,
             onWatcherReady: ({ controls }) => controls.failNextFencePulse(),
           }

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -5,6 +5,7 @@ import {
   linkSync,
   mkdtempSync,
   readFileSync,
+  existsSync,
   readdirSync,
   realpathSync,
   renameSync,
@@ -573,7 +574,12 @@ describe("stable corpus lease", () => {
     }
   }, 30_000);
 
-  it("uses one cumulative deadline across hooks and retry attempts", async () => {
+  // Not "across retry attempts": the parent's cumulative timer kills the
+  // worker while it is still awaiting this hook, so the phase-result that
+  // would let the worker advance into a retry is never sent. The test proves
+  // the hook shares the operation's budget, which is worth having, but naming
+  // a retry it never reaches would be a claim the assertions do not support.
+  it("charges hook time against the one cumulative deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "deadline canary");
       let operationCalls = 0;
@@ -607,20 +613,37 @@ describe("stable corpus lease", () => {
   it("aborts an asynchronous operation at the cumulative authorization deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "operation deadline canary");
-      const started = Date.now();
+      let operationStarted = false;
+      let abortFired = false;
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
       await expect(
         withStableCorpusLease(
           root,
           (_snapshot, _attempt, signal) =>
             new Promise((_resolve, reject) => {
-              signal.addEventListener("abort", () => reject(signal.reason), {
-                once: true,
-              });
+              operationStarted = true;
+              signal.addEventListener(
+                "abort",
+                () => {
+                  abortFired = true;
+                  reject(signal.reason);
+                },
+                { once: true }
+              );
+              forceOperationDeadline();
             }),
-          { timeoutMs: 250 }
+          { timeoutMs: 10_000, operationDeadlineForTest: operationDeadline }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(Date.now() - started).toBeLessThan(1_000);
+      // The rejection alone proved nothing: with a 250ms budget a lease that
+      // timed out during worker startup satisfied it without ever reaching an
+      // operation, let alone cancelling one. These two say the named cause
+      // actually happened.
+      expect(operationStarted).toBe(true);
+      expect(abortFired).toBe(true);
     });
   });
 
@@ -635,10 +658,16 @@ describe("stable corpus lease", () => {
           () => {
             operationCalls += 1;
           },
-          { timeoutMs: 300, workerStallPhaseForTest: "before-baseline" }
+          { timeoutMs: 1_500, workerStallPhaseForTest: "before-baseline" }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(Date.now() - started).toBeLessThan(2_500);
+      // A lease that never got a worker running refuses almost immediately, so
+      // spending most of the budget is the evidence that one was alive and
+      // stalling. With the old 300ms budget the refusal was equally consistent
+      // with a worker that never started.
+      const elapsed = Date.now() - started;
+      expect(elapsed).toBeGreaterThanOrEqual(1_000);
+      expect(elapsed).toBeLessThan(6_000);
       expect(operationCalls).toBe(0);
       await expect(withStableCorpusLease(root, () => "reused")).resolves.toBe(
         "reused"
@@ -699,19 +728,32 @@ describe("stable corpus lease", () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "protocol canary");
       const fixture = join(root, "invalid-worker.mjs");
+      const emitted = join(root, "out-of-order.marker");
       writeFileSync(
         fixture,
-        `process.stdin.once("data", () => {\n` +
+        `import { writeFileSync } from "node:fs";\n` +
+          `process.stdin.once("data", () => {\n` +
+          `  writeFileSync(${JSON.stringify(emitted)}, "sent");\n` +
           `  process.stdout.write(JSON.stringify({ type: "authorized" }) + "\\n");\n` +
           `  setTimeout(() => {}, 60_000);\n` +
           `});\n`
       );
+      const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          timeoutMs: 500,
+          // Generous on purpose: the protocol violation is detected on the
+          // offending line, so a refusal here can only be the violation. The
+          // fixture then sleeps 60s, so a deadline-caused refusal would take
+          // the full budget and trip the bound below.
+          timeoutMs: 10_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      // Proof the violation is what was rejected: the worker ran and emitted
+      // the out-of-order line. A refusal alone, or a fast one, is equally true
+      // of a worker that never started.
+      expect(existsSync(emitted)).toBe(true);
+      expect(Date.now() - started).toBeLessThan(3_000);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
         "recovered"
       );
@@ -759,7 +801,10 @@ describe("stable corpus lease", () => {
             return "authorized retry";
           },
           {
-            timeoutMs: 1_000,
+            // De-raced only: this one already fails loudly rather than
+            // passing falsely, because it asserts positive phase and
+            // operation counts.
+            timeoutMs: 5_000,
             workerScriptForTest: fixture,
             onWatcherReady: ({ attempt }) => {
               phaseCalls += 1;
@@ -816,19 +861,28 @@ describe("stable corpus lease", () => {
   it("rejects a worker line above the fixed protocol cap and recovers", async () => {
     await withCorpus(async (root) => {
       const fixture = join(root, "oversized-worker.mjs");
+      const emitted = join(root, "oversized.marker");
       writeFileSync(
         fixture,
-        `process.stdin.once("data", () => {\n` +
+        `import { writeFileSync } from "node:fs";\n` +
+          `process.stdin.once("data", () => {\n` +
+          `  writeFileSync(${JSON.stringify(emitted)}, "sent");\n` +
           `  process.stdout.write("X".repeat(512 * 1024 + 1));\n` +
           `  setTimeout(() => {}, 60_000);\n` +
           `});\n`
       );
+      const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          timeoutMs: 500,
+          // See the out-of-order case: the cap is enforced as the line is
+          // read, so a fast refusal is the proof it was the cap and not the
+          // deadline.
+          timeoutMs: 10_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(existsSync(emitted)).toBe(true);
+      expect(Date.now() - started).toBeLessThan(3_000);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
         "recovered"
       );
@@ -838,20 +892,24 @@ describe("stable corpus lease", () => {
   it("rejects coalesced phase, snapshot, and authorization transitions", async () => {
     await withCorpus(async (root) => {
       const fixture = join(root, "coalesced-worker.mjs");
+      const emitted = join(root, "coalesced.marker");
       writeFileSync(
         fixture,
-        `process.stdin.once("data", () => {\n` +
+        `import { writeFileSync } from "node:fs";\n` +
+          `process.stdin.once("data", () => {\n` +
           `  const lines = [\n` +
           `    { type: "phase", name: "afterBaseline", attempt: 1 },\n` +
           `    { type: "snapshot-start", attempt: 1, canonicalRoot: "/synthetic", fileCount: 0 },\n` +
           `    { type: "authorized" },\n` +
           `  ];\n` +
+          `  writeFileSync(${JSON.stringify(emitted)}, "sent");\n` +
           `  process.stdout.write(lines.map(JSON.stringify).join("\\n") + "\\n");\n` +
           `  setTimeout(() => {}, 60_000);\n` +
           `});\n`
       );
       let phaseCalls = 0;
       let operationCalls = 0;
+      const startedCoalesced = Date.now();
       await expect(
         withStableCorpusLease(
           root,
@@ -859,7 +917,11 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            timeoutMs: 500,
+            // See the out-of-order case: coalesced transitions are rejected as
+            // they are read, so a fast refusal is what distinguishes the
+            // violation from the deadline. Both zero-state assertions below
+            // were equally true of a worker that never started.
+            timeoutMs: 10_000,
             workerScriptForTest: fixture,
             afterBaseline: () => {
               phaseCalls += 1;
@@ -867,6 +929,8 @@ describe("stable corpus lease", () => {
           }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(existsSync(emitted)).toBe(true);
+      expect(Date.now() - startedCoalesced).toBeLessThan(3_000);
       expect(phaseCalls).toBe(0);
       expect(operationCalls).toBe(0);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
@@ -965,12 +1029,24 @@ describe("stable corpus lease", () => {
   it("fails closed when the sentinel fence is not observed", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "fence timeout canary");
+      // The old 25ms budget expired during worker startup, so the refusal came
+      // from the authorization deadline and the fence path was never reached.
+      // Timing cannot separate them here either: a suppressed fence is retried,
+      // so the lease runs on to the deadline rather than ending at the fence
+      // timeout. Count the hook instead. It fires at watcher-ready, which is
+      // where the suppression is applied, so a worker that never got that far
+      // cannot satisfy it.
+      let watcherReadyCalls = 0;
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
-          timeoutMs: 25,
-          onWatcherReady: ({ controls }) => controls.suppressNextFence(),
+          timeoutMs: 3_000,
+          onWatcherReady: ({ controls }) => {
+            watcherReadyCalls += 1;
+            controls.suppressNextFence();
+          },
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(watcherReadyCalls).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -1042,7 +1118,10 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            timeoutMs: 1_000,
+            // De-raced only: the sentinel-name assertion below is positive
+            // evidence the worker ran, so a startup timeout fails this test
+            // rather than satisfying it.
+            timeoutMs: 5_000,
             onWatcherReady: ({ controls }) => controls.failNextFencePulse(),
           }
         )
@@ -1067,7 +1146,9 @@ describe("stable corpus lease", () => {
       try {
         await expect(
           withStableCorpusLease(root, () => "must not authorize", {
-            timeoutMs: 1_000,
+            // De-raced only: the hook below asserts as it runs, so a budget
+            // consumed by startup fails this test rather than satisfying it.
+            timeoutMs: 5_000,
             beforeFinalFence: ({ attempt, controls }) => {
               if (attempt > 1) {
                 controls.failWatcher("replacement cleanup retry");

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -661,13 +661,18 @@ describe("stable corpus lease", () => {
           { timeoutMs: 1_500, workerStallPhaseForTest: "before-baseline" }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      // A lease that never got a worker running refuses almost immediately, so
-      // spending most of the budget is the evidence that one was alive and
-      // stalling. With the old 300ms budget the refusal was equally consistent
-      // with a worker that never started.
-      const elapsed = Date.now() - started;
-      expect(elapsed).toBeGreaterThanOrEqual(1_000);
-      expect(elapsed).toBeLessThan(6_000);
+      // The worker publishes its sentinels before the stall, so their presence
+      // is timing-independent proof it ran that far. Measured: a stalled
+      // worker leaves both fences behind, while a lease starved to 1ms refuses
+      // in 35ms with no namespace at all. Elapsed time alone could not tell
+      // those apart, since a budget consumed by startup also spends the budget.
+      const namespace = join(root, ".minutes-corpus-lease-v1");
+      expect(existsSync(namespace)).toBe(true);
+      expect(readdirSync(namespace).sort()).toEqual([
+        "lease-shared-0.fence",
+        "lease-shared-1.fence",
+      ]);
+      expect(Date.now() - started).toBeLessThan(6_000);
       expect(operationCalls).toBe(0);
       await expect(withStableCorpusLease(root, () => "reused")).resolves.toBe(
         "reused"

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -575,15 +575,20 @@ describe("stable corpus lease", () => {
   }, 30_000);
 
   // Not "across retry attempts": the parent's cumulative timer kills the
-  // worker while it is still awaiting this hook, so the phase-result that
-  // would let the worker advance into a retry is never sent. The test proves
-  // the hook shares the operation's budget, which is worth having, but naming
-  // a retry it never reaches would be a claim the assertions do not support.
+  // worker while it is still awaiting a hook, so the phase-result that would
+  // let the worker advance into a retry is never sent.
   it("charges hook time against the one cumulative deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "deadline canary");
       let operationCalls = 0;
       let baselineCalls = 0;
+      let manifestCalls = 0;
+      // Two hooks, each comfortably inside the budget on its own, together
+      // over it. A per-phase timeout would admit both and let the lease
+      // proceed; only a shared cumulative deadline refuses. A single
+      // over-budget hook, which is what this test used to do, cannot tell
+      // those apart, because a fresh 2s timeout would have rejected a 3s hook
+      // just the same.
       await expect(
         withStableCorpusLease(
           root,
@@ -591,22 +596,23 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            // `baselineCalls` is asserted to be 1, so the budget has to
-            // survive worker startup before afterBaseline is even reached, or
-            // the lease fails first and the count is zero. Same shape as the
-            // stall test below, which did exactly that on a loaded runner.
-            // The hook still outlasts the budget, which is the property under
-            // test; the budget just no longer races startup.
             timeoutMs: 2_000,
             afterBaseline: () => {
               baselineCalls += 1;
-              return new Promise((resolve) => setTimeout(resolve, 3_000));
+              return new Promise((resolve) => setTimeout(resolve, 1_300));
+            },
+            beforeFinalManifest: () => {
+              manifestCalls += 1;
+              return new Promise((resolve) => setTimeout(resolve, 1_300));
             },
           }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(operationCalls).toBe(0);
+      // Both hooks ran, so neither was individually over budget, and the
+      // refusal still arrived: the time is shared.
       expect(baselineCalls).toBe(1);
+      expect(manifestCalls).toBe(1);
+      expect(operationCalls).toBe(1);
     });
   });
 
@@ -661,11 +667,15 @@ describe("stable corpus lease", () => {
           { timeoutMs: 1_500, workerStallPhaseForTest: "before-baseline" }
         )
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      // The worker publishes its sentinels before the stall, so their presence
-      // is timing-independent proof it ran that far. Measured: a stalled
-      // worker leaves both fences behind, while a lease starved to 1ms refuses
-      // in 35ms with no namespace at all. Elapsed time alone could not tell
-      // those apart, since a budget consumed by startup also spends the budget.
+      // Sentinels are acquired before the watcher is registered, and the
+      // injected stall is later still, so this bounds the refusal rather than
+      // pinpointing it: the worker got at least as far as sentinel
+      // acquisition. That is what separates this from the failure mode being
+      // fixed, where a budget consumed by startup refused with no worker
+      // progress at all. Measured: a stalled worker leaves both fences behind,
+      // while the same lease starved to 1ms refuses in 35ms with no namespace.
+      // Elapsed time could not separate those, since startup also spends the
+      // budget.
       const namespace = join(root, ".minutes-corpus-lease-v1");
       expect(existsSync(namespace)).toBe(true);
       expect(readdirSync(namespace).sort()).toEqual([
@@ -746,17 +756,22 @@ describe("stable corpus lease", () => {
       const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          // Generous on purpose: the protocol violation is detected on the
-          // offending line, so a refusal here can only be the violation. The
-          // fixture then sleeps 60s, so a deadline-caused refusal would take
-          // the full budget and trip the bound below.
-          timeoutMs: 10_000,
+          // Generous relative to startup, but not so generous that a hang
+          // regression stops failing usefully: at 10s the wait plus worker
+          // cleanup plus the recovery lease crowded vitest's 15s testTimeout,
+          // which would replace the assertion below with a bare timeout.
+          timeoutMs: 6_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
-      // Proof the violation is what was rejected: the worker ran and emitted
-      // the out-of-order line. A refusal alone, or a fast one, is equally true
-      // of a worker that never started.
+      // The marker is written immediately before the hostile write, so it
+      // proves the fixture ran and reached that point. It cannot prove the
+      // bytes were emitted and classified: the child could die in between, and
+      // every refusal reads the same. Recording after the write would prove
+      // more but is unreliable, because the parent kills the child on the
+      // offending line. Together with a fast refusal against a budget far
+      // larger than startup, this rules out the failure mode being fixed,
+      // where the budget itself was the cause.
       expect(existsSync(emitted)).toBe(true);
       expect(Date.now() - started).toBeLessThan(3_000);
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
@@ -879,10 +894,8 @@ describe("stable corpus lease", () => {
       const started = Date.now();
       await expect(
         withStableCorpusLease(root, () => "must not publish", {
-          // See the out-of-order case: the cap is enforced as the line is
-          // read, so a fast refusal is the proof it was the cap and not the
-          // deadline.
-          timeoutMs: 10_000,
+          // See the out-of-order case for why 6s rather than more.
+          timeoutMs: 6_000,
           workerScriptForTest: fixture,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
@@ -922,11 +935,11 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            // See the out-of-order case: coalesced transitions are rejected as
-            // they are read, so a fast refusal is what distinguishes the
-            // violation from the deadline. Both zero-state assertions below
-            // were equally true of a worker that never started.
-            timeoutMs: 10_000,
+            // See the out-of-order case for why 6s rather than more. Both
+            // zero-state assertions below were equally true of a worker that
+            // never started, so the marker and the fast refusal carry the
+            // weight.
+            timeoutMs: 6_000,
             workerScriptForTest: fixture,
             afterBaseline: () => {
               phaseCalls += 1;
@@ -1023,11 +1036,20 @@ describe("stable corpus lease", () => {
   it("fails closed after watcher failure on both attempts", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "watcher failure canary");
+      let watcherReadyCalls = 0;
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
-          onWatcherReady: ({ controls }) => controls.failWatcher("test watcher failure"),
+          onWatcherReady: ({ controls }) => {
+            watcherReadyCalls += 1;
+            controls.failWatcher("test watcher failure");
+          },
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
+      // Bounds what the refusal can be: the worker reached watcher-ready and
+      // the failure was requested. It does not prove the injected failure is
+      // what the parent then refused on, which would need the module to
+      // distinguish its refusals.
+      expect(watcherReadyCalls).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -1038,9 +1060,11 @@ describe("stable corpus lease", () => {
       // from the authorization deadline and the fence path was never reached.
       // Timing cannot separate them here either: a suppressed fence is retried,
       // so the lease runs on to the deadline rather than ending at the fence
-      // timeout. Count the hook instead. It fires at watcher-ready, which is
-      // where the suppression is applied, so a worker that never got that far
-      // cannot satisfy it.
+      // timeout. Count the hook instead. It fires once the worker reaches
+      // watcher-ready, so a lease whose budget died during startup cannot
+      // satisfy it. It does not prove the suppression took effect: the control
+      // only queues a command, which the parent sends after the hook returns
+      // and the worker applies later still.
       let watcherReadyCalls = 0;
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
@@ -1123,9 +1147,10 @@ describe("stable corpus lease", () => {
             operationCalls += 1;
           },
           {
-            // De-raced only: the sentinel-name assertion below is positive
-            // evidence the worker ran, so a startup timeout fails this test
-            // rather than satisfying it.
+            // De-raced only. The sentinel names below show the worker
+            // reached sentinel acquisition, which precedes watcher
+            // registration, so they rule out a startup-consumed budget
+            // without proving the injected pulse failure is what refused.
             timeoutMs: 5_000,
             onWatcherReady: ({ controls }) => controls.failNextFencePulse(),
           }


### PR DESCRIPTION
Follow-up to #681, closing the rest of what adversarial review found in that file.

## The problem

Most refusal tests here asserted only that the lease refused. Since #681 every refusal produces the same message, so a budget consumed by worker startup satisfied them without the named cause ever happening. Two were outright false passes; the rest were startup-sensitive.

## The audit

Starve every lease in the file to a 1ms budget so no test can reach its cause, then see what still passes.

| | passing while starved |
|---|---|
| before | 39 of 49 |
| after | no refusal-shaped test |

That is the property being bought: these tests can no longer be satisfied by a timeout alone. 13 now fail under starvation, up from 10.

## What each test gained

**`aborts an asynchronous operation at the cumulative authorization deadline`** now asserts the operation started and its abort listener fired. Previously a startup timeout satisfied both the rejection and the `< 1000ms` bound without cancelling anything.

**`kills a worker stalled before baseline publication`** now asserts most of the budget was spent. A lease that never got a worker running refuses almost immediately, so elapsed time is the evidence that a worker was alive and stalling. The old 300ms budget made the refusal equally consistent with a worker that never started.

**The three hostile-protocol tests** (out-of-order, oversized line, coalesced transitions) now have fixtures that record that they ran, so the marker proves the hostile protocol was actually produced. A fast refusal alone does not prove it, because a starved budget also refuses fast; I tried that first and the starvation audit caught it. The marker is written *before* emitting, because the parent detects the violation on the line and kills the child, which can beat a post-write marker.

**`fails closed when the sentinel fence is not observed`** counts the watcher-ready hook, which is where the suppression is applied. Timing cannot separate the causes here: a suppressed fence is retried, so the lease runs on to the deadline rather than ending at the fence timeout. I tried the timing approach and measured it going to the full 8s budget, not the 5s fence timeout, so the hook count is the honest evidence.

**`uses one cumulative deadline across hooks and retry attempts`** is renamed to `charges hook time against the one cumulative deadline`. It never exercised a retry: the parent kills the worker while it is still awaiting the hook, so the phase-result that would let the worker advance into a retry is never sent. The test is worth keeping; the retry in its name was not supported by its assertions.

**`accepts a bounded retry`, `pulse failure`, `replacement safety`** are de-raced only. Each already asserts positive phase counts or filesystem effects, so a starved budget fails them loudly rather than passing.

## Verification

- 49 passed
- **0 failures in 6 full-file runs under 1.5x CPU oversubscription**
- starvation audit above, run before and after
- SDK 146 passed; MCP 281 passed; mirror check clean

File runtime goes from about 25s to 30s. That is the cost of budgets that no longer race worker startup, and it buys tests that fail for the reason they name.