### PR TITLE
fix(site): FAQ structured-data violation + first anti-bot cluster page

### DIFF
--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -240,6 +240,28 @@ Verify `https://useminutes.pages.dev`, `https://www.useminutes.app`, and
 `https://useminutes.app` after deployment. `/llms.txt` must remain
 `text/plain; charset=utf-8` with `Cache-Control: public, max-age=3600`.
 
+**Assert the canonical host serves directly — do not eyeball this in a browser.**
+A browser follows redirects silently, so a misrouted apex still renders the site
+and passes a visual check while telling Google the canonical URL is a redirect.
+Every canonical tag and every `sitemap.xml` entry uses the apex, so the apex must
+return `200`, not `3xx`:
+
+```bash
+for path in / /llms.txt /resources/hipaa-compliant-ai-note-taker; do
+  code=$(curl -s -o /dev/null -w '%{http_code}' "https://useminutes.app$path")
+  [ "$code" = 200 ] || echo "FAIL apex $path -> $code (canonical host must serve 200)"
+done
+# www must 301 to the apex, not the reverse
+curl -s -o /dev/null -w 'www -> %{http_code} %{redirect_url}\n' -I https://www.useminutes.app/
+# the declared canonical must match the host that served the page
+curl -s https://useminutes.app/ | grep -o '<link rel="canonical"[^>]*>'
+```
+
+This check exists because in 2026-08 the apex spent a month resolving to a stale
+Vercel project that `307`-redirected to www. The site looked fine, and the entire
+40-route content build stayed effectively unindexed: 496 referring domains, one
+ranking keyword.
+
 ### 16. Update Homebrew tap formula if CLI changed
 The formula lives at `silverstein/homebrew-tap` → `Formula/minutes.rb`. Update the `tag:` to the new version:
 ```bash

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -127,6 +127,16 @@ summary:focus-visible {
   display: none;
 }
 
+/* FAQ disclosure rows. Safari draws its own triangle via a -webkit pseudo that
+   Tailwind's `marker:` variant cannot reach, same as the mobile menu above. */
+.faq-disclosure summary {
+  list-style: none;
+}
+
+.faq-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
 .marketing-mobile-links {
   position: absolute;
   top: calc(100% + 12px);

--- a/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
+++ b/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "AI notetakers and attorney–client privilege",
@@ -10,44 +12,24 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "Does using an AI notetaker waive attorney–client privilege?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "There is no blanket answer — waiver is fact-specific and courts have not squarely resolved cloud AI notetakers. The risk vector is clear, though: privilege depends on confidentiality, and sending client conversations to a third-party cloud service is a disclosure that opposing counsel can probe. Vendor terms allowing human review or model training make the argument harder to defend.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What does ABA Formal Opinion 512 say about AI tools and confidentiality?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "ABA Formal Opinion 512 (July 2024) addresses generative AI under Model Rule 1.6: lawyers must evaluate a tool's data handling before inputting client information, may need informed client consent for self-learning tools, and remain responsible for understanding where client data goes. It does not ban AI tools; it requires lawyers to actually understand the data flow.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Do I need consent to record client meetings?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Recording-consent law is separate from privilege and varies by state: some states require all-party consent, others one-party. Best practice for client conversations is explicit consent regardless of state law — it is also the professional norm.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How does on-device transcription change the privilege analysis?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "If transcription runs entirely on the attorney's own machine and the transcript is a local file, no third party ever receives the communication — there is no vendor disclosure to analyze, no terms of service governing client data, and no vendor to subpoena. The remaining duties are the familiar ones: device security and access control.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "Does using an AI notetaker waive attorney–client privilege?",
+    answer: "There is no blanket answer — waiver is fact-specific and courts have not squarely resolved cloud AI notetakers. The risk vector is clear, though: privilege depends on confidentiality, and sending client conversations to a third-party cloud service is a disclosure that opposing counsel can probe. Vendor terms allowing human review or model training make the argument harder to defend.",
+  },
+  {
+    question: "What does ABA Formal Opinion 512 say about AI tools and confidentiality?",
+    answer: "ABA Formal Opinion 512 (July 2024) addresses generative AI under Model Rule 1.6: lawyers must evaluate a tool's data handling before inputting client information, may need informed client consent for self-learning tools, and remain responsible for understanding where client data goes. It does not ban AI tools; it requires lawyers to actually understand the data flow.",
+  },
+  {
+    question: "Do I need consent to record client meetings?",
+    answer: "Recording-consent law is separate from privilege and varies by state: some states require all-party consent, others one-party. Best practice for client conversations is explicit consent regardless of state law — it is also the professional norm.",
+  },
+  {
+    question: "How does on-device transcription change the privilege analysis?",
+    answer: "If transcription runs entirely on the attorney's own machine and the transcript is a local file, no third party ever receives the communication — there is no vendor disclosure to analyze, no terms of service governing client data, and no vendor to subpoena. The remaining duties are the familiar ones: device security and access control.",
+  },
+] as const;
 
 const sources = [
   {
@@ -81,7 +63,7 @@ export default function AiNotetakersPrivilegePage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -242,6 +224,8 @@ export default function AiNotetakersPrivilegePage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
+++ b/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "HIPAA-compliant AI note takers: the actual state of play",
@@ -10,44 +12,24 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "Which AI note takers are HIPAA compliant?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "As of July 2026, per each vendor's own documentation: Otter (Enterprise plan + signed BAA only), Fireflies (Enterprise + Private Storage + signed BAA, all three simultaneously), Fathom (publishes a blanket BAA; pricing lists HIPAA BAA under Enterprise), and Krisp (BAA on business/enterprise tiers). Granola states it is not HIPAA compliant and cannot sign BAAs. On-device tools like Minutes sit outside the BAA framework entirely because no vendor ever receives the audio.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is any AI note taker 'HIPAA certified'?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "No. HHS certifies no product. 'HIPAA compliant' is a vendor self-attestation that its safeguards meet HIPAA requirements when used under a signed BAA. Any tool marketing itself as 'HIPAA certified' is being imprecise.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Does using a free or Pro plan of these tools violate HIPAA?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Recording PHI on a plan tier with no BAA in effect is an impermissible disclosure to a vendor, regardless of the vendor's general security quality. Every cloud vendor on this page gates its BAA to its top tier — free and mid-tier plans are not covered.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Why don't on-device note takers need a BAA?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "A BAA governs a vendor's handling of PHI it receives on your behalf. Software that captures, transcribes, and stores entirely on your own machine never gives the vendor the data — no business associate relationship is created, so there is nothing for a BAA to govern. Your own obligations (device encryption, access controls, patient consent) remain.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "Which AI note takers are HIPAA compliant?",
+    answer: "As of July 2026, per each vendor's own documentation: Otter (Enterprise plan + signed BAA only), Fireflies (Enterprise + Private Storage + signed BAA, all three simultaneously), Fathom (publishes a blanket BAA; pricing lists HIPAA BAA under Enterprise), and Krisp (BAA on business/enterprise tiers). Granola states it is not HIPAA compliant and cannot sign BAAs. On-device tools like Minutes sit outside the BAA framework entirely because no vendor ever receives the audio.",
+  },
+  {
+    question: "Is any AI note taker 'HIPAA certified'?",
+    answer: "No. HHS certifies no product. 'HIPAA compliant' is a vendor self-attestation that its safeguards meet HIPAA requirements when used under a signed BAA. Any tool marketing itself as 'HIPAA certified' is being imprecise.",
+  },
+  {
+    question: "Does using a free or Pro plan of these tools violate HIPAA?",
+    answer: "Recording PHI on a plan tier with no BAA in effect is an impermissible disclosure to a vendor, regardless of the vendor's general security quality. Every cloud vendor on this page gates its BAA to its top tier — free and mid-tier plans are not covered.",
+  },
+  {
+    question: "Why don't on-device note takers need a BAA?",
+    answer: "A BAA governs a vendor's handling of PHI it receives on your behalf. Software that captures, transcribes, and stores entirely on your own machine never gives the vendor the data — no business associate relationship is created, so there is nothing for a BAA to govern. Your own obligations (device encryption, access controls, patient consent) remain.",
+  },
+] as const;
 
 const vendors = [
   {
@@ -133,7 +115,7 @@ export default function HipaaCompliantAiNoteTakerPage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -274,6 +256,8 @@ export default function HipaaCompliantAiNoteTakerPage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/is-fireflies-ai-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-fireflies-ai-hipaa-compliant/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is Fireflies.ai HIPAA compliant?",
@@ -10,44 +12,24 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "Is Fireflies.ai HIPAA compliant?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Conditionally. Per Fireflies' own documentation, HIPAA compliance requires three things simultaneously: an active Enterprise plan, Private Storage enabled, and a signed BAA. If any one lapses, compliance is disabled. Free, Pro, and Business plans cannot be used for PHI in a compliant way.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Does Fireflies sign a BAA?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes, via a self-serve BAA page (fireflies.ai/baa) — but the BAA only takes effect with Private Storage enabled, and the HIPAA configuration is Enterprise-only ($39/user/month, billed annually).",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Where does Fireflies process and store meeting audio?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "In Fireflies' cloud in the United States (AWS and GCP) by default, with transcription and AI passing through vendors including OpenAI under zero-retention BAAs. Enterprise Private Storage allows dedicated or bring-your-own storage. Nothing runs on the user's device.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is there a meeting notetaker that doesn't need a BAA at all?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes — on-device tools. A BAA exists to govern a vendor's handling of PHI; software that transcribes and stores entirely on your own machine (like Minutes, open source) never gives a vendor the data, so no business associate relationship is created. Device security and consent obligations remain yours.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "Is Fireflies.ai HIPAA compliant?",
+    answer: "Conditionally. Per Fireflies' own documentation, HIPAA compliance requires three things simultaneously: an active Enterprise plan, Private Storage enabled, and a signed BAA. If any one lapses, compliance is disabled. Free, Pro, and Business plans cannot be used for PHI in a compliant way.",
+  },
+  {
+    question: "Does Fireflies sign a BAA?",
+    answer: "Yes, via a self-serve BAA page (fireflies.ai/baa) — but the BAA only takes effect with Private Storage enabled, and the HIPAA configuration is Enterprise-only ($39/user/month, billed annually).",
+  },
+  {
+    question: "Where does Fireflies process and store meeting audio?",
+    answer: "In Fireflies' cloud in the United States (AWS and GCP) by default, with transcription and AI passing through vendors including OpenAI under zero-retention BAAs. Enterprise Private Storage allows dedicated or bring-your-own storage. Nothing runs on the user's device.",
+  },
+  {
+    question: "Is there a meeting notetaker that doesn't need a BAA at all?",
+    answer: "Yes — on-device tools. A BAA exists to govern a vendor's handling of PHI; software that transcribes and stores entirely on your own machine (like Minutes, open source) never gives a vendor the data, so no business associate relationship is created. Device security and consent obligations remain yours.",
+  },
+] as const;
 
 const sources = [
   { label: "Fireflies security", href: "https://fireflies.ai/security" },
@@ -82,7 +64,7 @@ export default function IsFirefliesHipaaCompliantPage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -218,6 +200,8 @@ export default function IsFirefliesHipaaCompliantPage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/is-granola-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-granola-hipaa-compliant/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is Granola HIPAA compliant?",
@@ -10,44 +12,24 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "Is Granola HIPAA compliant?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "No. Granola's official documentation states: 'Granola is not currently HIPAA compliant and should not be used to store or process Protected Health Information (PHI) at this time.' This applies to every plan, including Enterprise.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Does Granola sign BAAs?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "No. Granola's docs state it 'cannot sign Business Associate Agreements (BAAs)' on any plan, and give no timeline for HIPAA compliance.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What security does Granola actually offer?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "A genuinely decent cloud posture for non-PHI work: SOC 2 Type 2 (achieved July 2025), GDPR with a standard DPA, audio deleted after transcription, and contractual bans on OpenAI/Anthropic training on customer data. Transcripts and notes are stored on US AWS servers.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What should clinicians use instead for recorded conversations?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Either a vendor that offers a BAA in a documented configuration (Otter Enterprise, Fireflies Enterprise with Private Storage, Fathom's published BAA), or an on-device tool where no vendor ever receives the audio — such as Minutes, open source, which transcribes and stores everything on your own machine, so no BAA is needed because no disclosure occurs.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "Is Granola HIPAA compliant?",
+    answer: "No. Granola's official documentation states: 'Granola is not currently HIPAA compliant and should not be used to store or process Protected Health Information (PHI) at this time.' This applies to every plan, including Enterprise.",
+  },
+  {
+    question: "Does Granola sign BAAs?",
+    answer: "No. Granola's docs state it 'cannot sign Business Associate Agreements (BAAs)' on any plan, and give no timeline for HIPAA compliance.",
+  },
+  {
+    question: "What security does Granola actually offer?",
+    answer: "A genuinely decent cloud posture for non-PHI work: SOC 2 Type 2 (achieved July 2025), GDPR with a standard DPA, audio deleted after transcription, and contractual bans on OpenAI/Anthropic training on customer data. Transcripts and notes are stored on US AWS servers.",
+  },
+  {
+    question: "What should clinicians use instead for recorded conversations?",
+    answer: "Either a vendor that offers a BAA in a documented configuration (Otter Enterprise, Fireflies Enterprise with Private Storage, Fathom's published BAA), or an on-device tool where no vendor ever receives the audio — such as Minutes, open source, which transcribes and stores everything on your own machine, so no BAA is needed because no disclosure occurs.",
+  },
+] as const;
 
 const sources = [
   {
@@ -82,7 +64,7 @@ export default function IsGranolaHipaaCompliantPage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -207,6 +189,8 @@ export default function IsGranolaHipaaCompliantPage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
+++ b/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is it legal to record a meeting? Consent law, explained",
@@ -10,44 +12,24 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "Is it legal to record a meeting you're part of?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "In most US states, yes — federal law and roughly three dozen states require only one party's consent, and as a participant you are that party. But eleven-plus states, including California, Florida, Illinois, Massachusetts, Pennsylvania, and Washington, require all parties' consent for confidential communications. Cross-state calls should follow the strictest applicable rule.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Does using an AI notetaker change recording-consent law?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The consent rules are the same — a recording is a recording whether a human presses the button or software does. What changes is disclosure mechanics: bot notetakers announce themselves as visible participants, while device-side capture tools are silent, so the duty to inform participants falls entirely on you. Some vendors also display recording notices; that supplements but does not replace your consent obligation in all-party states.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What is the safest practice for recording meetings?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Announce and get affirmative acknowledgment at the start of every recorded meeting, regardless of state: 'I'd like to record this for notes — everyone okay with that?' It satisfies all-party states, is professionally courteous everywhere, and creates a consent record on the recording itself.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Can my employer record meetings without telling me?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Workplace rules layer on top of state law: one-party states give employers more room, all-party states don't. Many employers handle consent through policy and meeting-platform notices. Union agreements, sector rules, and jurisdictions like the EU (GDPR) add further constraints. Check policy and local law rather than assuming.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "Is it legal to record a meeting you're part of?",
+    answer: "In most US states, yes — federal law and roughly three dozen states require only one party's consent, and as a participant you are that party. But eleven-plus states, including California, Florida, Illinois, Massachusetts, Pennsylvania, and Washington, require all parties' consent for confidential communications. Cross-state calls should follow the strictest applicable rule.",
+  },
+  {
+    question: "Does using an AI notetaker change recording-consent law?",
+    answer: "The consent rules are the same — a recording is a recording whether a human presses the button or software does. What changes is disclosure mechanics: bot notetakers announce themselves as visible participants, while device-side capture tools are silent, so the duty to inform participants falls entirely on you. Some vendors also display recording notices; that supplements but does not replace your consent obligation in all-party states.",
+  },
+  {
+    question: "What is the safest practice for recording meetings?",
+    answer: "Announce and get affirmative acknowledgment at the start of every recorded meeting, regardless of state: 'I'd like to record this for notes — everyone okay with that?' It satisfies all-party states, is professionally courteous everywhere, and creates a consent record on the recording itself.",
+  },
+  {
+    question: "Can my employer record meetings without telling me?",
+    answer: "Workplace rules layer on top of state law: one-party states give employers more room, all-party states don't. Many employers handle consent through policy and meeting-platform notices. Union agreements, sector rules, and jurisdictions like the EU (GDPR) add further constraints. Check policy and local law rather than assuming.",
+  },
+] as const;
 
 const sources = [
   {
@@ -89,7 +71,7 @@ export default function IsItLegalToRecordAMeetingPage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -239,6 +221,8 @@ export default function IsItLegalToRecordAMeetingPage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is Otter.ai HIPAA compliant?",
@@ -10,44 +12,24 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "Is Otter.ai HIPAA compliant?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Conditionally. Otter.ai announced HIPAA compliance in July 2025, but per its help center it is only available to Enterprise plan customers who sign a Business Associate Agreement (BAA). Users on Basic, Pro, or Business plans cannot obtain a BAA and cannot use Otter for protected health information in a compliant way.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Does Otter.ai sign a Business Associate Agreement (BAA)?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes, for Enterprise plan customers only, through its sales and account management process. Without a signed BAA in place, Otter is not acting as a HIPAA business associate.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Can I use Otter's free, Pro, or Business plan for patient conversations?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "No. Per Otter's help center, HIPAA compliance is restricted to the Enterprise plan with a signed BAA. Recording conversations containing PHI on other plans would be an impermissible disclosure to a vendor with no BAA.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Do on-device transcription tools need a BAA?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "No. A BAA is required when a vendor receives, stores, or processes PHI on your behalf. Software that transcribes entirely on your own device — such as open-source tools built on whisper.cpp, like Minutes — never transmits the conversation to a vendor, so there is no business associate relationship to paper over. Your own HIPAA obligations (device encryption, access controls) still apply.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "Is Otter.ai HIPAA compliant?",
+    answer: "Conditionally. Otter.ai announced HIPAA compliance in July 2025, but per its help center it is only available to Enterprise plan customers who sign a Business Associate Agreement (BAA). Users on Basic, Pro, or Business plans cannot obtain a BAA and cannot use Otter for protected health information in a compliant way.",
+  },
+  {
+    question: "Does Otter.ai sign a Business Associate Agreement (BAA)?",
+    answer: "Yes, for Enterprise plan customers only, through its sales and account management process. Without a signed BAA in place, Otter is not acting as a HIPAA business associate.",
+  },
+  {
+    question: "Can I use Otter's free, Pro, or Business plan for patient conversations?",
+    answer: "No. Per Otter's help center, HIPAA compliance is restricted to the Enterprise plan with a signed BAA. Recording conversations containing PHI on other plans would be an impermissible disclosure to a vendor with no BAA.",
+  },
+  {
+    question: "Do on-device transcription tools need a BAA?",
+    answer: "No. A BAA is required when a vendor receives, stores, or processes PHI on your behalf. Software that transcribes entirely on your own device — such as open-source tools built on whisper.cpp, like Minutes — never transmits the conversation to a vendor, so there is no business associate relationship to paper over. Your own HIPAA obligations (device encryption, access controls) still apply.",
+  },
+] as const;
 
 const sources = [
   {
@@ -82,7 +64,7 @@ export default function IsOtterAiHipaaCompliantPage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -281,6 +263,8 @@ export default function IsOtterAiHipaaCompliantPage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/legal-transcription-software/page.tsx
+++ b/site/app/resources/legal-transcription-software/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Legal transcription software: what confidentiality actually requires",
@@ -10,36 +12,20 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What's the difference between legal transcription services and legal transcription software?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Services use human transcriptionists and can produce certified transcripts admissible in court proceedings. Software produces working transcripts instantly and privately for internal use — depositions prep, client meetings, dictated memos. Most firms need both, for different jobs: certification is a human service; speed and confidentiality for internal work is a software job.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is AI transcription safe for privileged conversations?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "It depends on the architecture. Cloud AI transcription sends privileged audio to a third party under that vendor's terms — a disclosure your ethics counsel has to analyze. On-device transcription (software that runs entirely on your own machine) involves no third party, so there is no vendor disclosure to analyze. Device security and consent obligations remain yours either way.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Can software-generated transcripts be used in court?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Software transcripts are working documents, not certified transcripts. Court-grade transcripts of proceedings generally require a certified transcriptionist or court reporter. Use software for speed and confidentiality on internal material; hire certification when the transcript itself must be evidence.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "What's the difference between legal transcription services and legal transcription software?",
+    answer: "Services use human transcriptionists and can produce certified transcripts admissible in court proceedings. Software produces working transcripts instantly and privately for internal use — depositions prep, client meetings, dictated memos. Most firms need both, for different jobs: certification is a human service; speed and confidentiality for internal work is a software job.",
+  },
+  {
+    question: "Is AI transcription safe for privileged conversations?",
+    answer: "It depends on the architecture. Cloud AI transcription sends privileged audio to a third party under that vendor's terms — a disclosure your ethics counsel has to analyze. On-device transcription (software that runs entirely on your own machine) involves no third party, so there is no vendor disclosure to analyze. Device security and consent obligations remain yours either way.",
+  },
+  {
+    question: "Can software-generated transcripts be used in court?",
+    answer: "Software transcripts are working documents, not certified transcripts. Court-grade transcripts of proceedings generally require a certified transcriptionist or court reporter. Use software for speed and confidentiality on internal material; hire certification when the transcript itself must be evidence.",
+  },
+] as const;
 
 const sources = [
   {
@@ -70,7 +56,7 @@ export default function LegalTranscriptionSoftwarePage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -209,6 +195,8 @@ export default function LegalTranscriptionSoftwarePage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "How to remove AI notetaker bots from your meetings",
@@ -10,44 +12,24 @@ export const metadata: Metadata = {
   },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "How do I stop Otter from automatically joining my meetings?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "In Otter's settings, disable auto-join for calendar events (Otter Assistant / OtterPilot settings), or disconnect your calendar entirely so Otter can't see meeting links. To remove it from a live call, use the meeting platform's participant list to remove the bot like any attendee. Otter's help center documents both paths.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How do I remove Fireflies (Fred) from a meeting?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Remove the Fireflies notetaker from the participant list as host, and in Fireflies settings change the autojoin rule (or disconnect the calendar) so it stops joining future calls. Fireflies' guide documents removal and autojoin settings.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Can I block all AI notetaker bots from my meetings?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Largely, yes: enable the waiting room, require sign-in, and admit only human participants — bots arrive as visible guest participants and can be denied or removed. But you cannot disable another attendee's bot from your side except by removing it per meeting or setting an organizational policy.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is there a way to get AI meeting notes without any bot?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes — device-side capture. Tools like Minutes (open source, on-device) record audio directly on the participant's machine, so no bot ever appears in the meeting, and with Minutes the audio is also transcribed locally rather than uploaded. You should still tell participants you're recording; the difference is architectural, not a way around consent.",
-      },
-    },
-  ],
-} as const;
+const faqs = [
+  {
+    question: "How do I stop Otter from automatically joining my meetings?",
+    answer: "In Otter's settings, disable auto-join for calendar events (Otter Assistant / OtterPilot settings), or disconnect your calendar entirely so Otter can't see meeting links. To remove it from a live call, use the meeting platform's participant list to remove the bot like any attendee. Otter's help center documents both paths.",
+  },
+  {
+    question: "How do I remove Fireflies (Fred) from a meeting?",
+    answer: "Remove the Fireflies notetaker from the participant list as host, and in Fireflies settings change the autojoin rule (or disconnect the calendar) so it stops joining future calls. Fireflies' guide documents removal and autojoin settings.",
+  },
+  {
+    question: "Can I block all AI notetaker bots from my meetings?",
+    answer: "Largely, yes: enable the waiting room, require sign-in, and admit only human participants — bots arrive as visible guest participants and can be denied or removed. But you cannot disable another attendee's bot from your side except by removing it per meeting or setting an organizational policy.",
+  },
+  {
+    question: "Is there a way to get AI meeting notes without any bot?",
+    answer: "Yes — device-side capture. Tools like Minutes (open source, on-device) record audio directly on the participant's machine, so no bot ever appears in the meeting, and with Minutes the audio is also transcribed locally rather than uploaded. You should still tell participants you're recording; the difference is architectural, not a way around consent.",
+  },
+] as const;
 
 const sources = [
   {
@@ -81,7 +63,7 @@ export default function RemoveNotetakerBotsPage() {
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -149,7 +131,18 @@ export default function RemoveNotetakerBotsPage() {
             events, or disconnect Google/Microsoft calendar entirely so it never sees links. To
             eject it from one live meeting: open the participant list in Zoom/Meet/Teams and
             remove it like any attendee. Both procedures are in Otter&rsquo;s help center,
-            linked below.
+            linked below. Faster than either, and available to non-hosts: type{" "}
+            <code className="rounded-[4px] bg-[var(--bg-elevated)] px-1.5 py-0.5 font-mono text-[13px] text-[var(--text)]">
+              stop otter
+            </code>{" "}
+            in the meeting chat. Full detail in{" "}
+            <a
+              href="/resources/remove-otter-ai-from-zoom"
+              className="text-[var(--accent)] hover:underline"
+            >
+              how to remove Otter AI from Zoom
+            </a>
+            .
           </p>
           <p>
             <span className="font-medium text-[var(--text)]">Fireflies (Fred).</span> Same
@@ -241,6 +234,8 @@ export default function RemoveNotetakerBotsPage() {
           </a>
         </div>
       </section>
+
+      <FaqSection items={faqs} />
 
       <section className="mt-14">
         <SectionLabel label="Sources" />

--- a/site/app/resources/remove-otter-ai-from-zoom/page.tsx
+++ b/site/app/resources/remove-otter-ai-from-zoom/page.tsx
@@ -1,0 +1,345 @@
+import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
+import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
+
+export const metadata: Metadata = {
+  title: "How to remove Otter AI from Zoom",
+  description:
+    "Remove Otter Notetaker from a Zoom call in ten seconds, even if you are not the host, then stop it coming back. Includes the auto-join setting that silently ignores your change, and what you can actually do about someone else's bot.",
+  alternates: {
+    canonical: "/resources/remove-otter-ai-from-zoom",
+  },
+};
+
+const faqs = [
+  {
+    question: "How do I remove Otter AI from a Zoom meeting?",
+    answer: "Type \"stop otter\" into the Zoom meeting chat. Any participant can do this, including people without an Otter account, and the Notetaker leaves immediately. If you are the host you can also open Participants, click the ellipsis next to the Notetaker, and choose Remove.",
+  },
+  {
+    question: "Can I remove Otter from Zoom if I am not the host?",
+    answer: "Yes. The \"stop otter\" chat command works for any participant regardless of host status or whether you have an Otter account. This is the only removal method that does not require host controls, which is why it matters when the bot belongs to someone else in the call.",
+  },
+  {
+    question: "Why does Otter keep joining my meetings after I turned auto-join off?",
+    answer: "Changing the default auto-join setting only applies to calendar events you have not already customized. Any event where you previously toggled auto-join on keeps that setting. You have to revisit those individual events in the Otter calendar view and turn them off one by one.",
+  },
+  {
+    question: "How do I stop Otter Notetaker joining all my Zoom meetings?",
+    answer: "In Otter, go to Integrations, then Meetings, open the Default auto-join settings dropdown, and choose \"Meetings I manually select.\" Disconnecting the calendar entirely is the stronger version: with no calendar access, Otter cannot see your meeting links at all.",
+  },
+  {
+    question: "How do I block other people's AI notetakers from my Zoom meetings?",
+    answer: "Enable the Waiting Room and require authenticated users. Notetaker bots cannot sign in to Zoom accounts, so authentication blocks most of them. Admins can also restrict third-party apps under Admin, Advanced, App Marketplace. The gap: some bots stream through a participant's own authenticated session rather than joining separately, and no Zoom setting stops that.",
+  },
+] as const;
+
+const sources = [
+  {
+    label: "Otter help: remove Otter Notetaker from your meeting (Zoom, Google Meet, Microsoft Teams)",
+    href: "https://help.otter.ai/hc/en-us/articles/14288936562199-Remove-Otter-Notetaker-from-your-meeting-Zoom-Google-Meet-or-Microsoft-Teams",
+  },
+  {
+    label: "Otter help: stop Otter Notetaker from automatically joining your meetings",
+    href: "https://help.otter.ai/hc/en-us/articles/12906714508823-Stop-Otter-Notetaker-from-automatically-joining-your-meetings",
+  },
+  {
+    label: "Otter help: choose which meetings Otter Notetaker records",
+    href: "https://help.otter.ai/hc/en-us/articles/26010355877911-Choose-which-meetings-Otter-Notetaker-records",
+  },
+  {
+    label: "Zoom Community: disabling AI notetakers (Otter, Read.ai, Fireflies) from joining meetings",
+    href: "https://community.zoom.com/meetings-2/how-do-i-disable-ai-notetakers-otter-ai-read-ai-fireflies-ai-etc-from-joining-our-meetings-17388",
+  },
+  {
+    label: "IT@Cornell: strategies to block AI bots from Zoom sessions",
+    href: "https://it.cornell.edu/zoom/zoom-block-ai-bots",
+  },
+  { label: "Minutes security & privacy architecture", href: "/security" },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function RemoveOtterFromZoomPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a
+            href="/resources/remove-otter-ai-from-zoom.md"
+            className="hover:text-[var(--accent)]"
+          >
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          How to remove Otter AI from Zoom
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          There is a ten-second fix that works even when you are not the host, and almost
+          nobody knows it. Below: the immediate removal, the setting that stops Otter coming
+          back (including the one that silently ignores you), and an honest account of what you
+          can and cannot do about somebody else&rsquo;s bot.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-08-09
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            How-to guide
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Ten-Second Answer" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Type{" "}
+            <code className="rounded-[4px] bg-[var(--bg-elevated)] px-1.5 py-0.5 font-mono text-[13px] text-[var(--text)]">
+              stop otter
+            </code>{" "}
+            into the Zoom meeting chat. The Notetaker leaves.
+          </p>
+          <p>
+            The part that matters:{" "}
+            <span className="font-medium text-[var(--text)]">
+              any participant can do this
+            </span>
+            . You do not need to be the host. You do not need an Otter account. It works in
+            Google Meet and Microsoft Teams chat too. This is the only removal method that
+            requires no permissions at all, which makes it the one to remember when the bot
+            belongs to somebody else in the call.
+          </p>
+          <p>
+            One caveat worth knowing before you use it: if several Otter Notetakers are in the
+            meeting, because more than one attendee brought one,{" "}
+            <code className="rounded-[4px] bg-[var(--bg-elevated)] px-1.5 py-0.5 font-mono text-[13px] text-[var(--text)]">
+              stop otter
+            </code>{" "}
+            removes all of them, not just the one you had in mind. To remove a single
+            Notetaker, use the participant-list method below.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="If You Are The Host" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Host controls remove one specific bot rather than all of them:
+          </p>
+          <ol className="list-decimal space-y-2 pl-6">
+            <li>Click <span className="font-medium text-[var(--text)]">Participants</span> in the Zoom toolbar.</li>
+            <li>Find the Notetaker in the list. It appears as a normal participant with a name like &ldquo;Otter.ai Notetaker.&rdquo;</li>
+            <li>Click the <span className="font-medium text-[var(--text)]">ellipsis</span> next to its name.</li>
+            <li>Choose <span className="font-medium text-[var(--text)]">Remove</span>.</li>
+          </ol>
+          <p>
+            This ejects the bot from the current meeting only. It does nothing about the next
+            one, which is the next section.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Stop It Coming Back" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            In Otter, open <span className="font-medium text-[var(--text)]">Integrations</span>{" "}
+            → <span className="font-medium text-[var(--text)]">Meetings</span>, open the{" "}
+            <span className="font-medium text-[var(--text)]">Default auto-join settings</span>{" "}
+            dropdown, and choose{" "}
+            <span className="font-medium text-[var(--text)]">
+              &ldquo;Meetings I manually select.&rdquo;
+            </span>
+          </p>
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              The gotcha that sends people back to Google
+            </p>
+            <p className="mt-3">
+              Changing the default does{" "}
+              <span className="font-medium text-[var(--text)]">not</span> apply retroactively to
+              calendar events you already customized. If you ever toggled auto-join on for a
+              specific recurring meeting, that event keeps its own setting and Otter will keep
+              joining it, no matter what the default now says. You have to open the calendar
+              view in Otter and turn those events off individually.
+            </p>
+            <p className="mt-3">
+              This is the single most common reason people believe they disabled Otter and then
+              watch it walk into a call the following week.
+            </p>
+          </div>
+          <p>
+            The stronger version is to sever the supply line entirely: disconnect the Google or
+            Microsoft calendar from Otter. A notetaker that cannot read your calendar cannot
+            discover your meeting links, so there is nothing left to auto-join. If you only
+            ever want Otter in meetings you deliberately choose, this is the setting that
+            actually guarantees it.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Somebody Else's Otter Bot" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            This is the case every vendor help page skips, because the honest answer is
+            awkward: you cannot reach into a colleague&rsquo;s or client&rsquo;s Otter account
+            and turn their bot off. What you can do, roughly in order of how well it works:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <span className="font-medium text-[var(--text)]">Ask.</span> &ldquo;Could you drop
+              the notetaker for this one?&rdquo; is ordinary meeting etiquette now, and the
+              person who owns the bot can remove it in a single click. For a sensitive
+              conversation this is faster and less strange than any technical control.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">
+                Type the chat command.
+              </span>{" "}
+              As above, it works from any seat in the room.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">
+                Waiting Room plus authentication.
+              </span>{" "}
+              The strongest standing control. Notetaker bots cannot sign in to Zoom accounts, so
+              requiring authenticated users blocks most of them outright, and the Waiting Room
+              gives you a look at anything that still turns up before it hears anything.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">Admin app controls.</span> Zoom
+              admins can restrict or allow-list third-party apps under{" "}
+              <span className="font-medium text-[var(--text)]">
+                Admin → Advanced → App Marketplace
+              </span>
+              , and review what users have already installed under Apps on Account. This is the
+              only option that scales past a single meeting.
+            </li>
+          </ul>
+          <p>
+            And the limit worth stating plainly, because the pages that sell you a blocker will
+            not: some notetakers no longer join as a separate participant at all. They capture
+            audio through an attendee&rsquo;s own authenticated session, which means there is no
+            bot in the participant list to remove and no Zoom setting that stops it. Waiting
+            rooms and authentication defeat the bots that dial in. Nothing defeats a
+            participant who is recording. That has always been true of meetings; AI just made it
+            cheaper.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Version Of This Problem That Solves Itself" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Every step above manages a symptom. The bot exists because cloud notetakers need
+            your meeting&rsquo;s audio on their servers, and joining the call as a synthetic
+            participant is how they get it. Capture the audio on your own device instead and the
+            entire category disappears: nothing joins, nothing appears in the participant list,
+            nothing needs admitting, ejecting, or explaining to a client.
+          </p>
+          <p>
+            That is how <span className="font-medium text-[var(--text)]">Minutes</span> works. It
+            records device-side, transcribes locally with whisper.cpp, and writes markdown to
+            your own disk. No bot, and no cloud either. Granola is also botless if you want the
+            comparison, though it transcribes in the cloud, which is{" "}
+            <a
+              href="/compare/granola-vs-minutes"
+              className="text-[var(--accent)] hover:underline"
+            >
+              a different trade
+            </a>
+            . If you are weighing Otter specifically, we keep an{" "}
+            <a href="/compare/otter-vs-minutes" className="text-[var(--accent)] hover:underline">
+              honest side-by-side
+            </a>
+            .
+          </p>
+          <p>
+            One thing device-side capture does not change: tell people you are recording. The
+            bot&rsquo;s single virtue was announcing itself. Remove it and consent becomes your
+            job, which is where it belonged in the first place. If you need the legal detail,
+            see{" "}
+            <a
+              href="/resources/is-it-legal-to-record-a-meeting"
+              className="text-[var(--accent)] hover:underline"
+            >
+              recording consent law by state
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            How botless capture works
+          </a>
+          <a
+            href="/resources/remove-ai-notetaker-bots-from-meetings"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Other notetakers &amp; platforms
+          </a>
+        </div>
+      </section>
+
+      <FaqSection items={faqs} />
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/remove-otter-ai-from-zoom/page.tsx
+++ b/site/app/resources/remove-otter-ai-from-zoom/page.tsx
@@ -6,7 +6,7 @@ import { faqPageSchema } from "@/lib/schema";
 export const metadata: Metadata = {
   title: "How to remove Otter AI from Zoom",
   description:
-    "Remove Otter Notetaker from a Zoom call in ten seconds, even if you are not the host, then stop it coming back. Includes the auto-join setting that silently ignores your change, and what you can actually do about someone else's bot.",
+    "Remove Otter Notetaker from a Zoom call immediately, even if you are not the host, then stop it coming back. Includes the auto-join setting that silently ignores your change, and what you can actually do about someone else's bot.",
   alternates: {
     canonical: "/resources/remove-otter-ai-from-zoom",
   },
@@ -31,7 +31,7 @@ const faqs = [
   },
   {
     question: "How do I block other people's AI notetakers from my Zoom meetings?",
-    answer: "Enable the Waiting Room and require authenticated users. Notetaker bots cannot sign in to Zoom accounts, so authentication blocks most of them. Admins can also restrict third-party apps under Admin, Advanced, App Marketplace. The gap: some bots stream through a participant's own authenticated session rather than joining separately, and no Zoom setting stops that.",
+    answer: "Enable the Waiting Room and admit only recognized attendees, and require authenticated users. That blocks some standalone bot participants, but it is not a guarantee: notetakers operating through an already-admitted attendee's own authenticated session are unaffected. Admins can disable or remove installed apps at marketplace.zoom.us under Manage, Admin App Management, Apps on Account, which stops internal users from running them but does not restrict external participants. Disabling local recording may block tools that rely on Zoom's recording channel; nothing in Zoom prevents out-of-band capture by a participant or a separate device.",
   },
 ] as const;
 
@@ -105,10 +105,10 @@ export default function RemoveOtterFromZoomPage() {
           How to remove Otter AI from Zoom
         </h1>
         <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
-          There is a ten-second fix that works even when you are not the host, and almost
-          nobody knows it. Below: the immediate removal, the setting that stops Otter coming
-          back (including the one that silently ignores you), and an honest account of what you
-          can and cannot do about somebody else&rsquo;s bot.
+          There is a one-line fix that works even when you are not the host, and almost nobody
+          knows it. Below: the immediate removal, the setting that stops Otter coming back
+          (including the one that silently ignores you), and an honest account of what you can
+          and cannot do about somebody else&rsquo;s bot.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
@@ -121,7 +121,7 @@ export default function RemoveOtterFromZoomPage() {
       </section>
 
       <section className="mt-14 max-w-[800px]">
-        <SectionLabel label="The Ten-Second Answer" />
+        <SectionLabel label="The One-Line Answer" />
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
             Type{" "}
@@ -196,8 +196,9 @@ export default function RemoveOtterFromZoomPage() {
               view in Otter and turn those events off individually.
             </p>
             <p className="mt-3">
-              This is the single most common reason people believe they disabled Otter and then
-              watch it walk into a call the following week.
+              Otter documents the behavior but publishes no figures on how often it bites. It is
+              worth checking first when you believe you disabled Otter and then watch it walk
+              into a call the following week.
             </p>
           </div>
           <p>
@@ -235,28 +236,32 @@ export default function RemoveOtterFromZoomPage() {
               <span className="font-medium text-[var(--text)]">
                 Waiting Room plus authentication.
               </span>{" "}
-              The strongest standing control. Notetaker bots cannot sign in to Zoom accounts, so
-              requiring authenticated users blocks most of them outright, and the Waiting Room
-              gives you a look at anything that still turns up before it hears anything.
+              The strongest standing control, though not a guarantee. Requiring authenticated
+              users blocks some standalone bot participants, and the Waiting Room lets you admit
+              only people you recognize before anything hears the room. It does not stop a
+              notetaker running through an attendee you have already admitted, and Cornell&rsquo;s
+              IT guidance is explicit that this only helps prevent bot access rather than
+              eliminating it.
             </li>
             <li>
               <span className="font-medium text-[var(--text)]">Admin app controls.</span> Zoom
-              admins can restrict or allow-list third-party apps under{" "}
+              admins can disable or remove installed apps at{" "}
               <span className="font-medium text-[var(--text)]">
-                Admin → Advanced → App Marketplace
+                marketplace.zoom.us → Manage → Admin App Management → Apps on Account
               </span>
-              , and review what users have already installed under Apps on Account. This is the
-              only option that scales past a single meeting.
+              . Read the scope carefully: this stops users on your account from running the app.
+              It does not restrict external participants who bring their own.
             </li>
           </ul>
           <p>
             And the limit worth stating plainly, because the pages that sell you a blocker will
             not: some notetakers no longer join as a separate participant at all. They capture
-            audio through an attendee&rsquo;s own authenticated session, which means there is no
-            bot in the participant list to remove and no Zoom setting that stops it. Waiting
-            rooms and authentication defeat the bots that dial in. Nothing defeats a
-            participant who is recording. That has always been true of meetings; AI just made it
-            cheaper.
+            through an attendee&rsquo;s own authenticated session, so there is no bot in the
+            participant list to remove. Admission controls do not reach that case. Disabling
+            local recording may block tools that depend on Zoom&rsquo;s own recording channel,
+            which is worth doing, but Zoom cannot prevent genuinely out-of-band capture by a
+            participant or a separate device in the room. That has always been true of meetings;
+            AI just made it cheaper.
           </p>
         </div>
       </section>

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -37,6 +37,7 @@ const routes = [
   "/resources/meeting-minutes-template",
   "/resources/open-source-alternatives-to-granola-ai",
   "/resources/remove-ai-notetaker-bots-from-meetings",
+  "/resources/remove-otter-ai-from-zoom",
   "/security",
   "/writing",
   "/writing/governance-built-in-not-retrofitted",

--- a/site/components/faq-section.tsx
+++ b/site/components/faq-section.tsx
@@ -1,0 +1,43 @@
+import type { FaqItem } from "@/lib/schema";
+
+/** Visible FAQ block, rendered from the same array that produces FAQPage markup.
+ *
+ * Google requires FAQPage structured data to describe content the user can
+ * actually see. Rendering and markup therefore read from one array: see
+ * `faqPageSchema` in `@/lib/schema`.
+ *
+ * Native `<details>` keeps the answers in the DOM whether or not they are
+ * expanded, so crawlers and answer engines read them without running JS.
+ */
+export function FaqSection({ items }: { items: ReadonlyArray<FaqItem> }) {
+  if (items.length === 0) return null;
+
+  return (
+    <section className="mt-14 max-w-[800px]">
+      <div className="mb-6 flex items-center gap-3">
+        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Common questions
+        </span>
+        <div className="h-px flex-1 bg-[var(--border)]" />
+      </div>
+      <dl className="divide-y divide-[color:var(--border)] border-y border-[color:var(--border)]">
+        {items.map((item) => (
+          <details key={item.question} className="faq-disclosure group py-4">
+            <summary className="flex cursor-pointer list-none items-start justify-between gap-4 text-[15px] font-medium leading-7 text-[var(--text)] marker:content-none">
+              <dt>{item.question}</dt>
+              <span
+                aria-hidden="true"
+                className="mt-1 shrink-0 font-mono text-[13px] text-[var(--text-secondary)] transition-transform group-open:rotate-45"
+              >
+                +
+              </span>
+            </summary>
+            <dd className="mt-3 pr-8 text-[15px] leading-8 text-[var(--text-secondary)]">
+              {item.answer}
+            </dd>
+          </details>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/site/components/faq-section.tsx
+++ b/site/components/faq-section.tsx
@@ -20,11 +20,11 @@ export function FaqSection({ items }: { items: ReadonlyArray<FaqItem> }) {
         </span>
         <div className="h-px flex-1 bg-[var(--border)]" />
       </div>
-      <dl className="divide-y divide-[color:var(--border)] border-y border-[color:var(--border)]">
+      <div className="divide-y divide-[color:var(--border)] border-y border-[color:var(--border)]">
         {items.map((item) => (
           <details key={item.question} className="faq-disclosure group py-4">
             <summary className="flex cursor-pointer list-none items-start justify-between gap-4 text-[15px] font-medium leading-7 text-[var(--text)] marker:content-none">
-              <dt>{item.question}</dt>
+              <span>{item.question}</span>
               <span
                 aria-hidden="true"
                 className="mt-1 shrink-0 font-mono text-[13px] text-[var(--text-secondary)] transition-transform group-open:rotate-45"
@@ -32,12 +32,12 @@ export function FaqSection({ items }: { items: ReadonlyArray<FaqItem> }) {
                 +
               </span>
             </summary>
-            <dd className="mt-3 pr-8 text-[15px] leading-8 text-[var(--text-secondary)]">
+            <div className="mt-3 pr-8 text-[15px] leading-8 text-[var(--text-secondary)]">
               {item.answer}
-            </dd>
+            </div>
           </details>
         ))}
-      </dl>
+      </div>
     </section>
   );
 }

--- a/site/lib/schema.ts
+++ b/site/lib/schema.ts
@@ -5,11 +5,11 @@
  * the markup cannot drift from the copy.
  *
  * That rule is why `faqPageSchema` takes the same array the page renders through
- * `<FaqSection>` rather than a separate literal. Until 2026-08-09 nine resource
- * pages hand-rolled FAQPage JSON-LD that appeared nowhere in their visible copy
- * (0 of 36 answers rendered), which is a structured-data violation Google can
- * penalize. Pairing the builder with the component makes the compliant thing the
- * easy thing: you cannot emit the markup without also rendering the content.
+ * `<FaqSection>` rather than a separate literal. Until 2026-08-09 every resource
+ * page hand-rolled FAQPage JSON-LD that appeared nowhere in its visible copy, a
+ * structured-data violation Google can penalize. Pairing the builder with the
+ * component makes the compliant thing the easy thing: you cannot emit the markup
+ * without also rendering the content.
  *
  * Comparison pages still emit no FAQPage, because they have no FAQ section.
  */

--- a/site/lib/schema.ts
+++ b/site/lib/schema.ts
@@ -2,9 +2,16 @@
  *
  * Schema.org markup must describe content that is actually visible on the page.
  * Every field produced here is derived from data the page already renders, so
- * the markup cannot drift from the copy. Notably there is no FAQPage builder:
- * FAQPage requires visible question/answer content, and the comparison pages do
- * not have an FAQ section today.
+ * the markup cannot drift from the copy.
+ *
+ * That rule is why `faqPageSchema` takes the same array the page renders through
+ * `<FaqSection>` rather than a separate literal. Until 2026-08-09 nine resource
+ * pages hand-rolled FAQPage JSON-LD that appeared nowhere in their visible copy
+ * (0 of 36 answers rendered), which is a structured-data violation Google can
+ * penalize. Pairing the builder with the component makes the compliant thing the
+ * easy thing: you cannot emit the markup without also rendering the content.
+ *
+ * Comparison pages still emit no FAQPage, because they have no FAQ section.
  */
 
 const SITE_URL = "https://useminutes.app";
@@ -79,6 +86,27 @@ function competitorSchema(label: string) {
     "@type": "SoftwareApplication",
     name: label.replace(/\s*\([^)]*\)\s*$/, ""),
     applicationCategory: "BusinessApplication",
+  };
+}
+
+/** One question and its answer, rendered visibly and emitted as markup. */
+export type FaqItem = { question: string; answer: string };
+
+/** Structured data for a page's FAQ.
+ *
+ * Pass the exact array the page renders through `<FaqSection>`. Google requires
+ * FAQPage content to be visible to the user, so emitting this for questions that
+ * only exist in JSON-LD is a violation, not a shortcut.
+ */
+export function faqPageSchema(items: ReadonlyArray<FaqItem>) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: { "@type": "Answer", text: item.answer },
+    })),
   };
 }
 

--- a/site/public/resources/remove-otter-ai-from-zoom.md
+++ b/site/public/resources/remove-otter-ai-from-zoom.md
@@ -1,0 +1,58 @@
+# How to remove Otter AI from Zoom
+
+Last reviewed: 2026-08-09
+
+There is a ten-second fix that works even when you are not the host, and almost nobody knows it.
+
+## The ten-second answer
+
+Type `stop otter` into the Zoom meeting chat. The Notetaker leaves.
+
+**Any participant can do this.** You do not need to be the host, and you do not need an Otter account. It works in Google Meet and Microsoft Teams chat too. This is the only removal method that requires no permissions at all, which makes it the one to remember when the bot belongs to somebody else in the call.
+
+Caveat: if several Otter Notetakers are present because more than one attendee brought one, `stop otter` removes all of them. To remove a single Notetaker, use the participant-list method.
+
+## If you are the host
+
+1. Click **Participants** in the Zoom toolbar
+2. Find the Notetaker in the list (it appears as a normal participant, named something like "Otter.ai Notetaker")
+3. Click the **ellipsis** next to its name
+4. Choose **Remove**
+
+This ejects the bot from the current meeting only.
+
+## Stop it coming back
+
+In Otter: **Integrations → Meetings → Default auto-join settings → "Meetings I manually select."**
+
+**The gotcha:** changing the default does *not* apply retroactively to calendar events you already customized. If you ever toggled auto-join on for a specific recurring meeting, that event keeps its own setting and Otter keeps joining it regardless of the new default. Open the calendar view in Otter and turn those events off individually. This is the most common reason people believe they disabled Otter and then watch it walk into a call the following week.
+
+Stronger: disconnect the Google or Microsoft calendar from Otter entirely. A notetaker that cannot read your calendar cannot discover your meeting links, so there is nothing left to auto-join.
+
+Otter's docs: https://help.otter.ai/hc/en-us/articles/12906714508823-Stop-Otter-Notetaker-from-automatically-joining-your-meetings and https://help.otter.ai/hc/en-us/articles/26010355877911-Choose-which-meetings-Otter-Notetaker-records
+
+## Somebody else's Otter bot
+
+You cannot reach into another person's Otter account and turn their bot off. In order of how well it works:
+
+- **Ask.** "Could you drop the notetaker for this one?" is ordinary etiquette now, and the owner can remove it in one click. For a sensitive conversation this beats any technical control.
+- **Type the chat command.** Works from any seat in the room.
+- **Waiting Room plus authentication.** The strongest standing control. Notetaker bots cannot sign in to Zoom accounts, so requiring authenticated users blocks most of them outright.
+- **Admin app controls.** Zoom admins can restrict or allow-list third-party apps under Admin → Advanced → App Marketplace, and audit installs under Apps on Account. The only option that scales past one meeting.
+
+**The limit, stated plainly:** some notetakers no longer join as a separate participant. They capture audio through an attendee's own authenticated session, so there is no bot in the participant list and no Zoom setting that stops it. Waiting rooms and authentication defeat bots that dial in. Nothing defeats a participant who is recording. That has always been true of meetings; AI just made it cheaper.
+
+## The version of this problem that solves itself
+
+Every step above manages a symptom. The bot exists because cloud notetakers need your meeting audio on their servers, and joining as a synthetic participant is how they get it. Capture audio on your own device instead and the category disappears: nothing joins, nothing appears in the participant list, nothing needs admitting or ejecting.
+
+That is how Minutes works: device-side recording, local transcription (whisper.cpp), markdown on your own disk. No bot and no cloud. Granola is also botless, though it transcribes in the cloud, which is a different trade.
+
+One thing device-side capture does not change: tell people you are recording. The bot's single virtue was announcing itself; without it, consent is your job, which is where it belonged anyway.
+
+## Related
+
+- Other notetakers and platforms: https://useminutes.app/resources/remove-ai-notetaker-bots-from-meetings
+- Otter vs Minutes: https://useminutes.app/compare/otter-vs-minutes
+- Recording consent law by state: https://useminutes.app/resources/is-it-legal-to-record-a-meeting
+- How botless capture works: https://useminutes.app/security

--- a/site/public/resources/remove-otter-ai-from-zoom.md
+++ b/site/public/resources/remove-otter-ai-from-zoom.md
@@ -2,9 +2,9 @@
 
 Last reviewed: 2026-08-09
 
-There is a ten-second fix that works even when you are not the host, and almost nobody knows it.
+There is a one-line fix that works even when you are not the host, and almost nobody knows it.
 
-## The ten-second answer
+## The one-line answer
 
 Type `stop otter` into the Zoom meeting chat. The Notetaker leaves.
 
@@ -25,7 +25,7 @@ This ejects the bot from the current meeting only.
 
 In Otter: **Integrations → Meetings → Default auto-join settings → "Meetings I manually select."**
 
-**The gotcha:** changing the default does *not* apply retroactively to calendar events you already customized. If you ever toggled auto-join on for a specific recurring meeting, that event keeps its own setting and Otter keeps joining it regardless of the new default. Open the calendar view in Otter and turn those events off individually. This is the most common reason people believe they disabled Otter and then watch it walk into a call the following week.
+**The gotcha:** changing the default does *not* apply retroactively to calendar events you already customized. If you ever toggled auto-join on for a specific recurring meeting, that event keeps its own setting and Otter keeps joining it regardless of the new default. Open the calendar view in Otter and turn those events off individually. Otter documents the behavior but publishes no figures on how often it bites. Check it first when you believe you disabled Otter and then watch it walk into a call the following week.
 
 Stronger: disconnect the Google or Microsoft calendar from Otter entirely. A notetaker that cannot read your calendar cannot discover your meeting links, so there is nothing left to auto-join.
 
@@ -37,10 +37,10 @@ You cannot reach into another person's Otter account and turn their bot off. In 
 
 - **Ask.** "Could you drop the notetaker for this one?" is ordinary etiquette now, and the owner can remove it in one click. For a sensitive conversation this beats any technical control.
 - **Type the chat command.** Works from any seat in the room.
-- **Waiting Room plus authentication.** The strongest standing control. Notetaker bots cannot sign in to Zoom accounts, so requiring authenticated users blocks most of them outright.
-- **Admin app controls.** Zoom admins can restrict or allow-list third-party apps under Admin → Advanced → App Marketplace, and audit installs under Apps on Account. The only option that scales past one meeting.
+- **Waiting Room plus authentication.** The strongest standing control, though not a guarantee. Requiring authenticated users blocks some standalone bot participants, and the Waiting Room lets you admit only people you recognize. It does not stop a notetaker running through an attendee you already admitted; Cornell's IT guidance says this helps prevent bot access rather than eliminating it.
+- **Admin app controls.** Zoom admins can disable or remove installed apps at marketplace.zoom.us → Manage → Admin App Management → Apps on Account. Scope matters: this stops users on your account from running the app, but does not restrict external participants who bring their own.
 
-**The limit, stated plainly:** some notetakers no longer join as a separate participant. They capture audio through an attendee's own authenticated session, so there is no bot in the participant list and no Zoom setting that stops it. Waiting rooms and authentication defeat bots that dial in. Nothing defeats a participant who is recording. That has always been true of meetings; AI just made it cheaper.
+**The limit, stated plainly:** some notetakers no longer join as a separate participant. They capture through an attendee's own authenticated session, so there is no bot in the participant list to remove, and admission controls do not reach that case. Disabling local recording may block tools that depend on Zoom's own recording channel, which is worth doing, but Zoom cannot prevent out-of-band capture by a participant or a separate device in the room. That has always been true of meetings; AI just made it cheaper.
 
 ## The version of this problem that solves itself
 


### PR DESCRIPTION
Three related pieces of SEO work, following the apex/canonical fix that landed on Cloudflare earlier today.

## 1. The apex was telling Google its canonical URLs were redirects

`useminutes.app` resolved to a stale Vercel project that `307`-redirected to `www`, which Cloudflare Pages served. Meanwhile every canonical tag, all 36 sitemap entries, and the `robots.txt` sitemap declaration pointed at the apex. A 307 does not transfer canonical status, so Google was told the canonical version of every page was a URL that temporarily redirects somewhere else. The whole 40-route content build from July stayed effectively unindexed: 496 referring domains, one ranking keyword, ~20 visits/mo.

Fixed outside the repo (apex registered as a Pages custom domain, DNS repointed, `www` → apex 301). Verified: apex returns 200 with zero redirect hops, `www` 301s with path and query preserved, declared canonical equals serving host.

The release checklist already said to verify the apex. That check passed every single time, because a browser follows the 307 silently and renders the site. This PR replaces it with a `curl` assertion on status codes and canonical parity, which is the only form that would have caught it.

## 2. Nine pages claimed FAQ content they never rendered

While building the new page I copied the established pattern and then found it was broken. Nine resource pages emit `FAQPage` structured data whose questions and answers appear nowhere in the visible page. Measured: **0 of 36 pairs rendered**. Google requires FAQPage content to be user-visible, so this is a structured-data violation, and it was about to be crawled in earnest precisely because indexing now works.

`lib/schema.ts` (from #691) had already documented this exact constraint, which is why it deliberately shipped no FAQPage builder. Rather than delete the markup, this renders it: a shared `FaqSection` component and a new `faqPageSchema` builder read the same array, so copy and markup cannot drift. You can no longer emit the markup without also shipping the content.

Native `<details>` keeps answers in the DOM whether expanded or not, so crawlers read them without running JS. Safari draws its own disclosure triangle through a `-webkit` pseudo that Tailwind's `marker:` variant cannot reach, handled in `globals.css` the same way the mobile menu already does.

Verified: **36/36 pairs now present in rendered text**, both collapsed and expanded states visually checked.

## 3. First page of the anti-bot removal cluster

`/resources/remove-otter-ai-from-zoom` targets `how to remove otter ai from zoom` (250/mo, KD 2, traffic potential 450) plus four variants that collapse into the same intent, roughly 480/mo combined at KD 1-2. Competitors are forced to rank for their own churn queries defensively; botless capture is the product answer to that demand.

Two findings from primary sources keep it from being generic:

- Any participant can type `stop otter` in the meeting chat to eject the Notetaker. No host rights, no Otter account. That is the answer to "someone else brought a bot and I am not the host," which every vendor help page skips.
- Changing Otter's default auto-join does **not** apply to calendar events already customized. That is the likeliest reason people believe they disabled it and then watch it rejoin the following week.

It also states the limit honestly: some notetakers capture through an attendee's own authenticated session, so there is no participant to remove and no Zoom setting that stops it.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean, 41 static routes
- [x] 36/36 FAQ pairs verified present in rendered HTML text
- [x] Collapsed and expanded FAQ states visually verified
- [x] New page: title, canonical, FAQPage JSON-LD parses, in sitemap, `.md` twin, linked from hub
- [x] String literals moved verbatim during refactor; em dashes, curly quotes, escaped quotes intact, no mojibake

## Notes

Remaining in the cluster, each needing its own research pass: Fireflies (80/mo), Zoom AI Companion, Teams Copilot, Read.ai. Deliberately not templated.

GSC sitemap resubmission at `https://useminutes.app/sitemap.xml` is still a manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)