### PR TITLE
fix(attribution): decline to name a voice-stem label that holds two people (#169)

### DIFF
--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -2169,6 +2169,44 @@ fn merge_remote_diarization_into_stem_result(
     }
 }
 
+/// Speakers holding enough of a stem's speech to be treated as really present.
+///
+/// Deliberately stricter than `meaningful_speaker_count_excluding`'s
+/// half-second bar, because this gates a safety decision rather than a
+/// descriptive one. An incidental split (a cough picked up as its own cluster,
+/// a diarizer hiccup on one noisy window) must not read as a second person and
+/// suppress self-attribution that would otherwise be correct, so a speaker
+/// counts only when they hold both an absolute and a proportional share of the
+/// attributed speech.
+///
+/// The two people sharing a room in issue #169 held roughly even talk time
+/// across 17 minutes, which clears both bars by a wide margin; the artifacts
+/// this is written to ignore clear neither.
+pub(crate) fn substantial_speaker_count(result: &DiarizationResult) -> usize {
+    const MIN_ABSOLUTE_SECS: f64 = 5.0;
+    const MIN_SHARE_OF_SPEECH: f64 = 0.10;
+
+    let mut speaker_durations: std::collections::HashMap<&str, f64> =
+        std::collections::HashMap::new();
+    for segment in &result.segments {
+        *speaker_durations
+            .entry(segment.speaker.as_str())
+            .or_insert(0.0) += (segment.end - segment.start).max(0.0);
+    }
+
+    let total: f64 = speaker_durations.values().sum();
+    if total <= 0.0 {
+        return 0;
+    }
+
+    speaker_durations
+        .values()
+        .filter(|&&duration| {
+            duration >= MIN_ABSOLUTE_SECS && duration / total >= MIN_SHARE_OF_SPEECH
+        })
+        .count()
+}
+
 fn meaningful_speaker_count_excluding(result: &DiarizationResult, ignored: &[&str]) -> usize {
     let mut speaker_durations: std::collections::HashMap<&str, f64> =
         std::collections::HashMap::new();
@@ -3892,6 +3930,70 @@ fn find_python_with_candidates(
 
 #[cfg(test)]
 mod tests {
+
+    fn stem_result(segments: &[(&str, f64, f64)]) -> DiarizationResult {
+        DiarizationResult {
+            segments: segments
+                .iter()
+                .map(|(speaker, start, end)| SpeakerSegment {
+                    speaker: (*speaker).into(),
+                    start: *start,
+                    end: *end,
+                })
+                .collect(),
+            num_speakers: 0,
+            system_dominant_ratio: 0.0,
+            voice_dominant_ratio: 0.0,
+            degraded_capture: None,
+            from_stems: false,
+            source_aware: false,
+            speaker_embeddings: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn substantial_speaker_count_sees_two_people_sharing_one_microphone() {
+        // Issue #169: two colleagues in one room on one mic, roughly even talk
+        // time. This is the case that must be detected, because naming the
+        // shared label after the recorder misattributes the other person.
+        let shared_room = stem_result(&[
+            ("SPEAKER_0", 0.0, 240.0),
+            ("SPEAKER_1", 240.0, 500.0),
+            ("SPEAKER_0", 500.0, 760.0),
+        ]);
+        assert_eq!(substantial_speaker_count(&shared_room), 2);
+    }
+
+    #[test]
+    fn substantial_speaker_count_ignores_incidental_splits() {
+        // The regression this guard must not cause: one real speaker plus a
+        // brief artifact (a cough, one noisy window clustered on its own) has
+        // to read as one person, or self-attribution that was previously
+        // correct starts declining for solo recorders.
+        let solo_with_artifact = stem_result(&[
+            ("SPEAKER_0", 0.0, 600.0),
+            ("SPEAKER_1", 600.0, 602.0),
+            ("SPEAKER_0", 602.0, 900.0),
+        ]);
+        assert_eq!(substantial_speaker_count(&solo_with_artifact), 1);
+
+        // Long enough in absolute terms but a negligible share: still one.
+        let solo_with_long_artifact =
+            stem_result(&[("SPEAKER_0", 0.0, 3600.0), ("SPEAKER_1", 3600.0, 3610.0)]);
+        assert_eq!(substantial_speaker_count(&solo_with_long_artifact), 1);
+
+        // An even split, but only seconds of audio: neither voice clears the
+        // absolute bar, so the count is zero rather than two. What the guard
+        // needs is that it is not above one, because a clip this short cannot
+        // support the claim that a room was shared.
+        let short_clip = stem_result(&[("SPEAKER_0", 0.0, 4.0), ("SPEAKER_1", 4.0, 8.0)]);
+        assert_eq!(substantial_speaker_count(&short_clip), 0);
+    }
+
+    #[test]
+    fn substantial_speaker_count_handles_a_silent_stem() {
+        assert_eq!(substantial_speaker_count(&stem_result(&[])), 0);
+    }
     use super::*;
 
     static DIARIZATION_WORKER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -310,6 +310,10 @@ enum SelfAttributionAppliedVia {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum SelfAttributionSkippedReason {
+    /// The voice stem itself holds more than one person, so the local label is
+    /// a merge and naming it after the recorder would misattribute the other
+    /// speaker (issue #169).
+    VoiceStemMultipleSpeakers,
     NoDiarizedSpeakers,
     DiarizationNotFromStems,
     AlreadyMapped,
@@ -339,6 +343,14 @@ struct SelfAttributionDebug {
     skipped_reason: Option<SelfAttributionSkippedReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
     fallback_reason: Option<SelfAttributionSkippedReason>,
+    /// Substantial speakers found in the voice stem, when it was diarized.
+    ///
+    /// Recorded whether or not it changed the decision. Diagnosing #169 needed
+    /// a code trace to learn that one `applied_via` value covers both "matching
+    /// ran and missed" and "matching never ran", and that nothing anywhere
+    /// reported how many people the local stem held.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    voice_stem_speaker_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -388,9 +400,16 @@ impl SelfAttributionOutcome {
                 applied_via: Some(applied_via),
                 skipped_reason: None,
                 fallback_reason,
+                voice_stem_speaker_count: None,
             },
             attribution: Some(attribution),
         }
+    }
+
+    /// Attach the voice-stem speaker count to an outcome for the debug record.
+    fn with_voice_stem_speaker_count(mut self, count: usize) -> Self {
+        self.debug.voice_stem_speaker_count = Some(count);
+        self
     }
 
     fn skipped(reason: SelfAttributionSkippedReason) -> Self {
@@ -405,6 +424,7 @@ impl SelfAttributionOutcome {
                 applied_via: None,
                 skipped_reason: Some(reason),
                 fallback_reason: None,
+                voice_stem_speaker_count: None,
             },
         }
     }
@@ -2491,6 +2511,35 @@ fn single_stem_speaker_self_attribution(
     if let Some(stems) = diarize::discover_stems(audio_path) {
         if let Some(source_backed_label) = source_backed_speaker_label.clone() {
             if let Some(voice_stem_result) = diarize::diarize(&stems.voice, config) {
+                // A source-backed label says which STEM the speech came from,
+                // never how many people were in front of that microphone. Two
+                // colleagues sharing one room and one mic land in the same
+                // stem, so naming the label after the recorder would attribute
+                // the other person's speech to them (issue #169).
+                //
+                // Checked before the enrollment comparison because a match
+                // does not make it safe: a match proves the recorder is one of
+                // the voices in the stem, while the label still covers all of
+                // them. A wrong name is worse than an anonymous label, so this
+                // declines and leaves the label for the capped, clearly
+                // hedged suggestion paths.
+                //
+                // The count is free here: this branch already diarized the
+                // voice stem for embeddings and previously discarded
+                // everything except the match result.
+                let voice_stem_speakers = diarize::substantial_speaker_count(&voice_stem_result);
+                if voice_stem_speakers > 1 {
+                    tracing::info!(
+                        voice_stem_speakers,
+                        label = %source_backed_label,
+                        "declining deterministic self-attribution: the voice stem holds more than one speaker"
+                    );
+                    return SelfAttributionOutcome::skipped(
+                        SelfAttributionSkippedReason::VoiceStemMultipleSpeakers,
+                    )
+                    .with_voice_stem_speaker_count(voice_stem_speakers);
+                }
+
                 let matched_self =
                     match_speakers_by_voice(config, &voice_stem_result.speaker_embeddings)
                         .attributions
@@ -2517,7 +2566,8 @@ fn single_stem_speaker_self_attribution(
                         SelfAttributionAppliedVia::SourceBackedStem
                     },
                     None,
-                );
+                )
+                .with_voice_stem_speaker_count(voice_stem_speakers);
             }
 
             return SelfAttributionOutcome::applied(


### PR DESCRIPTION
Partial fix for #169, from akshay7394's hybrid-meeting report. It does not fix the diarization gap; it stops Minutes from putting a confident name on the merge that gap produces.

## The defect

Two people sharing one room and one mic, plus one remote participant. Both in-room speakers collapse into `SPEAKER_0`, and self-attribution then names that label after the recorder at medium confidence. The other person's speech is attributed to the recorder, and derived action items land on the wrong human.

The root assumption: a source-backed label says which **stem** speech came from, never how many people were in front of that microphone. The code treated those as the same fact. This is precisely what the project's own rule exists to prevent, that a wrong name is worse than an anonymous label.

## The fix, using evidence already in hand

That branch already diarizes the voice stem to compare embeddings against enrollments, then kept only the boolean match result. It now also counts speakers in that stem and declines deterministic self-attribution when there is more than one.

**Checked before the enrollment comparison, deliberately.** A match does not make naming safe: it proves the recorder is one of the voices in the stem, while the label still covers all of them. Declining leaves the label to the capped, visibly hedged suggestion paths.

**A stricter bar than the existing helper.** `meaningful_speaker_count_excluding` counts anything over half a second, which is right for describing a result and wrong for gating a safety decision. A speaker now counts only with at least 5 seconds AND at least 10% of the stem's attributed speech. Two colleagues with roughly even talk time over 17 minutes clear both by a wide margin; a cough or one mis-clustered noisy window clears neither. Tests pin both directions, because the regression risk here is real: an over-eager guard would silently stop naming solo recorders.

## Diagnosability, which is why this took a code trace

Diagnosing the report required reading the source to learn two things that should have been in the output: `applied_via: source-backed-stem` covers both "matching ran and missed" and "matching never ran" (only distinguishable via a separate `skipped_reason`), and nothing anywhere reported how many people the local stem held. `voice_stem_speaker_count` is now recorded whether or not it changes the decision.

## What stays open

The local stem is still never clustered. In `diarize.rs`, the hybrid merge that splices ML results into the energy timeline begins `if segment.speaker != "SPEAKER_1"`, so local regions pass through as one speaker no matter how many people are in the room. Those two in-room speakers remain merged in the transcript. That is the real fix and remains #169's scope; akshay's suggestion to cluster the local stem is the right shape for it.

## Verification

- `diarize` suite: 86 passed; `pipeline` suite: 143 passed
- fmt clean, clippy clean
- new tests cover the shared-room case (detected), a brief artifact, a long-but-negligible-share artifact, a too-short clip, and a silent stem