### PR TITLE
feat(site): structured data for AI-answer citation

### DIFF
--- a/site/app/compare/fireflies-vs-minutes/page.tsx
+++ b/site/app/compare/fireflies-vs-minutes/page.tsx
@@ -72,6 +72,7 @@ export default function FirefliesVsMinutesPage() {
       competitorName="Fireflies.ai"
       competitorLabel="Fireflies.ai"
       markdownHref="/compare/fireflies-vs-minutes.md"
+      lastReviewed="2026-07-23"
       heroSummary="Fireflies.ai and Minutes overlap around meeting capture and AI recall, but they are optimized for different jobs. Fireflies.ai is stronger if you want a hosted meeting assistant with integrations, team workflows, and centralized admin. Minutes is stronger if you want local-first meeting memory, inspectable markdown, and agent workflows that live beyond one hosted product."
       quickVerdictCompetitor="you want a hosted meeting assistant with stronger integrations, team workflows, admin controls, and a SaaS collaboration story."
       quickVerdictMinutes="you want local processing, open output, and a memory layer that Claude, Codex, and other MCP clients can query across files and tools."

--- a/site/app/compare/hyprnote-vs-minutes/page.tsx
+++ b/site/app/compare/hyprnote-vs-minutes/page.tsx
@@ -65,6 +65,7 @@ export default function HyprnoteVsMinutesPage() {
       competitorName="Hyprnote"
       competitorLabel="Hyprnote (Anarlog)"
       markdownHref="/compare/hyprnote-vs-minutes.md"
+      lastReviewed="2026-07-29"
       heroSummary="Hyprnote and Minutes are friendly neighbors: both are open source, local-first, and serious about privacy. The practical difference is the job. Hyprnote is a notepad you write in during meetings, with AI that enhances what you wrote. Minutes is a memory layer: it turns everything you record into structured markdown you own, then exposes policy-authorized normal sources to Claude, Codex, and MCP clients while excluding restricted meetings by default, with consent provenance in every file."
       quickVerdictCompetitor="you want a polished local notepad for taking and enhancing your own meeting notes, and the app itself is where you want to live."
       quickVerdictMinutes="you want a durable, agent-readable corpus: files on your disk, MCP tools, a CLI, and consent and provenance metadata your tools can rely on."

--- a/site/app/compare/otter-vs-minutes/page.tsx
+++ b/site/app/compare/otter-vs-minutes/page.tsx
@@ -69,6 +69,7 @@ export default function OtterVsMinutesPage() {
       competitorName="Otter"
       competitorLabel="Otter AI"
       markdownHref="/compare/otter-vs-minutes.md"
+      lastReviewed="2026-04-09"
       heroSummary="Otter and Minutes overlap around meeting capture and AI recall, but they are built around different operating assumptions. Otter is stronger if you want a hosted meeting assistant with auto-join, collaboration, and team workflows. Minutes is stronger if you want local-first meeting memory, inspectable markdown, and agent workflows that live beyond one hosted product."
       quickVerdictCompetitor="you want a hosted meeting assistant that joins calls, captures transcripts for teams, and plugs into a broader admin and integrations story."
       quickVerdictMinutes="you want local processing, open output, and a memory layer that Claude, Codex, and other MCP clients can query across files and tools."

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -8,6 +8,7 @@ import {
   MINUTES_TEST_COUNT,
   WINDOWS_SETUP_EXE,
 } from "@/lib/release";
+import { organizationSchema, softwareApplicationSchema } from "@/lib/schema";
 
 const featureGrid = [
   {
@@ -349,6 +350,15 @@ function HomeFlowCard({
 export default function Home() {
   return (
     <div className="pb-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify([
+            organizationSchema(),
+            softwareApplicationSchema(),
+          ]),
+        }}
+      />
       <MemoryCompoundsHero />
       <main className="mx-auto max-w-[840px] px-6 sm:px-8">
 

--- a/site/components/compare-page.tsx
+++ b/site/components/compare-page.tsx
@@ -1,4 +1,5 @@
 import { PublicFooter } from "@/components/public-footer";
+import { comparisonArticleSchema } from "@/lib/schema";
 
 type ComparisonRow = {
   label: string;
@@ -48,8 +49,9 @@ type ComparePageProps = {
   notRightFitSection: string[];
   evaluatedSection: string[];
   sources: SourceLink[];
-  /** Optional per-page override; defaults to the shared review date. */
-  lastReviewed?: string;
+  /** ISO date this page was last fact-checked. Required: a shared default
+   * silently understated the review date on pages that forgot to pass one. */
+  lastReviewed: string;
   /** Optional data-flow diagram (only some comparisons carry one). */
   architecture?: Architecture;
 };
@@ -145,11 +147,25 @@ export function ComparePage({
   notRightFitSection,
   evaluatedSection,
   sources,
-  lastReviewed = "2026-04-09",
+  lastReviewed,
   architecture,
 }: ComparePageProps) {
+  // Every comparison page is served at the markdown twin's path minus ".md".
+  const path = markdownHref.replace(/\.md$/, "");
+  const jsonLd = comparisonArticleSchema({
+    competitorLabel,
+    path,
+    description: heroSummary,
+    lastReviewed,
+    sources,
+  });
+
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
           minutes

--- a/site/lib/schema.ts
+++ b/site/lib/schema.ts
@@ -1,0 +1,132 @@
+/** Shared JSON-LD builders for structured data.
+ *
+ * Schema.org markup must describe content that is actually visible on the page.
+ * Every field produced here is derived from data the page already renders, so
+ * the markup cannot drift from the copy. Notably there is no FAQPage builder:
+ * FAQPage requires visible question/answer content, and the comparison pages do
+ * not have an FAQ section today.
+ */
+
+const SITE_URL = "https://useminutes.app";
+const REPO_URL = "https://github.com/silverstein/minutes";
+
+/** Absolute URL for a site-relative path, as schema.org requires. */
+function absolute(path: string): string {
+  return path.startsWith("http") ? path : `${SITE_URL}${path}`;
+}
+
+/** Mat Silverstein as the named author, for E-E-A-T author attribution. */
+function author() {
+  return {
+    "@type": "Person",
+    name: "Mat Silverstein",
+    url: REPO_URL.replace("/minutes", ""),
+  };
+}
+
+/** The Minutes project as the publishing entity. */
+export function organizationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Minutes",
+    url: SITE_URL,
+    logo: absolute("/favicon.svg"),
+    description:
+      "Open-source, privacy-first conversation memory. Records meetings and voice memos, transcribes and diarizes them on your own device, and writes searchable markdown you own.",
+    founder: author(),
+    sameAs: [REPO_URL],
+  };
+}
+
+/** Minutes as a software product.
+ *
+ * Free and MIT licensed, which is the differentiator an AI agent needs to be
+ * able to parse when it compares tools on a buyer's behalf.
+ */
+export function softwareApplicationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "Minutes",
+    url: SITE_URL,
+    applicationCategory: "BusinessApplication",
+    applicationSubCategory: "Conversation memory and meeting transcription",
+    operatingSystem: "macOS, Linux, Windows",
+    description:
+      "Captures meetings, voice memos, and dictation, transcribes locally with whisper.cpp, diarizes speakers with local ONNX models, and outputs searchable markdown with structured action items and decisions. Nothing is uploaded.",
+    license: "https://opensource.org/licenses/MIT",
+    isAccessibleForFree: true,
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    author: author(),
+    sameAs: [REPO_URL],
+  };
+}
+
+/** A competitor referenced by a comparison page.
+ *
+ * Declaring both products as `about` entities is what lets an answer engine
+ * resolve a "X vs Y" query to this page. Page labels sometimes carry a
+ * disambiguating parenthetical ("Hyprnote (Anarlog)") that reads as part of the
+ * product name to a matcher, so it is dropped from the entity name only.
+ */
+function competitorSchema(label: string) {
+  return {
+    "@type": "SoftwareApplication",
+    name: label.replace(/\s*\([^)]*\)\s*$/, ""),
+    applicationCategory: "BusinessApplication",
+  };
+}
+
+type ComparisonSchemaInput = {
+  /** Competitor as titled on the page, e.g. "Granola AI". */
+  competitorLabel: string;
+  /** Site-relative canonical path, e.g. "/compare/granola-vs-minutes". */
+  path: string;
+  /** The page's hero summary, reused verbatim as the description. */
+  description: string;
+  /** ISO date the page was last fact-checked; becomes dateModified. */
+  lastReviewed: string;
+  /** The page's visible Sources list, emitted as citations. */
+  sources: ReadonlyArray<{ label: string; href: string }>;
+};
+
+/** Structured data for a "Minutes vs X" comparison page.
+ *
+ * Comparison content is the most-cited format in AI answers, and the two
+ * signals that drive citation are sourced claims and a visible review date.
+ * Both already exist on these pages; this makes them machine-readable.
+ */
+export function comparisonArticleSchema({
+  competitorLabel,
+  path,
+  description,
+  lastReviewed,
+  sources,
+}: ComparisonSchemaInput) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: `Minutes vs ${competitorLabel}`,
+    description,
+    url: absolute(path),
+    mainEntityOfPage: { "@type": "WebPage", "@id": absolute(path) },
+    dateModified: lastReviewed,
+    inLanguage: "en",
+    author: author(),
+    publisher: organizationSchema(),
+    about: [
+      { "@type": "SoftwareApplication", name: "Minutes", url: SITE_URL },
+      competitorSchema(competitorLabel),
+    ],
+    citation: sources.map((source) => ({
+      "@type": "CreativeWork",
+      name: source.label,
+      url: source.href,
+    })),
+  };
+}


### PR DESCRIPTION
The comparison pages carried no structured data. This adds it through the shared `ComparePage` component, so it is one change rather than eight.

## What each comparison page emits now

`TechArticle` with:

- `dateModified` from the page's review date
- `citation` built from the Sources list the page already renders
- `about` naming both products
- `author` and `publisher`

## Homepage

Adds `Organization` and `SoftwareApplication`. Nothing on the site previously described Minutes as an entity, including the free and MIT-licensed terms.

## Fixes a stale-date bug

`lastReviewed` defaulted to a hardcoded date. Three pages never passed one and rendered that default as fact, publishing review dates several months older than the page's actual last revision. The prop is now required so this cannot recur; dates come from each page's last substantive commit.

## Deliberately not included

No `FAQPage` markup. It requires visible question and answer content and these pages have no FAQ section, so emitting it would describe content that is not there.

## Verification

Parsed the static export rather than trusting the source: 8/8 pages emit valid `TechArticle`, every visible review date equals its `dateModified`, no empty headlines. `tsc --noEmit` and `next build` clean.
