### PR TITLE
fix(site): restore conversation-memory positioning in homepage title

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -17,11 +17,21 @@ const instrumentSerif = Instrument_Serif({
 // positions 4 to 7. Free and open source lead because they are the two claims
 // no paid competitor in that SERP can make. Every negative below is literal:
 // there is no signup, no API key is required, and the app is MIT licensed.
-// Deliberately not "no cloud" — optional summarization can use a cloud LLM.
+// Deliberately not "no cloud": optional summarization can use a cloud LLM.
+//
+// The category noun is "conversation memory", not "meeting notes". This title
+// is the strongest entity signal on the domain and is what an LLM reads to
+// answer "what is Minutes", so it has to match the SoftwareApplication schema
+// in lib/schema.ts rather than file the product into the one category where
+// the comparison pages openly concede competitors are better. Google may
+// rewrite the SERP title when it does not match a generic "minutes app"
+// query; that costs the display but not the entity signal, which is the
+// asset worth protecting. Dictation is named because it is half the wedge
+// and "meeting notes" excludes it.
 export const metadata: Metadata = {
-  title: "Minutes: free, open-source meeting notes app",
+  title: "Minutes: free, open-source conversation memory app",
   description:
-    "Records meetings, calls, and voice memos, then transcribes them on your own machine. Searchable markdown you own. No account, no API keys, no subscription.",
+    "Meetings, calls, voice memos, and dictation, transcribed on your own machine and saved as markdown you own. No account, no API keys, no subscription.",
   metadataBase: new URL("https://useminutes.app"),
   alternates: { canonical: "/" },
   icons: {
@@ -30,18 +40,18 @@ export const metadata: Metadata = {
     ],
   },
   openGraph: {
-    title: "Minutes: free, open-source meeting notes app",
+    title: "Minutes: free, open-source conversation memory app",
     description:
-      "Records meetings, calls, and voice memos, transcribed on your own machine. Searchable markdown you own. Free and open source.",
+      "Meetings, calls, voice memos, and dictation, transcribed on your own machine and saved as markdown you own. Free and open source.",
     type: "website",
     url: "https://useminutes.app",
     siteName: "minutes",
   },
   twitter: {
     card: "summary",
-    title: "Minutes: free, open-source meeting notes app",
+    title: "Minutes: free, open-source conversation memory app",
     description:
-      "Meetings, calls, and voice memos transcribed on your own machine. Markdown you own. Free, MIT licensed.",
+      "Meetings, calls, voice memos, and dictation, transcribed on your own machine. Markdown you own. Free, MIT licensed.",
   },
 };
 


### PR DESCRIPTION
Corrects the category noun introduced in #695.

## Change

```
- title  Minutes: free, open-source meeting notes app
+ title  Minutes: free, open-source conversation memory app

  description now also names dictation
```

## Why

**It contradicted the schema shipped the same day.** #691 added `SoftwareApplication` with `applicationSubCategory: "Conversation memory and meeting transcription"`, whose description already names dictation. #695 then described the product as a meeting notes app. The title is the stronger signal, so the two disagreed about what this software is.

**It understated the product.** "Meeting notes" excludes dictation by construction, and dictation is a first-class capture mode. It is back in the description.

## Verification

Rendered `<title>`, `<meta name="description">` and `og:title` confirmed from the static export, both within length limits, no em dash. Title and `SoftwareApplication` schema now agree on the category and both name dictation. `tsc --noEmit` and `next build` clean.
