### PR TITLE
ci: build the site, which nothing in CI ever did

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      site: ${{ steps.filter.outputs.site }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
+            site:
+              # The landing page is the product demo, and nothing in CI
+              # compiled it until now: a TypeScript major bump merged green
+              # here while never having been built, because the only site job
+              # checks release constants. Cloudflare Pages would have caught a
+              # broken build at deploy time, after merge.
+              - 'site/**'
+              - '.github/workflows/ci.yml'
             rust:
               - 'tauri/**'
               # Enumerated, not 'crates/**'. crates/mcp and crates/sdk are npm
@@ -647,6 +656,31 @@ jobs:
       - name: Verify site release constants match manifest
         run: node scripts/sync_site_release_version.mjs --check
 
+  site_build:
+    name: Site Build
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install site dependencies
+        working-directory: site
+        run: npm ci
+
+      # `next build` type-checks as part of the build (no ignoreBuildErrors in
+      # next.config), so this covers both compilation and types in one step.
+      - name: Build the site
+        working-directory: site
+        run: npm run build
+
   agents_sync:
     name: Agents Skill Sync
     runs-on: ubuntu-latest
@@ -755,6 +789,7 @@ jobs:
       - skills_compiler
       - agents_sync
       - site_release_consistency
+      - site_build
       - llms_sync
       - live_sidekick_eval
     if: always()

--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## The gap

The landing page is the primary product demo, and **no CI job compiled it**. The only site-related job (`Site Release Link Consistency`) checks release constants.

I found this the embarrassing way. Yesterday's TypeScript 5 to 6 major bump for `/site` (#706) merged on green CI, and that green said nothing whatsoever about whether the site builds. It does build, which I verified locally afterward, but that was luck rather than evidence. Cloudflare Pages would have caught a break at deploy time, after merge, with the old version left live.

## The fix

A `Site Build` job running `npm ci` then `npm run build`. `next build` type-checks as part of the build (there is no `ignoreBuildErrors` in `next.config`), so one job covers compilation and types. Path-filtered on `site/**` so Rust-only PRs do not pay for it, and wired into `CI Gate` so it actually blocks rather than being advisory.

## Verified both directions

| | result |
|---|---|
| clean build | exit 0, `✓ Compiled successfully` |
| injected type error | exit 1, `app/layout.tsx(1,7): error TS2322: Type 'string' is not assignable to type 'number'` |

**The first attempt at that check was itself vacuous**, which is worth recording. With `node_modules` symlinked from another checkout, Turbopack fails on the symlink (`Symlink [project]/node_modules is invalid`), so the build exited nonzero for a reason unrelated to the injected error. It would have "proved" the job worked while testing nothing. Redone with a real `npm ci`.

## Also included

`site/next-env.d.ts` regenerated. The current Next version emits an extra reference there, so the tracked copy was stale and every local site build left a dirty tree.