### PR TITLE
fix(sdk): stop a never-fed worker's unconfirmed kill from poisoning the process

### DIFF
--- a/crates/mcp/src/corpus-lease-poisoning.test.ts
+++ b/crates/mcp/src/corpus-lease-poisoning.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// This file deliberately poisons the worker path and leaves the process
+// unusable, so it must stay a file of exactly one test.
+//
+// An earlier version kept this beside the recovery test with a comment saying
+// it must run last, plus an opening assertion that the process was still
+// clean. That only catches poison arriving from earlier tests; a test added
+// after it would inherit the poison and could pass for the wrong reason, since
+// most assertions here are of the shape "the lease is refused". Vitest runs
+// each file in its own process, so a file boundary enforces what a comment
+// could only request.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-poisoning-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+describe("stable corpus lease poisoning", () => {
+  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "disclosed canary");
+      // The counterpart to the never-fed recovery case in
+      // corpus-lease-refusal.test.ts, and the regression that fix must not
+      // introduce. A generous budget lets `begin` reach the child, so the
+      // worker knows which directory to read; stalling it forces the kill.
+      //
+      // Once the corpus root has been disclosed, an unconfirmed kill has to
+      // keep failing closed: the child may still be reading, and refusing
+      // every later lease is the intended answer to that.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 2_000,
+          workerStallPhaseForTest: "before-baseline",
+          forceUnconfirmedTerminationForTest: true,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow("requires a process restart");
+    });
+  });
+});

--- a/crates/mcp/src/corpus-lease-refusal.test.ts
+++ b/crates/mcp/src/corpus-lease-refusal.test.ts
@@ -68,16 +68,8 @@ describe("stable corpus lease refusal contract", () => {
     });
   });
 
-  // These two share this file's isolation for the same reason as the test
-  // above: they deliberately drive the worker-poisoning path, which is
-  // process-global. Vitest runs each file in its own process, so a poisoned
-  // outcome cannot leak into the main corpus suite.
-  //
-  // Whether a kill is confirmed inside the grace window is a race no test can
-  // force, since SIGKILL is untrappable. `workerTerminationGraceMsForTest: 0`
-  // makes every kill unconfirmed instead, which is the state the race
-  // produces, so the two cases below differ only in whether the child was
-  // told which corpus to read.
+  // Shares this file's isolation for the same reason as the test above: it
+  // drives the worker-termination path, which touches process-global state.
   it("keeps working after an unconfirmed kill of a worker that never learned the corpus", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "never fed canary");
@@ -86,7 +78,7 @@ describe("stable corpus lease refusal contract", () => {
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
           timeoutMs: 1,
-          workerTerminationGraceMsForTest: 0,
+          forceUnconfirmedTerminationForTest: true,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
 
@@ -96,37 +88,6 @@ describe("stable corpus lease refusal contract", () => {
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
         "recovered"
       );
-    });
-  });
-
-  // Must stay LAST in this file: it deliberately poisons the worker path, and
-  // unlike the two above it leaves the process unusable on purpose. The
-  // opening assertion turns that ordering requirement into a detectable
-  // failure rather than a silent one, since anything added after this test
-  // would inherit the poison.
-  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
-    await withCorpus(async (root) => {
-      writeFileSync(join(root, "meeting.md"), "disclosed canary");
-      // Everything before this point must have left the process usable.
-      await expect(withStableCorpusLease(root, () => "clean")).resolves.toBe(
-        "clean"
-      );
-      // A generous budget lets `begin` reach the child, so the worker knows
-      // which directory to read. Stalling it forces the kill, and the
-      // zero-length grace makes that kill unconfirmed. This must still poison:
-      // relaxing it for this case is the regression the change above must not
-      // introduce.
-      await expect(
-        withStableCorpusLease(root, () => "unreachable", {
-          timeoutMs: 2_000,
-          workerStallPhaseForTest: "before-baseline",
-          workerTerminationGraceMsForTest: 0,
-        })
-      ).rejects.toThrow("stable meeting corpus authorization failed");
-
-      await expect(
-        withStableCorpusLease(root, () => "must not run")
-      ).rejects.toThrow("requires a process restart");
     });
   });
 });

--- a/crates/mcp/src/corpus-lease-refusal.test.ts
+++ b/crates/mcp/src/corpus-lease-refusal.test.ts
@@ -67,4 +67,66 @@ describe("stable corpus lease refusal contract", () => {
       expect(projections).toBe(0);
     });
   });
+
+  // These two share this file's isolation for the same reason as the test
+  // above: they deliberately drive the worker-poisoning path, which is
+  // process-global. Vitest runs each file in its own process, so a poisoned
+  // outcome cannot leak into the main corpus suite.
+  //
+  // Whether a kill is confirmed inside the grace window is a race no test can
+  // force, since SIGKILL is untrappable. `workerTerminationGraceMsForTest: 0`
+  // makes every kill unconfirmed instead, which is the state the race
+  // produces, so the two cases below differ only in whether the child was
+  // told which corpus to read.
+  it("keeps working after an unconfirmed kill of a worker that never learned the corpus", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "never fed canary");
+      // A one-millisecond budget expires while the worker is still starting,
+      // so `begin` is never written and the child cannot hold corpus bytes.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 1,
+          workerTerminationGraceMsForTest: 0,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      // Issue #689: this used to refuse with "requires a process restart"
+      // until the host process was restarted, and to keep the killed lease's
+      // memory reservation charged forever.
+      await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
+        "recovered"
+      );
+    });
+  });
+
+  // Must stay LAST in this file: it deliberately poisons the worker path, and
+  // unlike the two above it leaves the process unusable on purpose. The
+  // opening assertion turns that ordering requirement into a detectable
+  // failure rather than a silent one, since anything added after this test
+  // would inherit the poison.
+  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "disclosed canary");
+      // Everything before this point must have left the process usable.
+      await expect(withStableCorpusLease(root, () => "clean")).resolves.toBe(
+        "clean"
+      );
+      // A generous budget lets `begin` reach the child, so the worker knows
+      // which directory to read. Stalling it forces the kill, and the
+      // zero-length grace makes that kill unconfirmed. This must still poison:
+      // relaxing it for this case is the regression the change above must not
+      // introduce.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 2_000,
+          workerStallPhaseForTest: "before-baseline",
+          workerTerminationGraceMsForTest: 0,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow("requires a process restart");
+    });
+  });
 });

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -170,18 +170,21 @@ export type CorpusLeaseHooks = {
   /** Test-only deterministic parent deadline after the projection has started. */
   operationDeadlineForTest?: Promise<void>;
   /**
-   * Test-only worker termination grace, in milliseconds.
+   * Test-only: treat worker termination as unconfirmed, whatever really happened.
    *
-   * Whether a kill is confirmed inside the grace window is a race that a test
-   * cannot force: SIGKILL is untrappable, so no fixture can refuse to die on
-   * cue. Shortening the window to zero makes the unconfirmed path
-   * deterministic instead.
+   * Whether a kill is confirmed inside the grace window is a race a test cannot
+   * force: SIGKILL is untrappable, so no fixture can refuse to die on cue, and
+   * a shortened window is not enough either. A never-fed child dies almost
+   * immediately, so the termination promise usually wins even a zero-length
+   * race, and a test written that way passes without ever entering the branch
+   * it claims to cover.
    *
-   * Safe as a knob because it can only make the parent more conservative. A
-   * shorter grace means more kills go unconfirmed, and an unconfirmed kill of
-   * a worker that was told which corpus to read still poisons the process.
+   * A boolean forces the branch instead. It is also the least powerful shape
+   * available: no delay to coerce, nothing to hold cleanup open, and it can
+   * only make the parent more conservative, since an unconfirmed kill of a
+   * worker that knew the corpus still poisons.
    */
-  workerTerminationGraceMsForTest?: number;
+  forceUnconfirmedTerminationForTest?: boolean;
 };
 
 type RootIdentity = {
@@ -1825,6 +1828,9 @@ async function dispatchStableCorpusLease<T>(
   let protocolQueue: Promise<void> = Promise.resolve();
   let releaseReservation = true;
   let releaseWorkerAdmission = true;
+  // Guards the admission slot against a double release when a late-reaped
+  // child's termination promise resolves after the cleanup block already ran.
+  let workerAdmissionReleased = false;
   // Whether the `begin` message, the only thing that tells the child which
   // corpus to read, was actually handed to the child's stdin. Authority is the
   // write itself, never anything the child echoes back, and never merely
@@ -2195,16 +2201,18 @@ async function dispatchStableCorpusLease<T>(
   } finally {
     if (!terminated) {
       killCorpusWorker(child);
-      const confirmed = await Promise.race([
-        termination.then(() => true),
-        new Promise<boolean>((resolve) => {
-          const timer = setTimeout(
-            () => resolve(false),
-            hooks.workerTerminationGraceMsForTest ?? CORPUS_WORKER_TERMINATION_GRACE_MS
-          );
-          timer.unref();
-        }),
-      ]);
+      const confirmed = hooks.forceUnconfirmedTerminationForTest
+        ? false
+        : await Promise.race([
+            termination.then(() => true),
+            new Promise<boolean>((resolve) => {
+              const timer = setTimeout(
+                () => resolve(false),
+                CORPUS_WORKER_TERMINATION_GRACE_MS
+              );
+              timer.unref();
+            }),
+          ]);
       // An unconfirmed kill means the child might still be running, and a
       // child that knows the corpus root might still be reading it. Retaining
       // its reservation and refusing further workers is the right answer to
@@ -2217,10 +2225,30 @@ async function dispatchStableCorpusLease<T>(
       // later lease until restart protects nothing. That case is reachable in
       // ordinary use, not just in tests, whenever a short budget expires while
       // the worker is still starting (issue #689).
-      if (!confirmed && corpusRootDisclosed) {
-        corpusWorkerPoisoned = true;
-        releaseReservation = false;
-        releaseWorkerAdmission = false;
+      if (!confirmed) {
+        if (corpusRootDisclosed) {
+          corpusWorkerPoisoned = true;
+          releaseReservation = false;
+          releaseWorkerAdmission = false;
+        } else {
+          // The child holds no corpus bytes, so its memory reservation is
+          // released below. Its admission slot is a different question: the
+          // kill is unconfirmed, so the process may genuinely still exist, and
+          // that cap counts live workers rather than retained bytes.
+          //
+          // Releasing it immediately would let repeated failures accumulate
+          // unbounded uncharged children; holding it forever would leak a slot
+          // for a child that, in the overwhelming majority of cases, died a
+          // moment after the grace expired. So the slot is handed to the
+          // termination promise and freed if and when the child is actually
+          // reaped, which is neither of those extremes.
+          releaseWorkerAdmission = false;
+          void termination.then(() => {
+            if (workerAdmissionReleased) return;
+            workerAdmissionReleased = true;
+            activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
+          });
+        }
       }
     }
     if (operationActive) {
@@ -2240,7 +2268,8 @@ async function dispatchStableCorpusLease<T>(
         releaseWorkerAdmission = false;
       }
     }
-    if (releaseWorkerAdmission) {
+    if (releaseWorkerAdmission && !workerAdmissionReleased) {
+      workerAdmissionReleased = true;
       activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
     }
     if (releaseReservation) releaseCorpusMemory(reservation);

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -169,6 +169,19 @@ export type CorpusLeaseHooks = {
     | "before-authorized";
   /** Test-only deterministic parent deadline after the projection has started. */
   operationDeadlineForTest?: Promise<void>;
+  /**
+   * Test-only worker termination grace, in milliseconds.
+   *
+   * Whether a kill is confirmed inside the grace window is a race that a test
+   * cannot force: SIGKILL is untrappable, so no fixture can refuse to die on
+   * cue. Shortening the window to zero makes the unconfirmed path
+   * deterministic instead.
+   *
+   * Safe as a knob because it can only make the parent more conservative. A
+   * shorter grace means more kills go unconfirmed, and an unconfirmed kill of
+   * a worker that was told which corpus to read still poisons the process.
+   */
+  workerTerminationGraceMsForTest?: number;
 };
 
 type RootIdentity = {
@@ -1812,6 +1825,12 @@ async function dispatchStableCorpusLease<T>(
   let protocolQueue: Promise<void> = Promise.resolve();
   let releaseReservation = true;
   let releaseWorkerAdmission = true;
+  // Whether the `begin` message, the only thing that tells the child which
+  // corpus to read, was actually handed to the child's stdin. Authority is the
+  // write itself, never anything the child echoes back, and never merely
+  // reaching the call site: `send` declines to write once the lease has
+  // settled or the pipe is gone.
+  let corpusRootDisclosed = false;
 
   const child = spawn(invocation.binary, invocation.args, {
     detached: process.platform !== "win32",
@@ -1837,13 +1856,15 @@ async function dispatchStableCorpusLease<T>(
   // and the message has nowhere useful to go.
   child.stdin?.on("error", () => {});
 
-  const send = (message: unknown): void => {
+  /** Write a protocol line, reporting whether it actually reached the pipe. */
+  const send = (message: unknown): boolean => {
     const serialized = JSON.stringify(message);
     if (Buffer.byteLength(serialized) > CORPUS_WORKER_PROTOCOL_MAX_BYTES || !child.stdin) {
       throw new CorpusLeaseBudgetError("meeting corpus worker protocol exceeded its budget");
     }
-    if (settled || child.stdin.destroyed || child.killed) return;
+    if (settled || child.stdin.destroyed || child.killed) return false;
     child.stdin.write(serialized + "\n");
+    return true;
   };
 
   try {
@@ -1887,7 +1908,9 @@ async function dispatchStableCorpusLease<T>(
         retainedPathBytes: number;
       };
       let stream: SnapshotStream | undefined;
-      const streamAck = (): void => send({ type: "stream-ack" });
+      const streamAck = (): void => {
+        send({ type: "stream-ack" });
+      };
       const handleProtocolLine = async (line: string): Promise<void> => {
         if (settled) return;
         let message: any;
@@ -2146,16 +2169,24 @@ async function dispatchStableCorpusLease<T>(
           });
       });
       try {
-        send({
-          type: "begin",
-          request: {
-            root,
-            budgets,
-            timeoutMs,
-            hookNames: workerHookNames(hooks),
-            stallPhase: hooks.workerStallPhaseForTest,
-          } satisfies CorpusLeaseWorkerRequest,
-        });
+        // Buffering means a `true` here proves the bytes were handed to the
+        // pipe, not that the child read them. That asymmetry is deliberate:
+        // over-reporting disclosure costs a conservative poisoning, while
+        // under-reporting would skip one that is required.
+        if (
+          send({
+            type: "begin",
+            request: {
+              root,
+              budgets,
+              timeoutMs,
+              hookNames: workerHookNames(hooks),
+              stallPhase: hooks.workerStallPhaseForTest,
+            } satisfies CorpusLeaseWorkerRequest,
+          })
+        ) {
+          corpusRootDisclosed = true;
+        }
       } catch {
         fail("meeting corpus worker request was invalid");
       }
@@ -2167,11 +2198,26 @@ async function dispatchStableCorpusLease<T>(
       const confirmed = await Promise.race([
         termination.then(() => true),
         new Promise<boolean>((resolve) => {
-          const timer = setTimeout(() => resolve(false), CORPUS_WORKER_TERMINATION_GRACE_MS);
+          const timer = setTimeout(
+            () => resolve(false),
+            hooks.workerTerminationGraceMsForTest ?? CORPUS_WORKER_TERMINATION_GRACE_MS
+          );
           timer.unref();
         }),
       ]);
-      if (!confirmed) {
+      // An unconfirmed kill means the child might still be running, and a
+      // child that knows the corpus root might still be reading it. Retaining
+      // its reservation and refusing further workers is the right answer to
+      // that, and stays the answer.
+      //
+      // A child killed before `begin` reached it is a different animal: the
+      // protocol is the only way it learns which directory to read, and it
+      // does nothing before that message. It cannot be holding corpus bytes,
+      // so charging the process for bytes it never read and blocking every
+      // later lease until restart protects nothing. That case is reachable in
+      // ordinary use, not just in tests, whenever a short budget expires while
+      // the worker is still starting (issue #689).
+      if (!confirmed && corpusRootDisclosed) {
         corpusWorkerPoisoned = true;
         releaseReservation = false;
         releaseWorkerAdmission = false;

--- a/crates/sdk/src/corpus-lease-poisoning.test.ts
+++ b/crates/sdk/src/corpus-lease-poisoning.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// This file deliberately poisons the worker path and leaves the process
+// unusable, so it must stay a file of exactly one test.
+//
+// An earlier version kept this beside the recovery test with a comment saying
+// it must run last, plus an opening assertion that the process was still
+// clean. That only catches poison arriving from earlier tests; a test added
+// after it would inherit the poison and could pass for the wrong reason, since
+// most assertions here are of the shape "the lease is refused". Vitest runs
+// each file in its own process, so a file boundary enforces what a comment
+// could only request.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-poisoning-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+describe("stable corpus lease poisoning", () => {
+  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "disclosed canary");
+      // The counterpart to the never-fed recovery case in
+      // corpus-lease-refusal.test.ts, and the regression that fix must not
+      // introduce. A generous budget lets `begin` reach the child, so the
+      // worker knows which directory to read; stalling it forces the kill.
+      //
+      // Once the corpus root has been disclosed, an unconfirmed kill has to
+      // keep failing closed: the child may still be reading, and refusing
+      // every later lease is the intended answer to that.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 2_000,
+          workerStallPhaseForTest: "before-baseline",
+          forceUnconfirmedTerminationForTest: true,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow("requires a process restart");
+    });
+  });
+});

--- a/crates/sdk/src/corpus-lease-refusal.test.ts
+++ b/crates/sdk/src/corpus-lease-refusal.test.ts
@@ -68,16 +68,8 @@ describe("stable corpus lease refusal contract", () => {
     });
   });
 
-  // These two share this file's isolation for the same reason as the test
-  // above: they deliberately drive the worker-poisoning path, which is
-  // process-global. Vitest runs each file in its own process, so a poisoned
-  // outcome cannot leak into the main corpus suite.
-  //
-  // Whether a kill is confirmed inside the grace window is a race no test can
-  // force, since SIGKILL is untrappable. `workerTerminationGraceMsForTest: 0`
-  // makes every kill unconfirmed instead, which is the state the race
-  // produces, so the two cases below differ only in whether the child was
-  // told which corpus to read.
+  // Shares this file's isolation for the same reason as the test above: it
+  // drives the worker-termination path, which touches process-global state.
   it("keeps working after an unconfirmed kill of a worker that never learned the corpus", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "never fed canary");
@@ -86,7 +78,7 @@ describe("stable corpus lease refusal contract", () => {
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
           timeoutMs: 1,
-          workerTerminationGraceMsForTest: 0,
+          forceUnconfirmedTerminationForTest: true,
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
 
@@ -96,37 +88,6 @@ describe("stable corpus lease refusal contract", () => {
       await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
         "recovered"
       );
-    });
-  });
-
-  // Must stay LAST in this file: it deliberately poisons the worker path, and
-  // unlike the two above it leaves the process unusable on purpose. The
-  // opening assertion turns that ordering requirement into a detectable
-  // failure rather than a silent one, since anything added after this test
-  // would inherit the poison.
-  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
-    await withCorpus(async (root) => {
-      writeFileSync(join(root, "meeting.md"), "disclosed canary");
-      // Everything before this point must have left the process usable.
-      await expect(withStableCorpusLease(root, () => "clean")).resolves.toBe(
-        "clean"
-      );
-      // A generous budget lets `begin` reach the child, so the worker knows
-      // which directory to read. Stalling it forces the kill, and the
-      // zero-length grace makes that kill unconfirmed. This must still poison:
-      // relaxing it for this case is the regression the change above must not
-      // introduce.
-      await expect(
-        withStableCorpusLease(root, () => "unreachable", {
-          timeoutMs: 2_000,
-          workerStallPhaseForTest: "before-baseline",
-          workerTerminationGraceMsForTest: 0,
-        })
-      ).rejects.toThrow("stable meeting corpus authorization failed");
-
-      await expect(
-        withStableCorpusLease(root, () => "must not run")
-      ).rejects.toThrow("requires a process restart");
     });
   });
 });

--- a/crates/sdk/src/corpus-lease-refusal.test.ts
+++ b/crates/sdk/src/corpus-lease-refusal.test.ts
@@ -67,4 +67,66 @@ describe("stable corpus lease refusal contract", () => {
       expect(projections).toBe(0);
     });
   });
+
+  // These two share this file's isolation for the same reason as the test
+  // above: they deliberately drive the worker-poisoning path, which is
+  // process-global. Vitest runs each file in its own process, so a poisoned
+  // outcome cannot leak into the main corpus suite.
+  //
+  // Whether a kill is confirmed inside the grace window is a race no test can
+  // force, since SIGKILL is untrappable. `workerTerminationGraceMsForTest: 0`
+  // makes every kill unconfirmed instead, which is the state the race
+  // produces, so the two cases below differ only in whether the child was
+  // told which corpus to read.
+  it("keeps working after an unconfirmed kill of a worker that never learned the corpus", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "never fed canary");
+      // A one-millisecond budget expires while the worker is still starting,
+      // so `begin` is never written and the child cannot hold corpus bytes.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 1,
+          workerTerminationGraceMsForTest: 0,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      // Issue #689: this used to refuse with "requires a process restart"
+      // until the host process was restarted, and to keep the killed lease's
+      // memory reservation charged forever.
+      await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe(
+        "recovered"
+      );
+    });
+  });
+
+  // Must stay LAST in this file: it deliberately poisons the worker path, and
+  // unlike the two above it leaves the process unusable on purpose. The
+  // opening assertion turns that ordering requirement into a detectable
+  // failure rather than a silent one, since anything added after this test
+  // would inherit the poison.
+  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "disclosed canary");
+      // Everything before this point must have left the process usable.
+      await expect(withStableCorpusLease(root, () => "clean")).resolves.toBe(
+        "clean"
+      );
+      // A generous budget lets `begin` reach the child, so the worker knows
+      // which directory to read. Stalling it forces the kill, and the
+      // zero-length grace makes that kill unconfirmed. This must still poison:
+      // relaxing it for this case is the regression the change above must not
+      // introduce.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 2_000,
+          workerStallPhaseForTest: "before-baseline",
+          workerTerminationGraceMsForTest: 0,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow("requires a process restart");
+    });
+  });
 });

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -170,18 +170,21 @@ export type CorpusLeaseHooks = {
   /** Test-only deterministic parent deadline after the projection has started. */
   operationDeadlineForTest?: Promise<void>;
   /**
-   * Test-only worker termination grace, in milliseconds.
+   * Test-only: treat worker termination as unconfirmed, whatever really happened.
    *
-   * Whether a kill is confirmed inside the grace window is a race that a test
-   * cannot force: SIGKILL is untrappable, so no fixture can refuse to die on
-   * cue. Shortening the window to zero makes the unconfirmed path
-   * deterministic instead.
+   * Whether a kill is confirmed inside the grace window is a race a test cannot
+   * force: SIGKILL is untrappable, so no fixture can refuse to die on cue, and
+   * a shortened window is not enough either. A never-fed child dies almost
+   * immediately, so the termination promise usually wins even a zero-length
+   * race, and a test written that way passes without ever entering the branch
+   * it claims to cover.
    *
-   * Safe as a knob because it can only make the parent more conservative. A
-   * shorter grace means more kills go unconfirmed, and an unconfirmed kill of
-   * a worker that was told which corpus to read still poisons the process.
+   * A boolean forces the branch instead. It is also the least powerful shape
+   * available: no delay to coerce, nothing to hold cleanup open, and it can
+   * only make the parent more conservative, since an unconfirmed kill of a
+   * worker that knew the corpus still poisons.
    */
-  workerTerminationGraceMsForTest?: number;
+  forceUnconfirmedTerminationForTest?: boolean;
 };
 
 type RootIdentity = {
@@ -1825,6 +1828,9 @@ async function dispatchStableCorpusLease<T>(
   let protocolQueue: Promise<void> = Promise.resolve();
   let releaseReservation = true;
   let releaseWorkerAdmission = true;
+  // Guards the admission slot against a double release when a late-reaped
+  // child's termination promise resolves after the cleanup block already ran.
+  let workerAdmissionReleased = false;
   // Whether the `begin` message, the only thing that tells the child which
   // corpus to read, was actually handed to the child's stdin. Authority is the
   // write itself, never anything the child echoes back, and never merely
@@ -2195,16 +2201,18 @@ async function dispatchStableCorpusLease<T>(
   } finally {
     if (!terminated) {
       killCorpusWorker(child);
-      const confirmed = await Promise.race([
-        termination.then(() => true),
-        new Promise<boolean>((resolve) => {
-          const timer = setTimeout(
-            () => resolve(false),
-            hooks.workerTerminationGraceMsForTest ?? CORPUS_WORKER_TERMINATION_GRACE_MS
-          );
-          timer.unref();
-        }),
-      ]);
+      const confirmed = hooks.forceUnconfirmedTerminationForTest
+        ? false
+        : await Promise.race([
+            termination.then(() => true),
+            new Promise<boolean>((resolve) => {
+              const timer = setTimeout(
+                () => resolve(false),
+                CORPUS_WORKER_TERMINATION_GRACE_MS
+              );
+              timer.unref();
+            }),
+          ]);
       // An unconfirmed kill means the child might still be running, and a
       // child that knows the corpus root might still be reading it. Retaining
       // its reservation and refusing further workers is the right answer to
@@ -2217,10 +2225,30 @@ async function dispatchStableCorpusLease<T>(
       // later lease until restart protects nothing. That case is reachable in
       // ordinary use, not just in tests, whenever a short budget expires while
       // the worker is still starting (issue #689).
-      if (!confirmed && corpusRootDisclosed) {
-        corpusWorkerPoisoned = true;
-        releaseReservation = false;
-        releaseWorkerAdmission = false;
+      if (!confirmed) {
+        if (corpusRootDisclosed) {
+          corpusWorkerPoisoned = true;
+          releaseReservation = false;
+          releaseWorkerAdmission = false;
+        } else {
+          // The child holds no corpus bytes, so its memory reservation is
+          // released below. Its admission slot is a different question: the
+          // kill is unconfirmed, so the process may genuinely still exist, and
+          // that cap counts live workers rather than retained bytes.
+          //
+          // Releasing it immediately would let repeated failures accumulate
+          // unbounded uncharged children; holding it forever would leak a slot
+          // for a child that, in the overwhelming majority of cases, died a
+          // moment after the grace expired. So the slot is handed to the
+          // termination promise and freed if and when the child is actually
+          // reaped, which is neither of those extremes.
+          releaseWorkerAdmission = false;
+          void termination.then(() => {
+            if (workerAdmissionReleased) return;
+            workerAdmissionReleased = true;
+            activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
+          });
+        }
       }
     }
     if (operationActive) {
@@ -2240,7 +2268,8 @@ async function dispatchStableCorpusLease<T>(
         releaseWorkerAdmission = false;
       }
     }
-    if (releaseWorkerAdmission) {
+    if (releaseWorkerAdmission && !workerAdmissionReleased) {
+      workerAdmissionReleased = true;
       activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
     }
     if (releaseReservation) releaseCorpusMemory(reservation);

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -169,6 +169,19 @@ export type CorpusLeaseHooks = {
     | "before-authorized";
   /** Test-only deterministic parent deadline after the projection has started. */
   operationDeadlineForTest?: Promise<void>;
+  /**
+   * Test-only worker termination grace, in milliseconds.
+   *
+   * Whether a kill is confirmed inside the grace window is a race that a test
+   * cannot force: SIGKILL is untrappable, so no fixture can refuse to die on
+   * cue. Shortening the window to zero makes the unconfirmed path
+   * deterministic instead.
+   *
+   * Safe as a knob because it can only make the parent more conservative. A
+   * shorter grace means more kills go unconfirmed, and an unconfirmed kill of
+   * a worker that was told which corpus to read still poisons the process.
+   */
+  workerTerminationGraceMsForTest?: number;
 };
 
 type RootIdentity = {
@@ -1812,6 +1825,12 @@ async function dispatchStableCorpusLease<T>(
   let protocolQueue: Promise<void> = Promise.resolve();
   let releaseReservation = true;
   let releaseWorkerAdmission = true;
+  // Whether the `begin` message, the only thing that tells the child which
+  // corpus to read, was actually handed to the child's stdin. Authority is the
+  // write itself, never anything the child echoes back, and never merely
+  // reaching the call site: `send` declines to write once the lease has
+  // settled or the pipe is gone.
+  let corpusRootDisclosed = false;
 
   const child = spawn(invocation.binary, invocation.args, {
     detached: process.platform !== "win32",
@@ -1837,13 +1856,15 @@ async function dispatchStableCorpusLease<T>(
   // and the message has nowhere useful to go.
   child.stdin?.on("error", () => {});
 
-  const send = (message: unknown): void => {
+  /** Write a protocol line, reporting whether it actually reached the pipe. */
+  const send = (message: unknown): boolean => {
     const serialized = JSON.stringify(message);
     if (Buffer.byteLength(serialized) > CORPUS_WORKER_PROTOCOL_MAX_BYTES || !child.stdin) {
       throw new CorpusLeaseBudgetError("meeting corpus worker protocol exceeded its budget");
     }
-    if (settled || child.stdin.destroyed || child.killed) return;
+    if (settled || child.stdin.destroyed || child.killed) return false;
     child.stdin.write(serialized + "\n");
+    return true;
   };
 
   try {
@@ -1887,7 +1908,9 @@ async function dispatchStableCorpusLease<T>(
         retainedPathBytes: number;
       };
       let stream: SnapshotStream | undefined;
-      const streamAck = (): void => send({ type: "stream-ack" });
+      const streamAck = (): void => {
+        send({ type: "stream-ack" });
+      };
       const handleProtocolLine = async (line: string): Promise<void> => {
         if (settled) return;
         let message: any;
@@ -2146,16 +2169,24 @@ async function dispatchStableCorpusLease<T>(
           });
       });
       try {
-        send({
-          type: "begin",
-          request: {
-            root,
-            budgets,
-            timeoutMs,
-            hookNames: workerHookNames(hooks),
-            stallPhase: hooks.workerStallPhaseForTest,
-          } satisfies CorpusLeaseWorkerRequest,
-        });
+        // Buffering means a `true` here proves the bytes were handed to the
+        // pipe, not that the child read them. That asymmetry is deliberate:
+        // over-reporting disclosure costs a conservative poisoning, while
+        // under-reporting would skip one that is required.
+        if (
+          send({
+            type: "begin",
+            request: {
+              root,
+              budgets,
+              timeoutMs,
+              hookNames: workerHookNames(hooks),
+              stallPhase: hooks.workerStallPhaseForTest,
+            } satisfies CorpusLeaseWorkerRequest,
+          })
+        ) {
+          corpusRootDisclosed = true;
+        }
       } catch {
         fail("meeting corpus worker request was invalid");
       }
@@ -2167,11 +2198,26 @@ async function dispatchStableCorpusLease<T>(
       const confirmed = await Promise.race([
         termination.then(() => true),
         new Promise<boolean>((resolve) => {
-          const timer = setTimeout(() => resolve(false), CORPUS_WORKER_TERMINATION_GRACE_MS);
+          const timer = setTimeout(
+            () => resolve(false),
+            hooks.workerTerminationGraceMsForTest ?? CORPUS_WORKER_TERMINATION_GRACE_MS
+          );
           timer.unref();
         }),
       ]);
-      if (!confirmed) {
+      // An unconfirmed kill means the child might still be running, and a
+      // child that knows the corpus root might still be reading it. Retaining
+      // its reservation and refusing further workers is the right answer to
+      // that, and stays the answer.
+      //
+      // A child killed before `begin` reached it is a different animal: the
+      // protocol is the only way it learns which directory to read, and it
+      // does nothing before that message. It cannot be holding corpus bytes,
+      // so charging the process for bytes it never read and blocking every
+      // later lease until restart protects nothing. That case is reachable in
+      // ordinary use, not just in tests, whenever a short budget expires while
+      // the worker is still starting (issue #689).
+      if (!confirmed && corpusRootDisclosed) {
         corpusWorkerPoisoned = true;
         releaseReservation = false;
         releaseWorkerAdmission = false;

--- a/scripts/check_corpus_lease_mirror.mjs
+++ b/scripts/check_corpus_lease_mirror.mjs
@@ -31,6 +31,7 @@ const MIRRORED_FILES = [
   "corpus-lease.ts",
   "corpus-lease.test.ts",
   "corpus-lease-refusal.test.ts",
+  "corpus-lease-poisoning.test.ts",
   "corpus-lease-worker.ts",
   "secure-read.ts",
 ];


### PR DESCRIPTION
Fixes #689.

## The defect

An unconfirmed kill (SIGKILL sent, `close` not observed inside the 2s grace) retains the killed lease's memory reservation and refuses every later corpus read with `requires a process restart`. That is correct when the child might still be reading the corpus, and it stays correct.

It is wrong for a child killed **before `begin` reached it**. The protocol is the only way a worker learns which directory to read, and it does nothing before that message, so such a child provably holds no corpus bytes. Charging the process for bytes never read, and locking every later lease until restart, protects nothing.

This is reachable in ordinary use, not just in tests: any short budget that expires while the worker is still starting hits it. On a busy machine, one such moment takes out corpus reads for the rest of an MCP server's lifetime.

## The rule

Poison only when the corpus root was actually disclosed to the child. Everything after `begin` keeps today's behavior exactly.

**The authority is the write itself.** `send` now reports whether the bytes reached the pipe, and it declines to write once the lease has settled, so merely reaching the call site does not count. Buffering means a `true` result proves the bytes were handed to the pipe, not that the child read them. That asymmetry is deliberate: over-reporting disclosure costs one conservative poisoning, while under-reporting would skip one that is required.

## Testing needed a seam, and this one cannot weaken the property

Whether a kill is confirmed inside the grace window is a race no test can force: SIGKILL is untrappable, so no fixture can refuse to die on cue. `workerTerminationGraceMsForTest` makes every kill unconfirmed instead, so the two cases differ only in whether the child was told which corpus to read.

Worth contrasting with the reset seam that adversarial review rejected on #690: that one could *disarm* the fail-closed barrier if reached from production. This one can only make the parent **more** conservative, since a shorter grace means more kills go unconfirmed, and an unconfirmed kill of a worker that knew the corpus still poisons.

## Verification

| | |
|---|---|
| never-fed worker, unconfirmed kill | process stays usable; a following lease succeeds |
| worker that knew the corpus, unconfirmed kill | still poisons; a following lease is refused |

Both fail without the change. Pre-fix, the first test poisons the process and the second then fails too, which is the cascade this fixes, visible in miniature.

They live in the isolated refusal file since they drive process-global state, and the poisoning test asserts the process is still clean when it starts, so its must-stay-last requirement fails loudly rather than silently.

SDK: 148 passed. MCP: 283 passed. Mirror check clean.