### PR TITLE
feat(site): structured data for the resource cluster

### DIFF
--- a/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
+++ b/site/app/resources/ai-notetakers-attorney-client-privilege/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "AI notetakers and attorney–client privilege",
@@ -49,12 +49,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function AiNotetakersPrivilegePage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/ai-notetakers-attorney-client-privilege", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -92,7 +97,7 @@ export default function AiNotetakersPrivilegePage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Not legal advice

--- a/site/app/resources/best-local-speech-to-text/page.tsx
+++ b/site/app/resources/best-local-speech-to-text/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
+import { resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "The best local speech-to-text apps (2026)",
@@ -70,9 +71,15 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function BestLocalSpeechToTextPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(resourceArticleSchema({ metadata, path: "/resources/best-local-speech-to-text", lastReviewed: LAST_REVIEWED, sources })) }}
+      />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
           minutes
@@ -107,7 +114,7 @@ export default function BestLocalSpeechToTextPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Fit-based resource

--- a/site/app/resources/best-mcp-meeting-memory-tools/page.tsx
+++ b/site/app/resources/best-mcp-meeting-memory-tools/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
+import { resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Best MCP meeting memory tools",
@@ -55,9 +56,15 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-04-09";
+
 export default function BestMcpMeetingMemoryToolsPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(resourceArticleSchema({ metadata, path: "/resources/best-mcp-meeting-memory-tools", lastReviewed: LAST_REVIEWED, sources })) }}
+      />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
           minutes
@@ -92,7 +99,7 @@ export default function BestMcpMeetingMemoryToolsPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-04-09
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Category-creation guide

--- a/site/app/resources/best-meeting-tools-for-claude-code-and-codex/page.tsx
+++ b/site/app/resources/best-meeting-tools-for-claude-code-and-codex/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
+import { resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Best meeting tools for Claude Code and Codex",
@@ -83,9 +84,15 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-04-09";
+
 export default function BestMeetingToolsPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(resourceArticleSchema({ metadata, path: "/resources/best-meeting-tools-for-claude-code-and-codex", lastReviewed: LAST_REVIEWED, sources })) }}
+      />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
           minutes
@@ -118,7 +125,7 @@ export default function BestMeetingToolsPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-04-09
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Category-creation guide

--- a/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
+++ b/site/app/resources/hipaa-compliant-ai-note-taker/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "HIPAA-compliant AI note takers: the actual state of play",
@@ -101,12 +101,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function HipaaCompliantAiNoteTakerPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/hipaa-compliant-ai-note-taker", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -140,7 +145,7 @@ export default function HipaaCompliantAiNoteTakerPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Sourced answer

--- a/site/app/resources/hipaa-compliant-transcription/page.tsx
+++ b/site/app/resources/hipaa-compliant-transcription/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "HIPAA-compliant transcription: what the rule actually requires",
@@ -108,12 +108,17 @@ const sources = [
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
 
+const LAST_REVIEWED = "2026-08-10";
+
 export default function HipaaTranscriptionPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/hipaa-compliant-transcription", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -151,7 +156,7 @@ export default function HipaaTranscriptionPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-08-10
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Sourced answer

--- a/site/app/resources/is-fireflies-ai-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-fireflies-ai-hipaa-compliant/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is Fireflies.ai HIPAA compliant?",
@@ -50,12 +50,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function IsFirefliesHipaaCompliantPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/is-fireflies-ai-hipaa-compliant", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -93,7 +98,7 @@ export default function IsFirefliesHipaaCompliantPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Sourced answer

--- a/site/app/resources/is-granola-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-granola-hipaa-compliant/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is Granola HIPAA compliant?",
@@ -50,12 +50,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function IsGranolaHipaaCompliantPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/is-granola-hipaa-compliant", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -90,7 +95,7 @@ export default function IsGranolaHipaaCompliantPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Sourced answer

--- a/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
+++ b/site/app/resources/is-it-legal-to-record-a-meeting/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is it legal to record a meeting? Consent law, explained",
@@ -57,12 +57,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function IsItLegalToRecordAMeetingPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/is-it-legal-to-record-a-meeting", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -99,7 +104,7 @@ export default function IsItLegalToRecordAMeetingPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Not legal advice

--- a/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
+++ b/site/app/resources/is-otter-ai-hipaa-compliant/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Is Otter.ai HIPAA compliant?",
@@ -50,12 +50,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function IsOtterAiHipaaCompliantPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/is-otter-ai-hipaa-compliant", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -90,7 +95,7 @@ export default function IsOtterAiHipaaCompliantPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Sourced answer

--- a/site/app/resources/legal-transcription-software/page.tsx
+++ b/site/app/resources/legal-transcription-software/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Legal transcription software: what confidentiality actually requires",
@@ -42,12 +42,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function LegalTranscriptionSoftwarePage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/legal-transcription-software", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -82,7 +87,7 @@ export default function LegalTranscriptionSoftwarePage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Not legal advice

--- a/site/app/resources/local-dictation-macos/page.tsx
+++ b/site/app/resources/local-dictation-macos/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
+import { resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Local dictation on macOS: the complete guide",
@@ -47,9 +48,15 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function LocalDictationMacosPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(resourceArticleSchema({ metadata, path: "/resources/local-dictation-macos", lastReviewed: LAST_REVIEWED, sources })) }}
+      />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
           minutes
@@ -83,7 +90,7 @@ export default function LocalDictationMacosPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Fit-based resource

--- a/site/app/resources/meeting-minutes-template/page.tsx
+++ b/site/app/resources/meeting-minutes-template/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
+import { resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Meeting minutes templates (markdown, copy-paste ready)",
@@ -103,9 +104,15 @@ Respectfully submitted, {secretary}`,
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function MeetingMinutesTemplatePage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(resourceArticleSchema({ metadata, path: "/resources/meeting-minutes-template", lastReviewed: LAST_REVIEWED })) }}
+      />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
           minutes
@@ -138,7 +145,7 @@ export default function MeetingMinutesTemplatePage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Copy-paste ready

--- a/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
+++ b/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
+import { resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Open-source alternatives to Granola AI",
@@ -45,9 +46,15 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-04-09";
+
 export default function OpenSourceAlternativesToGranolaPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(resourceArticleSchema({ metadata, path: "/resources/open-source-alternatives-to-granola-ai", lastReviewed: LAST_REVIEWED, sources })) }}
+      />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
           minutes
@@ -80,7 +87,7 @@ export default function OpenSourceAlternativesToGranolaPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-04-09
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             Fit-based resource

--- a/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
+++ b/site/app/resources/remove-ai-notetaker-bots-from-meetings/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "How to remove AI notetaker bots from your meetings",
@@ -49,12 +49,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-07-11";
+
 export default function RemoveNotetakerBotsPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/remove-ai-notetaker-bots-from-meetings", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -92,7 +97,7 @@ export default function RemoveNotetakerBotsPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-07-11
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             How-to guide

--- a/site/app/resources/remove-otter-ai-from-zoom/page.tsx
+++ b/site/app/resources/remove-otter-ai-from-zoom/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "How to remove Otter AI from Zoom",
@@ -61,12 +61,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-08-09";
+
 export default function RemoveOtterFromZoomPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/remove-otter-ai-from-zoom", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -103,7 +108,7 @@ export default function RemoveOtterFromZoomPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-08-09
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             How-to guide

--- a/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
+++ b/site/app/resources/stop-fireflies-from-joining-meetings/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "How to stop Fireflies from joining your meetings",
@@ -66,12 +66,17 @@ const sources = [
 ] as const;
 
 
+const LAST_REVIEWED = "2026-08-09";
+
 export default function StopFirefliesJoiningPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/stop-fireflies-from-joining-meetings", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -108,7 +113,7 @@ export default function StopFirefliesJoiningPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-08-09
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             How-to guide

--- a/site/app/resources/turn-off-built-in-ai-notetakers/page.tsx
+++ b/site/app/resources/turn-off-built-in-ai-notetakers/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { FaqSection } from "@/components/faq-section";
 import { PublicFooter } from "@/components/public-footer";
 import { SectionLabel } from "@/components/section-label";
-import { faqPageSchema } from "@/lib/schema";
+import { faqPageSchema, resourceArticleSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "How to turn off built-in AI notetakers in Zoom and Teams",
@@ -73,12 +73,17 @@ const sources = [
   { label: "Minutes security & privacy architecture", href: "/security" },
 ] as const;
 
+const LAST_REVIEWED = "2026-08-10";
+
 export default function BuiltInAiNotetakersPage() {
   return (
     <div className="mx-auto max-w-[980px] px-6 pb-16 pt-10 sm:px-8 sm:pt-14">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageSchema(faqs)) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([
+            resourceArticleSchema({ metadata, path: "/resources/turn-off-built-in-ai-notetakers", lastReviewed: LAST_REVIEWED, sources }),
+            faqPageSchema(faqs),
+          ]) }}
       />
       <div className="mb-10 flex items-center justify-between border-b border-[color:var(--border)] pb-4">
         <a href="/" className="font-mono text-[15px] font-medium text-[var(--text)]">
@@ -117,7 +122,7 @@ export default function BuiltInAiNotetakersPage() {
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <span className="rounded-full bg-[var(--bg-elevated)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
-            Last reviewed: 2026-08-10
+            Last reviewed: {LAST_REVIEWED}
           </span>
           <span className="rounded-full bg-[var(--accent-soft)] px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--accent)]">
             How-to guide

--- a/site/lib/schema.ts
+++ b/site/lib/schema.ts
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 /** Shared JSON-LD builders for structured data.
  *
  * Schema.org markup must describe content that is actually visible on the page.
@@ -106,6 +108,66 @@ export function faqPageSchema(items: ReadonlyArray<FaqItem>) {
       "@type": "Question",
       name: item.question,
       acceptedAnswer: { "@type": "Answer", text: item.answer },
+    })),
+  };
+}
+
+type ResourceSchemaInput = {
+  /** The page's own `metadata` export, so title and description cannot drift. */
+  metadata: Metadata;
+  /** Site-relative canonical path, e.g. "/resources/remove-otter-ai-from-zoom". */
+  path: string;
+  /** ISO date the page was last fact-checked; becomes dateModified. */
+  lastReviewed: string;
+  /** The page's visible Sources list, emitted as citations. */
+  sources?: ReadonlyArray<{ label: string; href: string }>;
+};
+
+/** Next's Metadata title is a union; every resource page uses a plain string. */
+function titleText(title: Metadata["title"]): string {
+  if (typeof title === "string") return title;
+  if (title && typeof title === "object") {
+    if ("absolute" in title && typeof title.absolute === "string") {
+      return title.absolute;
+    }
+    if ("default" in title && typeof title.default === "string") {
+      return title.default;
+    }
+  }
+  return "";
+}
+
+/** Structured data for a `/resources/*` guide or answer page.
+ *
+ * These pages carry the two signals that drive AI citation, sourced claims and
+ * a visible review date, but only in prose. This makes both machine-readable.
+ * Title and description are read from the page's own `metadata` export rather
+ * than restated, so the markup cannot disagree with the `<title>`.
+ *
+ * Emit alongside `faqPageSchema` where the page has a visible FAQ; the two are
+ * separate top-level objects in one JSON-LD array.
+ */
+export function resourceArticleSchema({
+  metadata,
+  path,
+  lastReviewed,
+  sources = [],
+}: ResourceSchemaInput) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: titleText(metadata.title),
+    description: metadata.description ?? "",
+    url: absolute(path),
+    mainEntityOfPage: { "@type": "WebPage", "@id": absolute(path) },
+    dateModified: lastReviewed,
+    inLanguage: "en",
+    author: author(),
+    publisher: organizationSchema(),
+    citation: sources.map((source) => ({
+      "@type": "CreativeWork",
+      name: source.label,
+      url: source.href,
     })),
   };
 }

--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Extends the structured-data pattern from #691 to all 18 `/resources/*` pages.

## Before

| State | Count |
|---|---|
| No structured data at all | 6 pages |
| `FAQPage` only | 12 pages |
| `TechArticle` | 0 pages |

## After

Every page emits `TechArticle` with `dateModified`, named author, publisher, and a `citation` list built from the Sources block it already renders. The twelve FAQ pages emit both objects in one JSON-LD array.

Title and description are read from each page's own `metadata` export rather than restated, so the markup cannot disagree with the `<title>`.

## Prevents a stale-date bug

Each page gains a `LAST_REVIEWED` constant feeding both the visible review date and `dateModified`. This is the same class of bug #691 fixed on the comparison pages, where a shared default silently published an out-of-date review date. One source of truth means the visible and machine-readable dates cannot drift.

## Invariants respected

No `FAQPage` was added or altered. The rule that FAQ markup must describe visibly rendered content still holds, verified at 51/51 question-answer pairs against the built HTML. `SectionLabel` untouched, no per-file copies reintroduced.

## Verification

Parsed the static export: 18/18 emit valid `TechArticle`, every visible review date equals its `dateModified`, no empty headlines, 51/51 FAQ answers present in the rendered HTML. `tsc --noEmit` and `next build` clean.
