### PR TITLE
fix(site): unfreeze the homepage demo animation

### DIFF
--- a/site/components/demo-player.tsx
+++ b/site/components/demo-player.tsx
@@ -15,6 +15,18 @@ export function DemoPlayer() {
         style={{ width: "100%" }}
         autoPlay
         loop
+        // Keeps the demo animating. MinutesDemo is silent, but an unmuted
+        // Player still builds an AudioContext and drives its timeline off that
+        // clock. Chrome leaves the context suspended until a user gesture, so
+        // the Player reported isPlaying() === true while the clock never ticked
+        // and the frame sat at 0: a demo that looked like a broken screenshot.
+        //
+        // SharedPlayerContext only creates the context when
+        // `audioEnabled && !playerMuted && mediaVolume > 0`, so muting from the
+        // first render skips it and playback runs on the normal RAF clock.
+        // It must be `initiallyMuted`; the `muted` prop does not set
+        // `playerMuted` and leaves the context in place.
+        initiallyMuted
         acknowledgeRemotionLicense
       />
     </div>


### PR DESCRIPTION
The Remotion demo on the homepage was frozen on frame 0.

## Root cause

`MinutesDemo` is completely silent (no `Audio` import, no media files), but an **unmuted** Player still constructs an `AudioContext` and drives its timeline off that clock. Chrome leaves the context `suspended` until a user gesture, so:

```
isPlaying() === true     // the Player believes it is playing
frame stays at 0         // the clock it is playing against never ticks
```

With no controls rendered, that reads to a visitor as a broken screenshot rather than a paused video.

`SharedPlayerContext` creates the context only when `audioEnabled && !playerMuted && mediaVolume > 0`. Muting from the first render skips it, and playback falls back to the normal RAF clock.

## Why `initiallyMuted` and not something simpler

Three plausible fixes were tested and **rejected on evidence**, not taste:

| Attempt | Result |
|---|---|
| `muted` | Does not feed `playerMuted`. Context still built, still frozen |
| `numberOfSharedAudioTags={0}` | Removes the `<audio>` tags, but the context is still built. Still frozen |
| ref + `play()` on mount, retry on first user gesture | Still frozen. `play()` does not resume the context |

## Not a regression from the dependency bump

Worth recording, since `@remotion/player` went 4.0.500 to 4.0.506 today in #684 and was the obvious suspect: **a local build pinned to 4.0.500 froze identically.** Also ruled out: missing JS chunks (all 200), version mismatch between `remotion` and `@remotion/player` (both 4.0.506), the `globals.css` change, the heading refactor in #699, and `prefers-reduced-motion` (animates either way).

## Verification

Headless Chrome probe under the **default** autoplay policy, hashing screenshots of the demo region over time:

```
before   contexts=1 (suspended)   frames identical   => STATIC
after    contexts=0               frames differ      => ANIMATING
```

The cause was identified by resuming the suspended context by hand on the deployed page, which unfroze it immediately. The `AudioContext was not allowed to start` console warning is now gone. `tsc --noEmit` clean, `next build` clean.

Nothing is lost by muting: the composition has no audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)