### PR TITLE
fix(build): refuse the sherpa+diarize combination on macOS (#683)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,16 +173,30 @@ jobs:
         # kaldi-native-fbank; the compile guard in crates/core/src/lib.rs is
         # what keeps it out of release builds. Assert it actually fires, so a
         # refactor cannot silently drop the cfg and re-open #683.
+        # The oracle greps for the guard's own message. Merely asserting a
+        # nonzero exit would pass on any unrelated failure (network error in a
+        # build script, toolchain breakage) while proving nothing about the
+        # guard.
         run: |
-          if cargo check -p minutes-core --no-default-features --features diarize,engine-sherpa 2>/dev/null; then
-            echo "::error::the #683 compile guard did not fire for diarize+engine-sherpa on macOS"
-            exit 1
-          fi
-          if cargo check -p minutes-core --no-default-features --features vad-ort,engine-sherpa 2>/dev/null; then
-            echo "::error::the #683 compile guard did not fire for vad-ort+engine-sherpa on macOS"
-            exit 1
-          fi
-          echo "guard fired as expected for both combinations"
+          check_guard() {
+            # bash -e: a failing command substitution in a plain assignment
+            # would abort the step before the oracle runs, so capture the
+            # status in the same statement.
+            status=0
+            out=$(cargo check -p minutes-core --no-default-features --features "$1" 2>&1) || status=$?
+            if [ $status -eq 0 ]; then
+              echo "::error::the #683 compile guard did not fire for $1 on macOS"
+              return 1
+            fi
+            if ! printf '%s' "$out" | grep -q "cannot share a macOS binary"; then
+              echo "::error::$1 failed for a reason other than the #683 guard:"
+              printf '%s\n' "$out" | tail -20
+              return 1
+            fi
+            echo "guard fired for $1"
+          }
+          check_guard diarize,engine-sherpa
+          check_guard vad-ort,engine-sherpa
 
       - name: Build full workspace (macOS only)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,11 @@ jobs:
             echo "::error::the #683 compile guard did not fire for diarize+engine-sherpa on macOS"
             exit 1
           fi
-          echo "guard fired as expected"
+          if cargo check -p minutes-core --no-default-features --features vad-ort,engine-sherpa 2>/dev/null; then
+            echo "::error::the #683 compile guard did not fire for vad-ort+engine-sherpa on macOS"
+            exit 1
+          fi
+          echo "guard fired as expected for both combinations"
 
       - name: Build full workspace (macOS only)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,19 @@ jobs:
         # otherwise only surfaces at release, and exercises Linux beyond no-default-features.
         run: cargo build -p minutes-core --no-default-features --features engine-sherpa
 
+      - name: Sherpa + diarize refuse to link on macOS (#683 guard)
+        if: runner.os == 'macOS'
+        # The combination vendors two conflicting copies of ONNX Runtime and
+        # kaldi-native-fbank; the compile guard in crates/core/src/lib.rs is
+        # what keeps it out of release builds. Assert it actually fires, so a
+        # refactor cannot silently drop the cfg and re-open #683.
+        run: |
+          if cargo check -p minutes-core --no-default-features --features diarize,engine-sherpa 2>/dev/null; then
+            echo "::error::the #683 compile guard did not fire for diarize+engine-sherpa on macOS"
+            exit 1
+          fi
+          echo "guard fired as expected"
+
       - name: Build full workspace (macOS only)
         if: runner.os == 'macOS'
         run: cargo build --no-default-features

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -46,10 +46,13 @@ jobs:
             os: macos-latest
             binary: minutes
             asset: minutes-macos-arm64
-            # engine-sherpa is macOS-only here: sherpa-onnx links statically on
-            # darwin (self-contained binary, #369) but dynamically on Linux and
-            # Windows, where shipping it would need the dylibs bundled alongside.
-            features: parakeet,metal,engine-sherpa
+            # engine-sherpa is OFF here until #683's isolation work lands:
+            # the release CLI carries diarize (default), and on macOS static
+            # sherpa and pyannote vendor conflicting copies of ONNX Runtime and
+            # kaldi-native-fbank, so one of them always breaks at runtime. The
+            # compile guard in crates/core/src/lib.rs enforces this; do not add
+            # engine-sherpa back without removing that guard's reason first.
+            features: parakeet,metal
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             binary: minutes.exe

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -193,7 +193,8 @@ jobs:
       # it). build.rs stages it from target/release/minutes, so the CLI must be
       # built first or the bundle ships a placeholder stub (#324).
       - name: Build release CLI for bundling
-        run: cargo build --release -p minutes-cli --features parakeet,metal,engine-sherpa
+        # engine-sherpa held out per #683 (conflicts with diarize on macOS; see crates/core/src/lib.rs guard)
+        run: cargo build --release -p minutes-cli --features parakeet,metal
 
       - name: Build signed bundle (helper identity is repaired before notarization)
         env:
@@ -206,7 +207,8 @@ jobs:
         # workspace, so cargo resolves --features against every member, and
         # minutes-archive-app has neither parakeet nor metal.
         working-directory: tauri/src-tauri
-        run: cargo tauri build --features parakeet,metal,engine-sherpa --bundles app
+        # engine-sherpa held out per #683 (the app hard-enables diarize; see crates/core/src/lib.rs guard)
+        run: cargo tauri build --features parakeet,metal --bundles app
 
       - name: Sign graph helper inside-out and notarize the final exact app
         env:

--- a/README.md
+++ b/README.md
@@ -975,8 +975,17 @@ minutes setup --diarization
 # Experimental engine: Sherpa (in-process sherpa-onnx running parakeet-tdt-0.6b-v3).
 # Newer multilingual model (EN/FR/ES and more EU languages), no Python. Opt-in and
 # NOT yet the recommended daily engine: in real-meeting A/B it trails the Parakeet
-# engine on segmentation/casing (see issue #369). Compile with `--features
-# engine-sherpa`, then enable in one command:
+# engine on segmentation/casing (see issue #369).
+#
+# macOS: engine-sherpa cannot be combined with the default `diarize` feature in
+# one binary. Both stacks vendor ONNX Runtime and kaldi-native-fbank, and the
+# static link can only keep one copy of each, which breaks voice enrollment or
+# sherpa itself depending on which copy wins (issue #683; the build refuses
+# with a compile error rather than shipping the broken combination). Build the
+# sherpa CLI without diarization:
+#   cargo build --release -p minutes-cli --no-default-features \
+#     --features whisper,engine-sherpa,metal
+# Then enable in one command:
 minutes setup --sherpa        # downloads the int8 ONNX model (~670MB) + sets engine = "sherpa"
 # If you select sherpa without the feature/model, transcription auto-falls-back
 # to Whisper (the bundled default), so a recording never breaks. See docs/architecture/sherpa-engine.md.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,41 @@
 #![warn(clippy::disallowed_methods)]
 
+// `engine-sherpa` and `diarize` cannot share one macOS binary (issue #683).
+//
+// sherpa-onnx's static bundle and pyannote's dependencies each vendor two of
+// the same native libraries: ONNX Runtime (sherpa 1.17.1 vs ort-sys 1.22.0)
+// and kaldi-native-fbank (both literally named libkaldi-native-fbank-core.a).
+// A Mach-O image has one definition per symbol, so whichever copy wins the
+// link serves both consumers. Measured on macOS arm64, every resolution is
+// broken in one direction or the other:
+//
+//   ORT winner   kaldi winner   pyannote            sherpa
+//   1.17.1       sherpa's       API 17/22 error     works
+//   1.22.0       sherpa's       SIGABRT in fbank    works
+//   1.22.0       knf-rs's       works               SIGABRT
+//
+// ORT could be unified upward because its C API is version-stable, but
+// kaldi-native-fbank has no ABI contract, and identical mangled names with
+// divergent layouts are undefined behavior, not a clean failure. Refusing to
+// link is the only honest option until the sherpa stack is isolated behind
+// its own namespace (dlopen plugin or worker process; see the tracking issue
+// referenced from #683).
+//
+// Linux and Windows are unaffected: sherpa links dynamically there, and its
+// shared library resolves against its own bundled dependencies rather than
+// the executable's.
+//
+// For a sherpa CLI build without diarization:
+//   cargo build --release -p minutes-cli --no-default-features \
+//     --features whisper,engine-sherpa,metal
+#[cfg(all(target_os = "macos", feature = "engine-sherpa", feature = "diarize"))]
+compile_error!(
+    "engine-sherpa and diarize cannot be linked into one macOS binary: sherpa-onnx and \
+     pyannote both vendor ONNX Runtime and kaldi-native-fbank, and whichever copy wins the \
+     link breaks the other consumer (issue #683). Build sherpa without diarization: \
+     cargo build -p minutes-cli --no-default-features --features whisper,engine-sherpa,metal"
+);
+
 pub mod apple_fm;
 pub mod apple_speech;
 pub mod apple_speech_worker;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,9 +21,15 @@
 // its own namespace (dlopen plugin or worker process; see the tracking issue
 // referenced from #683).
 //
-// Linux and Windows are unaffected: sherpa links dynamically there, and its
-// shared library resolves against its own bundled dependencies rather than
-// the executable's.
+// Linux is verified unaffected: with both stacks linked into one binary
+// (sherpa via libsherpa-onnx-c-api.so, pyannote via static ort 1.22.0),
+// enrollment saves a voice profile and sherpa transcribes, in one process
+// (x86_64, 2026-08-09). The dynamic sherpa library resolves ONNX Runtime from
+// its own DT_NEEDED libonnxruntime.so rather than the executable, which does
+// not export the colliding symbols. Windows is expected safe by the same
+// dynamic-linking structure (per-DLL imports), but has not been executed in
+// this combination; if sherpa ever links statically off macOS, this guard's
+// scope must widen.
 //
 // `vad-ort` is included because it also pulls `dep:ort`: the same two static
 // ONNX Runtimes collide even without pyannote in the picture, and which copy

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,14 +25,23 @@
 // shared library resolves against its own bundled dependencies rather than
 // the executable's.
 //
+// `vad-ort` is included because it also pulls `dep:ort`: the same two static
+// ONNX Runtimes collide even without pyannote in the picture, and which copy
+// wins is a link-order coin flip. The measured 1.17.1-wins outcome hard-fails
+// every ort-rs consumer at init with the API 17/22 error.
+//
 // For a sherpa CLI build without diarization:
 //   cargo build --release -p minutes-cli --no-default-features \
 //     --features whisper,engine-sherpa,metal
-#[cfg(all(target_os = "macos", feature = "engine-sherpa", feature = "diarize"))]
+#[cfg(all(
+    target_os = "macos",
+    feature = "engine-sherpa",
+    any(feature = "diarize", feature = "vad-ort")
+))]
 compile_error!(
-    "engine-sherpa and diarize cannot be linked into one macOS binary: sherpa-onnx and \
-     pyannote both vendor ONNX Runtime and kaldi-native-fbank, and whichever copy wins the \
-     link breaks the other consumer (issue #683). Build sherpa without diarization: \
+    "engine-sherpa cannot share a macOS binary with diarize or vad-ort: sherpa-onnx's static \
+     bundle vendors its own ONNX Runtime (and kaldi-native-fbank), and whichever copy wins \
+     the link breaks the other consumer (issue #683). Build sherpa without them: \
      cargo build -p minutes-cli --no-default-features --features whisper,engine-sherpa,metal"
 );
 

--- a/docs/architecture/sherpa-engine.md
+++ b/docs/architecture/sherpa-engine.md
@@ -183,15 +183,17 @@ The `engine-sherpa` Cargo feature must be enabled at build time:
 
 ```bash
 # Core library check
-cargo check -p minutes-core --features engine-sherpa
+cargo check -p minutes-core --no-default-features --features engine-sherpa
 
-# CLI build
-cargo build --release -p minutes-cli --features engine-sherpa
+# CLI build (macOS: --no-default-features is required, see the constraint above)
+cargo build --release -p minutes-cli --no-default-features --features whisper,engine-sherpa,metal
 ```
 
-The feature is opt-in and not included in the default build. Whisper is still
-the default feature, so a normal `--features engine-sherpa` build includes both
-Whisper and Sherpa unless you also pass `--no-default-features`.
+The feature is opt-in and not included in the default build. The CLI's default
+features are `whisper` and `diarize`, so a plain `--features engine-sherpa`
+build would include Whisper, Sherpa, and diarization; on macOS that
+combination refuses to compile (issue #683), which is why the commands above
+drop the defaults and re-add `whisper` explicitly.
 
 `sherpa-rs-sys` builds sherpa-onnx through CMake, so a working CMake toolchain
 must be available during the build.
@@ -216,7 +218,9 @@ Change `engine = "whisper"` in config.toml. No model deletion is required.
 The binary was built without the `engine-sherpa` feature. Rebuild with:
 
 ```bash
-cargo build -p minutes-cli --features engine-sherpa
+# macOS: the defaults include diarize, which cannot share a binary with
+# engine-sherpa (issue #683), so drop them and re-add whisper:
+cargo build -p minutes-cli --no-default-features --features whisper,engine-sherpa,metal
 ```
 
 ### "sherpa model not found"

--- a/docs/architecture/sherpa-engine.md
+++ b/docs/architecture/sherpa-engine.md
@@ -15,12 +15,28 @@ falls back to Whisper (with a warning) so a recording never breaks.
 ## Quick Start (recommended)
 
 ```bash
-# Build with the sherpa engine, then download + enable the model in one step:
-cargo build --release -p minutes-cli --features engine-sherpa
+# Build with the sherpa engine, then download + enable the model in one step.
+# On macOS, engine-sherpa cannot coexist with the default `diarize` feature in
+# one binary (issue #683; the build refuses with a compile error), so drop the
+# defaults and re-add whisper:
+cargo build --release -p minutes-cli --no-default-features --features whisper,engine-sherpa,metal
 rm -f ~/.local/bin/minutes && cp target/release/minutes ~/.local/bin/minutes
 
 minutes setup --sherpa     # downloads the int8 ONNX model + sets engine = "sherpa"
 ```
+
+> **macOS single-binary constraint (issue #683).** sherpa-onnx's static bundle
+> and pyannote's dependencies each vendor their own ONNX Runtime (1.17.1 vs
+> ort-sys 1.22.0) and their own kaldi-native-fbank. A Mach-O image keeps one
+> definition per symbol, so whichever copy wins the link serves both stacks:
+> measured on arm64, every resolution breaks either voice enrollment (ORT API
+> 17/22 mismatch, or SIGABRT in feature extraction) or sherpa itself (SIGABRT).
+> ONNX Runtime could be unified upward because its C API is backward
+> compatible, but kaldi-native-fbank has no ABI contract, and colliding mangled
+> names with divergent layouts are undefined behavior. `crates/core/src/lib.rs`
+> therefore refuses the combination at compile time until the sherpa stack is
+> isolated behind its own namespace. Linux and Windows are unaffected (dynamic
+> sherpa resolves against its own bundled libraries).
 
 > **Platform note.** On macOS, `engine-sherpa` links sherpa-onnx statically, so
 > the binary is self-contained and the copy above just works. On Linux and

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 # decision. Packaging is fixed for opt-in local builds: sherpa links statically
 # and the existing ort path does not leave dangling runtime dylib references.
 # Opt in explicitly:
-#   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa
+#   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort   # engine-sherpa conflicts with diarize/vad-ort on macOS (#683)
 if [ -z "${MINUTES_BUILD_FEATURES+x}" ]; then
     MINUTES_BUILD_FEATURES="parakeet,metal"
 fi

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -7,10 +7,10 @@ import { existsSync, readFileSync } from "node:fs";
 // These whole-file hashes prevent dead/comment-only duplicate code from
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
-  release: "70ec47bcb544362e3858abdf026010f83668f55c9945b824eaaf9fdf4158bc43",
+  release: "a64fa59520223c3b2c5ba44f9321d807eec045196ee630b03f9a14dc4f11c8dd",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
-  build: "9ca0741767b8e2fc49c4ffd200d5c5c43d13ddf0ebfd88fa2d6116d0cb3656ec",
-  dev: "6a1d680b57f6914bbcadda4b83ad4c1bc56c0d0f50bee11a9f9ebb294cbb029b",
+  build: "24fca291f683c7c6cc0599e7e88514f4f3374e357983298b857b4fef0acada9f",
+  dev: "f5376e40b3bdb57866d9fd675a14ea86d6825a5e3496e097502d2c193add1cf3",
   packageXpc: "baebd532d240fc26188c431f571d0a44f2ce1e7240c3277284c9ea9e69c1ef82",
   tauri: "f127e92a1a2a635326d13dd766b3e6cc841655bce30ea2d01d67d9f12c15502c",
   entitlements: "7971da95784f3bdeb3ea257b5c1a31317731b513b16c47e2c4e588fc0ac40bae",

--- a/scripts/install-dev-app.sh
+++ b/scripts/install-dev-app.sh
@@ -10,7 +10,7 @@ export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 # decision. Packaging is fixed for opt-in local builds: sherpa links statically
 # and the existing ort path does not leave dangling runtime dylib references.
 # Opt in explicitly:
-#   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort,engine-sherpa
+#   MINUTES_BUILD_FEATURES=parakeet,metal,vad-ort   # engine-sherpa conflicts with diarize/vad-ort on macOS (#683)
 if [ -z "${MINUTES_BUILD_FEATURES+x}" ]; then
     MINUTES_BUILD_FEATURES="parakeet,metal"
 fi


### PR DESCRIPTION
Fixes #683. The isolation work that makes the combination actually work is #685; this PR stops the broken combination from shipping or silently corrupting anyone's build in the meantime.

## The defect, fully reproduced

traoredev's A/B repro held up exactly on an arm64 iMac at `be2cad55`: with `engine-sherpa` compiled in, `minutes enroll` fails at pyannote's ORT init with the API 17/22 mismatch; the identical commit without sherpa enrolls fine.

The root cause is two pairs of vendored native libraries fighting over one symbol namespace:

| library | sherpa's copy | pyannote's copy |
|---|---|---|
| ONNX Runtime | 1.17.1 | 1.22.0 (ort-sys rc.10, requests API 22) |
| kaldi-native-fbank | `libkaldi-native-fbank-core.a` (sherpa-onnx v1.12.9) | same archive name (knf-rs-sys 0.3.2) |

I tested every resolution by substituting archives via `SHERPA_LIB_PATH`:

| ORT winner | kaldi winner | pyannote | sherpa |
|---|---|---|---|
| 1.17.1 | sherpa's | ✗ API 17/22 error | ✓ |
| 1.22.0 | sherpa's | ✗ SIGABRT in feature extraction | ✓ |
| 1.22.0 | knf-rs's | ✓ | ✗ SIGABRT |

ORT unifies upward fine (its C API is backward compatible; sherpa transcription runs on 1.22.0). kaldi-native-fbank has no ABI contract, so there is **no link order that works**, and the near-miss failure mode is undefined behavior rather than a clean error.

## What this PR does

- **Compile guard** in `crates/core/src/lib.rs`: `engine-sherpa` + `diarize` on macOS refuses with the working invocation in the error text. macOS-only by construction; Linux/Windows link sherpa dynamically and resolve against sherpa's own bundled libraries.
- **Release builds** drop `engine-sherpa` again: `release-cli.yml` (macOS CLI) and `release-macos.yml` (CLI and the Tauri app, which hard-enables `diarize`). Without this the next release would have shipped broken voice enrollment in both artifacts. v0.24.0 shipped without sherpa and is unaffected.
- **CI asserts the guard fires** on macOS, so a refactor cannot silently drop the cfg and re-open the issue.
- README and docs/architecture/sherpa-engine.md document the constraint and the sherpa-without-diarize build.

## Verified on real hardware (arm64 iMac)

- guard fires with `--features diarize,engine-sherpa`: compile error with the message
- documented escape hatch builds: `--no-default-features --features whisper,engine-sherpa,metal`
- Linux: `--features diarize,engine-sherpa` still checks clean (guard correctly scoped)
- both broken directions and the working directions in the matrix above were each observed, not inferred