### PR TITLE
feat(site): add /resources/turn-off-built-in-ai-notetakers

### DIFF
--- a/site/app/resources/hipaa-compliant-transcription/page.tsx
+++ b/site/app/resources/hipaa-compliant-transcription/page.tsx
@@ -425,6 +425,8 @@ export default function HipaaTranscriptionPage() {
             That conclusion is conditional on your deployment, and it is worth being blunt about
             what breaks it. Configure a provider-backed summarizer, which is off by default, and
             transcript text goes to whichever model provider you chose, whose terms then govern.
+            Connect an AI agent over MCP and ask it to read your meetings, and what it reads
+            travels to that agent's provider as context.
             Sync your meetings folder to a hosted drive and that host is now storing PHI. Grant
             anyone remote access to the machine and the same applies. None of those are exotic;
             they are ordinary choices that change the analysis, and each needs its own review

--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -154,8 +154,10 @@ export default function RemoveNotetakerBotsPage() {
             <span className="font-medium text-[var(--text)]">
               Zoom AI Companion and Teams Copilot are not this.
             </span>{" "}
-            They are features of the platform rather than participants, so there is nothing in
-            the list to eject and the controls are account and policy settings instead. See{" "}
+            Inside their own platform they are features rather than participants, so there is
+            nothing in the list to eject and the controls are account and policy settings
+            instead. (Zoom AI Companion brought into a Google Meet or Teams meeting is the
+            exception: there it does join as a participant.) See{" "}
             <a
               href="/resources/turn-off-built-in-ai-notetakers"
               className="text-[var(--accent)] hover:underline"

--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -151,6 +151,20 @@ export default function RemoveNotetakerBotsPage() {
             .
           </p>
           <p>
+            <span className="font-medium text-[var(--text)]">
+              Zoom AI Companion and Teams Copilot are not this.
+            </span>{" "}
+            They are features of the platform rather than participants, so there is nothing in
+            the list to eject and the controls are account and policy settings instead. See{" "}
+            <a
+              href="/resources/turn-off-built-in-ai-notetakers"
+              className="text-[var(--accent)] hover:underline"
+            >
+              turning off built-in AI notetakers
+            </a>
+            .
+          </p>
+          <p>
             <span className="font-medium text-[var(--text)]">Anything else.</span> The pattern
             generalizes: find the calendar connection and sever it, find the auto-join rule and
             turn it off. If a bot has no calendar access, it has no way to find your meetings.

--- a/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
+++ b/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
@@ -285,9 +285,11 @@ export default function StopFirefliesJoiningPage() {
             <span className="font-medium text-[var(--text)]">Minutes</span> is the architectural
             version: it records device-side and transcribes locally with whisper.cpp, writing
             markdown to your own disk, so no bot joins and no audio is uploaded. To be exact
-            about our own limits, transcript text leaves your machine only if you explicitly
-            configure a provider-backed summarizer, which is off by default and documented on
-            our <a href="/security" className="text-[var(--accent)] hover:underline">security page</a>.
+            about our own limits, conversation content leaves your machine when you send it
+            somewhere: a summarizer you configured, or an AI agent you connect and ask to read
+            your meetings, whose provider then receives what it reads. Out of the box neither is
+            happening, and the complete list is on our{" "}
+            <a href="/security" className="text-[var(--accent)] hover:underline">security page</a>.
             If you want the direct comparison, we keep one for{" "}
             <a
               href="/compare/fireflies-vs-minutes"

--- a/site/app/resources/turn-off-built-in-ai-notetakers/page.tsx
+++ b/site/app/resources/turn-off-built-in-ai-notetakers/page.tsx
@@ -1,0 +1,345 @@
+import type { Metadata } from "next";
+import { FaqSection } from "@/components/faq-section";
+import { PublicFooter } from "@/components/public-footer";
+import { SectionLabel } from "@/components/section-label";
+import { faqPageSchema } from "@/lib/schema";
+
+export const metadata: Metadata = {
+  title: "How to turn off built-in AI notetakers in Zoom and Teams",
+  description:
+    "Zoom AI Companion and Teams Copilot are platform features, not bots you can remove from the participant list. The exact admin paths, the Teams setting that is only a default rather than an enforcement, and why your Zoom toggle is grayed out.",
+  alternates: {
+    canonical: "/resources/turn-off-built-in-ai-notetakers",
+  },
+};
+
+const faqs = [
+  {
+    question: "How do I disable the AI notetaker in Zoom?",
+    answer:
+      "Sign in to the Zoom web portal and open Admin Center then Settings for the whole account, Admin Center then Users then Groups for one group, or your personal Settings for just yourself. Open Zoom AI and toggle the meeting summary features off. Admins can also click the lock icon to stop users changing it.",
+  },
+  {
+    question: "Why is the Zoom AI Companion setting grayed out?",
+    answer:
+      "Because it has been locked above you. Zoom's documentation says that if a feature is grayed out it has been locked at the account or group level and must be changed by an admin. This catches account owners too, since a setting locked at group level still shows as unavailable in a personal settings page.",
+  },
+  {
+    question: "How do I turn off Copilot in Microsoft Teams meetings?",
+    answer:
+      "In the Teams admin center go to Meetings, then Meeting policies, then the Recording & transcription section, and set Copilot. The dropdown offers On, On with saved transcript required, On with transcript saved by default, and Off. Assign the policy to the users or groups it should cover.",
+  },
+  {
+    question: "Does setting Teams Copilot to Off actually stop it?",
+    answer:
+      "Not necessarily. Microsoft states that the only Copilot policy setting you can enforce is \"On with saved transcript required\"; the others create a default that your organizers can change. So an admin who selects Off has expressed a default, not a guarantee, and an organizer can still turn Copilot on for their own meeting.",
+  },
+  {
+    question: "Can I remove a built-in AI notetaker from a meeting like a bot?",
+    answer:
+      "No, and this is the main difference from tools like Otter or Fireflies. Those join as participants, so you can remove them from the participant list. Zoom AI Companion and Teams Copilot are features of the platform itself, running inside the service that hosts your call. There is nothing in the participant list to eject, so the only controls are the account, policy, and per-meeting settings.",
+  },
+] as const;
+
+const sources = [
+  {
+    label: "Zoom support: enabling or disabling Zoom AI meeting summary (account, group, and user level)",
+    href: "https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0057623",
+  },
+  {
+    label: "Microsoft Learn: manage Microsoft 365 Copilot in Teams meetings and events",
+    href: "https://learn.microsoft.com/en-us/microsoftteams/copilot-teams-transcription",
+  },
+  {
+    label: "Microsoft Learn: admins, manage transcription and captions for Teams meetings",
+    href: "https://learn.microsoft.com/en-us/microsoftteams/meeting-transcription-captions",
+  },
+  {
+    label: "Microsoft Learn: recording and transcription options for sensitive meetings",
+    href: "https://learn.microsoft.com/en-us/microsoftteams/manage-meeting-recording-options",
+  },
+  { label: "Minutes security & privacy architecture", href: "/security" },
+] as const;
+
+export default function BuiltInAiNotetakersPage() {
+  return (
+    <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+      />
+      <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
+        <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
+          minutes
+        </a>
+        <div className="flex gap-5 text-sm text-[var(--text-secondary)]">
+          <a
+            href="/resources/turn-off-built-in-ai-notetakers.md"
+            className="hover:text-[var(--accent)]"
+          >
+            page.md
+          </a>
+          <a href="/security" className="hover:text-[var(--accent)]">
+            security
+          </a>
+          <a href="/compare" className="hover:text-[var(--accent)]">
+            compare
+          </a>
+        </div>
+      </div>
+
+      <section className="max-w-[800px]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          Resource
+        </p>
+        <h1 className="mt-4 font-serif text-[40px] leading-[0.98] tracking-[-0.045em] text-[var(--text)] sm:text-[58px]">
+          How to turn off built-in AI notetakers in Zoom and Teams
+        </h1>
+        <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
+          Zoom AI Companion and Teams Copilot are a different problem from Otter or Fireflies.
+          Those arrive as participants you can eject. These are features of the platform
+          hosting your call, so there is nothing in the participant list to remove, and the
+          controls live in settings you may not own. Here are the exact paths, and the two
+          places where turning it off does not do what it looks like.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            Last reviewed: 2026-08-10
+          </span>
+          <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
+            How-to guide
+          </span>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Why This One Is Different" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            A third-party notetaker has to get into your meeting the way a person does, by
+            dialing in as a participant. That is what makes it removable: it shows up in the
+            list, and you can eject it. Built-in AI is not in the list because it never joined.
+            It runs inside the service that is already carrying your audio.
+          </p>
+          <p>
+            The practical consequence is that every control here is a setting rather than an
+            action, and the setting is often owned by someone else. If you are not an admin, the
+            most reliable move in the room is still the social one: ask the organizer to turn it
+            off, and confirm they did.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Zoom AI Companion" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>Sign in to the Zoom web portal, then take the path that matches your scope:</p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <span className="font-medium text-[var(--text)]">Whole account:</span>{" "}
+              Admin Center → Settings
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">One group:</span> Admin Center →
+              Users → Groups, then select the group
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">Just you:</span> Settings
+            </li>
+          </ul>
+          <p>
+            In any of those, open{" "}
+            <span className="font-medium text-[var(--text)]">Zoom AI</span> and toggle the
+            meeting summary features off. Admins changing an account or group can also click the
+            lock icon, which prevents users below them from turning it back on.
+          </p>
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              If the toggle is grayed out
+            </p>
+            <p className="mt-3">
+              It has been locked above you. Zoom&rsquo;s documentation is explicit: if a feature
+              is grayed out, it has been locked at the account or group level and must be
+              changed by an admin. This is worth knowing because it catches account owners too,
+              who reasonably expect their own settings page to be authoritative. A setting locked
+              at the group level still reads as unavailable in your personal settings, so the
+              fix is to change it at the level where the lock was applied rather than the level
+              where you noticed it.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="Microsoft Teams Copilot" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            In the Teams admin center, go to{" "}
+            <span className="font-medium text-[var(--text)]">
+              Meetings → Meeting policies
+            </span>
+            , open the{" "}
+            <span className="font-medium text-[var(--text)]">Recording &amp; transcription</span>{" "}
+            section, and set{" "}
+            <span className="font-medium text-[var(--text)]">Copilot</span>. The dropdown offers
+            four options:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>On</li>
+            <li>On with saved transcript required</li>
+            <li>On with transcript saved by default</li>
+            <li>Off</li>
+          </ul>
+          <p>Assign the policy to the users or groups it should apply to.</p>
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              &ldquo;Off&rdquo; is a default, not an enforcement
+            </p>
+            <p className="mt-3">
+              This is the detail that catches people, and it comes from Microsoft&rsquo;s own
+              documentation:{" "}
+              <span className="font-medium text-[var(--text)]">
+                the only Copilot policy setting you can enforce is &ldquo;On with saved
+                transcript required.&rdquo;
+              </span>{" "}
+              The others create a default that your organizers can change.
+            </p>
+            <p className="mt-3">
+              So an admin who selects Off has expressed a preference, not a guarantee. An
+              organizer can still switch Copilot on for their own meeting. If your compliance
+              posture assumes the tenant setting is binding, that assumption is worth testing
+              before you rely on it, and enforcement of the outcome you actually want may need
+              to come from policy and training rather than the dropdown.
+            </p>
+          </div>
+          <p>
+            Because Copilot builds on the transcript, transcription policy is the other lever
+            worth reviewing at the same time. Check what your meeting policies set for
+            transcription rather than assuming it matches the Copilot setting.
+          </p>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="What If You Are Not The Admin" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Most people asking this question do not run the tenant. Honest options, in order of
+            how well they work:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <span className="font-medium text-[var(--text)]">Ask the organizer.</span> They
+              hold the per-meeting controls in both platforms. &ldquo;Could we run this one
+              without the AI summary?&rdquo; is a normal request now.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">Say it before the substance.</span>{" "}
+              If a call turns sensitive, raising it at that moment is late but still better than
+              not raising it; summaries are generated from the whole meeting.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">Escalate to whoever owns the tenant.</span>{" "}
+              For a recurring concern, the durable fix is a policy change, not a per-meeting
+              request repeated forever.
+            </li>
+            <li>
+              <span className="font-medium text-[var(--text)]">Move the conversation.</span> For
+              genuinely confidential discussion, a platform whose vendor is not summarizing by
+              default is a cleaner answer than fighting settings you do not control.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="mt-14 max-w-[800px]">
+        <SectionLabel label="The Version Of This Problem That Solves Itself" />
+        <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
+          <p>
+            Notice what all of the above has in common: the notes are being produced by the
+            company hosting your call, using settings owned by someone in your organization, and
+            your ability to say no depends on where you sit in an admin hierarchy. That is a
+            governance arrangement, not a product feature you can toggle away.
+          </p>
+          <p>
+            The alternative is to let the platform do the call and keep the record yourself.{" "}
+            <span className="font-medium text-[var(--text)]">Minutes</span> records device-side,
+            transcribes locally with whisper.cpp, and writes markdown to your own disk, so the
+            notes exist because you made them rather than because a tenant policy allowed it. It
+            does not disable anything the platform is doing, and it should not be read as a way
+            around your organization&rsquo;s rules. It changes who holds the copy you rely on.
+          </p>
+          <p>
+            To be exact about our own limits: transcript text leaves your machine only if you
+            deliberately configure a provider-backed summarizer, which is off by default and
+            documented on our{" "}
+            <a href="/security" className="text-[var(--accent)] hover:underline">
+              security page
+            </a>
+            . And for third-party bots, which are a different problem with different fixes, see{" "}
+            <a
+              href="/resources/remove-ai-notetaker-bots-from-meetings"
+              className="text-[var(--accent)] hover:underline"
+            >
+              removing AI notetaker bots
+            </a>
+            .
+          </p>
+          <p>
+            One thing device-side capture does not change: tell people you are recording, and
+            follow your own organization&rsquo;s policy on it. The legal detail is in{" "}
+            <a
+              href="/resources/is-it-legal-to-record-a-meeting"
+              className="text-[var(--accent)] hover:underline"
+            >
+              recording consent law by state
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+
+      <FaqSection items={faqs} />
+
+      <section className="mt-14 rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-6 shadow-[var(--shadow-panel)]">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+          Next step
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/security"
+            className="inline-flex items-center rounded-[5px] bg-[var(--accent)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-black hover:bg-[var(--accent-hover)]"
+          >
+            How botless capture works
+          </a>
+          <a
+            href="/resources/remove-ai-notetaker-bots-from-meetings"
+            className="inline-flex items-center rounded-[5px] border border-[color:var(--border-mid)] px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--text)] hover:bg-[var(--bg-hover)]"
+          >
+            Third-party bots
+          </a>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <SectionLabel label="Sources" />
+        <ul className="space-y-2 text-[14px] leading-7 text-[var(--text-secondary)]">
+          {sources.map((source) => (
+            <li key={source.href}>
+              <a href={source.href} className="text-[var(--accent)] hover:underline">
+                {source.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-6 text-[13px] leading-7 text-[var(--text-secondary)]">
+          Admin interfaces in both products change often. Verify the current path in your own
+          tenant before relying on any of this, and confirm the effect on a test meeting rather
+          than assuming a saved setting took effect.
+        </p>
+      </section>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/site/app/resources/turn-off-built-in-ai-notetakers/page.tsx
+++ b/site/app/resources/turn-off-built-in-ai-notetakers/page.tsx
@@ -7,7 +7,7 @@ import { faqPageSchema } from "@/lib/schema";
 export const metadata: Metadata = {
   title: "How to turn off built-in AI notetakers in Zoom and Teams",
   description:
-    "Zoom AI Companion and Teams Copilot are platform features, not bots you can remove from the participant list. The exact admin paths, the Teams setting that is only a default rather than an enforcement, and why your Zoom toggle is grayed out.",
+    "Inside their own platform there is no bot to eject, so the controls are settings. The exact Zoom and Teams admin paths, the in-meeting stop most guides omit, the Teams setting that is only a default rather than an enforcement, and why your Zoom toggle is grayed out.",
   alternates: {
     canonical: "/resources/turn-off-built-in-ai-notetakers",
   },
@@ -37,7 +37,7 @@ const faqs = [
   {
     question: "Can I remove a built-in AI notetaker from a meeting like a bot?",
     answer:
-      "No, and this is the main difference from tools like Otter or Fireflies. Those join as participants, so you can remove them from the participant list. Zoom AI Companion and Teams Copilot are features of the platform itself, running inside the service that hosts your call. There is nothing in the participant list to eject, so the only controls are the account, policy, and per-meeting settings.",
+      "Generally no, when the AI belongs to the platform hosting the meeting. Zoom AI Companion in a Zoom meeting and Teams Copilot in a Teams meeting run inside the service itself, so there is no participant to eject and the controls are account, policy, and per-meeting settings. A Zoom host can still stop Meeting Summary during the call. One exception: Zoom supports bringing AI Companion into Google Meet and Microsoft Teams meetings, and there it does join as a participant and can be removed like one.",
   },
 ] as const;
 
@@ -45,6 +45,18 @@ const sources = [
   {
     label: "Zoom support: enabling or disabling Zoom AI meeting summary (account, group, and user level)",
     href: "https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0057623",
+  },
+  {
+    label: "Zoom support: stopping Zoom AI Companion during a meeting",
+    href: "https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0058013",
+  },
+  {
+    label: "Zoom support: enabling Meeting Summary at account, group, and user level",
+    href: "https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0057960",
+  },
+  {
+    label: "Zoom support: using AI Companion in Google Meet and Microsoft Teams meetings",
+    href: "https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0080354",
   },
   {
     label: "Microsoft Learn: manage Microsoft 365 Copilot in Teams meetings and events",
@@ -96,11 +108,12 @@ export default function BuiltInAiNotetakersPage() {
           How to turn off built-in AI notetakers in Zoom and Teams
         </h1>
         <p className="mt-5 text-[17px] leading-8 text-[var(--text-secondary)]">
-          Zoom AI Companion and Teams Copilot are a different problem from Otter or Fireflies.
-          Those arrive as participants you can eject. These are features of the platform
-          hosting your call, so there is nothing in the participant list to remove, and the
-          controls live in settings you may not own. Here are the exact paths, and the two
-          places where turning it off does not do what it looks like.
+          Zoom AI Companion and Teams Copilot are a different problem from Otter or Fireflies
+          when they run inside their own platform. There is no bot in the participant list to
+          eject, because the feature lives in the service already hosting your call, and the
+          controls sit in settings you may not own. Here are the exact paths, the live control
+          most guides omit, and the two places where turning it off does not do what it looks
+          like.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
@@ -122,10 +135,18 @@ export default function BuiltInAiNotetakersPage() {
             It runs inside the service that is already carrying your audio.
           </p>
           <p>
-            The practical consequence is that every control here is a setting rather than an
-            action, and the setting is often owned by someone else. If you are not an admin, the
-            most reliable move in the room is still the social one: ask the organizer to turn it
-            off, and confirm they did.
+            The practical consequence is that most controls here are settings rather than
+            actions, and the setting is often owned by someone else. There is one real live
+            action, covered below: a Zoom host can stop Meeting Summary during the call. If you
+            are not the host or an admin, the most reliable move in the room is the social one:
+            ask the organizer to stop it, and confirm they did.
+          </p>
+          <p>
+            One qualification, because it cuts against the framing above. Zoom now supports
+            bringing AI Companion into meetings hosted on Google Meet and Microsoft Teams, and in
+            that configuration it does join as a participant and can be removed like one. The
+            &ldquo;nothing to eject&rdquo; rule holds for a platform&rsquo;s own AI inside its
+            own meetings; it does not hold for Zoom&rsquo;s AI visiting someone else&rsquo;s.
           </p>
         </div>
       </section>
@@ -141,7 +162,8 @@ export default function BuiltInAiNotetakersPage() {
             </li>
             <li>
               <span className="font-medium text-[var(--text)]">One group:</span> Admin Center →
-              Users → Groups, then select the group
+              Users → Groups → select the group → General configuration → Edit product
+              settings
             </li>
             <li>
               <span className="font-medium text-[var(--text)]">Just you:</span> Settings
@@ -165,6 +187,23 @@ export default function BuiltInAiNotetakersPage() {
               at the group level still reads as unavailable in your personal settings, so the
               fix is to change it at the level where the lock was applied rather than the level
               where you noticed it.
+            </p>
+          </div>
+          <div className="rounded-[8px] border border-[color:var(--border)] bg-[var(--bg-elevated)] p-5">
+            <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--accent)]">
+              Stopping it during the meeting
+            </p>
+            <p className="mt-3">
+              This is the control most guides skip, and it is the only one that works in the
+              moment. A Zoom host can open Zoom AI during the call and stop Meeting Summary, or
+              stop all Zoom AI use, and has the option to delete the associated meeting assets.
+            </p>
+            <p className="mt-3">
+              It matters more than it sounds, because of how the summary is scoped: Zoom
+              documents that Meeting Summary covers the meeting from the point it was enabled.
+              Stopping it partway therefore limits the summary to what came before, rather than
+              leaving a full-meeting summary behind. If a call turns sensitive halfway through,
+              speaking up is not futile.
             </p>
           </div>
         </div>
@@ -234,9 +273,10 @@ export default function BuiltInAiNotetakersPage() {
               without the AI summary?&rdquo; is a normal request now.
             </li>
             <li>
-              <span className="font-medium text-[var(--text)]">Say it before the substance.</span>{" "}
-              If a call turns sensitive, raising it at that moment is late but still better than
-              not raising it; summaries are generated from the whole meeting.
+              <span className="font-medium text-[var(--text)]">Speak up even mid-call.</span>{" "}
+              Worth knowing: Zoom says Meeting Summary covers the meeting from the point it was
+              enabled, so stopping it partway genuinely limits the summary to what came before.
+              Raising it late is not futile.
             </li>
             <li>
               <span className="font-medium text-[var(--text)]">Escalate to whoever owns the tenant.</span>{" "}
@@ -245,38 +285,51 @@ export default function BuiltInAiNotetakersPage() {
             </li>
             <li>
               <span className="font-medium text-[var(--text)]">Move the conversation.</span> For
-              genuinely confidential discussion, a platform whose vendor is not summarizing by
-              default is a cleaner answer than fighting settings you do not control.
+              genuinely confidential discussion, holding it somewhere you have confirmed the AI
+              features are off is cleaner than fighting settings you do not control. Confirm
+              rather than assume, since what is enabled depends on how your tenant is
+              configured.
             </li>
           </ul>
         </div>
       </section>
 
       <section className="mt-14 max-w-[800px]">
-        <SectionLabel label="The Version Of This Problem That Solves Itself" />
+        <SectionLabel label="A Note On What This Page Is Not" />
         <div className="space-y-4 text-[15px] leading-8 text-[var(--text-secondary)]">
           <p>
-            Notice what all of the above has in common: the notes are being produced by the
-            company hosting your call, using settings owned by someone in your organization, and
-            your ability to say no depends on where you sit in an admin hierarchy. That is a
-            governance arrangement, not a product feature you can toggle away.
+            We make a local notetaker, so it is worth being direct about where it does and does
+            not belong in this conversation.
           </p>
           <p>
-            The alternative is to let the platform do the call and keep the record yourself.{" "}
-            <span className="font-medium text-[var(--text)]">Minutes</span> records device-side,
-            transcribes locally with whisper.cpp, and writes markdown to your own disk, so the
-            notes exist because you made them rather than because a tenant policy allowed it. It
-            does not disable anything the platform is doing, and it should not be read as a way
-            around your organization&rsquo;s rules. It changes who holds the copy you rely on.
+            Everything above is governed by your organization. When an admin disables Copilot or
+            locks Zoom AI, that is a decision your employer is entitled to make, frequently for
+            legal or records-retention reasons you may not be able to see from your seat.{" "}
+            <span className="font-medium text-[var(--text)]">
+              Running your own capture tool is not the workaround for that
+            </span>
+            , and we are not suggesting it. If your organization has decided meetings are not
+            recorded, a local recording is still a recording, and it is still your
+            employer&rsquo;s policy that governs it.
           </p>
           <p>
-            To be exact about our own limits: transcript text leaves your machine only if you
-            deliberately configure a provider-backed summarizer, which is off by default and
-            documented on our{" "}
+            Where <span className="font-medium text-[var(--text)]">Minutes</span> is a
+            reasonable answer is the case where notes are wanted and permitted, and the open
+            question is only where they live. It records device-side, transcribes locally with
+            whisper.cpp, and writes markdown to a folder you control, which some organizations
+            prefer for confidential work precisely because it keeps the record inside the
+            perimeter they already govern. That is an architecture to propose to whoever owns
+            the policy, not a way around them.
+          </p>
+          <p>
+            To be exact about our own limits: conversation content leaves your machine when you
+            send it somewhere, which means a summarizer you configured, or an AI agent you
+            connect and ask to read your meetings, whose provider then receives what it reads.
+            Out of the box neither is happening. The complete list is on our{" "}
             <a href="/security" className="text-[var(--accent)] hover:underline">
               security page
             </a>
-            . And for third-party bots, which are a different problem with different fixes, see{" "}
+            . For third-party bots, which are a different problem with different fixes, see{" "}
             <a
               href="/resources/remove-ai-notetaker-bots-from-meetings"
               className="text-[var(--accent)] hover:underline"
@@ -286,8 +339,8 @@ export default function BuiltInAiNotetakersPage() {
             .
           </p>
           <p>
-            One thing device-side capture does not change: tell people you are recording, and
-            follow your own organization&rsquo;s policy on it. The legal detail is in{" "}
+            And the constant: tell people you are recording, and follow your
+            organization&rsquo;s policy on it. The legal detail is in{" "}
             <a
               href="/resources/is-it-legal-to-record-a-meeting"
               className="text-[var(--accent)] hover:underline"

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -40,6 +40,7 @@ const routes = [
   "/resources/remove-ai-notetaker-bots-from-meetings",
   "/resources/remove-otter-ai-from-zoom",
   "/resources/stop-fireflies-from-joining-meetings",
+  "/resources/turn-off-built-in-ai-notetakers",
   "/security",
   "/writing",
   "/writing/governance-built-in-not-retrofitted",

--- a/site/public/resources/hipaa-compliant-transcription.md
+++ b/site/public/resources/hipaa-compliant-transcription.md
@@ -65,7 +65,7 @@ Local processing converts a vendor-disclosure problem into an endpoint problem. 
 
 Minutes is built for the third architecture: records on your device, transcribes locally with whisper.cpp, diarizes with local models, writes markdown into a folder you control. In a local-only deployment we do not receive, maintain, or transmit your PHI, and supplying software to someone who uses it that way does not by itself create a business associate relationship.
 
-That conclusion is conditional on your deployment, and it is worth being blunt about what breaks it. Configure a provider-backed summarizer, which is off by default, and transcript text goes to whichever model provider you chose, whose terms then govern. Sync your meetings folder to a hosted drive and that host is now storing PHI. Grant anyone remote access to the machine and the same applies. Each needs its own review and ordinarily a BAA with that party.
+That conclusion is conditional on your deployment, and it is worth being blunt about what breaks it. Configure a provider-backed summarizer, which is off by default, and transcript text goes to whichever model provider you chose, whose terms then govern. Connect an AI agent over MCP and ask it to read your meetings, and what it reads travels to that agent's provider as context. Sync your meetings folder to a hosted drive and that host is now storing PHI. Grant anyone remote access to the machine and the same applies. Each needs its own review and ordinarily a BAA with that party.
 
 Where it is the wrong tool:
 

--- a/site/public/resources/stop-fireflies-from-joining-meetings.md
+++ b/site/public/resources/stop-fireflies-from-joining-meetings.md
@@ -50,7 +50,7 @@ Everything above manages a symptom. The bot exists because cloud notetakers need
 
 In fairness, Fireflies now offers bot-free capture of its own via a Google Meet SDK integration and a desktop app. Read it precisely: those remove the visible bot from the call, not the upload. Fireflies' own SDK documentation describes meeting audio and video being shared with Fireflies and processed into its notebook. No bot in the participant list is a courtesy improvement, not an architectural one.
 
-Minutes is the architectural version: device-side recording, local transcription (whisper.cpp), markdown on your own disk, so no bot joins and no audio is uploaded. To be exact about our own limits, transcript text leaves your machine only if you explicitly configure a provider-backed summarizer, which is off by default and documented on our security page.
+Minutes is the architectural version: device-side recording, local transcription (whisper.cpp), markdown on your own disk, so no bot joins and no audio is uploaded. To be exact about our own limits, conversation content leaves your machine when you send it somewhere: a summarizer you configured, or an AI agent you connect and ask to read your meetings, whose provider then receives what it reads. Out of the box neither is happening.
 
 One thing device-side capture does not change: tell people you are recording. The bot's single virtue was announcing itself; without it, consent is your job, which is where it belonged anyway.
 

--- a/site/public/resources/turn-off-built-in-ai-notetakers.md
+++ b/site/public/resources/turn-off-built-in-ai-notetakers.md
@@ -2,25 +2,29 @@
 
 Last reviewed: 2026-08-10
 
-Zoom AI Companion and Teams Copilot are a different problem from Otter or Fireflies. Those arrive as participants you can eject. These are features of the platform hosting your call, so there is nothing in the participant list to remove, and the controls live in settings you may not own.
+Zoom AI Companion and Teams Copilot are a different problem from Otter or Fireflies when they run inside their own platform. There is no bot in the participant list to eject, because the feature lives in the service already hosting your call, and the controls sit in settings you may not own.
 
 ## Why this one is different
 
 A third-party notetaker has to get into your meeting the way a person does, by dialing in as a participant. That is what makes it removable. Built-in AI is not in the list because it never joined; it runs inside the service already carrying your audio.
 
-Every control here is therefore a setting rather than an action, and the setting is often owned by someone else. If you are not an admin, the most reliable move in the room is the social one: ask the organizer to turn it off, and confirm they did.
+Most controls here are therefore settings rather than actions, and the setting is often owned by someone else. There is one real live action, below: a Zoom host can stop Meeting Summary during the call.
+
+One qualification that cuts against the framing above: Zoom now supports bringing AI Companion into meetings hosted on Google Meet and Microsoft Teams, and in that configuration it does join as a participant and can be removed like one. The "nothing to eject" rule holds for a platform's own AI inside its own meetings, not for Zoom's AI visiting someone else's.
 
 ## Zoom AI Companion
 
 Sign in to the Zoom web portal, then take the path matching your scope:
 
 - **Whole account:** Admin Center → Settings
-- **One group:** Admin Center → Users → Groups, then select the group
+- **One group:** Admin Center → Users → Groups → select the group → General configuration → Edit product settings
 - **Just you:** Settings
 
 In any of those, open **Zoom AI** and toggle the meeting summary features off. Admins changing an account or group can also click the lock icon, which prevents users below them turning it back on.
 
 **If the toggle is grayed out**, it has been locked above you. Zoom's documentation is explicit: if a feature is grayed out, it has been locked at the account or group level and must be changed by an admin. This catches account owners too, who reasonably expect their own settings page to be authoritative. A setting locked at group level still reads as unavailable in your personal settings, so change it at the level where the lock was applied, not the level where you noticed it.
+
+**Stopping it during the meeting.** This is the control most guides skip, and the only one that works in the moment. A Zoom host can open Zoom AI during the call and stop Meeting Summary, or stop all Zoom AI use, with the option to delete the associated meeting assets. It matters because of how the summary is scoped: Zoom documents that Meeting Summary covers the meeting from the point it was enabled, so stopping it partway limits the summary to what came before.
 
 ## Microsoft Teams Copilot
 
@@ -42,23 +46,27 @@ Because Copilot builds on the transcript, review transcription policy at the sam
 ## What if you are not the admin
 
 - **Ask the organizer.** They hold the per-meeting controls in both platforms.
-- **Say it before the substance.** Summaries are generated from the whole meeting, so raising it late is worse than raising it early.
+- **Speak up even mid-call.** Zoom says Meeting Summary covers the meeting from the point it was enabled, so stopping it partway genuinely limits the summary to what came before. Raising it late is not futile.
 - **Escalate to whoever owns the tenant.** For a recurring concern, the durable fix is a policy change, not a per-meeting request repeated forever.
-- **Move the conversation.** For genuinely confidential discussion, a platform whose vendor is not summarizing by default is cleaner than fighting settings you do not control.
+- **Move the conversation.** For genuinely confidential discussion, holding it somewhere you have confirmed the AI features are off is cleaner than fighting settings you do not control. Confirm rather than assume; what is enabled depends on how your tenant is configured.
 
-## The version of this problem that solves itself
+## A note on what this page is not
 
-Notice what the above has in common: the notes are produced by the company hosting your call, using settings owned by someone in your organization, and your ability to say no depends on where you sit in an admin hierarchy. That is a governance arrangement, not a product feature you can toggle away.
+We make a local notetaker, so it is worth being direct about where it does and does not belong here.
 
-The alternative is to let the platform run the call and keep the record yourself. Minutes records device-side, transcribes locally with whisper.cpp, and writes markdown to your own disk, so the notes exist because you made them rather than because a tenant policy allowed it. It does not disable anything the platform is doing, and it is not a way around your organization's rules. It changes who holds the copy you rely on.
+Everything above is governed by your organization. When an admin disables Copilot or locks Zoom AI, that is a decision your employer is entitled to make, often for legal or records-retention reasons you cannot see from your seat. **Running your own capture tool is not the workaround for that**, and we are not suggesting it. If your organization has decided meetings are not recorded, a local recording is still a recording, and your employer's policy still governs it.
 
-To be exact about our own limits: transcript text leaves your machine only if you deliberately configure a provider-backed summarizer, which is off by default.
+Where Minutes is a reasonable answer is the case where notes are wanted and permitted, and the only open question is where they live. It records device-side, transcribes locally with whisper.cpp, and writes markdown to a folder you control, which some organizations prefer for confidential work precisely because the record stays inside a perimeter they already govern. That is an architecture to propose to whoever owns the policy, not a way around them.
 
-One thing device-side capture does not change: tell people you are recording, and follow your organization's policy on it.
+To be exact about our own limits: conversation content leaves your machine when you send it somewhere, meaning a summarizer you configured, or an AI agent you connect and ask to read your meetings, whose provider then receives what it reads. Out of the box neither is happening.
+
+And the constant: tell people you are recording, and follow your organization's policy on it.
 
 ## Sources
 
 - Zoom: enabling/disabling Zoom AI meeting summary: https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0057623
+- Zoom: stopping AI Companion during a meeting: https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0058013
+- Zoom: AI Companion in Google Meet and Microsoft Teams meetings: https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0080354
 - Microsoft Learn, Copilot in Teams meetings and events: https://learn.microsoft.com/en-us/microsoftteams/copilot-teams-transcription
 - Microsoft Learn, transcription and captions for Teams meetings: https://learn.microsoft.com/en-us/microsoftteams/meeting-transcription-captions
 - Microsoft Learn, recording and transcription for sensitive meetings: https://learn.microsoft.com/en-us/microsoftteams/manage-meeting-recording-options

--- a/site/public/resources/turn-off-built-in-ai-notetakers.md
+++ b/site/public/resources/turn-off-built-in-ai-notetakers.md
@@ -1,0 +1,72 @@
+# How to turn off built-in AI notetakers in Zoom and Teams
+
+Last reviewed: 2026-08-10
+
+Zoom AI Companion and Teams Copilot are a different problem from Otter or Fireflies. Those arrive as participants you can eject. These are features of the platform hosting your call, so there is nothing in the participant list to remove, and the controls live in settings you may not own.
+
+## Why this one is different
+
+A third-party notetaker has to get into your meeting the way a person does, by dialing in as a participant. That is what makes it removable. Built-in AI is not in the list because it never joined; it runs inside the service already carrying your audio.
+
+Every control here is therefore a setting rather than an action, and the setting is often owned by someone else. If you are not an admin, the most reliable move in the room is the social one: ask the organizer to turn it off, and confirm they did.
+
+## Zoom AI Companion
+
+Sign in to the Zoom web portal, then take the path matching your scope:
+
+- **Whole account:** Admin Center → Settings
+- **One group:** Admin Center → Users → Groups, then select the group
+- **Just you:** Settings
+
+In any of those, open **Zoom AI** and toggle the meeting summary features off. Admins changing an account or group can also click the lock icon, which prevents users below them turning it back on.
+
+**If the toggle is grayed out**, it has been locked above you. Zoom's documentation is explicit: if a feature is grayed out, it has been locked at the account or group level and must be changed by an admin. This catches account owners too, who reasonably expect their own settings page to be authoritative. A setting locked at group level still reads as unavailable in your personal settings, so change it at the level where the lock was applied, not the level where you noticed it.
+
+## Microsoft Teams Copilot
+
+In the Teams admin center: **Meetings → Meeting policies → Recording & transcription → Copilot**. The dropdown offers four options:
+
+- On
+- On with saved transcript required
+- On with transcript saved by default
+- Off
+
+Assign the policy to the users or groups it should apply to.
+
+**"Off" is a default, not an enforcement.** From Microsoft's own documentation: the only Copilot policy setting you can enforce is "On with saved transcript required." The others create a default that your organizers can change.
+
+So an admin who selects Off has expressed a preference, not a guarantee, and an organizer can still switch Copilot on for their own meeting. If your compliance posture assumes the tenant setting is binding, test that assumption before relying on it; enforcement of the outcome you want may need to come from policy and training rather than the dropdown.
+
+Because Copilot builds on the transcript, review transcription policy at the same time rather than assuming it matches the Copilot setting.
+
+## What if you are not the admin
+
+- **Ask the organizer.** They hold the per-meeting controls in both platforms.
+- **Say it before the substance.** Summaries are generated from the whole meeting, so raising it late is worse than raising it early.
+- **Escalate to whoever owns the tenant.** For a recurring concern, the durable fix is a policy change, not a per-meeting request repeated forever.
+- **Move the conversation.** For genuinely confidential discussion, a platform whose vendor is not summarizing by default is cleaner than fighting settings you do not control.
+
+## The version of this problem that solves itself
+
+Notice what the above has in common: the notes are produced by the company hosting your call, using settings owned by someone in your organization, and your ability to say no depends on where you sit in an admin hierarchy. That is a governance arrangement, not a product feature you can toggle away.
+
+The alternative is to let the platform run the call and keep the record yourself. Minutes records device-side, transcribes locally with whisper.cpp, and writes markdown to your own disk, so the notes exist because you made them rather than because a tenant policy allowed it. It does not disable anything the platform is doing, and it is not a way around your organization's rules. It changes who holds the copy you rely on.
+
+To be exact about our own limits: transcript text leaves your machine only if you deliberately configure a provider-backed summarizer, which is off by default.
+
+One thing device-side capture does not change: tell people you are recording, and follow your organization's policy on it.
+
+## Sources
+
+- Zoom: enabling/disabling Zoom AI meeting summary: https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0057623
+- Microsoft Learn, Copilot in Teams meetings and events: https://learn.microsoft.com/en-us/microsoftteams/copilot-teams-transcription
+- Microsoft Learn, transcription and captions for Teams meetings: https://learn.microsoft.com/en-us/microsoftteams/meeting-transcription-captions
+- Microsoft Learn, recording and transcription for sensitive meetings: https://learn.microsoft.com/en-us/microsoftteams/manage-meeting-recording-options
+
+Admin interfaces in both products change often. Verify the current path in your own tenant, and confirm the effect on a test meeting rather than assuming a saved setting took effect.
+
+## Related
+
+- Third-party notetaker bots (Otter, Fireflies): https://useminutes.app/resources/remove-ai-notetaker-bots-from-meetings
+- Recording consent law by state: https://useminutes.app/resources/is-it-legal-to-record-a-meeting
+- How botless capture works: https://useminutes.app/security


### PR DESCRIPTION
Closes the anti-bot cluster with one page instead of three.

## Why one page, not three

The plan listed separate pages for Zoom AI Companion, Teams Copilot, and Read.ai. Measured volume for each is ~30-40/mo and the mechanism is identical, because they are all first-party platform features. Three pages built from the same material is the doorway-page pattern the plan itself warned against, so this is one page with a section per platform.

## What makes it distinct

These are not bots you can eject. Inside their own platform they run in the service already carrying your audio, so every control is a setting, usually owned by someone else. Two gotchas, both from vendor docs:

- **Zoom's grayed-out toggle is not a bug.** A feature locked at account or group level must be changed by an admin. This catches account owners, who reasonably expect their own settings page to be authoritative.
- **Teams "Off" is a default, not an enforcement.** Microsoft states the only enforceable Copilot policy setting is "On with saved transcript required"; the others create a default organizers can change. Anyone whose compliance posture assumes the tenant setting binds should test that.

Also documents the in-meeting host control to stop Zoom Meeting Summary, which most guides omit and which actually matters, since Zoom scopes the summary from the point it was enabled.

## Review found seven defects, two worth flagging beyond this page

**The framing was wrong for this topic.** My standard closing section pitches local capture as "the version of this problem that solves itself." That works when the reader owns the decision. Here they usually do not: when an admin disables Copilot, that is the employer's call, often for records-retention reasons invisible from the reader's seat. As written it read as "your org turned notes off, so keep your own copy," which is bad advice and worse positioning. The section now says plainly that running your own capture tool is **not** the workaround, and positions Minutes as an architecture to propose to whoever owns the policy.

**A product claim was too narrow, on three live pages.** "Transcript text leaves only if you configure a summarizer" omits the MCP path our own `/security` page documents: an agent you connect and ask to read your meetings sends what it reads to its provider. Corrected here and on the live Fireflies and HIPAA transcription pages.

Five factual corrections: Zoom AI Companion **can** join Google Meet and Teams meetings as a participant (so the "nothing to eject" framing needed qualifying here and on the hub page); Zoom Meeting Summary covers from the point it was enabled, which inverts my advice about speaking up late; there is a live host control I claimed did not exist; the Zoom group path was missing two steps; and "a vendor not summarizing by default" asserted a default state neither vendor documents.

## Test plan

- [x] `tsc --noEmit` and `npm run build` clean
- [x] All seven corrections verified in the rendered page
- [x] 51/51 FAQ pairs visible sitewide
- [x] No stale narrow product claim anywhere in the build
- [x] 1 h1 / 7 h2, in sitemap, cross-linked from the hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)