### PR TITLE
fix(sdk): contain the refusal test's worker-kill fallout, prove it deterministically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ __pycache__/
 *.pyc
 docs/marketing/
 docs/demo/node_modules/
+# Also as a bare name: a symlink named node_modules is not a directory, so the
+# trailing-slash pattern above does not ignore it, and `git add -A` in a
+# worktree using linked deps once committed two machine-absolute symlinks.
+node_modules
 docs/demo/.remotion/
 
 # Build artifacts

--- a/crates/mcp/src/corpus-lease-refusal.test.ts
+++ b/crates/mcp/src/corpus-lease-refusal.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// This test lives in its own file on purpose, and must stay alone here.
+//
+// A one-millisecond budget kills the corpus worker while it may still be
+// spawning. When the kill misses the termination-grace window, the module
+// deliberately retains the process-global memory reservation and poisons the
+// worker path; that fail-closed design is correct product behavior, but it is
+// process-wide, so in a shared test file it cascades into every later corpus
+// test as "retained snapshots exceeded" failures. Observed on windows-latest
+// in CI.
+//
+// Vitest runs each test file in its own isolated process (the default forks
+// pool), so whatever state this test leaves behind dies with this process and
+// can never reach the main corpus-lease suite. That containment is
+// structural: no reset seam in production code, nothing exported that could
+// disarm the fail-closed barrier, and nothing here that has to simulate the
+// race. Adding further tests to this file would put them back inside the
+// blast radius.
+//
+// The worker route is load-bearing. The raw-error escape this pins lived in
+// the worker dispatcher's pre-spawn guards, and the in-process dispatcher
+// wraps its own errors before the public entry ever sees them: an in-process
+// variant of this test kept passing with the fix removed.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-refusal-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+describe("stable corpus lease refusal contract", () => {
+  it("reports the documented refusal when the budget expires, whichever guard trips", async () => {
+    // An exhausted budget can be noticed by several guards, and only some sit
+    // inside the worker machinery that wraps refusals. The ones outside it
+    // used to escape as the raw "meeting corpus authorization deadline
+    // elapsed", so callers saw two different sentences for one condition
+    // depending only on which guard won. CI hit it on a contended Windows
+    // runner, where a short budget can expire between computing the deadline
+    // and the next statement checking it.
+    //
+    // This pins the contract rather than a route: the smallest budget the API
+    // accepts is reliably gone by the time some guard notices, and every guard
+    // has to produce the same sentence. Which one fires is timing-dependent
+    // and deliberately not asserted -- claiming a specific one would be the
+    // same kind of unverified detail this fix exists to remove.
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
+      let projections = 0;
+      await expect(
+        withStableCorpusLease(
+          root,
+          () => {
+            projections += 1;
+            return "unreachable";
+          },
+          { timeoutMs: 1 }
+        )
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(projections).toBe(0);
+    });
+  });
+});

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -1079,37 +1079,6 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("reports the documented refusal when the budget expires, whichever guard trips", async () => {
-    // An exhausted budget can be noticed by several guards, and only some sit
-    // inside the worker machinery that wraps refusals. The ones outside it
-    // used to escape as the raw "meeting corpus authorization deadline
-    // elapsed", so callers saw two different sentences for one condition
-    // depending only on which guard won. CI hit it on a contended Windows
-    // runner, where a short budget can expire between computing the deadline
-    // and the next statement checking it.
-    //
-    // This pins the contract rather than a route: the smallest budget the API
-    // accepts is reliably gone by the time some guard notices, and every guard
-    // has to produce the same sentence. Which one fires is timing-dependent
-    // and deliberately not asserted -- claiming a specific one would be the
-    // same kind of unverified detail this fix exists to remove.
-    await withCorpus(async (root) => {
-      writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
-      let projections = 0;
-      await expect(
-        withStableCorpusLease(
-          root,
-          () => {
-            projections += 1;
-            return "unreachable";
-          },
-          { timeoutMs: 1 }
-        )
-      ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(projections).toBe(0);
-    });
-  });
-
   it("requires and acknowledges a bounded sentinel repulse", async () => {
     await withCorpus(async (root) => {
       const nested = join(root, "nested");

--- a/crates/sdk/src/corpus-lease-refusal.test.ts
+++ b/crates/sdk/src/corpus-lease-refusal.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// This test lives in its own file on purpose, and must stay alone here.
+//
+// A one-millisecond budget kills the corpus worker while it may still be
+// spawning. When the kill misses the termination-grace window, the module
+// deliberately retains the process-global memory reservation and poisons the
+// worker path; that fail-closed design is correct product behavior, but it is
+// process-wide, so in a shared test file it cascades into every later corpus
+// test as "retained snapshots exceeded" failures. Observed on windows-latest
+// in CI.
+//
+// Vitest runs each test file in its own isolated process (the default forks
+// pool), so whatever state this test leaves behind dies with this process and
+// can never reach the main corpus-lease suite. That containment is
+// structural: no reset seam in production code, nothing exported that could
+// disarm the fail-closed barrier, and nothing here that has to simulate the
+// race. Adding further tests to this file would put them back inside the
+// blast radius.
+//
+// The worker route is load-bearing. The raw-error escape this pins lived in
+// the worker dispatcher's pre-spawn guards, and the in-process dispatcher
+// wraps its own errors before the public entry ever sees them: an in-process
+// variant of this test kept passing with the fix removed.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-refusal-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+describe("stable corpus lease refusal contract", () => {
+  it("reports the documented refusal when the budget expires, whichever guard trips", async () => {
+    // An exhausted budget can be noticed by several guards, and only some sit
+    // inside the worker machinery that wraps refusals. The ones outside it
+    // used to escape as the raw "meeting corpus authorization deadline
+    // elapsed", so callers saw two different sentences for one condition
+    // depending only on which guard won. CI hit it on a contended Windows
+    // runner, where a short budget can expire between computing the deadline
+    // and the next statement checking it.
+    //
+    // This pins the contract rather than a route: the smallest budget the API
+    // accepts is reliably gone by the time some guard notices, and every guard
+    // has to produce the same sentence. Which one fires is timing-dependent
+    // and deliberately not asserted -- claiming a specific one would be the
+    // same kind of unverified detail this fix exists to remove.
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
+      let projections = 0;
+      await expect(
+        withStableCorpusLease(
+          root,
+          () => {
+            projections += 1;
+            return "unreachable";
+          },
+          { timeoutMs: 1 }
+        )
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+      expect(projections).toBe(0);
+    });
+  });
+});

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -1079,37 +1079,6 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("reports the documented refusal when the budget expires, whichever guard trips", async () => {
-    // An exhausted budget can be noticed by several guards, and only some sit
-    // inside the worker machinery that wraps refusals. The ones outside it
-    // used to escape as the raw "meeting corpus authorization deadline
-    // elapsed", so callers saw two different sentences for one condition
-    // depending only on which guard won. CI hit it on a contended Windows
-    // runner, where a short budget can expire between computing the deadline
-    // and the next statement checking it.
-    //
-    // This pins the contract rather than a route: the smallest budget the API
-    // accepts is reliably gone by the time some guard notices, and every guard
-    // has to produce the same sentence. Which one fires is timing-dependent
-    // and deliberately not asserted -- claiming a specific one would be the
-    // same kind of unverified detail this fix exists to remove.
-    await withCorpus(async (root) => {
-      writeFileSync(join(root, "meeting.md"), "elapsed budget canary");
-      let projections = 0;
-      await expect(
-        withStableCorpusLease(
-          root,
-          () => {
-            projections += 1;
-            return "unreachable";
-          },
-          { timeoutMs: 1 }
-        )
-      ).rejects.toThrow("stable meeting corpus authorization failed");
-      expect(projections).toBe(0);
-    });
-  });
-
   it("requires and acknowledges a bounded sentinel repulse", async () => {
     await withCorpus(async (root) => {
       const nested = join(root, "nested");

--- a/scripts/check_corpus_lease_mirror.mjs
+++ b/scripts/check_corpus_lease_mirror.mjs
@@ -30,6 +30,7 @@ import { fileURLToPath } from "node:url";
 const MIRRORED_FILES = [
   "corpus-lease.ts",
   "corpus-lease.test.ts",
+  "corpus-lease-refusal.test.ts",
   "corpus-lease-worker.ts",
   "secure-read.ts",
 ];


### PR DESCRIPTION
Fixes the corpus-lease cascade first seen in #684's CI run, where later tests failed with `retained snapshots exceeded` after the 1ms-budget refusal test killed its worker mid-spawn. Companion product issue: #689.

## The mechanism

The 1ms test from #682 kills a worker that may still be spawning. When the kill misses the 2s termination-grace window, the module deliberately retains the process-global memory reservation and poisons the worker path. Correct fail-closed product behavior; process-wide cascade in a shared test file.

## Three designs, two rejected on evidence

**1. In-process reroute** (the obvious deflake): verifiably wrong. The in-process dispatcher wraps its own errors before the public entry sees them, so the rerouted test kept passing with the #681 fix removed. Caught by re-running the negative direction. The worker route is load-bearing.

**2. Test-only reset/simulate seams in the production module**: built, then adversarially rejected (codex, review comment below). The reset seam shipped in published runtime modules and, deep-imported, could disarm the fail-closed restart barrier in a real process; the unconditional counter zero could undercount a concurrent live lease; and the simulation installed neither the exact reservation nor the retained admission slot, so its "deterministic proof" proved only a boolean flip. The review also caught two machine-absolute `node_modules` symlinks accidentally committed (gitignore's `node_modules/` matches directories, not symlinks).

**3. File isolation** (this PR): vitest runs each test file in its own process (default forks pool), so the aggressive test moves verbatim to `corpus-lease-refusal.test.ts` and whatever state it leaves behind dies with its own process. No production code changes at all. The branch was rebuilt from main, so the rejected seams and the symlinks never existed in this history.

## What's in the diff

- the 1ms test moves, byte-for-byte, to its own file with a header explaining why it must stay alone there
- the new file joins the corpus-lease mirror set (sdk/mcp byte-identical, now 5 files)
- `.gitignore` gains a bare `node_modules` entry so a symlink can never be committed again

## Verification

- SDK: 146 passed across 4 files; MCP: 281 passed; mirror check clean
- negative direction: with the #681 wrapper removed, the relocated test still fails with the exact raw CI message
- 0 failures in 5 two-file runs under CPU oversubscription
- Windows VM verification was attempted and rejected as evidence: the corpus suite fails 28/49 there at default budgets (126s file runtime) because VirtualBox on an Intel Mac host is far outside windows-latest's envelope. Reported rather than laundered.
