### PR TITLE
fix(funding): prove useminutes.app ownership for FLOSS/fund

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -10,7 +10,7 @@
         "description": "I build local-first software for people who would rather own their data than be promised it is safe. My main project is Minutes, a conversation memory layer that transcribes and diarizes meetings entirely on your own machine, so there is no cloud service to breach and no vendor database of your conversations to subpoena.\n\nI am the sole maintainer. Funding goes toward maintainer time and toward security and privacy work that I currently cannot finish at the pace the project needs.",
         "webpageUrl": {
             "url": "https://useminutes.app",
-            "wellKnown": ""
+            "wellKnown": "https://useminutes.app/.well-known/funding-manifest-urls"
         }
     },
     "projects": [{
@@ -18,7 +18,8 @@
         "name": "Minutes",
         "description": "Minutes is an open-source, privacy-first conversation memory layer for AI assistants. It captures audio (meetings, calls, voice memos), transcribes it locally with whisper.cpp or parakeet.cpp, diarizes and attributes speakers using local ONNX models, and writes searchable markdown with structured action items and decisions to your own disk.\n\nNothing is uploaded. Transcription, diarization, and speaker matching all run on the device, output files are written with owner-only permissions, and no API key is required to use it. Every meeting notetaker on the market answers the privacy question with policy; Minutes answers it with architecture.\n\nIt ships a CLI, a Tauri desktop app, an MCP server, and a TypeScript SDK, so any AI assistant can read a meeting corpus without the audio ever leaving the machine. It also publishes whisper-guard, a standalone Rust crate that defends against local transcription models fabricating text on silence and noise, which matters because that fabricated text otherwise becomes a record of what somebody said.",
         "webpageUrl": {
-            "url": "https://useminutes.app"
+            "url": "https://useminutes.app",
+            "wellKnown": "https://useminutes.app/.well-known/funding-manifest-urls"
         },
         "repositoryUrl": {
             "url": "https://github.com/silverstein/minutes",

--- a/site/public/.well-known/funding-manifest-urls
+++ b/site/public/.well-known/funding-manifest-urls
@@ -1,0 +1,2 @@
+https://github.com/silverstein/minutes/blob/main/funding.json
+https://raw.githubusercontent.com/silverstein/minutes/main/funding.json

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,3 +1,7 @@
 /llms.txt
   Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=3600
+
+/.well-known/funding-manifest-urls
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: public, max-age=3600


### PR DESCRIPTION
The FLOSS/fund directory flags the Minutes listing with an "Unverified URL" warning on the project webpage link.

**Cause.** `funding.json` claims `https://useminutes.app` as both the entity webpage and the project webpage, but that domain served no proof of ownership. FLOSS/fund requires the claimed domain to host `/.well-known/funding-manifest-urls` listing the manifest URLs that reference it. `https://useminutes.app/.well-known/funding-manifest-urls` returned 404.

The repository link already verifies correctly: the manifest is served from this repo and `.well-known/funding-manifest-urls` here points back at it. Only the webpage links were unproven, which is why the directory shows a warning on the globe icon and not the branch icon.

Two gaps in the manifest itself:

- `entity.webpageUrl.wellKnown` was an empty string
- `projects[0].webpageUrl` had no `wellKnown` key at all

**Change.**

- Serve `/.well-known/funding-manifest-urls` from the site, listing both manifest URLs
- Add a `_headers` rule so Cloudflare serves it as `text/plain`
- Fill in `wellKnown` on both `webpageUrl` entries

**Verification.** Ran `next build` and confirmed `out/.well-known/funding-manifest-urls` is present with the correct contents and that the `_headers` rule survives into the export. Next.js copying a dotfile directory out of `public/` is not something to assume.

**After merge.** The `wellKnown` URL 404s until the Pages deploy lands, and `raw.githubusercontent.com` serves the manifest from `main`, so the directory can only verify once both are live. Order: merge, wait for the Cloudflare Pages deploy, confirm the URL returns 200, then re-submit the manifest at dir.floss.fund.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
