### PR TITLE
feat(site): add /resources/hipaa-compliant-transcription

### DIFF
--- a/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
+++ b/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
@@ -225,6 +225,18 @@ export default function HipaaCompliantAiNoteTakerPage() {
             control, patient consent). But the vendor-risk column of your HIPAA analysis goes to
             zero, permanently, on every &ldquo;plan.&rdquo;
           </p>
+          <p>
+            For why that follows from the rule rather than from a marketing claim, including the
+            definition that decides it and what on-device processing pointedly does{" "}
+            <em>not</em> excuse you from, see{" "}
+            <a
+              href="/resources/hipaa-compliant-transcription"
+              className="text-[var(--accent)] hover:underline"
+            >
+              what HIPAA actually requires of transcription
+            </a>
+            .
+          </p>
         </div>
       </section>
 

--- a/site/app/resources/hipaa-compliant-transcription/page.tsx
+++ b/site/app/resources/hipaa-compliant-transcription/page.tsx
@@ -7,7 +7,7 @@ import { faqPageSchema } from "@/lib/schema";
 export const metadata: Metadata = {
   title: "HIPAA-compliant transcription: what the rule actually requires",
   description:
-    "No product is HIPAA certified, because HHS certifies nothing. What the rule turns on is whether a vendor receives PHI at all. The three transcription architectures, what a BAA does and does not buy, and the obligations that stay yours either way.",
+    "No product is HIPAA certified, because HHS certifies none. What decides the vendor question is the business associate test in 45 CFR 160.103. The three transcription architectures, what a BAA does and does not settle, and the obligations that stay yours either way.",
   alternates: {
     canonical: "/resources/hipaa-compliant-transcription",
   },
@@ -17,51 +17,54 @@ const faqs = [
   {
     question: "Is there such a thing as HIPAA-certified transcription software?",
     answer:
-      "No. HHS does not certify or endorse any product, service, or vendor as HIPAA compliant, and no standard requires a covered entity to obtain certification. A vendor advertising itself as \"HIPAA certified\" is describing a private audit it purchased, which carries no government recognition and does not shield you from an OCR finding. What matters is whether the arrangement satisfies the rule, not what badge is on the marketing page.",
+      "Not in any official sense. HHS states that no standard requires a covered entity to certify compliance, that it does not recognize private Security Rule certifications, and that OCR does not endorse or certify specific products. A private certification can still be real evidence of diligence, but it carries no government recognition and does not prevent an OCR finding later. Treat the badge as a claim to examine, not a legal status.",
   },
   {
-    question: "Does a transcription service need to sign a BAA?",
+    question: "Does a transcription vendor need to sign a BAA?",
     answer:
-      "If it receives protected health information on your behalf, yes. 45 CFR 160.103 defines a business associate as a person who creates, receives, maintains, or transmits PHI on behalf of a covered entity, and the Privacy Rule requires satisfactory assurances in a written contract before you disclose PHI to them. Encryption does not substitute for the contract, and the contract does not substitute for the safeguards.",
+      "Ordinarily yes, if it processes identifiable patient audio for you. Under 45 CFR 160.103 a business associate is a person who, on behalf of a covered entity and other than as a member of its workforce, creates, receives, maintains, or transmits PHI for a function or activity the rule regulates. A transcription service handling your patients' recordings normally meets that test, and 45 CFR 164.502(e) then requires the written contract before you disclose. The BAA is necessary, but it does not by itself make the disclosure permissible or complete your own risk analysis.",
   },
   {
     question: "Is on-device transcription HIPAA compliant?",
     answer:
-      "That question is aimed at the wrong object. Software is not compliant or non-compliant; an arrangement is. What on-device processing changes is narrower and more useful: if the vendor never receives, maintains, or transmits PHI, it does not meet the definition of a business associate, so there is no BAA to negotiate and no vendor breach exposure to inherit. Every obligation you already have (device encryption, access control, workforce training, patient authorization where required, breach notification) is unchanged.",
+      "Software is not compliant or non-compliant; a deployment is. What local processing can change is narrower: where the software vendor never receives, maintains, or transmits PHI, merely supplying that software does not make it a business associate, so there is no BAA to negotiate with them. That conclusion depends on the deployment actually being local-only. Enable a cloud summarizer, sync the folder to a hosted drive, or grant vendor support access to the files, and a party is receiving PHI again, which requires its own analysis and ordinarily a BAA.",
   },
   {
     question: "What is the difference between transcription services and transcription software?",
     answer:
-      "Services use human transcriptionists and can produce certified transcripts; the transcriptionist and the agency are business associates and need a BAA. Cloud software sends your audio to a vendor's servers, which also makes that vendor a business associate. On-device software runs the model on your own machine, so no third party receives the audio at all. All three can be appropriate; they differ in who else ends up holding the PHI.",
+      "Human transcription services use transcriptionists, can produce certified transcripts where a use requires one, and are ordinarily business associates. Cloud software sends audio to a vendor's servers, which ordinarily makes that vendor a business associate too. On-device software runs the model on your own machine, so no third party receives the audio at all. All three can be appropriate; they differ in who else ends up holding the PHI and what contracts that requires.",
   },
   {
     question: "Does the HIPAA conduit exception cover a transcription vendor?",
     answer:
-      "Almost never. 45 CFR 160.103 lists only four exclusions from the business associate definition, covering health care providers receiving treatment disclosures, plan sponsors, government agencies determining eligibility, and covered entities in an organized health care arrangement. There is no exception for software vendors or storage providers. OCR reads the conduit concept narrowly, as mere transmission without access to content, which a service that transcribes and stores your audio plainly exceeds.",
+      "Almost never. OCR reads the conduit concept narrowly, covering transmission-only services plus any storage that is temporary and incidental to transmission, and access that is transient or infrequent and necessary to that transmission. A service that transcribes your audio and stores the result persistently exceeds that, and OCR has said persistent storage defeats conduit status even where the provider cannot decrypt the data. Note also that a vendor which never meets the positive definition of business associate does not need an exception at all.",
   },
 ] as const;
 
 const architectures = [
   {
     name: "Human transcription service",
-    role: "Business associate",
-    needsBaa: true,
+    role: "Ordinarily a business associate",
+    baa: "BAA required before PHI is disclosed",
+    highlight: false,
     who: "The agency and its transcriptionists receive and store your audio and the finished transcript.",
-    note: "The traditional model, and still the one that produces certified transcripts. Ask who subcontracts, where staff are located, and whether the agency signs BAAs with its own vendors.",
+    note: "The traditional model, and where a use requires a certified transcript this is generally the route to one. Ask who subcontracts, where staff are located, and whether the agency signs BAAs with its own vendors.",
   },
   {
     name: "Cloud AI transcription",
-    role: "Business associate",
-    needsBaa: true,
+    role: "Ordinarily a business associate",
+    baa: "BAA required before PHI is disclosed",
+    highlight: false,
     who: "The vendor receives your audio, processes it on its servers, and usually stores the transcript.",
-    note: "Fast and cheap, but you are adding a party that holds PHI. Check the plan tier: most vendors gate BAAs to an enterprise plan, so the same product is appropriate on one tier and impermissible on another.",
+    note: "Fast and inexpensive, but you are adding a party that holds PHI. Check whether your plan is one the vendor will actually sign a BAA for, since several vendors offer that only on higher tiers; the plan decides whether the required contract is even available to you.",
   },
   {
     name: "On-device transcription",
-    role: "Not a business associate",
-    needsBaa: false,
-    who: "Nobody outside your organization receives the audio. The model runs on the machine you already control.",
-    note: "There is no BAA because there is no disclosure to contract about. The tradeoff is that the device becomes the whole security surface, and you get no vendor to hold accountable if you misconfigure it.",
+    role: "No vendor in the path, if deployed local-only",
+    baa: "No BAA with the software vendor, provided it never receives PHI",
+    highlight: true,
+    who: "The model runs on a machine you already control, and no third party receives the audio.",
+    note: "Whether this holds is a fact about your deployment, not a property of the software. Any cloud summarizer, synced folder, hosted backup, or vendor support access puts PHI back in someone else's hands and needs its own analysis. The tradeoff is that the endpoint becomes the security surface, and there is no vendor contract to fall back on.",
   },
 ] as const;
 
@@ -83,8 +86,24 @@ const sources = [
     href: "https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html",
   },
   {
-    label: "HHS: sample business associate agreement provisions",
-    href: "https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html",
+    label: "OCR: guidance on HIPAA and cloud computing (conduit scope, storage, encryption)",
+    href: "https://www.hhs.gov/hipaa/for-professionals/special-topics/health-information-technology/cloud-computing/index.html",
+  },
+  {
+    label: "HHS FAQ: is the use of encryption mandatory in the Security Rule?",
+    href: "https://www.hhs.gov/hipaa/for-professionals/faq/2001/is-the-use-of-encryption-mandatory-in-the-security-rule/index.html",
+  },
+  {
+    label: "HHS: guidance on risk analysis requirements under the Security Rule",
+    href: "https://www.hhs.gov/hipaa/for-professionals/security/guidance/guidance-risk-analysis/index.html",
+  },
+  {
+    label: "HHS: breach notification guidance (unsecured PHI, risk assessment)",
+    href: "https://www.hhs.gov/hipaa/for-professionals/breach-notification/guidance/index.html",
+  },
+  {
+    label: "HHS FAQ: difference between consent and authorization",
+    href: "https://www.hhs.gov/hipaa/for-professionals/faq/264/what-is-the-difference-between-consent-and-authorization/index.html",
   },
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
@@ -127,8 +146,8 @@ export default function HipaaTranscriptionPage() {
           Every vendor in this category has a page telling you to look for encryption, SOC 2,
           and a signed BAA. That list is not wrong, but it skips the question underneath it:
           whether the vendor should be receiving your patients&rsquo; audio at all. Here is the
-          rule as written, the three architectures it produces, and the obligations that stay
-          yours no matter which you pick.
+          test the rule actually applies, the three architectures it produces, and the
+          obligations that stay yours no matter which you pick.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
@@ -138,6 +157,12 @@ export default function HipaaTranscriptionPage() {
             Sourced answer
           </span>
         </div>
+        <p className="mt-6 text-[14px] leading-7 text-[var(--text-secondary)]">
+          Scope: this concerns HIPAA covered entities and their business associates. Not every
+          clinician is a covered entity, since that status also depends on conducting covered
+          electronic transactions. If HIPAA does not apply to you, state law, professional
+          ethics rules, and your own contracts still do.
+        </p>
       </section>
 
       <section className="mt-14 max-w-[800px]">
@@ -145,65 +170,113 @@ export default function HipaaTranscriptionPage() {
         <div className="space-y-5 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
             <span className="font-medium text-[var(--text)]">
-              Nothing is &ldquo;HIPAA certified.&rdquo;
+              There is no official HIPAA certification.
             </span>{" "}
-            HHS certifies no product, service, or vendor, and no standard requires a covered
-            entity to obtain certification. A private audit can be genuinely useful evidence of
-            diligence, but it carries no government recognition and does not stop OCR finding a
-            violation afterward. When a transcription vendor leads with a HIPAA badge, you are
-            looking at marketing, not a legal status.
+            HHS says no standard requires a covered entity to certify its compliance, that it
+            does not recognize private Security Rule certifications, and that OCR does not
+            endorse or certify particular products. A private certification may still be
+            meaningful evidence of diligence, and some represent substantial audits. What none
+            of them carries is government recognition, and none prevents OCR finding a violation
+            afterward. When a vendor leads with a HIPAA badge, the useful response is to ask
+            what program issued it and what it examined.
           </p>
           <p>
             <span className="font-medium text-[var(--text)]">
               Compliance is a property of the arrangement, not the software.
             </span>{" "}
             No tool can be compliant on your behalf, because most of the obligations are about
-            what your organization does: who can access the files, whether the disk is
-            encrypted, whether staff are trained, whether the patient authorized the disclosure.
-            The right question is never &ldquo;is this app HIPAA compliant.&rdquo; It is
-            &ldquo;who ends up holding this audio, and under what contract.&rdquo;
+            what your organization does: your risk analysis, who can access the files, how the
+            endpoint is configured, whether staff are trained. The right question is never
+            &ldquo;is this app HIPAA compliant.&rdquo; It is &ldquo;who ends up holding this
+            audio, under what contract, and have I analyzed the risk of the setup I actually
+            have.&rdquo;
           </p>
         </div>
       </section>
 
       <section className="mt-14 max-w-[800px]">
-        <SectionLabel label="The Rule As Written" />
+        <SectionLabel label="The Test The Rule Applies" />
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
-            Everything about vendor selection follows from one definition. Under{" "}
+            Vendor selection follows from one definition. Under{" "}
             <span className="font-medium text-[var(--text)]">45 CFR 160.103</span>, a business
-            associate is a person who, on behalf of a covered entity,
+            associate is a person who,
           </p>
           <blockquote className="border-l-2 border-[color:var(--accent)] pl-5 text-[var(--text)]">
-            &ldquo;creates, receives, maintains, or transmits protected health information for a
-            function or activity regulated by this subchapter&hellip;&rdquo;
+            &ldquo;On behalf of such covered entity&hellip; but other than in the capacity of a
+            member of the workforce of such covered entity&hellip; creates, receives, maintains,
+            or transmits protected health information for a function or activity regulated by
+            this subchapter&hellip;&rdquo;
           </blockquote>
           <p>
-            Read those four verbs carefully, because the entire vendor question is decided by
-            them. A transcription provider that takes in your audio{" "}
-            <em>receives</em> PHI. One that keeps the transcript on its servers{" "}
-            <em>maintains</em> it. Either verb makes the provider a business associate, and the
-            Privacy Rule then requires a written contract with satisfactory assurances{" "}
-            <em>before</em> you hand over the recording.
+            Every element matters, and reducing this to &ldquo;they received PHI&rdquo; is the
+            most common way to get it wrong. The party must be acting{" "}
+            <em>on your behalf</em>, must be outside your workforce, and the activity must be
+            one the rule regulates. Someone can receive PHI and still not be a business
+            associate, most obviously another provider receiving it for treatment. A separate
+            branch of the definition covers enumerated professional services, such as legal or
+            accounting work, where providing the service involves disclosure of PHI.
           </p>
           <p>
-            Note what the definition does not say. It does not turn on how good the encryption
-            is, where the data center sits, or whether the vendor has SOC 2. Those are
-            safeguards that a business associate must have; they are not what makes someone a
-            business associate. The trigger is receipt of PHI.
+            Applied to this category the answer is usually straightforward: a transcription
+            provider that processes identifiable patient recordings for you is ordinarily a
+            business associate, and{" "}
+            <span className="font-medium text-[var(--text)]">45 CFR 164.502(e)</span> then
+            requires a written contract with satisfactory assurances{" "}
+            <em>before</em> you disclose the recording.
           </p>
           <p>
-            One more thing worth knowing, because vendors reach for it:{" "}
+            Notice what the definition does not turn on: encryption strength, data center
+            location, or SOC 2. Those are safeguards a business associate must implement. They
+            are not what makes someone a business associate in the first place.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Exclusions, And The Conduit Idea" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Paragraph (4) of the definition excludes four categories, each with conditions worth
+            reading rather than paraphrasing loosely:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              A health care provider, with respect to disclosures{" "}
+              <em>concerning the treatment of the individual</em>.
+            </li>
+            <li>
+              A plan sponsor, with respect to disclosures by a group health plan, but only to
+              the extent the requirements of &sect; 164.504(f) apply and are met.
+            </li>
+            <li>
+              A government agency determining eligibility for or enrollment in a government
+              health plan providing public benefits that is administered by another agency, to
+              the extent those activities are authorized by law.
+            </li>
+            <li>
+              A covered entity participating in an organized health care arrangement that
+              performs the specified functions or services for that arrangement by virtue of
+              those activities.
+            </li>
+          </ul>
+          <p>
+            Software vendors are not on that list, and vendors sometimes present that as
+            ominous. It is not, and the reason matters:{" "}
             <span className="font-medium text-[var(--text)]">
-              there is no software exception
+              paragraph (4) is not the only route to not being a business associate
             </span>
-            . Paragraph (4) of the definition excludes exactly four categories, being health
-            care providers receiving treatment disclosures, plan sponsors, government agencies
-            determining eligibility, and covered entities within an organized health care
-            arrangement. Software vendors, cloud providers, and transcription platforms appear
-            nowhere on that list. The narrow &ldquo;conduit&rdquo; idea covers mere transmission
-            without access to content, which a service that transcribes and stores your audio
-            plainly exceeds.
+            . A vendor that never satisfies the positive definition, because it never creates,
+            receives, maintains, or transmits PHI on your behalf, needs no exception at all. It
+            simply is not one.
+          </p>
+          <p>
+            The related &ldquo;conduit&rdquo; idea is narrower than its reputation. OCR treats
+            it as covering transmission-only services, storage that is temporary and incidental
+            to transmission, and access that is transient or infrequent and necessary to that
+            transmission or required by law. A transcription service that stores your audio or
+            transcripts persistently is outside it, and OCR has been explicit that persistent
+            storage defeats conduit status even where the provider holds no decryption key.
           </p>
         </div>
       </section>
@@ -220,9 +293,9 @@ export default function HipaaTranscriptionPage() {
                 <h3 className="font-serif text-[22px] text-[var(--text)]">{a.name}</h3>
                 <span
                   className={`rounded-full px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${
-                    a.needsBaa
-                      ? "bg-[var(--bg-hover)] text-[var(--text-secondary)]"
-                      : "bg-[var(--accent-soft)] text-[var(--accent)]"
+                    a.highlight
+                      ? "bg-[var(--accent-soft)] text-[var(--accent)]"
+                      : "bg-[var(--bg-hover)] text-[var(--text-secondary)]"
                   }`}
                 >
                   {a.role}
@@ -230,50 +303,95 @@ export default function HipaaTranscriptionPage() {
               </div>
               <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">{a.who}</p>
               <p className="mt-2 font-mono text-[12px] leading-6 text-[var(--text-secondary)]">
-                {a.needsBaa ? "BAA required before any PHI is disclosed" : "No BAA — no disclosure to contract about"}
+                {a.baa}
               </p>
               <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">{a.note}</p>
             </div>
           ))}
         </div>
+        <p className="mt-6 max-w-[800px] text-[15px] leading-8 text-[var(--text-secondary)]">
+          One caution that applies to the first two: a signed BAA is necessary when a vendor is
+          a business associate, but it is not sufficient. The disclosure still has to be
+          permissible, still has to satisfy minimum necessary where that applies, and your own
+          risk analysis and safeguards remain your responsibility. The contract allocates
+          obligations; it does not discharge yours.
+        </p>
       </section>
 
       <section className="mt-14 max-w-[800px]">
         <SectionLabel label="What On-Device Does Not Do" />
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
-            This is the part our own category tends to oversell, so here it is plainly. Running
-            transcription on your own machine removes one question: whether a third party
-            receives PHI, and therefore whether you need a BAA and inherit that vendor&rsquo;s
-            breach exposure. It removes nothing else.
+            This is the part our own category oversells, so here it is plainly. Keeping
+            processing local can remove one question, whether a software vendor receives PHI and
+            therefore needs a BAA. It removes nothing else, and it creates work of its own.
           </p>
           <ul className="list-disc space-y-2 pl-6">
             <li>
-              You still owe the Security Rule&rsquo;s safeguards. Full-disk encryption, screen
-              lock, access control, audit, and a real answer for a stolen laptop.
+              <span className="font-medium text-[var(--text)]">
+                You owe a fresh risk analysis.
+              </span>{" "}
+              The Security Rule requires an accurate and thorough assessment of risks to all
+              ePHI you hold, and recording consultations creates a new corpus of audio and
+              transcripts on an endpoint that may never have held a designated record set
+              before. That is a change to analyze, not a step you skip because nothing was
+              uploaded.
             </li>
             <li>
-              You still owe workforce training and sanctions, and you still owe breach
-              notification if the device is lost.
+              <span className="font-medium text-[var(--text)]">Encryption is risk-based.</span>{" "}
+              Encryption is an addressable implementation specification, so the question is what
+              your risk analysis concludes and what you document, not a universal checkbox. In
+              practice, full-disk encryption on a portable endpoint holding patient audio is
+              very hard to reason your way out of.
             </li>
             <li>
-              Consent and authorization rules are untouched. Recording a patient encounter is
-              subject to the same state law and the same professional obligations either way.
+              <span className="font-medium text-[var(--text)]">
+                A lost laptop triggers an assessment, not automatic notification.
+              </span>{" "}
+              Breach notification concerns unsecured PHI and requires the regulatory risk
+              assessment. PHI encrypted to the specified standard can fall outside the
+              notification requirement entirely, which is the practical argument for encrypting
+              before you need it.
             </li>
             <li>
-              Local files are still discoverable, and a subpoena reaches your disk as readily as
-              a vendor&rsquo;s.
+              <span className="font-medium text-[var(--text)]">
+                The rest of the Security Rule still applies.
+              </span>{" "}
+              Access control, audit controls, integrity, authentication, device and media
+              controls, contingency planning and backup, and retention and disposal all reach
+              these files.
             </li>
             <li>
-              You lose a party to hold accountable. A cloud vendor under a BAA carries
-              contractual obligations; your laptop carries none.
+              <span className="font-medium text-[var(--text)]">
+                Privacy Rule duties follow the record.
+              </span>{" "}
+              If a transcript becomes part of a designated record set, patient access and
+              amendment rights attach to it.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">
+                Recording consent is a separate question.
+              </span>{" "}
+              State wiretap and recording law, and professional ethics rules, apply regardless
+              of where processing happens, and they are not the same thing as a HIPAA
+              authorization. HIPAA permits many treatment, payment, and operations uses without
+              individual authorization; authorization is required where the Privacy Rule does
+              not otherwise permit the use or disclosure.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">
+                You lose a party to hold accountable.
+              </span>{" "}
+              A business associate under contract carries obligations and liability. Your own
+              endpoint carries none.
             </li>
           </ul>
           <p>
-            The honest summary: on-device processing converts a vendor-disclosure problem into a
-            device-security problem. For many clinicians that is a very good trade, because the
-            device-security problem is one they already solved for their EHR workstation. It is
-            still a trade, not an exemption.
+            The honest summary: local processing converts a vendor-disclosure problem into an
+            endpoint problem. That can be a very good trade, particularly where the endpoint is
+            already managed to the standard your other clinical systems require. It is a trade,
+            not an exemption, and an unmanaged personal laptop is a materially worse place for
+            this corpus than a managed workstation.
           </p>
         </div>
       </section>
@@ -282,27 +400,31 @@ export default function HipaaTranscriptionPage() {
         <SectionLabel label="Where Minutes Fits, And Where It Does Not" />
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
-            <span className="font-medium text-[var(--text)]">Minutes</span> is the third
-            architecture. It records on your device, transcribes locally with whisper.cpp,
-            diarizes speakers with local models, and writes markdown to a folder you control. No
-            audio is uploaded, so no vendor receives PHI, so there is no BAA to negotiate with
-            us. We are not a business associate because we are never in the path.
+            <span className="font-medium text-[var(--text)]">Minutes</span> is built for the
+            third architecture. It records on your device, transcribes locally with whisper.cpp,
+            diarizes with local models, and writes markdown into a folder you control. In a
+            local-only deployment, we do not receive, maintain, or transmit your PHI, and
+            supplying software to someone who uses it that way does not by itself create a
+            business associate relationship.
           </p>
           <p>
-            To be exact about the one carve-out: transcript text leaves your machine only if you
-            deliberately configure a provider-backed summarizer, which is off by default. Point
-            it at a cloud model and you have re-created the disclosure this architecture avoids,
-            and that provider&rsquo;s terms then govern. Our{" "}
+            That conclusion is conditional on your deployment, and it is worth being blunt about
+            what breaks it. Configure a provider-backed summarizer, which is off by default, and
+            transcript text goes to whichever model provider you chose, whose terms then govern.
+            Sync your meetings folder to a hosted drive and that host is now storing PHI. Grant
+            anyone remote access to the machine and the same applies. None of those are exotic;
+            they are ordinary choices that change the analysis, and each needs its own review
+            and ordinarily a BAA with that party. Our{" "}
             <a href="/security" className="text-[var(--accent)] hover:underline">
               security page
             </a>{" "}
-            lists every case where bytes touch the network.
+            enumerates every case where bytes touch the network.
           </p>
           <p className="font-medium text-[var(--text)]">Where it is the wrong tool:</p>
           <ul className="list-disc space-y-2 pl-6">
             <li>
-              You need a <span className="font-medium text-[var(--text)]">certified</span>{" "}
-              transcript for a legal or regulatory filing. That is a human service.
+              You need a certified transcript for a filing or proceeding. Requirements vary by
+              jurisdiction and use, and that is generally a human service.
             </li>
             <li>
               You want an ambient clinical scribe that writes structured notes into your EHR,
@@ -310,12 +432,16 @@ export default function HipaaTranscriptionPage() {
               has no EHR integration.
             </li>
             <li>
-              You need vendor-side audit logs and administrative oversight across a practice.
-              Local files give you ownership, not centralized governance.
+              You need centralized audit logs and administrative oversight across a practice.
+              Local files give you ownership, not governance.
             </li>
             <li>
-              Your compliance posture depends on having a business associate to hold
-              accountable. Sometimes that contract is the point.
+              Your posture depends on having a business associate to hold accountable. Sometimes
+              that contract is precisely the point.
+            </li>
+            <li>
+              The endpoint is an unmanaged personal device. Then you have moved the risk rather
+              than reduced it.
             </li>
           </ul>
           <p>
@@ -366,10 +492,11 @@ export default function HipaaTranscriptionPage() {
           ))}
         </ul>
         <p className="mt-6 text-[13px] leading-7 text-[var(--text-secondary)]">
-          Informational, not legal advice. HIPAA analysis is fact-specific, vendor terms and
-          plan gating change, and your own counsel or compliance officer is the one who signs
-          off. Verify against the regulation and the vendor&rsquo;s current documentation before
-          relying on any of it.
+          Informational, not legal advice. HIPAA analysis is fact-specific and turns on your
+          actual deployment; covered-entity status, permitted uses, and state recording law all
+          vary. Vendor terms and plan gating change. Your own counsel or compliance officer is
+          the one who signs off, and this page is a starting point for that conversation rather
+          than a substitute for it.
         </p>
       </section>
 

--- a/site/app/resources/hipaa-compliant-transcription/page.tsx
+++ b/site/app/resources/hipaa-compliant-transcription/page.tsx
@@ -1,0 +1,379 @@
+import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
+import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
+import { faqPageSchema } from "@/lib/schema";
+
+export const metadata: Metadata = {
+  title: "HIPAA-compliant transcription: what the rule actually requires",
+  description:
+    "No product is HIPAA certified, because HHS certifies nothing. What the rule turns on is whether a vendor receives PHI at all. The three transcription architectures, what a BAA does and does not buy, and the obligations that stay yours either way.",
+  alternates: {
+    canonical: "/resources/hipaa-compliant-transcription",
+  },
+};
+
+const faqs = [
+  {
+    question: "Is there such a thing as HIPAA-certified transcription software?",
+    answer:
+      "No. HHS does not certify or endorse any product, service, or vendor as HIPAA compliant, and no standard requires a covered entity to obtain certification. A vendor advertising itself as \"HIPAA certified\" is describing a private audit it purchased, which carries no government recognition and does not shield you from an OCR finding. What matters is whether the arrangement satisfies the rule, not what badge is on the marketing page.",
+  },
+  {
+    question: "Does a transcription service need to sign a BAA?",
+    answer:
+      "If it receives protected health information on your behalf, yes. 45 CFR 160.103 defines a business associate as a person who creates, receives, maintains, or transmits PHI on behalf of a covered entity, and the Privacy Rule requires satisfactory assurances in a written contract before you disclose PHI to them. Encryption does not substitute for the contract, and the contract does not substitute for the safeguards.",
+  },
+  {
+    question: "Is on-device transcription HIPAA compliant?",
+    answer:
+      "That question is aimed at the wrong object. Software is not compliant or non-compliant; an arrangement is. What on-device processing changes is narrower and more useful: if the vendor never receives, maintains, or transmits PHI, it does not meet the definition of a business associate, so there is no BAA to negotiate and no vendor breach exposure to inherit. Every obligation you already have (device encryption, access control, workforce training, patient authorization where required, breach notification) is unchanged.",
+  },
+  {
+    question: "What is the difference between transcription services and transcription software?",
+    answer:
+      "Services use human transcriptionists and can produce certified transcripts; the transcriptionist and the agency are business associates and need a BAA. Cloud software sends your audio to a vendor's servers, which also makes that vendor a business associate. On-device software runs the model on your own machine, so no third party receives the audio at all. All three can be appropriate; they differ in who else ends up holding the PHI.",
+  },
+  {
+    question: "Does the HIPAA conduit exception cover a transcription vendor?",
+    answer:
+      "Almost never. 45 CFR 160.103 lists only four exclusions from the business associate definition, covering health care providers receiving treatment disclosures, plan sponsors, government agencies determining eligibility, and covered entities in an organized health care arrangement. There is no exception for software vendors or storage providers. OCR reads the conduit concept narrowly, as mere transmission without access to content, which a service that transcribes and stores your audio plainly exceeds.",
+  },
+] as const;
+
+const architectures = [
+  {
+    name: "Human transcription service",
+    role: "Business associate",
+    needsBaa: true,
+    who: "The agency and its transcriptionists receive and store your audio and the finished transcript.",
+    note: "The traditional model, and still the one that produces certified transcripts. Ask who subcontracts, where staff are located, and whether the agency signs BAAs with its own vendors.",
+  },
+  {
+    name: "Cloud AI transcription",
+    role: "Business associate",
+    needsBaa: true,
+    who: "The vendor receives your audio, processes it on its servers, and usually stores the transcript.",
+    note: "Fast and cheap, but you are adding a party that holds PHI. Check the plan tier: most vendors gate BAAs to an enterprise plan, so the same product is appropriate on one tier and impermissible on another.",
+  },
+  {
+    name: "On-device transcription",
+    role: "Not a business associate",
+    needsBaa: false,
+    who: "Nobody outside your organization receives the audio. The model runs on the machine you already control.",
+    note: "There is no BAA because there is no disclosure to contract about. The tradeoff is that the device becomes the whole security surface, and you get no vendor to hold accountable if you misconfigure it.",
+  },
+] as const;
+
+const sources = [
+  {
+    label: "45 CFR 160.103 — definition of business associate (eCFR)",
+    href: "https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-160/subpart-A/section-160.103",
+  },
+  {
+    label: "45 CFR 164.502(e) — business associate contracts (eCFR)",
+    href: "https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-E/section-164.502",
+  },
+  {
+    label: "HHS FAQ: are we required to certify our organization's compliance with the standards?",
+    href: "https://www.hhs.gov/hipaa/for-professionals/faq/2003/are-we-required-to-certify-our-organizations-compliance-with-the-standards/index.html",
+  },
+  {
+    label: "HHS: business associate guidance",
+    href: "https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html",
+  },
+  {
+    label: "HHS: sample business associate agreement provisions",
+    href: "https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html",
+  },
+  { label: "Minutes security & privacy architecture", href: "/security" },
+] as const;
+
+export default function HipaaTranscriptionPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a
+            href="/resources/hipaa-compliant-transcription.md"
+            className="hover:text-[var(--accent)]"
+          >
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          HIPAA-compliant transcription: what the rule actually requires
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          Every vendor in this category has a page telling you to look for encryption, SOC 2,
+          and a signed BAA. That list is not wrong, but it skips the question underneath it:
+          whether the vendor should be receiving your patients&rsquo; audio at all. Here is the
+          rule as written, the three architectures it produces, and the obligations that stay
+          yours no matter which you pick.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-08-10
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            Sourced answer
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Two Things To Get Straight First" />
+        <div className="space-y-5 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              Nothing is &ldquo;HIPAA certified.&rdquo;
+            </span>{" "}
+            HHS certifies no product, service, or vendor, and no standard requires a covered
+            entity to obtain certification. A private audit can be genuinely useful evidence of
+            diligence, but it carries no government recognition and does not stop OCR finding a
+            violation afterward. When a transcription vendor leads with a HIPAA badge, you are
+            looking at marketing, not a legal status.
+          </p>
+          <p>
+            <span className="font-medium text-[var(--text)]">
+              Compliance is a property of the arrangement, not the software.
+            </span>{" "}
+            No tool can be compliant on your behalf, because most of the obligations are about
+            what your organization does: who can access the files, whether the disk is
+            encrypted, whether staff are trained, whether the patient authorized the disclosure.
+            The right question is never &ldquo;is this app HIPAA compliant.&rdquo; It is
+            &ldquo;who ends up holding this audio, and under what contract.&rdquo;
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Rule As Written" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Everything about vendor selection follows from one definition. Under{" "}
+            <span className="font-medium text-[var(--text)]">45 CFR 160.103</span>, a business
+            associate is a person who, on behalf of a covered entity,
+          </p>
+          <blockquote className="border-l-2 border-[color:var(--accent)] pl-5 text-[var(--text)]">
+            &ldquo;creates, receives, maintains, or transmits protected health information for a
+            function or activity regulated by this subchapter&hellip;&rdquo;
+          </blockquote>
+          <p>
+            Read those four verbs carefully, because the entire vendor question is decided by
+            them. A transcription provider that takes in your audio{" "}
+            <em>receives</em> PHI. One that keeps the transcript on its servers{" "}
+            <em>maintains</em> it. Either verb makes the provider a business associate, and the
+            Privacy Rule then requires a written contract with satisfactory assurances{" "}
+            <em>before</em> you hand over the recording.
+          </p>
+          <p>
+            Note what the definition does not say. It does not turn on how good the encryption
+            is, where the data center sits, or whether the vendor has SOC 2. Those are
+            safeguards that a business associate must have; they are not what makes someone a
+            business associate. The trigger is receipt of PHI.
+          </p>
+          <p>
+            One more thing worth knowing, because vendors reach for it:{" "}
+            <span className="font-medium text-[var(--text)]">
+              there is no software exception
+            </span>
+            . Paragraph (4) of the definition excludes exactly four categories, being health
+            care providers receiving treatment disclosures, plan sponsors, government agencies
+            determining eligibility, and covered entities within an organized health care
+            arrangement. Software vendors, cloud providers, and transcription platforms appear
+            nowhere on that list. The narrow &ldquo;conduit&rdquo; idea covers mere transmission
+            without access to content, which a service that transcribes and stores your audio
+            plainly exceeds.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="The Three Architectures" />
+        <div className="grid gap-4">
+          {architectures.map((a) => (
+            <div
+              key={a.name}
+              className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h3 className="font-serif text-[22px] text-[var(--text)]">{a.name}</h3>
+                <span
+                  className={`rounded-full px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${
+                    a.needsBaa
+                      ? "bg-[var(--bg-hover)] text-[var(--text-secondary)]"
+                      : "bg-[var(--accent-soft)] text-[var(--accent)]"
+                  }`}
+                >
+                  {a.role}
+                </span>
+              </div>
+              <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">{a.who}</p>
+              <p className="mt-2 font-mono text-[12px] leading-6 text-[var(--text-secondary)]">
+                {a.needsBaa ? "BAA required before any PHI is disclosed" : "No BAA — no disclosure to contract about"}
+              </p>
+              <p className="mt-3 text-[15px] leading-8 text-[var(--text-secondary)]">{a.note}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="What On-Device Does Not Do" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            This is the part our own category tends to oversell, so here it is plainly. Running
+            transcription on your own machine removes one question: whether a third party
+            receives PHI, and therefore whether you need a BAA and inherit that vendor&rsquo;s
+            breach exposure. It removes nothing else.
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              You still owe the Security Rule&rsquo;s safeguards. Full-disk encryption, screen
+              lock, access control, audit, and a real answer for a stolen laptop.
+            </li>
+            <li>
+              You still owe workforce training and sanctions, and you still owe breach
+              notification if the device is lost.
+            </li>
+            <li>
+              Consent and authorization rules are untouched. Recording a patient encounter is
+              subject to the same state law and the same professional obligations either way.
+            </li>
+            <li>
+              Local files are still discoverable, and a subpoena reaches your disk as readily as
+              a vendor&rsquo;s.
+            </li>
+            <li>
+              You lose a party to hold accountable. A cloud vendor under a BAA carries
+              contractual obligations; your laptop carries none.
+            </li>
+          </ul>
+          <p>
+            The honest summary: on-device processing converts a vendor-disclosure problem into a
+            device-security problem. For many clinicians that is a very good trade, because the
+            device-security problem is one they already solved for their EHR workstation. It is
+            still a trade, not an exemption.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Where Minutes Fits, And Where It Does Not" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            <span className="font-medium text-[var(--text)]">Minutes</span> is the third
+            architecture. It records on your device, transcribes locally with whisper.cpp,
+            diarizes speakers with local models, and writes markdown to a folder you control. No
+            audio is uploaded, so no vendor receives PHI, so there is no BAA to negotiate with
+            us. We are not a business associate because we are never in the path.
+          </p>
+          <p>
+            To be exact about the one carve-out: transcript text leaves your machine only if you
+            deliberately configure a provider-backed summarizer, which is off by default. Point
+            it at a cloud model and you have re-created the disclosure this architecture avoids,
+            and that provider&rsquo;s terms then govern. Our{" "}
+            <a href="/security" className="text-[var(--accent)] hover:underline">
+              security page
+            </a>{" "}
+            lists every case where bytes touch the network.
+          </p>
+          <p className="font-medium text-[var(--text)]">Where it is the wrong tool:</p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              You need a <span className="font-medium text-[var(--text)]">certified</span>{" "}
+              transcript for a legal or regulatory filing. That is a human service.
+            </li>
+            <li>
+              You want an ambient clinical scribe that writes structured notes into your EHR,
+              suggests codes, or drafts to a SOAP template. Minutes is not a medical scribe and
+              has no EHR integration.
+            </li>
+            <li>
+              You need vendor-side audit logs and administrative oversight across a practice.
+              Local files give you ownership, not centralized governance.
+            </li>
+            <li>
+              Your compliance posture depends on having a business associate to hold
+              accountable. Sometimes that contract is the point.
+            </li>
+          </ul>
+          <p>
+            If you are comparing named products rather than architectures, we keep a sourced
+            vendor-by-vendor breakdown of{" "}
+            <a
+              href="/resources/hipaa-compliant-ai-note-taker"
+              className="text-[var(--accent)] hover:underline"
+            >
+              which AI note takers can be used with PHI, and on which plan tier
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+
+      <FaqSection items={faqs} />
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            What touches the network
+          </a>
+          <a
+            href="/resources/hipaa-compliant-ai-note-taker"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Vendor-by-vendor breakdown
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-6 text-[13px] leading-7 text-[var(--text-secondary)]">
+          Informational, not legal advice. HIPAA analysis is fact-specific, vendor terms and
+          plan gating change, and your own counsel or compliance officer is the one who signs
+          off. Verify against the regulation and the vendor&rsquo;s current documentation before
+          relying on any of it.
+        </p>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/hipaa-compliant-transcription/page.tsx
+++ b/site/app/resources/hipaa-compliant-transcription/page.tsx
@@ -32,7 +32,7 @@ const faqs = [
   {
     question: "What is the difference between transcription services and transcription software?",
     answer:
-      "Human transcription services use transcriptionists, can produce certified transcripts where a use requires one, and are ordinarily business associates. Cloud software sends audio to a vendor's servers, which ordinarily makes that vendor a business associate too. On-device software runs the model on your own machine, so no third party receives the audio at all. All three can be appropriate; they differ in who else ends up holding the PHI and what contracts that requires.",
+      "Human transcription services use transcriptionists, can produce certified transcripts where a use requires one, and are ordinarily business associates. Cloud software sends audio to a vendor's servers, which ordinarily makes that vendor a business associate too. On-device software runs the model on your own machine, so in a genuinely local-only deployment, where no separate service receives or maintains the files, no third party receives the audio. Local inference by itself does not establish that: sync, backup, upload, and remote support paths all have to be absent too. All three architectures can be appropriate; they differ in who else ends up holding the PHI and what contracts that requires.",
   },
   {
     question: "Does the HIPAA conduit exception cover a transcription vendor?",
@@ -227,8 +227,11 @@ export default function HipaaTranscriptionPage() {
           </p>
           <p>
             Notice what the definition does not turn on: encryption strength, data center
-            location, or SOC 2. Those are safeguards a business associate must implement. They
-            are not what makes someone a business associate in the first place.
+            location, or SOC 2. Those may be useful inputs to your risk management and your
+            vendor diligence, but none of them determines business associate status, and two of
+            them are not HIPAA requirements at all. What the Security Rule requires is
+            reasonable and appropriate safeguards, with encryption treated as addressable rather
+            than mandatory in every case.
           </p>
         </div>
       </section>
@@ -243,21 +246,30 @@ export default function HipaaTranscriptionPage() {
           <ul className="list-disc space-y-2 pl-6">
             <li>
               A health care provider, with respect to disclosures{" "}
-              <em>concerning the treatment of the individual</em>.
+              <em>by a covered entity to that provider</em> concerning the treatment of the
+              individual.
             </li>
             <li>
-              A plan sponsor, with respect to disclosures by a group health plan, but only to
-              the extent the requirements of &sect; 164.504(f) apply and are met.
+              A plan sponsor, with respect to disclosures{" "}
+              <em>
+                by a group health plan, or by a health insurance issuer or HMO with respect to a
+                group health plan
+              </em>
+              , to the plan sponsor, and only to the extent the requirements of &sect;
+              164.504(f) apply and are met.
             </li>
             <li>
-              A government agency determining eligibility for or enrollment in a government
-              health plan providing public benefits that is administered by another agency, to
-              the extent those activities are authorized by law.
+              A government agency, with respect to determining eligibility for or enrollment in
+              a government health plan that provides public benefits and is administered by
+              another government agency,{" "}
+              <em>or collecting PHI for such purposes</em>, to the extent those activities are
+              authorized by law.
             </li>
             <li>
               A covered entity participating in an organized health care arrangement that
-              performs the specified functions or services for that arrangement by virtue of
-              those activities.
+              performs a function or activity described in paragraph (1)(i) for that
+              arrangement, or provides a service described in paragraph (1)(ii) to or for it, by
+              virtue of those activities or services.
             </li>
           </ul>
           <p>
@@ -358,8 +370,10 @@ export default function HipaaTranscriptionPage() {
                 The rest of the Security Rule still applies.
               </span>{" "}
               Access control, audit controls, integrity, authentication, device and media
-              controls, contingency planning and backup, and retention and disposal all reach
-              these files.
+              controls, contingency planning and backup, and secure disposal all reach these
+              files. How long you must keep the records themselves is a separate question: the
+              Security Rule&rsquo;s six-year rule governs required HIPAA documentation, while
+              medical record retention periods generally come from other federal or state law.
             </li>
             <li>
               <span className="font-medium text-[var(--text)]">

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -26,6 +26,7 @@ const routes = [
   "/resources/ai-notetakers-attorney-client-privilege",
   "/resources/best-local-speech-to-text",
   "/resources/hipaa-compliant-ai-note-taker",
+  "/resources/hipaa-compliant-transcription",
   "/resources/is-it-legal-to-record-a-meeting",
   "/resources/best-mcp-meeting-memory-tools",
   "/resources/best-meeting-tools-for-claude-code-and-codex",

--- a/site/components/faq-section.tsx
+++ b/site/components/faq-section.tsx
@@ -15,9 +15,9 @@ export function FaqSection({ items }: { items: ReadonlyArray<FaqItem> }) {
   return (
     <section className="mt-14 max-w-[800px]">
       <div className="mb-6 flex items-center gap-3">
-        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
           Common questions
-        </span>
+        </h2>
         <div className="h-px flex-1 bg-[var(--border)]" />
       </div>
       <div className="divide-y divide-[color:var(--border)] border-y border-[color:var(--border)]">

--- a/site/public/resources/hipaa-compliant-transcription.md
+++ b/site/public/resources/hipaa-compliant-transcription.md
@@ -1,0 +1,71 @@
+# HIPAA-compliant transcription: what the rule actually requires
+
+Last reviewed: 2026-08-10
+
+Every vendor in this category has a page telling you to look for encryption, SOC 2, and a signed BAA. That list is not wrong, but it skips the question underneath it: whether the vendor should be receiving your patients' audio at all.
+
+## Two things to get straight first
+
+**Nothing is "HIPAA certified."** HHS certifies no product, service, or vendor, and no standard requires a covered entity to obtain certification. A private audit can be useful evidence of diligence, but it carries no government recognition and does not stop OCR finding a violation afterward. A HIPAA badge on a vendor page is marketing, not a legal status.
+
+**Compliance is a property of the arrangement, not the software.** No tool can be compliant on your behalf, because most obligations are about what your organization does: who can access the files, whether the disk is encrypted, whether staff are trained, whether the patient authorized the disclosure. The question is never "is this app HIPAA compliant." It is "who ends up holding this audio, and under what contract."
+
+## The rule as written
+
+Under **45 CFR 160.103**, a business associate is a person who, on behalf of a covered entity,
+
+> "creates, receives, maintains, or transmits protected health information for a function or activity regulated by this subchapter…"
+
+Read those four verbs carefully; the entire vendor question is decided by them. A transcription provider that takes in your audio *receives* PHI. One that keeps the transcript on its servers *maintains* it. Either verb makes it a business associate, and the Privacy Rule then requires a written contract with satisfactory assurances *before* you hand over the recording.
+
+Note what the definition does not say. It does not turn on encryption strength, data center location, or SOC 2. Those are safeguards a business associate must have; they are not what makes someone a business associate. The trigger is receipt of PHI.
+
+And there is **no software exception**. Paragraph (4) excludes exactly four categories: health care providers receiving treatment disclosures, plan sponsors, government agencies determining eligibility, and covered entities within an organized health care arrangement. Software vendors, cloud providers, and transcription platforms appear nowhere. The narrow "conduit" idea covers mere transmission without access to content, which a service that transcribes and stores your audio plainly exceeds.
+
+## The three architectures
+
+**Human transcription service** — business associate, BAA required. The agency and its transcriptionists receive and store your audio and the finished transcript. Still the model that produces certified transcripts. Ask who subcontracts, where staff are located, and whether the agency signs BAAs with its own vendors.
+
+**Cloud AI transcription** — business associate, BAA required. The vendor receives your audio, processes it on its servers, and usually stores the transcript. Fast and cheap, but you are adding a party that holds PHI. Check the plan tier: most vendors gate BAAs to enterprise, so the same product is appropriate on one tier and impermissible on another.
+
+**On-device transcription** — not a business associate, no BAA. Nobody outside your organization receives the audio; the model runs on a machine you already control. There is no BAA because there is no disclosure to contract about. The tradeoff is that the device becomes the whole security surface, and there is no vendor to hold accountable if you misconfigure it.
+
+## What on-device does not do
+
+Running transcription on your own machine removes one question: whether a third party receives PHI, and therefore whether you need a BAA and inherit that vendor's breach exposure. It removes nothing else.
+
+- You still owe the Security Rule's safeguards: full-disk encryption, screen lock, access control, audit, and a real answer for a stolen laptop
+- You still owe workforce training and sanctions, and breach notification if the device is lost
+- Consent and authorization rules are untouched; recording a patient encounter is subject to the same state law either way
+- Local files are still discoverable, and a subpoena reaches your disk as readily as a vendor's
+- You lose a party to hold accountable; a cloud vendor under a BAA carries contractual obligations, your laptop carries none
+
+On-device processing converts a vendor-disclosure problem into a device-security problem. For many clinicians that is a good trade, because the device-security problem is one they already solved for their EHR workstation. It is still a trade, not an exemption.
+
+## Where Minutes fits, and where it does not
+
+Minutes is the third architecture: records on your device, transcribes locally with whisper.cpp, diarizes with local models, writes markdown to a folder you control. No audio is uploaded, so no vendor receives PHI, so there is no BAA to negotiate with us. We are not a business associate because we are never in the path.
+
+The one carve-out, stated exactly: transcript text leaves your machine only if you deliberately configure a provider-backed summarizer, which is off by default. Point it at a cloud model and you have re-created the disclosure this architecture avoids, and that provider's terms govern.
+
+Where it is the wrong tool:
+
+- You need a **certified** transcript for a legal or regulatory filing (that is a human service)
+- You want an ambient clinical scribe writing structured notes into your EHR, suggesting codes, or drafting to a SOAP template — Minutes is not a medical scribe and has no EHR integration
+- You need vendor-side audit logs and administrative oversight across a practice; local files give you ownership, not centralized governance
+- Your compliance posture depends on having a business associate to hold accountable — sometimes that contract is the point
+
+## Sources
+
+- 45 CFR 160.103, business associate definition: https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-160/subpart-A/section-160.103
+- 45 CFR 164.502(e), business associate contracts: https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-E/section-164.502
+- HHS FAQ on certifying compliance: https://www.hhs.gov/hipaa/for-professionals/faq/2003/are-we-required-to-certify-our-organizations-compliance-with-the-standards/index.html
+- HHS business associate guidance: https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html
+- HHS sample BAA provisions: https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html
+
+Informational, not legal advice. HIPAA analysis is fact-specific, vendor terms and plan gating change, and your own counsel or compliance officer is the one who signs off.
+
+## Related
+
+- Which AI note takers can be used with PHI, vendor by vendor: https://useminutes.app/resources/hipaa-compliant-ai-note-taker
+- What touches the network: https://useminutes.app/security

--- a/site/public/resources/hipaa-compliant-transcription.md
+++ b/site/public/resources/hipaa-compliant-transcription.md
@@ -22,16 +22,16 @@ Every element matters, and reducing this to "they received PHI" is the most comm
 
 Applied to this category the answer is usually straightforward: a transcription provider that processes identifiable patient recordings for you is ordinarily a business associate, and **45 CFR 164.502(e)** then requires a written contract with satisfactory assurances *before* you disclose the recording.
 
-Notice what the definition does not turn on: encryption strength, data center location, or SOC 2. Those are safeguards a business associate must implement; they are not what makes someone a business associate.
+Notice what the definition does not turn on: encryption strength, data center location, or SOC 2. Those may inform your risk management and vendor diligence, but none determines business associate status, and two of them are not HIPAA requirements at all. The Security Rule requires reasonable and appropriate safeguards, with encryption treated as addressable rather than mandatory in every case.
 
 ## The exclusions, and the conduit idea
 
 Paragraph (4) excludes four categories, each with conditions worth reading rather than paraphrasing loosely:
 
-- A health care provider, with respect to disclosures *concerning the treatment of the individual*
-- A plan sponsor, with respect to disclosures by a group health plan, but only to the extent the requirements of § 164.504(f) apply and are met
-- A government agency determining eligibility for or enrollment in a government health plan providing public benefits administered by another agency, to the extent authorized by law
-- A covered entity participating in an organized health care arrangement that performs the specified functions or services for that arrangement by virtue of those activities
+- A health care provider, with respect to disclosures *by a covered entity to that provider* concerning the treatment of the individual
+- A plan sponsor, with respect to disclosures *by a group health plan, or by a health insurance issuer or HMO with respect to a group health plan*, to the plan sponsor, and only to the extent the requirements of § 164.504(f) apply and are met
+- A government agency, with respect to determining eligibility for or enrollment in a government health plan that provides public benefits and is administered by another government agency, *or collecting PHI for such purposes*, to the extent authorized by law
+- A covered entity participating in an organized health care arrangement that performs a function or activity described in paragraph (1)(i) for that arrangement, or provides a service described in paragraph (1)(ii) to or for it, by virtue of those activities or services
 
 Software vendors are not on that list, and vendors sometimes present that as ominous. It is not, and the reason matters: **paragraph (4) is not the only route to not being a business associate**. A vendor that never satisfies the positive definition, because it never creates, receives, maintains, or transmits PHI on your behalf, needs no exception at all. It simply is not one.
 
@@ -43,7 +43,7 @@ The related "conduit" idea is narrower than its reputation. OCR treats it as cov
 
 **Cloud AI transcription** — ordinarily a business associate; BAA required before PHI is disclosed. The vendor receives your audio, processes it on its servers, and usually stores the transcript. Check whether your plan is one the vendor will actually sign a BAA for, since several offer that only on higher tiers; the plan decides whether the required contract is even available to you.
 
-**On-device transcription** — no vendor in the path, if deployed local-only; no BAA with the software vendor provided it never receives PHI. Whether this holds is a fact about your deployment, not a property of the software. Any cloud summarizer, synced folder, hosted backup, or vendor support access puts PHI back in someone else's hands and needs its own analysis. The tradeoff is that the endpoint becomes the security surface, with no vendor contract to fall back on.
+**On-device transcription** — no vendor in the path, in a genuinely local-only deployment; no BAA with the software vendor provided it never receives PHI. Whether this holds is a fact about your deployment, not a property of the software. Any cloud summarizer, synced folder, hosted backup, or vendor support access puts PHI back in someone else's hands and needs its own analysis. The tradeoff is that the endpoint becomes the security surface, with no vendor contract to fall back on.
 
 A caution for the first two: a signed BAA is necessary when a vendor is a business associate, but not sufficient. The disclosure still has to be permissible, still has to satisfy minimum necessary where that applies, and your own risk analysis and safeguards remain yours. The contract allocates obligations; it does not discharge yours.
 
@@ -54,7 +54,7 @@ Keeping processing local can remove one question, whether a software vendor rece
 - **You owe a fresh risk analysis.** The Security Rule requires an accurate and thorough assessment of risks to all ePHI you hold, and recording consultations creates a new corpus of audio and transcripts on an endpoint that may never have held a designated record set before.
 - **Encryption is risk-based.** It is an addressable implementation specification, so the question is what your risk analysis concludes and what you document. In practice, full-disk encryption on a portable endpoint holding patient audio is very hard to reason your way out of.
 - **A lost laptop triggers an assessment, not automatic notification.** Breach notification concerns unsecured PHI and requires the regulatory risk assessment; PHI encrypted to the specified standard can fall outside the requirement entirely.
-- **The rest of the Security Rule still applies:** access control, audit controls, integrity, authentication, device and media controls, contingency planning and backup, retention and disposal.
+- **The rest of the Security Rule still applies:** access control, audit controls, integrity, authentication, device and media controls, contingency planning and backup, secure disposal. Retention is separate: the six-year rule governs required HIPAA documentation, while medical record retention periods generally come from other federal or state law.
 - **Privacy Rule duties follow the record.** If a transcript becomes part of a designated record set, patient access and amendment rights attach.
 - **Recording consent is a separate question.** State wiretap and recording law and professional ethics rules apply regardless of where processing happens, and are not the same as a HIPAA authorization. HIPAA permits many treatment, payment, and operations uses without individual authorization; authorization is required where the Privacy Rule does not otherwise permit the use or disclosure.
 - **You lose a party to hold accountable.** A business associate under contract carries obligations and liability. Your own endpoint carries none.

--- a/site/public/resources/hipaa-compliant-transcription.md
+++ b/site/public/resources/hipaa-compliant-transcription.md
@@ -4,56 +4,76 @@ Last reviewed: 2026-08-10
 
 Every vendor in this category has a page telling you to look for encryption, SOC 2, and a signed BAA. That list is not wrong, but it skips the question underneath it: whether the vendor should be receiving your patients' audio at all.
 
+Scope: this concerns HIPAA covered entities and their business associates. Not every clinician is a covered entity, since that status also depends on conducting covered electronic transactions. If HIPAA does not apply to you, state law, professional ethics rules, and your own contracts still do.
+
 ## Two things to get straight first
 
-**Nothing is "HIPAA certified."** HHS certifies no product, service, or vendor, and no standard requires a covered entity to obtain certification. A private audit can be useful evidence of diligence, but it carries no government recognition and does not stop OCR finding a violation afterward. A HIPAA badge on a vendor page is marketing, not a legal status.
+**There is no official HIPAA certification.** HHS says no standard requires a covered entity to certify its compliance, that it does not recognize private Security Rule certifications, and that OCR does not endorse or certify particular products. A private certification may still be meaningful evidence of diligence, and some represent substantial audits. What none carries is government recognition, and none prevents an OCR finding afterward. When a vendor leads with a HIPAA badge, ask what program issued it and what it examined.
 
-**Compliance is a property of the arrangement, not the software.** No tool can be compliant on your behalf, because most obligations are about what your organization does: who can access the files, whether the disk is encrypted, whether staff are trained, whether the patient authorized the disclosure. The question is never "is this app HIPAA compliant." It is "who ends up holding this audio, and under what contract."
+**Compliance is a property of the arrangement, not the software.** No tool can be compliant on your behalf, because most obligations are about what your organization does: your risk analysis, who can access the files, how the endpoint is configured, whether staff are trained. The question is never "is this app HIPAA compliant." It is "who ends up holding this audio, under what contract, and have I analyzed the risk of the setup I actually have."
 
-## The rule as written
+## The test the rule applies
 
-Under **45 CFR 160.103**, a business associate is a person who, on behalf of a covered entity,
+Under **45 CFR 160.103**, a business associate is a person who,
 
-> "creates, receives, maintains, or transmits protected health information for a function or activity regulated by this subchapter…"
+> "On behalf of such covered entity… but other than in the capacity of a member of the workforce of such covered entity… creates, receives, maintains, or transmits protected health information for a function or activity regulated by this subchapter…"
 
-Read those four verbs carefully; the entire vendor question is decided by them. A transcription provider that takes in your audio *receives* PHI. One that keeps the transcript on its servers *maintains* it. Either verb makes it a business associate, and the Privacy Rule then requires a written contract with satisfactory assurances *before* you hand over the recording.
+Every element matters, and reducing this to "they received PHI" is the most common way to get it wrong. The party must be acting *on your behalf*, must be outside your workforce, and the activity must be one the rule regulates. Someone can receive PHI and still not be a business associate, most obviously another provider receiving it for treatment. A separate branch of the definition covers enumerated professional services, such as legal or accounting work, where providing the service involves disclosure of PHI.
 
-Note what the definition does not say. It does not turn on encryption strength, data center location, or SOC 2. Those are safeguards a business associate must have; they are not what makes someone a business associate. The trigger is receipt of PHI.
+Applied to this category the answer is usually straightforward: a transcription provider that processes identifiable patient recordings for you is ordinarily a business associate, and **45 CFR 164.502(e)** then requires a written contract with satisfactory assurances *before* you disclose the recording.
 
-And there is **no software exception**. Paragraph (4) excludes exactly four categories: health care providers receiving treatment disclosures, plan sponsors, government agencies determining eligibility, and covered entities within an organized health care arrangement. Software vendors, cloud providers, and transcription platforms appear nowhere. The narrow "conduit" idea covers mere transmission without access to content, which a service that transcribes and stores your audio plainly exceeds.
+Notice what the definition does not turn on: encryption strength, data center location, or SOC 2. Those are safeguards a business associate must implement; they are not what makes someone a business associate.
+
+## The exclusions, and the conduit idea
+
+Paragraph (4) excludes four categories, each with conditions worth reading rather than paraphrasing loosely:
+
+- A health care provider, with respect to disclosures *concerning the treatment of the individual*
+- A plan sponsor, with respect to disclosures by a group health plan, but only to the extent the requirements of § 164.504(f) apply and are met
+- A government agency determining eligibility for or enrollment in a government health plan providing public benefits administered by another agency, to the extent authorized by law
+- A covered entity participating in an organized health care arrangement that performs the specified functions or services for that arrangement by virtue of those activities
+
+Software vendors are not on that list, and vendors sometimes present that as ominous. It is not, and the reason matters: **paragraph (4) is not the only route to not being a business associate**. A vendor that never satisfies the positive definition, because it never creates, receives, maintains, or transmits PHI on your behalf, needs no exception at all. It simply is not one.
+
+The related "conduit" idea is narrower than its reputation. OCR treats it as covering transmission-only services, storage that is temporary and incidental to transmission, and access that is transient or infrequent and necessary to that transmission or required by law. A transcription service that stores audio or transcripts persistently is outside it, and OCR has been explicit that persistent storage defeats conduit status even where the provider holds no decryption key.
 
 ## The three architectures
 
-**Human transcription service** — business associate, BAA required. The agency and its transcriptionists receive and store your audio and the finished transcript. Still the model that produces certified transcripts. Ask who subcontracts, where staff are located, and whether the agency signs BAAs with its own vendors.
+**Human transcription service** — ordinarily a business associate; BAA required before PHI is disclosed. The agency and its transcriptionists receive and store your audio and the finished transcript. Where a use requires a certified transcript this is generally the route to one. Ask who subcontracts, where staff are located, and whether the agency signs BAAs with its own vendors.
 
-**Cloud AI transcription** — business associate, BAA required. The vendor receives your audio, processes it on its servers, and usually stores the transcript. Fast and cheap, but you are adding a party that holds PHI. Check the plan tier: most vendors gate BAAs to enterprise, so the same product is appropriate on one tier and impermissible on another.
+**Cloud AI transcription** — ordinarily a business associate; BAA required before PHI is disclosed. The vendor receives your audio, processes it on its servers, and usually stores the transcript. Check whether your plan is one the vendor will actually sign a BAA for, since several offer that only on higher tiers; the plan decides whether the required contract is even available to you.
 
-**On-device transcription** — not a business associate, no BAA. Nobody outside your organization receives the audio; the model runs on a machine you already control. There is no BAA because there is no disclosure to contract about. The tradeoff is that the device becomes the whole security surface, and there is no vendor to hold accountable if you misconfigure it.
+**On-device transcription** — no vendor in the path, if deployed local-only; no BAA with the software vendor provided it never receives PHI. Whether this holds is a fact about your deployment, not a property of the software. Any cloud summarizer, synced folder, hosted backup, or vendor support access puts PHI back in someone else's hands and needs its own analysis. The tradeoff is that the endpoint becomes the security surface, with no vendor contract to fall back on.
+
+A caution for the first two: a signed BAA is necessary when a vendor is a business associate, but not sufficient. The disclosure still has to be permissible, still has to satisfy minimum necessary where that applies, and your own risk analysis and safeguards remain yours. The contract allocates obligations; it does not discharge yours.
 
 ## What on-device does not do
 
-Running transcription on your own machine removes one question: whether a third party receives PHI, and therefore whether you need a BAA and inherit that vendor's breach exposure. It removes nothing else.
+Keeping processing local can remove one question, whether a software vendor receives PHI and therefore needs a BAA. It removes nothing else, and it creates work of its own.
 
-- You still owe the Security Rule's safeguards: full-disk encryption, screen lock, access control, audit, and a real answer for a stolen laptop
-- You still owe workforce training and sanctions, and breach notification if the device is lost
-- Consent and authorization rules are untouched; recording a patient encounter is subject to the same state law either way
-- Local files are still discoverable, and a subpoena reaches your disk as readily as a vendor's
-- You lose a party to hold accountable; a cloud vendor under a BAA carries contractual obligations, your laptop carries none
+- **You owe a fresh risk analysis.** The Security Rule requires an accurate and thorough assessment of risks to all ePHI you hold, and recording consultations creates a new corpus of audio and transcripts on an endpoint that may never have held a designated record set before.
+- **Encryption is risk-based.** It is an addressable implementation specification, so the question is what your risk analysis concludes and what you document. In practice, full-disk encryption on a portable endpoint holding patient audio is very hard to reason your way out of.
+- **A lost laptop triggers an assessment, not automatic notification.** Breach notification concerns unsecured PHI and requires the regulatory risk assessment; PHI encrypted to the specified standard can fall outside the requirement entirely.
+- **The rest of the Security Rule still applies:** access control, audit controls, integrity, authentication, device and media controls, contingency planning and backup, retention and disposal.
+- **Privacy Rule duties follow the record.** If a transcript becomes part of a designated record set, patient access and amendment rights attach.
+- **Recording consent is a separate question.** State wiretap and recording law and professional ethics rules apply regardless of where processing happens, and are not the same as a HIPAA authorization. HIPAA permits many treatment, payment, and operations uses without individual authorization; authorization is required where the Privacy Rule does not otherwise permit the use or disclosure.
+- **You lose a party to hold accountable.** A business associate under contract carries obligations and liability. Your own endpoint carries none.
 
-On-device processing converts a vendor-disclosure problem into a device-security problem. For many clinicians that is a good trade, because the device-security problem is one they already solved for their EHR workstation. It is still a trade, not an exemption.
+Local processing converts a vendor-disclosure problem into an endpoint problem. That can be a very good trade, particularly where the endpoint is already managed to the standard your other clinical systems require. It is a trade, not an exemption, and an unmanaged personal laptop is a materially worse place for this corpus than a managed workstation.
 
 ## Where Minutes fits, and where it does not
 
-Minutes is the third architecture: records on your device, transcribes locally with whisper.cpp, diarizes with local models, writes markdown to a folder you control. No audio is uploaded, so no vendor receives PHI, so there is no BAA to negotiate with us. We are not a business associate because we are never in the path.
+Minutes is built for the third architecture: records on your device, transcribes locally with whisper.cpp, diarizes with local models, writes markdown into a folder you control. In a local-only deployment we do not receive, maintain, or transmit your PHI, and supplying software to someone who uses it that way does not by itself create a business associate relationship.
 
-The one carve-out, stated exactly: transcript text leaves your machine only if you deliberately configure a provider-backed summarizer, which is off by default. Point it at a cloud model and you have re-created the disclosure this architecture avoids, and that provider's terms govern.
+That conclusion is conditional on your deployment, and it is worth being blunt about what breaks it. Configure a provider-backed summarizer, which is off by default, and transcript text goes to whichever model provider you chose, whose terms then govern. Sync your meetings folder to a hosted drive and that host is now storing PHI. Grant anyone remote access to the machine and the same applies. Each needs its own review and ordinarily a BAA with that party.
 
 Where it is the wrong tool:
 
-- You need a **certified** transcript for a legal or regulatory filing (that is a human service)
+- You need a certified transcript for a filing or proceeding (requirements vary by jurisdiction and use; generally a human service)
 - You want an ambient clinical scribe writing structured notes into your EHR, suggesting codes, or drafting to a SOAP template — Minutes is not a medical scribe and has no EHR integration
-- You need vendor-side audit logs and administrative oversight across a practice; local files give you ownership, not centralized governance
-- Your compliance posture depends on having a business associate to hold accountable — sometimes that contract is the point
+- You need centralized audit logs and administrative oversight across a practice; local files give ownership, not governance
+- Your posture depends on having a business associate to hold accountable — sometimes that contract is precisely the point
+- The endpoint is an unmanaged personal device, in which case you have moved the risk rather than reduced it
 
 ## Sources
 
@@ -61,9 +81,13 @@ Where it is the wrong tool:
 - 45 CFR 164.502(e), business associate contracts: https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-E/section-164.502
 - HHS FAQ on certifying compliance: https://www.hhs.gov/hipaa/for-professionals/faq/2003/are-we-required-to-certify-our-organizations-compliance-with-the-standards/index.html
 - HHS business associate guidance: https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html
-- HHS sample BAA provisions: https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html
+- OCR guidance on HIPAA and cloud computing: https://www.hhs.gov/hipaa/for-professionals/special-topics/health-information-technology/cloud-computing/index.html
+- HHS FAQ on encryption in the Security Rule: https://www.hhs.gov/hipaa/for-professionals/faq/2001/is-the-use-of-encryption-mandatory-in-the-security-rule/index.html
+- HHS risk analysis guidance: https://www.hhs.gov/hipaa/for-professionals/security/guidance/guidance-risk-analysis/index.html
+- HHS breach notification guidance: https://www.hhs.gov/hipaa/for-professionals/breach-notification/guidance/index.html
+- HHS FAQ on consent versus authorization: https://www.hhs.gov/hipaa/for-professionals/faq/264/what-is-the-difference-between-consent-and-authorization/index.html
 
-Informational, not legal advice. HIPAA analysis is fact-specific, vendor terms and plan gating change, and your own counsel or compliance officer is the one who signs off.
+Informational, not legal advice. HIPAA analysis is fact-specific and turns on your actual deployment; covered-entity status, permitted uses, and state recording law all vary. Your own counsel or compliance officer is the one who signs off.
 
 ## Related
 


### PR DESCRIPTION
Fills the largest remaining gap in the HIPAA cluster: the **transcription** framing, which the site had no page for.

| Keyword | Vol/mo | KD | CPC |
|---|---|---|---|
| hipaa compliant transcription services | 200 | 2 | **$11.00** |
| hipaa compliant transcription software | 150 | 1 | $5.00 |
| hipaa compliant transcription | 150 | 2 | $5.00 |
| hipaa compliant ai transcription | 100 | — | **$13.00** |

Roughly 600/mo at KD 1-2 with double-digit CPCs, which is what advertisers pay when nobody competes organically.

Distinct from `/resources/hipaa-compliant-ai-note-taker`, which answers "which vendor, on which plan tier." This answers the prior question of what the rule requires, so the two link rather than compete.

## The angle

The SERP is entirely vendor listicles reciting the same checklist: encryption, SOC 2, signed BAA. The differentiated content is the structural analysis, grounded in the regulation:

- **45 CFR 160.103** decides the vendor question, and its elements are more specific than "they got the audio": the party must act on your behalf, outside your workforce, for a regulated function.
- **Paragraph (4) is not the only route to non-BA status.** A vendor that never satisfies the positive definition needs no exception. Worth saying because vendors reach for the conduit idea to cover services that plainly exceed it.
- **Nothing is HIPAA certified.** HHS recognizes no private certification and OCR endorses no products.

Two sections exist specifically to avoid overselling: "What on-device does not do" leads with the required risk analysis and lists the duties that survive, and "Where Minutes fits, and where it does not" says outright that we are not a medical scribe, have no EHR integration, cannot produce certified transcripts, and are the wrong choice when the endpoint is an unmanaged personal laptop.

## Review

This is regulatory content aimed at compliance officers, so it got two adversarial passes. The first found **nine defects including two critical legal errors**, both of which would have discredited the page:

1. It reduced the business associate test to "the vendor received PHI," dropping the on-behalf-of and workforce elements. That is why another provider can receive PHI for treatment and not be a business associate.
2. It stated "on-device means no business associate" as a property of the software, then contradicted itself two paragraphs later by admitting transcript text can reach a configured summarizer. Now conditional on the deployment, with the ways a local-only setup stops being local-only named explicitly.

Also corrected: encryption is addressable rather than mandatory; a lost laptop triggers a breach risk assessment rather than automatic notification; HIPAA authorization is not routinely required since the Privacy Rule permits many treatment/payment/operations uses, and state recording consent is a separate question; and the page now scopes itself to covered entities rather than addressing all clinicians.

A second pass confirmed those resolved and found four more, fixed in the last commit: SOC 2 and data center location are not HIPAA requirements, the paragraph (4) exclusions needed to track the regulation rather than paraphrase it, one FAQ answer was still unconditional, and listing "retention" implied the Security Rule sets a record retention period when its six-year rule covers HIPAA documentation.

## Also in this PR

`FaqSection` rendered "Common questions" as a `<span>`, leaving that section unnamed in the heading outline on every page that uses it. Now an `h2`.

## Test plan

- [x] `tsc --noEmit` and `npm run build` clean
- [x] All corrected propositions verified present in the **rendered** page, not just source
- [x] No sentence claims Minutes is HIPAA compliant
- [x] 46/46 FAQ pairs visible across resource pages
- [x] 1 h1 / 8 h2 / 3 h3
- [x] In `sitemap.ts`, cross-linked from the vendor-by-vendor HIPAA page

🤖 Generated with [Claude Code](https://claude.com/claude-code)