### PR TITLE
fix(site): give every page a heading structure below the H1

### DIFF
--- a/site/app/docs/agent-integrations/page.tsx
+++ b/site/app/docs/agent-integrations/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Adding agent integrations — Minutes",
@@ -61,16 +62,6 @@ const current = [
   ["Cursor and editors", "Raw meeting files and MCP where the host supports it."],
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function AgentIntegrationsPage() {
   return (

--- a/site/app/docs/errors/page.tsx
+++ b/site/app/docs/errors/page.tsx
@@ -70,7 +70,7 @@ export default function ErrorsPage() {
         <div className="space-y-10">
           {data.groups.map((group) => (
             <div key={group.enumName}>
-              <SectionLabel label={`${group.enumName} (${group.count})`} />
+              <SectionLabel label={`${group.enumName} (${group.count})`} level={3} />
               <div className="grid gap-4">
                 {group.entries.map((entry) => (
                   <div

--- a/site/app/docs/errors/page.tsx
+++ b/site/app/docs/errors/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import data from "./data.json";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Minutes error reference",
@@ -11,16 +12,6 @@ export const metadata: Metadata = {
   },
 };
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 function LinkPill({ href }: { href: string }) {
   return (

--- a/site/app/docs/mcp/tools/page.tsx
+++ b/site/app/docs/mcp/tools/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import data from "./data.json";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Minutes MCP tools",
@@ -11,16 +12,6 @@ export const metadata: Metadata = {
   },
 };
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 function LinkPill({ href }: { href: string }) {
   return (

--- a/site/app/docs/mcp/tools/page.tsx
+++ b/site/app/docs/mcp/tools/page.tsx
@@ -103,7 +103,7 @@ export default function MpcToolsPage() {
         <div className="space-y-8">
           {toolGroups.map(([group, tools]) => (
             <div key={group}>
-              <SectionLabel label={group} />
+              <SectionLabel label={group} level={3} />
               <div className="grid gap-4">
                 {tools.map((tool) => (
                   <div
@@ -131,7 +131,7 @@ export default function MpcToolsPage() {
         <div className="space-y-8">
           {resourceGroups.map(([group, resources]) => (
             <div key={group}>
-              <SectionLabel label={group} />
+              <SectionLabel label={group} level={3} />
               <div className="grid gap-4">
                 {resources.map((resource) => (
                   <div
@@ -159,7 +159,7 @@ export default function MpcToolsPage() {
         <div className="space-y-8">
           {promptGroups.map(([group, prompts]) => (
             <div key={group}>
-              <SectionLabel label={group} />
+              <SectionLabel label={group} level={3} />
               <div className="grid gap-4">
                 {prompts.map((prompt) => (
                   <div

--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import surfaces from "@/lib/product-surfaces.json";
 
 export const metadata: Metadata = {
@@ -101,16 +102,6 @@ const docsSections = [
   },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function DocsIndexPage() {
   return (

--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -178,7 +178,7 @@ export default function DocsIndexPage() {
                   <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
                     {section.label}
                   </p>
-                  <h2 className="mt-3 text-[18px] font-medium text-[var(--text)]">{link.title}</h2>
+                  <h3 className="mt-3 text-[18px] font-medium text-[var(--text)]">{link.title}</h3>
                   <p className="mt-2 text-[15px] leading-8 text-[var(--text-secondary)]">
                     {link.blurb}
                   </p>

--- a/site/app/docs/using-minutes/page.tsx
+++ b/site/app/docs/using-minutes/page.tsx
@@ -150,9 +150,9 @@ export default function UsingMinutesPage() {
       <div className="space-y-12 border-t border-[color:var(--border)] pt-10">
         {sections.map((section) => (
           <section key={section.label}>
-            <p className="mb-5 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+            <h2 className="mb-5 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
               {section.label}
-            </p>
+            </h2>
             <div className="space-y-4">
               {section.items.map(([title, description]) => (
                 <div key={title} className="flex gap-3 text-sm">

--- a/site/app/for-agents/page.tsx
+++ b/site/app/for-agents/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { CopyButton } from "@/components/copy-button";
 import { PublicFooter } from "@/components/public-footer";
+import { NumberedSectionLabel as SectionLabel } from "@/components/section-label";
 import surfaces from "@/lib/product-surfaces.json";
 import {
   MINUTES_MCP_PROMPT_COUNT,
@@ -861,16 +862,3 @@ export default function ForAgentsPage() {
   );
 }
 
-function SectionLabel({ n, label }: { n: string; label: string }) {
-  return (
-    <div className="mb-8 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {n}
-      </span>
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -9,6 +9,7 @@ import {
   WINDOWS_SETUP_EXE,
 } from "@/lib/release";
 import { organizationSchema, softwareApplicationSchema } from "@/lib/schema";
+import { NumberedSectionLabel as SectionLabel } from "@/components/section-label";
 
 const featureGrid = [
   {
@@ -131,19 +132,6 @@ const comparisons = [
   ["Agent-agnostic", "No", "No", "Partially", "Yes"],
 ] as const;
 
-function SectionLabel({ n, label }: { n: string; label: string }) {
-  return (
-    <div className="mb-8 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {n}
-      </span>
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 function TranscriptCard() {
   return (

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -482,7 +482,7 @@ export default function Home() {
       </section>
 
       <section id="dictation" className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="01" label="Dictation" />
+        <SectionLabel n="01" label="Dictation" heading={false} />
         <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           The fastest way in is your voice.
         </h2>
@@ -503,7 +503,7 @@ export default function Home() {
       </section>
 
       <section id="local" className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="02" label="On-device" />
+        <SectionLabel n="02" label="On-device" heading={false} />
         <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           Your conversation never leaves your machine.
         </h2>
@@ -530,7 +530,7 @@ export default function Home() {
       </section>
 
       <section className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="03" label="Proof" />
+        <SectionLabel n="03" label="Proof" heading={false} />
         <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           See it work before you believe it.
         </h2>
@@ -576,7 +576,7 @@ export default function Home() {
       </section>
 
       <section id="pipeline" className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="04" label="Pipeline" />
+        <SectionLabel n="04" label="Pipeline" heading={false} />
         <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           How it works
         </h2>
@@ -597,7 +597,7 @@ export default function Home() {
       </section>
 
       <section className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="05" label="Audience" />
+        <SectionLabel n="05" label="Audience" heading={false} />
         <h2 className="max-w-[620px] font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           Capture it anywhere. Find it everywhere.
         </h2>
@@ -622,7 +622,7 @@ export default function Home() {
       </section>
 
       <section className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="06" label="Features" />
+        <SectionLabel n="06" label="Features" heading={false} />
         <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           What you get
         </h2>
@@ -653,7 +653,7 @@ export default function Home() {
       </section>
 
       <section className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="07" label="Comparison" />
+        <SectionLabel n="07" label="Comparison" heading={false} />
         <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           How it compares
         </h2>
@@ -728,7 +728,7 @@ export default function Home() {
       </section>
 
       <section className="border-t border-[color:var(--border)] py-16">
-        <SectionLabel n="08" label="Governance" />
+        <SectionLabel n="08" label="Governance" heading={false} />
         <h2 className="font-serif text-[30px] leading-tight tracking-[-0.035em] text-[var(--text)] sm:text-[32px]">
           Built in, not retrofitted.
         </h2>

--- a/site/app/proof/page.tsx
+++ b/site/app/proof/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Minutes proof",
@@ -73,16 +74,6 @@ const nextMilestones = [
   },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function ProofPage() {
   return (

--- a/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
+++ b/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -47,16 +48,6 @@ const sources = [
   },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function AiNotetakersPrivilegePage() {
   return (

--- a/site/app/resources/best-local-speech-to-text/page.tsx
+++ b/site/app/resources/best-local-speech-to-text/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "The best local speech-to-text apps (2026)",
@@ -68,16 +69,6 @@ const sources = [
   },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function BestLocalSpeechToTextPage() {
   return (

--- a/site/app/resources/best-local-speech-to-text/page.tsx
+++ b/site/app/resources/best-local-speech-to-text/page.tsx
@@ -146,7 +146,7 @@ export default function BestLocalSpeechToTextPage() {
               className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="font-serif text-[22px] text-[var(--text)]">{tool.name}</h2>
+                <h3 className="font-serif text-[22px] text-[var(--text)]">{tool.name}</h3>
                 <span className="rounded-full bg-[var(--bg-hover)] px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
                   {tool.license}
                 </span>

--- a/site/app/resources/best-mcp-meeting-memory-tools/page.tsx
+++ b/site/app/resources/best-mcp-meeting-memory-tools/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Best MCP meeting memory tools",
@@ -53,16 +54,6 @@ const sources = [
   { label: "Otter pricing", href: "https://otter.ai/pricing" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function BestMcpMeetingMemoryToolsPage() {
   return (

--- a/site/app/resources/best-mcp-meeting-memory-tools/page.tsx
+++ b/site/app/resources/best-mcp-meeting-memory-tools/page.tsx
@@ -141,7 +141,7 @@ export default function BestMcpMeetingMemoryToolsPage() {
               <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
                 {tool.bestFor}
               </p>
-              <h2 className="mt-3 text-[18px] font-medium text-[var(--text)]">{tool.name}</h2>
+              <h3 className="mt-3 text-[18px] font-medium text-[var(--text)]">{tool.name}</h3>
               <p className="mt-2 text-[15px] leading-8 text-[var(--text-secondary)]">
                 {tool.summary}
               </p>

--- a/site/app/resources/best-meeting-tools-for-claude-code-and-codex/page.tsx
+++ b/site/app/resources/best-meeting-tools-for-claude-code-and-codex/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Best meeting tools for Claude Code and Codex",
@@ -81,16 +82,6 @@ const sources = [
   { label: "Fireflies apps", href: "https://fireflies.ai/apps" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function BestMeetingToolsPage() {
   return (

--- a/site/app/resources/best-meeting-tools-for-claude-code-and-codex/page.tsx
+++ b/site/app/resources/best-meeting-tools-for-claude-code-and-codex/page.tsx
@@ -185,7 +185,7 @@ export default function BestMeetingToolsPage() {
               <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
                 {tool.bestFor}
               </p>
-              <h2 className="mt-3 text-[18px] font-medium text-[var(--text)]">{tool.name}</h2>
+              <h3 className="mt-3 text-[18px] font-medium text-[var(--text)]">{tool.name}</h3>
               <p className="mt-2 text-[15px] leading-8 text-[var(--text-secondary)]">
                 {tool.summary}
               </p>

--- a/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
+++ b/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
@@ -177,7 +177,7 @@ export default function HipaaCompliantAiNoteTakerPage() {
               className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="font-serif text-[22px] text-[var(--text)]">{v.name}</h2>
+                <h3 className="font-serif text-[22px] text-[var(--text)]">{v.name}</h3>
                 <span
                   className={`rounded-full px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${
                     v.verdict === "No"

--- a/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
+++ b/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -99,16 +100,6 @@ const sources = [
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function HipaaCompliantAiNoteTakerPage() {
   return (

--- a/site/app/resources/is-fireflies-ai-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-fireflies-ai-hipaa-compliant/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -48,16 +49,6 @@ const sources = [
   { label: "Is Otter.ai HIPAA compliant?", href: "/resources/is-otter-ai-hipaa-compliant" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function IsFirefliesHipaaCompliantPage() {
   return (

--- a/site/app/resources/is-granola-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-granola-hipaa-compliant/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -48,16 +49,6 @@ const sources = [
   { label: "Is Fireflies.ai HIPAA compliant?", href: "/resources/is-fireflies-ai-hipaa-compliant" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function IsGranolaHipaaCompliantPage() {
   return (

--- a/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
+++ b/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -55,16 +56,6 @@ const sources = [
   { label: "Minutes consent-in-frontmatter design", href: "/writing/governance-built-in-not-retrofitted" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function IsItLegalToRecordAMeetingPage() {
   return (

--- a/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -48,16 +49,6 @@ const sources = [
   { label: "Minutes on GitHub", href: "https://github.com/silverstein/minutes" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function IsOtterAiHipaaCompliantPage() {
   return (

--- a/site/app/resources/legal-transcription-software/page.tsx
+++ b/site/app/resources/legal-transcription-software/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -40,16 +41,6 @@ const sources = [
   { label: "Minutes on GitHub (MIT)", href: "https://github.com/silverstein/minutes" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function LegalTranscriptionSoftwarePage() {
   return (

--- a/site/app/resources/local-dictation-macos/page.tsx
+++ b/site/app/resources/local-dictation-macos/page.tsx
@@ -123,7 +123,7 @@ export default function LocalDictationMacosPage() {
               key={opt.name}
               className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
             >
-              <h2 className="font-serif text-[22px] text-[var(--text)]">{opt.name}</h2>
+              <h3 className="font-serif text-[22px] text-[var(--text)]">{opt.name}</h3>
               <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
                 {opt.bestFor}
               </p>

--- a/site/app/resources/local-dictation-macos/page.tsx
+++ b/site/app/resources/local-dictation-macos/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Local dictation on macOS: the complete guide",
@@ -45,16 +46,6 @@ const sources = [
   { label: "Minutes vs superwhisper — full comparison", href: "/compare/superwhisper-vs-minutes" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function LocalDictationMacosPage() {
   return (

--- a/site/app/resources/meeting-minutes-template/page.tsx
+++ b/site/app/resources/meeting-minutes-template/page.tsx
@@ -155,7 +155,7 @@ export default function MeetingMinutesTemplatePage() {
               className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] shadow-[var(--shadow-panel)]"
             >
               <div className="border-b border-[color:var(--border)] px-5 py-3">
-                <h2 className="font-serif text-[19px] text-[var(--text)]">{t.title}</h2>
+                <h3 className="font-serif text-[19px] text-[var(--text)]">{t.title}</h3>
               </div>
               <div className="overflow-x-auto p-5">
                 <pre className="whitespace-pre font-mono text-[12px] leading-6 text-[var(--text-secondary)]">

--- a/site/app/resources/meeting-minutes-template/page.tsx
+++ b/site/app/resources/meeting-minutes-template/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Meeting minutes templates (markdown, copy-paste ready)",
@@ -101,16 +102,6 @@ Respectfully submitted, {secretary}`,
   },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function MeetingMinutesTemplatePage() {
   return (

--- a/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
+++ b/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
@@ -119,7 +119,7 @@ export default function OpenSourceAlternativesToGranolaPage() {
               <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
                 {tool.bestFor}
               </p>
-              <h2 className="mt-3 text-[18px] font-medium text-[var(--text)]">{tool.name}</h2>
+              <h3 className="mt-3 text-[18px] font-medium text-[var(--text)]">{tool.name}</h3>
               <p className="mt-2 text-[15px] leading-8 text-[var(--text-secondary)]">
                 {tool.summary}
               </p>

--- a/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
+++ b/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Open-source alternatives to Granola AI",
@@ -43,16 +44,6 @@ const sources = [
   { label: "Meetily GitHub", href: "https://github.com/Zackriya-Solutions/meeting-minutes" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function OpenSourceAlternativesToGranolaPage() {
   return (

--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -47,16 +48,6 @@ const sources = [
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function RemoveNotetakerBotsPage() {
   return (

--- a/site/app/resources/remove-otter-ai-from-zoom/page.tsx
+++ b/site/app/resources/remove-otter-ai-from-zoom/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -59,16 +60,6 @@ const sources = [
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function RemoveOtterFromZoomPage() {
   return (

--- a/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
+++ b/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { faqPageSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
@@ -64,16 +65,6 @@ const sources = [
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </h2>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function StopFirefliesJoiningPage() {
   return (

--- a/site/app/security/page.tsx
+++ b/site/app/security/page.tsx
@@ -141,7 +141,7 @@ export default function SecurityPage() {
               key={g.title}
               className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
             >
-              <h2 className="font-serif text-[20px] text-[var(--text)]">{g.title}</h2>
+              <h3 className="font-serif text-[20px] text-[var(--text)]">{g.title}</h3>
               <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">{g.body}</p>
             </div>
           ))}

--- a/site/app/security/page.tsx
+++ b/site/app/security/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 
 export const metadata: Metadata = {
   title: "Security — audio that never leaves your device",
@@ -55,16 +56,6 @@ const sources = [
   { label: "Compare Minutes", href: "/compare" },
 ] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 export default function SecurityPage() {
   return (

--- a/site/components/compare-page.tsx
+++ b/site/components/compare-page.tsx
@@ -1,4 +1,5 @@
 import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
 import { comparisonArticleSchema } from "@/lib/schema";
 
 type ComparisonRow = {
@@ -56,16 +57,6 @@ type ComparePageProps = {
   architecture?: Architecture;
 };
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-6 flex items-center gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
-        {label}
-      </span>
-      <div className="h-px flex-1 bg-[var(--border)]" />
-    </div>
-  );
-}
 
 function FlowCard({ column }: { column: FlowColumn }) {
   return (

--- a/site/components/section-label.tsx
+++ b/site/components/section-label.tsx
@@ -1,0 +1,43 @@
+/** Section headings for marketing and docs pages.
+ *
+ * These render as `<h2>`, not styled text. Until 2026-08-10 the same component
+ * was copy-pasted into 25 page files, all rendering the label inside a `<span>`,
+ * so every page on the site exposed exactly one heading (its `<h1>`) and nothing
+ * below it. Screen-reader heading navigation had nothing to navigate, and search
+ * engines saw no section structure on pages whose whole job is ranking.
+ *
+ * Tailwind preflight strips the browser's default `h2` size and margin, so the
+ * rendered appearance is unchanged from the `<span>` version.
+ */
+
+const LABEL_CLASSES =
+  "font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]";
+
+/** A titled section divider: the label, then a rule filling the remaining width. */
+export function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex items-center gap-3">
+      <h2 className={LABEL_CLASSES}>{label}</h2>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}
+
+/** The numbered variant used by the homepage and /for-agents onramps.
+ *
+ * The number and the label are one heading, so assistive technology announces
+ * "01 Dictation" rather than a bare ordinal followed by unrelated text.
+ */
+export function NumberedSectionLabel({ n, label }: { n: string; label: string }) {
+  return (
+    <div className="mb-8 flex items-center gap-3">
+      <h2 className="flex items-center gap-3">
+        <span className={LABEL_CLASSES}>{n}</span>
+        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+          {label}
+        </span>
+      </h2>
+      <div className="h-px flex-1 bg-[var(--border)]" />
+    </div>
+  );
+}

--- a/site/components/section-label.tsx
+++ b/site/components/section-label.tsx
@@ -1,23 +1,44 @@
 /** Section headings for marketing and docs pages.
  *
- * These render as `<h2>`, not styled text. Until 2026-08-10 the same component
- * was copy-pasted into 25 page files, all rendering the label inside a `<span>`,
- * so every page on the site exposed exactly one heading (its `<h1>`) and nothing
- * below it. Screen-reader heading navigation had nothing to navigate, and search
- * engines saw no section structure on pages whose whole job is ranking.
+ * Until 2026-08-10 this component was copy-pasted into 25 page files. Nearly
+ * every copy rendered the section title inside a `<span>`, so most pages exposed
+ * only their `<h1>` and no structure beneath it: screen-reader heading
+ * navigation had nothing to move through, and search engines saw no sections on
+ * pages whose entire job is ranking.
  *
- * Tailwind preflight strips the browser's default `h2` size and margin, so the
- * rendered appearance is unchanged from the `<span>` version.
+ * Heading level is a prop rather than hard-coded, because a label is not always
+ * a top-level section title. Docs pages nest group labels inside a section, and
+ * the homepage pairs a numbered kicker with a real `<h2>` title underneath it.
+ * Promoting either to `<h2>` would announce a section that does not exist, which
+ * is the same class of error as the `<span>` it replaced, just in the opposite
+ * direction.
+ *
+ * Tailwind preflight strips the browser's default heading size and margin, so
+ * these render identically to the original `<span>` markup.
  */
 
 const LABEL_CLASSES =
   "font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]";
 
-/** A titled section divider: the label, then a rule filling the remaining width. */
-export function SectionLabel({ label }: { label: string }) {
+/** A titled section divider: the label, then a rule filling the remaining width.
+ *
+ * Pass `level={3}` when the label names a group nested inside a section that
+ * already has its own `<h2>`.
+ */
+export function SectionLabel({
+  label,
+  level = 2,
+}: {
+  label: string;
+  level?: 2 | 3;
+}) {
   return (
     <div className="mb-6 flex items-center gap-3">
-      <h2 className={LABEL_CLASSES}>{label}</h2>
+      {level === 3 ? (
+        <h3 className={LABEL_CLASSES}>{label}</h3>
+      ) : (
+        <h2 className={LABEL_CLASSES}>{label}</h2>
+      )}
       <div className="h-px flex-1 bg-[var(--border)]" />
     </div>
   );
@@ -25,18 +46,34 @@ export function SectionLabel({ label }: { label: string }) {
 
 /** The numbered variant used by the homepage and /for-agents onramps.
  *
- * The number and the label are one heading, so assistive technology announces
- * "01 Dictation" rather than a bare ordinal followed by unrelated text.
+ * On /for-agents the numbered label is the section's only title, so it is the
+ * heading. On the homepage each one sits above a separate `<h2>`, making it a
+ * kicker; pass `heading={false}` there so the page does not report two peer
+ * headings per section. When it is a heading, the ordinal and label live inside
+ * one element so assistive tech announces "01 Dictation" rather than a bare
+ * ordinal followed by unrelated text.
  */
-export function NumberedSectionLabel({ n, label }: { n: string; label: string }) {
+export function NumberedSectionLabel({
+  n,
+  label,
+  heading = true,
+}: {
+  n: string;
+  label: string;
+  heading?: boolean;
+}) {
+  const parts = (
+    <>
+      <span className={LABEL_CLASSES}>{n}</span>
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+        {label}
+      </span>
+    </>
+  );
+
   return (
     <div className="mb-8 flex items-center gap-3">
-      <h2 className="flex items-center gap-3">
-        <span className={LABEL_CLASSES}>{n}</span>
-        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
-          {label}
-        </span>
-      </h2>
+      {heading ? <h2 className="flex items-center gap-3">{parts}</h2> : parts}
       <div className="h-px flex-1 bg-[var(--border)]" />
     </div>
   );


### PR DESCRIPTION
Sitewide accessibility and SEO fix, found while shipping the anti-bot cluster.

## The problem

`SectionLabel` was copy-pasted into **25 page files**, and nearly every copy rendered the section title inside a `<span>`. So almost every page on the site exposed exactly one heading, its `<h1>`, and nothing beneath it. Screen-reader heading navigation had nothing to move through, and search engines saw no section structure on pages whose entire job is ranking.

## What changed

One shared `components/section-label.tsx` replaces all 25 local definitions, deleting 258 lines of duplication.

Heading level is a **prop**, not hard-coded, because a blanket `<h2>` is wrong in several places and announcing structure that does not exist is the same class of error as hiding it:

- **Homepage numbered labels are kickers.** Each sits above a real `<h2>` title, so promoting them created eight pairs of peer headings and a phantom section before every real one. They render as spans there via `heading={false}`. `/for-agents` keeps its numbered labels as headings, since there they *are* the only section titles.
- **Docs group labels nest.** Error-code groups, and the Tools / Resources / Prompt Templates groups, sit inside a section that already has an `<h2>`, so they are `h3`.
- **Nine card and item headings** were already `<h2>` inside a labelled section, making them peers of their own container. Now `h3`.
- `/docs/using-minutes` rendered its section titles as styled `<p>` rather than through the component; those are `h2` now.

Deliberately left alone: the "User guide" kicker above the H1 on `/docs/using-minutes`, and the byline on the governance post. Both are eyebrow text, not section titles.

Tailwind preflight strips the browser's default heading size and margin, so this is semantics only.

## Verification

- `tsc --noEmit` and `npm run build` clean
- **196 `h2`, 107 `h3`** across 42 built pages
- Hierarchy audit reports **zero defects**: no page has multiple `h1`s, starts below `h1`, skips a level, or repeats a numbered kicker as a peer heading
- Visually confirmed unchanged on the homepage, resource, compare, and security templates

## Review

Codex reviewed before merge and caught all three level defects above (the homepage kickers, the docs nesting, and the card headings), plus a factually wrong claim in my own rationale comment. Fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)