### PR TITLE
fix(site): correct live Zoom guidance and invalid FAQ markup

### DIFF
--- a/site/app/resources/remove-otter-ai-from-zoom/page.tsx
+++ b/site/app/resources/remove-otter-ai-from-zoom/page.tsx
@@ -6,7 +6,7 @@ import { faqPageSchema } from "@/lib/schema";
 export const metadata: Metadata = {
   title: "How to remove Otter AI from Zoom",
   description:
-    "Remove Otter Notetaker from a Zoom call in ten seconds, even if you are not the host, then stop it coming back. Includes the auto-join setting that silently ignores your change, and what you can actually do about someone else's bot.",
+    "Remove Otter Notetaker from a Zoom call immediately, even if you are not the host, then stop it coming back. Includes the auto-join setting that silently ignores your change, and what you can actually do about someone else's bot.",
   alternates: {
     canonical: "/resources/remove-otter-ai-from-zoom",
   },
@@ -31,7 +31,7 @@ const faqs = [
   },
   {
     question: "How do I block other people's AI notetakers from my Zoom meetings?",
-    answer: "Enable the Waiting Room and require authenticated users. Notetaker bots cannot sign in to Zoom accounts, so authentication blocks most of them. Admins can also restrict third-party apps under Admin, Advanced, App Marketplace. The gap: some bots stream through a participant's own authenticated session rather than joining separately, and no Zoom setting stops that.",
+    answer: "Enable the Waiting Room and admit only recognized attendees, and require authenticated users. That blocks some standalone bot participants, but it is not a guarantee: notetakers operating through an already-admitted attendee's own authenticated session are unaffected. Admins can disable or remove installed apps at marketplace.zoom.us under Manage, Admin App Management, Apps on Account, which stops internal users from running them but does not restrict external participants. Disabling local recording may block tools that rely on Zoom's recording channel; nothing in Zoom prevents out-of-band capture by a participant or a separate device.",
   },
 ] as const;
 
@@ -105,10 +105,10 @@ export default function RemoveOtterFromZoomPage() {
           How to remove Otter AI from Zoom
         </h1>
         <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
-          There is a ten-second fix that works even when you are not the host, and almost
-          nobody knows it. Below: the immediate removal, the setting that stops Otter coming
-          back (including the one that silently ignores you), and an honest account of what you
-          can and cannot do about somebody else&rsquo;s bot.
+          There is a one-line fix that works even when you are not the host, and almost nobody
+          knows it. Below: the immediate removal, the setting that stops Otter coming back
+          (including the one that silently ignores you), and an honest account of what you can
+          and cannot do about somebody else&rsquo;s bot.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
@@ -121,7 +121,7 @@ export default function RemoveOtterFromZoomPage() {
       </section>
 
       <section className="mt-14 max-w-[800px]">
-        <SectionLabel label="The Ten-Second Answer" />
+        <SectionLabel label="The One-Line Answer" />
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
             Type{" "}
@@ -196,8 +196,9 @@ export default function RemoveOtterFromZoomPage() {
               view in Otter and turn those events off individually.
             </p>
             <p className="mt-3">
-              This is the single most common reason people believe they disabled Otter and then
-              watch it walk into a call the following week.
+              Otter documents the behavior but publishes no figures on how often it bites. It is
+              worth checking first when you believe you disabled Otter and then watch it walk
+              into a call the following week.
             </p>
           </div>
           <p>
@@ -235,28 +236,32 @@ export default function RemoveOtterFromZoomPage() {
               <span className="font-medium text-[var(--text)]">
                 Waiting Room plus authentication.
               </span>{" "}
-              The strongest standing control. Notetaker bots cannot sign in to Zoom accounts, so
-              requiring authenticated users blocks most of them outright, and the Waiting Room
-              gives you a look at anything that still turns up before it hears anything.
+              The strongest standing control, though not a guarantee. Requiring authenticated
+              users blocks some standalone bot participants, and the Waiting Room lets you admit
+              only people you recognize before anything hears the room. It does not stop a
+              notetaker running through an attendee you have already admitted, and Cornell&rsquo;s
+              IT guidance is explicit that this only helps prevent bot access rather than
+              eliminating it.
             </li>
             <li>
               <span className="font-medium text-[var(--text)]">Admin app controls.</span> Zoom
-              admins can restrict or allow-list third-party apps under{" "}
+              admins can disable or remove installed apps at{" "}
               <span className="font-medium text-[var(--text)]">
-                Admin → Advanced → App Marketplace
+                marketplace.zoom.us → Manage → Admin App Management → Apps on Account
               </span>
-              , and review what users have already installed under Apps on Account. This is the
-              only option that scales past a single meeting.
+              . Read the scope carefully: this stops users on your account from running the app.
+              It does not restrict external participants who bring their own.
             </li>
           </ul>
           <p>
             And the limit worth stating plainly, because the pages that sell you a blocker will
             not: some notetakers no longer join as a separate participant at all. They capture
-            audio through an attendee&rsquo;s own authenticated session, which means there is no
-            bot in the participant list to remove and no Zoom setting that stops it. Waiting
-            rooms and authentication defeat the bots that dial in. Nothing defeats a
-            participant who is recording. That has always been true of meetings; AI just made it
-            cheaper.
+            through an attendee&rsquo;s own authenticated session, so there is no bot in the
+            participant list to remove. Admission controls do not reach that case. Disabling
+            local recording may block tools that depend on Zoom&rsquo;s own recording channel,
+            which is worth doing, but Zoom cannot prevent genuinely out-of-band capture by a
+            participant or a separate device in the room. That has always been true of meetings;
+            AI just made it cheaper.
           </p>
         </div>
       </section>

--- a/site/components/faq-section.tsx
+++ b/site/components/faq-section.tsx
@@ -20,11 +20,11 @@ export function FaqSection({ items }: { items: ReadonlyArray<FaqItem> }) {
         </span>
         <div className="h-px flex-1 bg-[var(--border)]" />
       </div>
-      <dl className="divide-y divide-[color:var(--border)] border-y border-[color:var(--border)]">
+      <div className="divide-y divide-[color:var(--border)] border-y border-[color:var(--border)]">
         {items.map((item) => (
           <details key={item.question} className="faq-disclosure group py-4">
             <summary className="flex cursor-pointer list-none items-start justify-between gap-4 text-[15px] font-medium leading-7 text-[var(--text)] marker:content-none">
-              <dt>{item.question}</dt>
+              <span>{item.question}</span>
               <span
                 aria-hidden="true"
                 className="mt-1 shrink-0 font-mono text-[13px] text-[var(--text-secondary)] transition-transform group-open:rotate-45"
@@ -32,12 +32,12 @@ export function FaqSection({ items }: { items: ReadonlyArray<FaqItem> }) {
                 +
               </span>
             </summary>
-            <dd className="mt-3 pr-8 text-[15px] leading-8 text-[var(--text-secondary)]">
+            <div className="mt-3 pr-8 text-[15px] leading-8 text-[var(--text-secondary)]">
               {item.answer}
-            </dd>
+            </div>
           </details>
         ))}
-      </dl>
+      </div>
     </section>
   );
 }

--- a/site/lib/schema.ts
+++ b/site/lib/schema.ts
@@ -5,11 +5,11 @@
  * the markup cannot drift from the copy.
  *
  * That rule is why `faqPageSchema` takes the same array the page renders through
- * `<FaqSection>` rather than a separate literal. Until 2026-08-09 nine resource
- * pages hand-rolled FAQPage JSON-LD that appeared nowhere in their visible copy
- * (0 of 36 answers rendered), which is a structured-data violation Google can
- * penalize. Pairing the builder with the component makes the compliant thing the
- * easy thing: you cannot emit the markup without also rendering the content.
+ * `<FaqSection>` rather than a separate literal. Until 2026-08-09 every resource
+ * page hand-rolled FAQPage JSON-LD that appeared nowhere in its visible copy, a
+ * structured-data violation Google can penalize. Pairing the builder with the
+ * component makes the compliant thing the easy thing: you cannot emit the markup
+ * without also rendering the content.
  *
  * Comparison pages still emit no FAQPage, because they have no FAQ section.
  */

--- a/site/public/resources/remove-otter-ai-from-zoom.md
+++ b/site/public/resources/remove-otter-ai-from-zoom.md
@@ -2,9 +2,9 @@
 
 Last reviewed: 2026-08-09
 
-There is a ten-second fix that works even when you are not the host, and almost nobody knows it.
+There is a one-line fix that works even when you are not the host, and almost nobody knows it.
 
-## The ten-second answer
+## The one-line answer
 
 Type `stop otter` into the Zoom meeting chat. The Notetaker leaves.
 
@@ -25,7 +25,7 @@ This ejects the bot from the current meeting only.
 
 In Otter: **Integrations → Meetings → Default auto-join settings → "Meetings I manually select."**
 
-**The gotcha:** changing the default does *not* apply retroactively to calendar events you already customized. If you ever toggled auto-join on for a specific recurring meeting, that event keeps its own setting and Otter keeps joining it regardless of the new default. Open the calendar view in Otter and turn those events off individually. This is the most common reason people believe they disabled Otter and then watch it walk into a call the following week.
+**The gotcha:** changing the default does *not* apply retroactively to calendar events you already customized. If you ever toggled auto-join on for a specific recurring meeting, that event keeps its own setting and Otter keeps joining it regardless of the new default. Open the calendar view in Otter and turn those events off individually. Otter documents the behavior but publishes no figures on how often it bites. Check it first when you believe you disabled Otter and then watch it walk into a call the following week.
 
 Stronger: disconnect the Google or Microsoft calendar from Otter entirely. A notetaker that cannot read your calendar cannot discover your meeting links, so there is nothing left to auto-join.
 
@@ -37,10 +37,10 @@ You cannot reach into another person's Otter account and turn their bot off. In 
 
 - **Ask.** "Could you drop the notetaker for this one?" is ordinary etiquette now, and the owner can remove it in one click. For a sensitive conversation this beats any technical control.
 - **Type the chat command.** Works from any seat in the room.
-- **Waiting Room plus authentication.** The strongest standing control. Notetaker bots cannot sign in to Zoom accounts, so requiring authenticated users blocks most of them outright.
-- **Admin app controls.** Zoom admins can restrict or allow-list third-party apps under Admin → Advanced → App Marketplace, and audit installs under Apps on Account. The only option that scales past one meeting.
+- **Waiting Room plus authentication.** The strongest standing control, though not a guarantee. Requiring authenticated users blocks some standalone bot participants, and the Waiting Room lets you admit only people you recognize. It does not stop a notetaker running through an attendee you already admitted; Cornell's IT guidance says this helps prevent bot access rather than eliminating it.
+- **Admin app controls.** Zoom admins can disable or remove installed apps at marketplace.zoom.us → Manage → Admin App Management → Apps on Account. Scope matters: this stops users on your account from running the app, but does not restrict external participants who bring their own.
 
-**The limit, stated plainly:** some notetakers no longer join as a separate participant. They capture audio through an attendee's own authenticated session, so there is no bot in the participant list and no Zoom setting that stops it. Waiting rooms and authentication defeat bots that dial in. Nothing defeats a participant who is recording. That has always been true of meetings; AI just made it cheaper.
+**The limit, stated plainly:** some notetakers no longer join as a separate participant. They capture through an attendee's own authenticated session, so there is no bot in the participant list to remove, and admission controls do not reach that case. Disabling local recording may block tools that depend on Zoom's own recording channel, which is worth doing, but Zoom cannot prevent out-of-band capture by a participant or a separate device in the room. That has always been true of meetings; AI just made it cheaper.
 
 ## The version of this problem that solves itself
 


### PR DESCRIPTION
**Live-content fix. Please merge ahead of other site work.**

## How this got live unreviewed

This work was on an open PR (#692) awaiting an adversarial review pass. That pass ran and found six defects. Before the corrections could land, **#693 (an unrelated dependabot nanoid bump) swept the uncommitted work onto `main`** because its branch was created from a shared working tree that had these files in it. Cloudflare Pages auto-deploys `site/*` from `main`, so the pre-review version is serving right now, `<dl>` and all.

Nothing here is new content. It is only the corrections.

## What was wrong

**Two factual errors**, on a page whose whole value proposition is being more accurate than the competitors outranking it:

1. The page said notetaker bots "cannot sign in to Zoom accounts," which reads as a guarantee. [Cornell's guidance](https://it.cornell.edu/zoom/zoom-block-ai-bots) says authentication only *helps prevent* bot access, and the [Zoom Community thread the page itself cites](https://community.zoom.com/meetings-2/how-do-i-disable-ai-notetakers-otter-ai-read-ai-fireflies-ai-etc-from-joining-our-meetings-17388) reports notetakers joining through an attendee's authenticated session. A host could read our page and wrongly conclude a sensitive meeting was protected.
2. The Zoom admin path was wrong. It is `marketplace.zoom.us → Manage → Admin App Management → Apps on Account`, and its scope is users on your own account, not external participants. The claim that it was the "only option that scales past a single meeting" was also false.

**One nuance error:** "no Zoom setting stops it" conflated two cases. Disabling local recording may block tools using Zoom's recording channel; out-of-band capture is the part Zoom genuinely cannot prevent.

**One markup defect:** `FaqSection` emitted `<details>` as a direct child of `<dl>`, `<dt>` inside `<summary>`, and `<dd>` inside `<details>`. Not a valid content model. Browsers toggled it fine, but the description-list association was lost to accessibility APIs. Native disclosure semantics already carry this UI, so those become `div`/`span`.

**Two unsupported claims dropped:** a "ten-second" fix Otter never measures, and "the single most common reason" where Otter publishes no prevalence data.

**One comment fix:** `schema.ts` counted this work's own new page as part of the pre-existing damage it was describing.

## Verification

Content is byte-identical to a tree that passed `tsc --noEmit`, `npm run build`, and a 36/36 FAQ-visibility audit. Rebuilt here by CI against the new base. Post-merge I will re-run the visibility audit and confirm `<dt>`/`<dd>` are gone from the deployed HTML.

## Follow-up

- #692 is now redundant (its content reached main via #693) and I will close it, pointing here.
- Worth deciding separately: dependabot branches being cut from a shared working tree is how unreviewed work reached production. That is a process hole, not a one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)