### PR TITLE
feat(site): add /resources/stop-fireflies-from-joining-meetings

### DIFF
--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -148,7 +148,16 @@ export default function RemoveNotetakerBotsPage() {
             <span className="font-medium text-[var(--text)]">Fireflies (Fred).</span> Same
             pattern: Fireflies settings → autojoin rules (change to invite-only or off, or
             disconnect the calendar), and remove the notetaker from the participant list
-            mid-call. Fireflies&rsquo; own guide is linked below.
+            mid-call. Fireflies&rsquo; own guide is linked below. One detail worth knowing
+            before the call rather than during it: remove it within three minutes and no
+            transcript is created at all. Full detail in{" "}
+            <a
+              href="/resources/stop-fireflies-from-joining-meetings"
+              className="text-[var(--accent)] hover:underline"
+            >
+              how to stop Fireflies joining your meetings
+            </a>
+            .
           </p>
           <p>
             <span className="font-medium text-[var(--text)]">Anything else.</span> The pattern

--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -149,8 +149,8 @@ export default function RemoveNotetakerBotsPage() {
             pattern: Fireflies settings → autojoin rules (change to invite-only or off, or
             disconnect the calendar), and remove the notetaker from the participant list
             mid-call. Fireflies&rsquo; own guide is linked below. One detail worth knowing
-            before the call rather than during it: remove it within three minutes and no
-            transcript is created at all. Full detail in{" "}
+            before the call rather than during it: Fireflies says that removing the notetaker
+            within three minutes means no transcript or notes are created. Full detail in{" "}
             <a
               href="/resources/stop-fireflies-from-joining-meetings"
               className="text-[var(--accent)] hover:underline"

--- a/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
+++ b/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
@@ -1,0 +1,329 @@
+import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
+import { PublicFooter } from "@/components/public-footer";
+import { faqPageSchema } from "@/lib/schema";
+
+export const metadata: Metadata = {
+  title: "How to stop Fireflies from joining your meetings",
+  description:
+    "Remove Fred within three minutes and Fireflies creates no transcript at all. Then the two settings that stop it returning, the recording rules that outrank them, and what to do when the bot belongs to someone else.",
+  alternates: {
+    canonical: "/resources/stop-fireflies-from-joining-meetings",
+  },
+};
+
+const faqs = [
+  {
+    question: "How do I stop Fireflies from joining my meetings?",
+    answer:
+      "Open Settings, then Recording & Privacy, and toggle off Auto-record meetings. That stops Fireflies joining any future meeting on your connected calendar. If you still want it sometimes, use the Calendar meeting settings dropdown under Fireflies Notetaker and choose \"Only when I invite fred@fireflies.ai\" so it joins on invitation instead of automatically.",
+  },
+  {
+    question: "If I remove Fireflies from a meeting, does it keep the recording?",
+    answer:
+      "Not if you are quick. Fireflies' own documentation states that if the notetaker is removed before 3 minutes elapse, no transcript or notes will be created. After that window a transcript exists and removing the bot only stops it capturing more.",
+  },
+  {
+    question: "How do I remove Fireflies from a live Zoom, Meet, or Teams call?",
+    answer:
+      "In Zoom, open the participant list, click More next to Fireflies Notetaker, and choose Remove. In Google Meet, open the participant list, click the three-dot menu next to Fireflies, and select Remove from the call. In Microsoft Teams, open the participant list, click the ellipsis next to Fireflies, and select Remove from meeting.",
+  },
+  {
+    question: "Why does Fireflies still join after I turned auto-join off?",
+    answer:
+      "Check your recording rules. Fireflies supports rules that target meetings by keyword, participant email address, or domain, and per its documentation those rules override the auto-join setting. A rule you created earlier can therefore keep pulling the notetaker into calls after you believe you disabled it.",
+  },
+  {
+    question: "Can someone else make Fireflies join my meeting?",
+    answer:
+      "Yes. Fireflies joins when fred@fireflies.ai is added as a guest on the calendar invite, so any organizer can bring it into a meeting you attend without you having a Fireflies account. If it is on your calendar you can find the event under Upcoming Meetings in Fireflies and switch it off; otherwise you are down to removing the bot in the call or asking the organizer.",
+  },
+] as const;
+
+const sources = [
+  {
+    label: "Fireflies guide: how to remove Fireflies from a meeting (or stop it from joining)",
+    href: "https://guide.fireflies.ai/articles/7098191513-how-to-remove-fireflies-from-a-meeting-or-stop-it-from-joining",
+  },
+  {
+    label: "Fireflies guide: how to disable the Fireflies auto-join settings",
+    href: "https://guide.fireflies.ai/articles/8587670572-how-to-disable-the-fireflies-auto-join-settings",
+  },
+  {
+    label: "Fireflies guide: learn about Fireflies auto-join settings",
+    href: "https://guide.fireflies.ai/articles/5074225515-learn-about-fireflies-auto-join-settings",
+  },
+  {
+    label: "Fireflies guide: how Fireflies joins and records your meetings (FAQs)",
+    href: "https://guide.fireflies.ai/articles/9554534786-how-fireflies-joins-and-records-your-meetings-faqs",
+  },
+  { label: "Minutes security & privacy architecture", href: "/security" },
+] as const;
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+export default function StopFirefliesJoiningPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a
+            href="/resources/stop-fireflies-from-joining-meetings.md"
+            className="hover:text-[var(--accent)]"
+          >
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          How to stop Fireflies from joining your meetings
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          There is a deadline on this one. Get Fred out fast enough and Fireflies keeps nothing
+          at all. Below: the three-minute rule, the two settings that stop it returning, the
+          rules that quietly outrank those settings, and what you can do when the bot belongs to
+          somebody else.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-08-09
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            How-to guide
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Three-Minute Rule" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5">
+            <p>
+              Fireflies&rsquo; own documentation states that if the notetaker is removed{" "}
+              <span className="font-medium text-[var(--text)]">before 3 minutes elapse</span>,
+              no transcript or notes will be created.
+            </p>
+          </div>
+          <p>
+            That makes the first three minutes of a call qualitatively different from every
+            minute after. Eject Fred inside the window and there is nothing to delete, nothing
+            to request, nothing sitting in someone else&rsquo;s workspace. Miss it and a
+            transcript exists; removing the bot then only stops it capturing more.
+          </p>
+          <p>
+            Worth knowing before the meeting rather than during it, which is the entire reason
+            this page leads with it. If a call turns sensitive in the first minute, you have a
+            real deadline and it is short.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Remove It Now" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>The bot appears as an ordinary participant. Per platform:</p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <span className="font-medium text-[var(--text)]">Zoom.</span> Open the participant
+              list, click <span className="font-medium text-[var(--text)]">More</span> next to
+              Fireflies Notetaker, choose{" "}
+              <span className="font-medium text-[var(--text)]">Remove</span>.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">Google Meet.</span> Open the
+              participant list, click the three-dot menu next to Fireflies, select{" "}
+              <span className="font-medium text-[var(--text)]">Remove from the call</span>.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">Microsoft Teams.</span> Open the
+              participant list, click the ellipsis next to Fireflies, select{" "}
+              <span className="font-medium text-[var(--text)]">Remove from meeting</span>.
+            </li>
+          </ul>
+          <p>
+            These are host-side participant controls. Fireflies&rsquo; documentation does not
+            state whether a non-host can remove the notetaker, and it publishes no chat command
+            for doing so, so if you are not the host, treat asking the organizer as the reliable
+            path rather than assuming a shortcut exists.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Stop It Coming Back" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">Turn it off entirely.</span>{" "}
+            Settings → <span className="font-medium text-[var(--text)]">Recording &amp; Privacy</span>{" "}
+            → Recording, then toggle off{" "}
+            <span className="font-medium text-[var(--text)]">Auto-record meetings</span>. Per
+            Fireflies, that stops the notetaker joining any future meeting scheduled on your
+            connected calendar.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Or keep it, on invitation only.</span>{" "}
+            From the homepage <span className="font-medium text-[var(--text)]">Upcoming</span>{" "}
+            button, open{" "}
+            <span className="font-medium text-[var(--text)]">Calendar meeting settings</span>{" "}
+            under Fireflies Notetaker. The default is every meeting with a web-conference link;
+            switch it to{" "}
+            <span className="font-medium text-[var(--text)]">
+              &ldquo;Only when I invite fred@fireflies.ai&rdquo;
+            </span>{" "}
+            and it joins when you ask rather than by default. This is usually the setting people
+            actually wanted.
+          </p>
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              If it still joins, check your recording rules
+            </p>
+            <p className="mt-3">
+              Fireflies supports rules that target meetings by keyword, participant email
+              address, or domain, and per its documentation those rules{" "}
+              <span className="font-medium text-[var(--text)]">override auto-join settings</span>.
+              A rule you set up months ago can keep pulling Fred into calls long after you
+              believe you switched auto-join off. Auto-join is the first place people look and
+              the second place the answer usually is.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="When The Bot Is Not Yours" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Fireflies has a route into your meeting that does not require you to use Fireflies
+            at all: it joins when{" "}
+            <code className="rounded-[4px] bg-[var(--bg-elevated)] px-1.5 py-0.5 font-mono text-[13px] text-[var(--text)]">
+              fred@fireflies.ai
+            </code>{" "}
+            is added as a guest on the calendar invite. Any organizer can do that. You do not
+            need an account, and you were never asked.
+          </p>
+          <p>
+            If the meeting is on your own connected calendar, Fireflies lets you find the event
+            under <span className="font-medium text-[var(--text)]">Upcoming Meetings</span> and
+            switch it off so the notetaker does not attend. If it is not your calendar, your
+            options narrow to the two honest ones: remove the bot in the call if you are host,
+            or say something. &ldquo;Could we do this one without the notetaker?&rdquo; costs
+            nothing and works immediately, and the person who invited Fred can uninvite him in a
+            click.
+          </p>
+          <p>
+            For an organization, the durable version is a recording rule scoped to a domain,
+            which is the same mechanism that causes the surprise above, used deliberately.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Version Of This Problem That Solves Itself" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Everything above manages a symptom. The bot exists because cloud notetakers need
+            your meeting audio on their servers, and sending a synthetic participant into the
+            call is how they collect it. Capture on your own device instead and the whole
+            category evaporates: nothing joins, nothing shows in the participant list, no
+            three-minute deadline, nothing to explain to a client.
+          </p>
+          <p>
+            In fairness, Fireflies now offers bot-free capture of its own, through a Google Meet
+            SDK integration and a desktop app. Worth knowing, and worth reading precisely: those
+            remove the visible bot from the call, not the upload. The audio still goes to
+            Fireflies.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">Minutes</span> removes both. It
+            records device-side, transcribes locally with whisper.cpp, and writes markdown to
+            your own disk, so there is no bot and no vendor copy. If you want the direct
+            comparison, we keep one for{" "}
+            <a
+              href="/compare/fireflies-vs-minutes"
+              className="text-[var(--accent)] hover:underline"
+            >
+              Fireflies and Minutes
+            </a>
+            .
+          </p>
+          <p>
+            One thing device-side capture does not change: tell people you are recording. The
+            bot&rsquo;s single virtue was announcing itself. Without it, consent is your job,
+            which is where it belonged anyway. The legal detail is in{" "}
+            <a
+              href="/resources/is-it-legal-to-record-a-meeting"
+              className="text-[var(--accent)] hover:underline"
+            >
+              recording consent law by state
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+
+      <FaqSection items={faqs} />
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            How botless capture works
+          </a>
+          <a
+            href="/resources/remove-ai-notetaker-bots-from-meetings"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Other notetakers &amp; platforms
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
+++ b/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
@@ -6,7 +6,7 @@ import { faqPageSchema } from "@/lib/schema";
 export const metadata: Metadata = {
   title: "How to stop Fireflies from joining your meetings",
   description:
-    "Remove Fred within three minutes and Fireflies creates no transcript at all. Then the two settings that stop it returning, the recording rules that outrank them, and what to do when the bot belongs to someone else.",
+    "Fireflies says that removing the notetaker within three minutes means no transcript or notes are created. Then the two settings that stop it returning, the recording rules that outrank them, and what you can actually do about somebody else's bot.",
   alternates: {
     canonical: "/resources/stop-fireflies-from-joining-meetings",
   },
@@ -16,12 +16,12 @@ const faqs = [
   {
     question: "How do I stop Fireflies from joining my meetings?",
     answer:
-      "Open Settings, then Recording & Privacy, and toggle off Auto-record meetings. That stops Fireflies joining any future meeting on your connected calendar. If you still want it sometimes, use the Calendar meeting settings dropdown under Fireflies Notetaker and choose \"Only when I invite fred@fireflies.ai\" so it joins on invitation instead of automatically.",
+      "Open Settings, then Recording & Privacy, and toggle off Auto-record meetings. Per Fireflies, that stops the notetaker joining future meetings scheduled on your connected calendar. If you still want it sometimes, use the Calendar meeting settings dropdown under Fireflies Notetaker and choose \"Only when I invite fred@fireflies.ai\" so it joins on invitation instead of by default.",
   },
   {
-    question: "If I remove Fireflies from a meeting, does it keep the recording?",
+    question: "If I remove Fireflies quickly, does it still produce a transcript?",
     answer:
-      "Not if you are quick. Fireflies' own documentation states that if the notetaker is removed before 3 minutes elapse, no transcript or notes will be created. After that window a transcript exists and removing the bot only stops it capturing more.",
+      "Fireflies' documentation states that if the notetaker is removed before 3 minutes elapse, no transcript or notes will be created. That is specifically a statement about transcript and notes creation. Fireflies does not document what happens to any audio captured during those first minutes, so treat this as avoiding a transcript rather than as a guarantee that nothing was ever recorded.",
   },
   {
     question: "How do I remove Fireflies from a live Zoom, Meet, or Teams call?",
@@ -31,12 +31,12 @@ const faqs = [
   {
     question: "Why does Fireflies still join after I turned auto-join off?",
     answer:
-      "Check your recording rules. Fireflies supports rules that target meetings by keyword, participant email address, or domain, and per its documentation those rules override the auto-join setting. A rule you created earlier can therefore keep pulling the notetaker into calls after you believe you disabled it.",
+      "Check your recording rules. Fireflies documents rules that target meetings by keyword, participant email address, or domain, and states they take precedence over the auto-join setting, including overriding a manual-only configuration. A rule you created earlier can therefore keep bringing the notetaker into calls after you believe you disabled auto-join.",
   },
   {
     question: "Can someone else make Fireflies join my meeting?",
     answer:
-      "Yes. Fireflies joins when fred@fireflies.ai is added as a guest on the calendar invite, so any organizer can bring it into a meeting you attend without you having a Fireflies account. If it is on your calendar you can find the event under Upcoming Meetings in Fireflies and switch it off; otherwise you are down to removing the bot in the call or asking the organizer.",
+      "Effectively yes, though the person inviting it needs Fireflies. A Fireflies user with a connected Google or Outlook calendar can add fred@fireflies.ai to an invite, and the bot then attempts to join subject to their settings and the meeting platform's admission controls. Other attendees need no Fireflies account. Your own Fireflies settings only govern your own notetaker, so for someone else's bot the routes are removing it from the call as host, asking them to cancel it, or removing the address from the invite if you can edit it.",
   },
 ] as const;
 
@@ -50,12 +50,16 @@ const sources = [
     href: "https://guide.fireflies.ai/articles/8587670572-how-to-disable-the-fireflies-auto-join-settings",
   },
   {
-    label: "Fireflies guide: learn about Fireflies auto-join settings",
-    href: "https://guide.fireflies.ai/articles/5074225515-learn-about-fireflies-auto-join-settings",
+    label: "Fireflies guide: use recording rules to record or skip specific meetings",
+    href: "https://guide.fireflies.ai/articles/3115936908-how-to-use-recording-rules-to-record-or-skip-specific-meetings",
   },
   {
-    label: "Fireflies guide: how Fireflies joins and records your meetings (FAQs)",
-    href: "https://guide.fireflies.ai/articles/9554534786-how-fireflies-joins-and-records-your-meetings-faqs",
+    label: "Fireflies guide: how to invite Fireflies to meetings",
+    href: "https://guide.fireflies.ai/articles/4335268657-how-to-invite-fireflies-to-meetings",
+  },
+  {
+    label: "Fireflies guide: Google Meet SDK integration for bot-free recording",
+    href: "https://guide.fireflies.ai/articles/3309351579-integrate-google-meet-sdk-with-fireflies-for-bot-free-meeting-recording",
   },
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
@@ -63,9 +67,9 @@ const sources = [
 function SectionLabel({ label }: { label: string }) {
   return (
     <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
         {label}
-      </span>
+      </h2>
       <div className="h-px flex-1 bg-[var(--border)]" />
     </div>
   );
@@ -106,10 +110,10 @@ export default function StopFirefliesJoiningPage() {
           How to stop Fireflies from joining your meetings
         </h1>
         <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
-          There is a deadline on this one. Get Fred out fast enough and Fireflies keeps nothing
-          at all. Below: the three-minute rule, the two settings that stop it returning, the
-          rules that quietly outrank those settings, and what you can do when the bot belongs to
-          somebody else.
+          There is a documented deadline on this one, and it is three minutes. Below: what that
+          deadline does and does not promise, the two settings that stop Fred returning, the
+          rules that quietly outrank those settings, and an honest account of your options when
+          the bot belongs to somebody else.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
@@ -126,21 +130,23 @@ export default function StopFirefliesJoiningPage() {
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5">
             <p>
-              Fireflies&rsquo; own documentation states that if the notetaker is removed{" "}
+              Fireflies&rsquo; documentation states that if the notetaker is removed{" "}
               <span className="font-medium text-[var(--text)]">before 3 minutes elapse</span>,
               no transcript or notes will be created.
             </p>
           </div>
           <p>
-            That makes the first three minutes of a call qualitatively different from every
-            minute after. Eject Fred inside the window and there is nothing to delete, nothing
-            to request, nothing sitting in someone else&rsquo;s workspace. Miss it and a
-            transcript exists; removing the bot then only stops it capturing more.
+            That is worth knowing before a call rather than during one, because it turns a vague
+            annoyance into a deadline you can actually act on.
           </p>
           <p>
-            Worth knowing before the meeting rather than during it, which is the entire reason
-            this page leads with it. If a call turns sensitive in the first minute, you have a
-            real deadline and it is short.
+            Read the claim precisely, though, because it is narrower than it first sounds. It is
+            a statement about <em>transcript and notes creation</em>. Fireflies does not document
+            what happens to audio captured during those first minutes, and it does not say the
+            bot recorded nothing. Treat the window as a reliable way to avoid a transcript
+            existing, not as a guarantee that nothing was ever captured. If that distinction
+            matters for your meeting, the honest answer is to keep the bot out rather than race
+            it.
           </p>
         </div>
       </section>
@@ -168,10 +174,11 @@ export default function StopFirefliesJoiningPage() {
             </li>
           </ul>
           <p>
-            These are host-side participant controls. Fireflies&rsquo; documentation does not
-            state whether a non-host can remove the notetaker, and it publishes no chat command
-            for doing so, so if you are not the host, treat asking the organizer as the reliable
-            path rather than assuming a shortcut exists.
+            These are participant controls, which in practice means host or co-host.
+            Fireflies&rsquo; documentation does not state whether a non-host can remove the
+            notetaker, and it publishes no chat command for doing so. If you are not the host,
+            treat asking the organizer as the reliable path rather than assuming a shortcut
+            exists.
           </p>
         </div>
       </section>
@@ -181,10 +188,11 @@ export default function StopFirefliesJoiningPage() {
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
             <span className="font-medium text-[var(--text)]">Turn it off entirely.</span>{" "}
-            Settings → <span className="font-medium text-[var(--text)]">Recording &amp; Privacy</span>{" "}
-            → Recording, then toggle off{" "}
+            Settings →{" "}
+            <span className="font-medium text-[var(--text)]">Recording &amp; Privacy</span> →
+            Recording, then toggle off{" "}
             <span className="font-medium text-[var(--text)]">Auto-record meetings</span>. Per
-            Fireflies, that stops the notetaker joining any future meeting scheduled on your
+            Fireflies, that stops the notetaker joining future meetings scheduled on your
             connected calendar.
           </p>
           <p>
@@ -192,8 +200,8 @@ export default function StopFirefliesJoiningPage() {
             From the homepage <span className="font-medium text-[var(--text)]">Upcoming</span>{" "}
             button, open{" "}
             <span className="font-medium text-[var(--text)]">Calendar meeting settings</span>{" "}
-            under Fireflies Notetaker. The default is every meeting with a web-conference link;
-            switch it to{" "}
+            under Fireflies Notetaker. The default covers every meeting with a web-conference
+            link; switch it to{" "}
             <span className="font-medium text-[var(--text)]">
               &ldquo;Only when I invite fred@fireflies.ai&rdquo;
             </span>{" "}
@@ -205,12 +213,16 @@ export default function StopFirefliesJoiningPage() {
               If it still joins, check your recording rules
             </p>
             <p className="mt-3">
-              Fireflies supports rules that target meetings by keyword, participant email
-              address, or domain, and per its documentation those rules{" "}
-              <span className="font-medium text-[var(--text)]">override auto-join settings</span>.
-              A rule you set up months ago can keep pulling Fred into calls long after you
-              believe you switched auto-join off. Auto-join is the first place people look and
-              the second place the answer usually is.
+              Fireflies documents rules that target meetings by keyword, participant email
+              address, or domain, and states they take precedence over your auto-join setting.
+              The direction that surprises people is the affirmative one: a recording rule can
+              pull Fred into a meeting even when auto-record is set to manual only. A rule you
+              created months ago can therefore keep producing transcripts long after you believe
+              you switched auto-join off.
+            </p>
+            <p className="mt-3">
+              Auto-join is the first place everyone looks, and recording rules are the second
+              place the answer usually is.
             </p>
           </div>
         </div>
@@ -220,26 +232,43 @@ export default function StopFirefliesJoiningPage() {
         <SectionLabel label="When The Bot Is Not Yours" />
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
-            Fireflies has a route into your meeting that does not require you to use Fireflies
-            at all: it joins when{" "}
+            Fireflies can reach a meeting through someone else entirely. A Fireflies user with a
+            connected Google or Outlook calendar adds{" "}
             <code className="rounded-[4px] bg-[var(--bg-elevated)] px-1.5 py-0.5 font-mono text-[13px] text-[var(--text)]">
               fred@fireflies.ai
             </code>{" "}
-            is added as a guest on the calendar invite. Any organizer can do that. You do not
-            need an account, and you were never asked.
+            to the invite, and the bot then attempts to join subject to that user&rsquo;s
+            settings and the meeting platform&rsquo;s admission controls. The other attendees
+            need no Fireflies account and were never asked.
           </p>
           <p>
-            If the meeting is on your own connected calendar, Fireflies lets you find the event
-            under <span className="font-medium text-[var(--text)]">Upcoming Meetings</span> and
-            switch it off so the notetaker does not attend. If it is not your calendar, your
-            options narrow to the two honest ones: remove the bot in the call if you are host,
-            or say something. &ldquo;Could we do this one without the notetaker?&rdquo; costs
-            nothing and works immediately, and the person who invited Fred can uninvite him in a
-            click.
+            Here is the part worth being straight about, because it is where most guides get
+            vague. Every Fireflies setting described above governs{" "}
+            <span className="font-medium text-[var(--text)]">your own notetaker</span>. Your
+            dashboard cannot cancel a bot that another person&rsquo;s account scheduled, even
+            when the meeting sits on your calendar. For somebody else&rsquo;s Fred your real
+            options are three:
           </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>Remove it from the call, if you are the host or a co-host.</li>
+            <li>Ask the person who invited it to cancel it. One click on their side.</li>
+            <li>
+              Remove <code className="font-mono text-[13px]">fred@fireflies.ai</code> from the
+              calendar invite, if it is an invite you have permission to edit.
+            </li>
+          </ul>
           <p>
-            For an organization, the durable version is a recording rule scoped to a domain,
-            which is the same mechanism that causes the surprise above, used deliberately.
+            For an organization, the durable control is not a Fireflies setting at all. Fireflies
+            rules only ever govern the account they belong to. Blocking external attendees&rsquo;
+            bots is a job for your meeting platform&rsquo;s admission and tenant policies, which
+            the{" "}
+            <a
+              href="/resources/remove-ai-notetaker-bots-from-meetings"
+              className="text-[var(--accent)] hover:underline"
+            >
+              general anti-bot guide
+            </a>{" "}
+            covers.
           </p>
         </div>
       </section>
@@ -250,21 +279,25 @@ export default function StopFirefliesJoiningPage() {
           <p>
             Everything above manages a symptom. The bot exists because cloud notetakers need
             your meeting audio on their servers, and sending a synthetic participant into the
-            call is how they collect it. Capture on your own device instead and the whole
-            category evaporates: nothing joins, nothing shows in the participant list, no
-            three-minute deadline, nothing to explain to a client.
+            call is how they collect it. Capture on the participant&rsquo;s own device instead
+            and the category evaporates: nothing joins, nothing shows in the participant list,
+            no three-minute deadline to race.
           </p>
           <p>
             In fairness, Fireflies now offers bot-free capture of its own, through a Google Meet
-            SDK integration and a desktop app. Worth knowing, and worth reading precisely: those
-            remove the visible bot from the call, not the upload. The audio still goes to
-            Fireflies.
+            SDK integration and a desktop app. Worth reading precisely: those remove the visible
+            bot from the call, not the upload. Fireflies&rsquo; own SDK documentation describes
+            meeting audio and video being shared with Fireflies and processed into its notebook.
+            No bot in the participant list is a courtesy improvement, not an architectural one.
           </p>
           <p>
-            <span className="font-medium text-[var(--text)]">Minutes</span> removes both. It
-            records device-side, transcribes locally with whisper.cpp, and writes markdown to
-            your own disk, so there is no bot and no vendor copy. If you want the direct
-            comparison, we keep one for{" "}
+            <span className="font-medium text-[var(--text)]">Minutes</span> is the architectural
+            version: it records device-side and transcribes locally with whisper.cpp, writing
+            markdown to your own disk, so no bot joins and no audio is uploaded. To be exact
+            about our own limits, transcript text leaves your machine only if you explicitly
+            configure a provider-backed summarizer, which is off by default and documented on
+            our <a href="/security" className="text-[var(--accent)] hover:underline">security page</a>.
+            If you want the direct comparison, we keep one for{" "}
             <a
               href="/compare/fireflies-vs-minutes"
               className="text-[var(--accent)] hover:underline"

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -38,6 +38,7 @@ const routes = [
   "/resources/open-source-alternatives-to-granola-ai",
   "/resources/remove-ai-notetaker-bots-from-meetings",
   "/resources/remove-otter-ai-from-zoom",
+  "/resources/stop-fireflies-from-joining-meetings",
   "/security",
   "/writing",
   "/writing/governance-built-in-not-retrofitted",

--- a/site/public/resources/stop-fireflies-from-joining-meetings.md
+++ b/site/public/resources/stop-fireflies-from-joining-meetings.md
@@ -2,15 +2,15 @@
 
 Last reviewed: 2026-08-09
 
-There is a deadline on this one. Get Fred out fast enough and Fireflies keeps nothing at all.
+There is a documented deadline on this one, and it is three minutes.
 
 ## The three-minute rule
 
-Fireflies' own documentation states that if the notetaker is removed **before 3 minutes elapse**, no transcript or notes will be created.
+Fireflies' documentation states that if the notetaker is removed **before 3 minutes elapse**, no transcript or notes will be created.
 
-That makes the first three minutes qualitatively different from every minute after. Eject Fred inside the window and there is nothing to delete, nothing to request, nothing sitting in someone else's workspace. Miss it and a transcript exists; removing the bot then only stops it capturing more.
+Worth knowing before a call rather than during one, because it turns a vague annoyance into a deadline you can act on.
 
-Worth knowing before the meeting rather than during it. If a call turns sensitive in the first minute, you have a real deadline and it is short.
+Read the claim precisely, though. It is a statement about *transcript and notes creation*. Fireflies does not document what happens to audio captured during those first minutes, and does not say the bot recorded nothing. Treat the window as a reliable way to avoid a transcript existing, not as a guarantee that nothing was captured. If that distinction matters for your meeting, keep the bot out rather than race it.
 
 ## Remove it now
 
@@ -20,33 +20,47 @@ The bot appears as an ordinary participant.
 - **Google Meet** — participant list → three-dot menu next to Fireflies → **Remove from the call**
 - **Microsoft Teams** — participant list → ellipsis next to Fireflies → **Remove from meeting**
 
-These are host-side participant controls. Fireflies' documentation does not state whether a non-host can remove the notetaker, and publishes no chat command for it, so if you are not the host, asking the organizer is the reliable path rather than assuming a shortcut exists.
+These are participant controls, which in practice means host or co-host. Fireflies' documentation does not state whether a non-host can remove the notetaker, and publishes no chat command for it. If you are not the host, asking the organizer is the reliable path rather than assuming a shortcut exists.
 
 ## Stop it coming back
 
-**Turn it off entirely:** Settings → **Recording & Privacy** → Recording → toggle off **Auto-record meetings**. Per Fireflies, that stops the notetaker joining any future meeting scheduled on your connected calendar.
+**Turn it off entirely:** Settings → **Recording & Privacy** → Recording → toggle off **Auto-record meetings**. Per Fireflies, that stops the notetaker joining future meetings scheduled on your connected calendar.
 
-**Or keep it, on invitation only:** from the homepage **Upcoming** button, open **Calendar meeting settings** under Fireflies Notetaker. The default is every meeting with a web-conference link; switch it to **"Only when I invite fred@fireflies.ai"**. This is usually the setting people actually wanted.
+**Or keep it, on invitation only:** from the homepage **Upcoming** button, open **Calendar meeting settings** under Fireflies Notetaker. The default covers every meeting with a web-conference link; switch it to **"Only when I invite fred@fireflies.ai"**. This is usually the setting people actually wanted.
 
-**If it still joins, check your recording rules.** Fireflies supports rules targeting meetings by keyword, participant email address, or domain, and per its documentation those rules **override auto-join settings**. A rule set up months ago can keep pulling Fred into calls long after you believe you switched auto-join off. Auto-join is the first place people look and the second place the answer usually is.
+**If it still joins, check your recording rules.** Fireflies documents rules targeting meetings by keyword, participant email address, or domain, and states they take precedence over your auto-join setting. The direction that surprises people is the affirmative one: a recording rule can pull Fred into a meeting even when auto-record is set to manual only. A rule created months ago can keep producing transcripts long after you believe you switched auto-join off.
+
+Auto-join is the first place everyone looks, and recording rules are the second place the answer usually is.
 
 ## When the bot is not yours
 
-Fireflies has a route into your meeting that does not require you to use Fireflies at all: it joins when `fred@fireflies.ai` is added as a guest on the calendar invite. Any organizer can do that. You do not need an account, and you were never asked.
+Fireflies can reach a meeting through someone else entirely. A Fireflies user with a connected Google or Outlook calendar adds `fred@fireflies.ai` to the invite, and the bot then attempts to join subject to that user's settings and the meeting platform's admission controls. Other attendees need no Fireflies account and were never asked.
 
-If the meeting is on your own connected calendar, find the event under **Upcoming Meetings** in Fireflies and switch it off. If it is not your calendar, the options narrow to two honest ones: remove the bot in the call if you are host, or say something. "Could we do this one without the notetaker?" costs nothing and works immediately.
+The part worth being straight about: every Fireflies setting above governs **your own notetaker**. Your dashboard cannot cancel a bot that another person's account scheduled, even when the meeting is on your calendar. For someone else's Fred the real options are three:
 
-For an organization, the durable version is a recording rule scoped to a domain: the same mechanism that causes the surprise above, used deliberately.
+- Remove it from the call, if you are host or co-host
+- Ask the person who invited it to cancel it (one click on their side)
+- Remove `fred@fireflies.ai` from the calendar invite, if it is an invite you can edit
+
+For an organization, the durable control is not a Fireflies setting at all. Fireflies rules only govern the account they belong to. Blocking external attendees' bots is a job for your meeting platform's admission and tenant policies.
 
 ## The version of this problem that solves itself
 
-Everything above manages a symptom. The bot exists because cloud notetakers need your meeting audio on their servers, and sending a synthetic participant is how they collect it. Capture on your own device instead and the category evaporates: nothing joins, nothing in the participant list, no three-minute deadline.
+Everything above manages a symptom. The bot exists because cloud notetakers need your meeting audio on their servers, and sending a synthetic participant is how they collect it. Capture on the participant's own device instead and the category evaporates: nothing joins, nothing in the participant list, no three-minute deadline to race.
 
-In fairness, Fireflies now offers bot-free capture of its own via a Google Meet SDK integration and a desktop app. Read it precisely: those remove the visible bot from the call, not the upload. The audio still goes to Fireflies.
+In fairness, Fireflies now offers bot-free capture of its own via a Google Meet SDK integration and a desktop app. Read it precisely: those remove the visible bot from the call, not the upload. Fireflies' own SDK documentation describes meeting audio and video being shared with Fireflies and processed into its notebook. No bot in the participant list is a courtesy improvement, not an architectural one.
 
-Minutes removes both: device-side recording, local transcription (whisper.cpp), markdown on your own disk. No bot and no vendor copy.
+Minutes is the architectural version: device-side recording, local transcription (whisper.cpp), markdown on your own disk, so no bot joins and no audio is uploaded. To be exact about our own limits, transcript text leaves your machine only if you explicitly configure a provider-backed summarizer, which is off by default and documented on our security page.
 
 One thing device-side capture does not change: tell people you are recording. The bot's single virtue was announcing itself; without it, consent is your job, which is where it belonged anyway.
+
+## Sources
+
+- Remove Fireflies from a meeting: https://guide.fireflies.ai/articles/7098191513-how-to-remove-fireflies-from-a-meeting-or-stop-it-from-joining
+- Disable auto-join settings: https://guide.fireflies.ai/articles/8587670572-how-to-disable-the-fireflies-auto-join-settings
+- Recording rules: https://guide.fireflies.ai/articles/3115936908-how-to-use-recording-rules-to-record-or-skip-specific-meetings
+- Invite Fireflies to meetings: https://guide.fireflies.ai/articles/4335268657-how-to-invite-fireflies-to-meetings
+- Google Meet SDK bot-free recording: https://guide.fireflies.ai/articles/3309351579-integrate-google-meet-sdk-with-fireflies-for-bot-free-meeting-recording
 
 ## Related
 

--- a/site/public/resources/stop-fireflies-from-joining-meetings.md
+++ b/site/public/resources/stop-fireflies-from-joining-meetings.md
@@ -1,0 +1,56 @@
+# How to stop Fireflies from joining your meetings
+
+Last reviewed: 2026-08-09
+
+There is a deadline on this one. Get Fred out fast enough and Fireflies keeps nothing at all.
+
+## The three-minute rule
+
+Fireflies' own documentation states that if the notetaker is removed **before 3 minutes elapse**, no transcript or notes will be created.
+
+That makes the first three minutes qualitatively different from every minute after. Eject Fred inside the window and there is nothing to delete, nothing to request, nothing sitting in someone else's workspace. Miss it and a transcript exists; removing the bot then only stops it capturing more.
+
+Worth knowing before the meeting rather than during it. If a call turns sensitive in the first minute, you have a real deadline and it is short.
+
+## Remove it now
+
+The bot appears as an ordinary participant.
+
+- **Zoom** — participant list → **More** next to Fireflies Notetaker → **Remove**
+- **Google Meet** — participant list → three-dot menu next to Fireflies → **Remove from the call**
+- **Microsoft Teams** — participant list → ellipsis next to Fireflies → **Remove from meeting**
+
+These are host-side participant controls. Fireflies' documentation does not state whether a non-host can remove the notetaker, and publishes no chat command for it, so if you are not the host, asking the organizer is the reliable path rather than assuming a shortcut exists.
+
+## Stop it coming back
+
+**Turn it off entirely:** Settings → **Recording & Privacy** → Recording → toggle off **Auto-record meetings**. Per Fireflies, that stops the notetaker joining any future meeting scheduled on your connected calendar.
+
+**Or keep it, on invitation only:** from the homepage **Upcoming** button, open **Calendar meeting settings** under Fireflies Notetaker. The default is every meeting with a web-conference link; switch it to **"Only when I invite fred@fireflies.ai"**. This is usually the setting people actually wanted.
+
+**If it still joins, check your recording rules.** Fireflies supports rules targeting meetings by keyword, participant email address, or domain, and per its documentation those rules **override auto-join settings**. A rule set up months ago can keep pulling Fred into calls long after you believe you switched auto-join off. Auto-join is the first place people look and the second place the answer usually is.
+
+## When the bot is not yours
+
+Fireflies has a route into your meeting that does not require you to use Fireflies at all: it joins when `fred@fireflies.ai` is added as a guest on the calendar invite. Any organizer can do that. You do not need an account, and you were never asked.
+
+If the meeting is on your own connected calendar, find the event under **Upcoming Meetings** in Fireflies and switch it off. If it is not your calendar, the options narrow to two honest ones: remove the bot in the call if you are host, or say something. "Could we do this one without the notetaker?" costs nothing and works immediately.
+
+For an organization, the durable version is a recording rule scoped to a domain: the same mechanism that causes the surprise above, used deliberately.
+
+## The version of this problem that solves itself
+
+Everything above manages a symptom. The bot exists because cloud notetakers need your meeting audio on their servers, and sending a synthetic participant is how they collect it. Capture on your own device instead and the category evaporates: nothing joins, nothing in the participant list, no three-minute deadline.
+
+In fairness, Fireflies now offers bot-free capture of its own via a Google Meet SDK integration and a desktop app. Read it precisely: those remove the visible bot from the call, not the upload. The audio still goes to Fireflies.
+
+Minutes removes both: device-side recording, local transcription (whisper.cpp), markdown on your own disk. No bot and no vendor copy.
+
+One thing device-side capture does not change: tell people you are recording. The bot's single virtue was announcing itself; without it, consent is your job, which is where it belonged anyway.
+
+## Related
+
+- Fireflies vs Minutes: https://useminutes.app/compare/fireflies-vs-minutes
+- Other notetakers and platforms: https://useminutes.app/resources/remove-ai-notetaker-bots-from-meetings
+- Recording consent law by state: https://useminutes.app/resources/is-it-legal-to-record-a-meeting
+- How botless capture works: https://useminutes.app/security


### PR DESCRIPTION
Second page of the anti-bot removal cluster. Targets `how to stop fireflies from joining meetings` (80/mo) plus its phrasing variants, roughly 170/mo combined at low difficulty. Competitors are forced to rank for their own churn queries defensively; botless capture is the product answer to that demand.

Reviewed by codex **before** merge this time, which found eight defects. They are fixed in the third commit and described below, because the pattern matters more than the page.

## What makes it non-generic

**The three-minute rule.** Fireflies' own docs say that removing the notetaker before three minutes elapse means no transcript or notes are created. That converts a vague annoyance into an actionable deadline, and it is only useful if you know it before the call.

**Recording rules outrank auto-join.** Fireflies documents rules targeting meetings by keyword, participant email, or domain, and states they take precedence over auto-join, including overriding a manual-only setting. That is the likeliest reason Fred reappears after someone believes they disabled auto-join, and it is a *different* mechanism from Otter's retained per-event overrides, so the two pages do not repeat each other.

**The honest limit on somebody else's bot.** Every Fireflies setting governs your own notetaker. Your dashboard cannot cancel a bot another account scheduled, even for a meeting on your calendar.

## What the review caught

Three HIGH, all the same failure mode as the previous page: stating a source more strongly than it supports.

1. The three-minute claim had been inflated into a retention guarantee ("keeps nothing at all", "nothing to delete", and a FAQ answering whether the *recording* is kept). The source only addresses transcript and notes creation and says nothing about captured audio. Now states the documented claim and names the gap, because for a sensitive call "avoid a transcript" and "nothing was recorded" are different promises.
2. Claimed the Upcoming Meetings toggle could disable someone else's bot. It governs your own, and the claim contradicted the hub page.
3. Presented a domain-scoped recording rule as the organization's answer to external bots. Fireflies rules govern the account they belong to; blocking external bots is a meeting-platform admission job.

Plus: invitation mechanics oversimplified (the inviting party does need Fireflies and a connected calendar); **we overstated our own product** with "no vendor copy", which is wrong when provider-backed summarization is enabled, per our own security page; three substantiating sources added; and `SectionLabel` rendered section titles as `<span>`, leaving no heading structure below the H1.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean, page prerenders with `.md` twin
- [x] 41/41 FAQ pairs visible in rendered text across all resource pages
- [x] No invalid `dt`/`dd`/`dl`
- [x] Heading structure: one h1, six h2s
- [x] In `sitemap.ts`, linked from the anti-bot hub
- [x] Every remaining claim traced to a listed source

## Note

`SectionLabel` renders as `<span>` on the other resource and compare pages too, so they also lack an h2 structure. Not fixed here to keep this diff scoped; worth a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)