### PR TITLE
Per-location counts, and say it the way a lawyer would say it

### DIFF
--- a/archive/src-tauri/src/main.rs
+++ b/archive/src-tauri/src/main.rs
@@ -104,6 +104,18 @@ impl Default for ArchiveState {
 struct LocationSummary {
     id: u64,
     label: String,
+    /// What this location contributed to the last census, or `None` before
+    /// one has run.
+    ///
+    /// The rows are deliberately indistinguishable by name, which leaves an
+    /// owner with several matters approved unable to tell them apart at a
+    /// glance. Counts separate them without naming anything: "4,102 items"
+    /// beside "12 items" is the difference between a matter archive and a
+    /// folder of exhibits, and neither number says whose.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifacts: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    regular_file_bytes: Option<u64>,
 }
 
 /// The result of a folder-picker round.
@@ -187,12 +199,35 @@ fn safe_census_error(error: impl std::fmt::Display) -> String {
 }
 
 fn location_summaries(locations: &[ApprovedLocation]) -> Vec<LocationSummary> {
+    location_summaries_with(locations, None)
+}
+
+/// Location rows, with the last census's per-location totals when there is a
+/// census to draw them from.
+///
+/// Totals are positional against the approved roots, exactly as the census
+/// produced them. A report from a different set of locations -- one taken
+/// before a folder was added or removed -- would misattribute every row, so a
+/// length mismatch drops the numbers rather than showing wrong ones. A row
+/// without a count is a smaller failure than a row with someone else's.
+fn location_summaries_with(
+    locations: &[ApprovedLocation],
+    report: Option<&CensusReport>,
+) -> Vec<LocationSummary> {
+    let totals = report
+        .map(|report| report.per_location.as_slice())
+        .filter(|totals| totals.len() == locations.len());
     locations
         .iter()
         .enumerate()
-        .map(|(index, location)| LocationSummary {
-            id: location.id,
-            label: format!("Approved location {}", index + 1),
+        .map(|(index, location)| {
+            let totals = totals.and_then(|totals| totals.get(index));
+            LocationSummary {
+                id: location.id,
+                label: format!("Approved location {}", index + 1),
+                artifacts: totals.map(|totals| totals.artifacts),
+                regular_file_bytes: totals.map(|totals| totals.regular_file_bytes),
+            }
         })
         .collect()
 }
@@ -311,7 +346,7 @@ fn archive_bootstrap(state: State<'_, ArchiveState>) -> Result<BootstrapState, S
     let session = state.session.lock().map_err(|_| lock_error())?;
     Ok(BootstrapState {
         build_identity: build_identity(),
-        locations: location_summaries(&session.locations),
+        locations: location_summaries_with(&session.locations, session.last_report.as_ref()),
         scan_running: session.scan.running,
         report: session.last_report.clone(),
         text_vault_report: session
@@ -345,7 +380,9 @@ async fn choose_archive_locations(
             folded: 0,
             forgotten_skips: 0,
             unskipped: 0,
-            locations: location_summaries(&session.locations),
+            // Nothing was approved or removed, so the last census still
+            // describes exactly these rows and its counts still belong on them.
+            locations: location_summaries_with(&session.locations, session.last_report.as_ref()),
         });
     };
 
@@ -1614,6 +1651,98 @@ mod tests {
         );
         assert!(!serialized.contains("client-alpha"));
         assert!(!serialized.contains("client-beta"));
+    }
+
+    /// Per-location counts distinguish the rows and never reach the export.
+    ///
+    /// The rows are deliberately unnameable, which left an owner unable to
+    /// tell one approved matter from another. Counts fix that without naming
+    /// anything -- but the exported report has been through a privacy review
+    /// and carries a versioned schema, so the numbers stop at the interface.
+    #[test]
+    fn per_location_counts_reach_the_interface_and_not_the_export() {
+        let temp = TempDir::new().expect("temp");
+        let big = temp.path().join("matter-archive");
+        let small = temp.path().join("exhibits");
+        fs::create_dir(&big).expect("big");
+        fs::create_dir(&small).expect("small");
+        for index in 0..7u32 {
+            fs::write(
+                big.join(format!("agreement-{index:02}.txt")),
+                "x".repeat(100),
+            )
+            .expect("write");
+        }
+        fs::write(small.join("exhibit-a.txt"), "y".repeat(10)).expect("write");
+
+        let approved = approve_roots(&[big, small]).expect("approve");
+        let report =
+            scan_approved_roots(&approved, CensusLimits::default(), &AtomicBool::new(false))
+                .expect("census");
+
+        // Positional against the approved roots, and each artifact counted
+        // once under the location it was actually found in.
+        assert_eq!(report.per_location.len(), 2);
+        assert_eq!(report.per_location[0].artifacts, 7);
+        assert_eq!(report.per_location[0].regular_file_bytes, 700);
+        assert_eq!(report.per_location[1].artifacts, 1);
+        assert_eq!(report.per_location[1].regular_file_bytes, 10);
+        // The per-location totals must reconcile with the aggregate, or one
+        // of the two numbers on screen is lying about the same archive.
+        let summed: u64 = report.per_location.iter().map(|t| t.artifacts).sum();
+        assert_eq!(summed, report.summary.artifacts);
+
+        // The interface receives them on the rows it could not otherwise tell
+        // apart.
+        let mut roots = approved.into_iter();
+        let locations = [
+            ApprovedLocation {
+                id: 1,
+                root: roots.next().expect("first"),
+            },
+            ApprovedLocation {
+                id: 2,
+                root: roots.next().expect("second"),
+            },
+        ];
+        let serialized = serde_json::to_string(&location_summaries_with(&locations, Some(&report)))
+            .expect("serialize");
+        assert!(serialized.contains(r#""artifacts":7"#), "{serialized}");
+        assert!(serialized.contains(r#""artifacts":1"#), "{serialized}");
+        // The interface reads these by name, and the struct renames to
+        // camelCase -- a mismatch here showed every location as "0 B" while
+        // the item count was right, which is the kind of half-correct row
+        // that reads as a real number.
+        assert!(
+            serialized.contains(r#""regularFileBytes":700"#),
+            "{serialized}"
+        );
+        assert!(!serialized.contains("matter-archive"), "{serialized}");
+        assert!(!serialized.contains("exhibits"), "{serialized}");
+
+        // The export does not, and stays exactly the reviewed shape.
+        let exported = serde_json::to_string(&report).expect("export");
+        assert!(
+            !exported.contains("per_location"),
+            "per-location totals must not enter the reviewed export shape: {exported}"
+        );
+
+        // A report taken against a different set of locations misattributes
+        // every row, so its numbers are dropped rather than shown wrong.
+        let one_location = [ApprovedLocation {
+            id: 1,
+            root: approve_roots(std::slice::from_ref(&temp.path().join("matter-archive")))
+                .ok()
+                .and_then(|mut roots| roots.pop())
+                .expect("re-approve"),
+        }];
+        let mismatched =
+            serde_json::to_string(&location_summaries_with(&one_location, Some(&report)))
+                .expect("serialize");
+        assert!(
+            !mismatched.contains("artifacts"),
+            "a report from a different location set must not label these rows: {mismatched}"
+        );
     }
 
     /// Revealing a location resolves its path here and never hands one out.

--- a/archive/src/app.js
+++ b/archive/src/app.js
@@ -127,7 +127,15 @@ function renderLocations(nextLocations) {
     const title = document.createElement("strong");
     title.textContent = location.label;
     const detail = document.createElement("span");
-    detail.textContent = "Read-only native authority";
+    // Counts, when a census has produced them, are what tells one opaque row
+    // from another. They name nothing: a folder of exhibits and a matter
+    // archive differ by two orders of magnitude and by nothing identifying.
+    detail.textContent =
+      typeof location.artifacts === "number"
+        ? `${location.artifacts.toLocaleString()} item${
+            location.artifacts === 1 ? "" : "s"
+          } · ${formatBytes(location.regularFileBytes ?? 0)} · read-only native authority`
+        : "Read-only native authority";
     text.append(title, detail);
     copy.append(icon, text);
 
@@ -1006,9 +1014,21 @@ async function searchVault(event) {
   }
 }
 
-function startOver() {
+async function startOver() {
   hideError();
   showView("setup");
+  // Re-read the rows rather than reusing the ones rendered before the census.
+  // The per-location counts only exist once a census has run, so the state
+  // this view was left in is exactly the state that lacks them, and the rows
+  // would stay unlabelled for the whole session.
+  try {
+    const state = await invoke("archive_bootstrap");
+    renderLocations(state.locations);
+  } catch (error) {
+    // A failed refresh costs the counts, never the view: the operator asked
+    // to change locations and must still land somewhere he can.
+    showError(String(error));
+  }
   elements.setupStatus.textContent = `${locations.length.toLocaleString()} approved location${
     locations.length === 1 ? "" : "s"
   }. Change locations or run the metadata census again.`;

--- a/archive/src/app.js
+++ b/archive/src/app.js
@@ -421,7 +421,7 @@ function renderReport(report) {
       "Scans that need reading",
       report.categories.find((item) => item.category === "image_or_scan")?.artifacts ?? 0,
     ),
-    createSignal("iCloud placeholders", report.signals.icloud_placeholders),
+    createSignal("Not downloaded from iCloud", report.signals.icloud_placeholders),
     createSignal("Pages, Numbers, Keynote", report.summary.packages),
     createSignal("Blocked by permissions", report.signals.permission_mode_unreadable),
     createSignal("Shortcuts skipped", report.signals.symlinks_skipped),
@@ -518,8 +518,10 @@ function renderVaultSummary(report) {
   }
   if (report.unsupported_files_skipped > 0 || report.ocr_required_files > 0) {
     notes.push({
-      text: `${report.unsupported_files_skipped.toLocaleString()} unsupported item${
+      text: `${report.unsupported_files_skipped.toLocaleString()} file${
         report.unsupported_files_skipped === 1 ? "" : "s"
+      } this app cannot open ${
+        report.unsupported_files_skipped === 1 ? "was" : "were"
       } skipped; ${report.ocr_required_files.toLocaleString()} PDF${
         report.ocr_required_files === 1 ? "" : "s"
       } are pictures of pages with no text to read.`,
@@ -541,7 +543,7 @@ function renderVaultSummary(report) {
   const inferredBoundaryDocuments = report.inferred_boundary_documents ?? 0;
   if (inferredBoundaryDocuments > 0) {
     notes.push({
-      text: `${inferredBoundaryDocuments.toLocaleString()} indexed document${
+      text: `${inferredBoundaryDocuments.toLocaleString()} document${
         inferredBoundaryDocuments === 1 ? "" : "s"
       } cannot answer "in the same clause" questions, because the file does not record where one clause ends and the next begins.`,
     });
@@ -716,7 +718,7 @@ async function buildTextVault() {
     elements.searchStatus.textContent =
       report.indexed_documents === 0
         ? "No searchable PDF, Word, OpenDocument, RTF, TXT, or Markdown documents were found in the approved locations."
-        : "Enter a legal retrieval question. Results are exact source excerpts, not generated answers.";
+        : "Type what you are looking for. You get exact quotes from your own documents, not an answer written by an AI.";
     showView("search");
     if (report.indexed_documents > 0) {
       elements.searchQuery.focus();
@@ -747,25 +749,23 @@ function renderQueryInterpretation(response) {
   const query = response.query;
   elements.queryChips.replaceChildren();
   addQueryChip(
-    query.scope === "same_provision" ? "Same provision" : "Anywhere in one document",
+    query.scope === "same_provision" ? "All in one clause" : "Anywhere in one document",
   );
   for (const concept of query.required_concepts) {
-    addQueryChip(`Must cover: ${humanize(concept)}`);
+    addQueryChip(`Must mention: ${humanize(concept)}`);
   }
   for (const concept of query.excluded_concepts) {
     addQueryChip(`Exclude: ${humanize(concept)}`);
   }
   if (query.exact_phrase) addQueryChip(`Exact: “${query.exact_phrase}”`);
   if (query.max_sentences) addQueryChip(`At most ${query.max_sentences} sentences`);
-  if (response.semantic_query_applied) addQueryChip("On-device meaning suggestions");
+  if (response.semantic_query_applied) addQueryChip("Close matches too");
   elements.candidateCount.textContent =
-    `${response.lexical_candidates_considered.toLocaleString()} lexical candidate${
+    `${response.lexical_candidates_considered.toLocaleString()} passage${
       response.lexical_candidates_considered === 1 ? "" : "s"
-    } checked` +
+    } checked word by word` +
     (response.semantic_query_applied
-      ? ` · ${response.semantic_candidates_considered.toLocaleString()} semantic vector${
-          response.semantic_candidates_considered === 1 ? "" : "s"
-        } ranked`
+      ? ` · ${response.semantic_candidates_considered.toLocaleString()} compared by meaning`
       : "");
   elements.queryInterpretation.hidden = false;
 }
@@ -968,10 +968,10 @@ function renderSearchResponse(response) {
     empty.textContent =
       response.stale_evidence_withdrawn > 0
         ? "This match is out of date, so it was withheld. Open your documents again before relying on it."
-        : "No current source satisfied every visible constraint. Try removing one constraint or search for a different legal concept.";
+        : "Nothing in your documents matched all of that. Try asking for less at once, or use different wording.";
     elements.searchResults.append(empty);
   }
-  const resultKind = response.query.scope === "same_provision" ? "provision" : "document";
+  const resultKind = response.query.scope === "same_provision" ? "clause" : "document";
   const staleNote =
     response.stale_evidence_withdrawn > 0
       ? ` ${response.stale_evidence_withdrawn.toLocaleString()} stale source${
@@ -980,18 +980,18 @@ function renderSearchResponse(response) {
       : "";
   const boundaryNote =
     (response.inferred_boundary_evidence_withdrawn ?? 0) > 0
-      ? ` ${(response.inferred_boundary_evidence_withdrawn ?? 0).toLocaleString()} searchable document${
+      ? ` ${(response.inferred_boundary_evidence_withdrawn ?? 0).toLocaleString()} document${
           response.inferred_boundary_evidence_withdrawn === 1 ? " does" : "s do"
         } not record where a clause ends, so ${
           response.inferred_boundary_evidence_withdrawn === 1 ? "it was" : "they were"
         } excluded from same-clause questions.`
       : "";
   elements.searchStatus.textContent =
-    `${verifiedCount.toLocaleString()} current ${resultKind}${
+    `${verifiedCount.toLocaleString()} ${resultKind}${
       verifiedCount === 1 ? "" : "s"
-    } matched every visible constraint; ${suggestionCount.toLocaleString()} separately labeled meaning suggestion${
-      suggestionCount === 1 ? "" : "s"
-    }.${staleNote}${boundaryNote}`;
+    } matched everything you asked for. ${suggestionCount.toLocaleString()} more ${
+      suggestionCount === 1 ? "is" : "are"
+    } close in meaning, listed separately below.${staleNote}${boundaryNote}`;
 }
 
 async function searchVault(event) {

--- a/archive/src/app.js
+++ b/archive/src/app.js
@@ -61,7 +61,7 @@ const categoryLabels = {
   archive: "Compressed archives",
   database: "Databases",
   apple_document: "Apple documents",
-  icloud_placeholder: "iCloud placeholders",
+  icloud_placeholder: "Still in iCloud",
   other: "Other formats",
 };
 
@@ -134,8 +134,8 @@ function renderLocations(nextLocations) {
       typeof location.artifacts === "number"
         ? `${location.artifacts.toLocaleString()} item${
             location.artifacts === 1 ? "" : "s"
-          } · ${formatBytes(location.regularFileBytes ?? 0)} · read-only native authority`
-        : "Read-only native authority";
+          } · ${formatBytes(location.regularFileBytes ?? 0)} · read-only`
+        : "Read-only";
     text.append(title, detail);
     copy.append(icon, text);
 
@@ -175,10 +175,10 @@ function renderLocations(nextLocations) {
   elements.skipFolders.disabled = locations.length === 0;
   elements.setupStatus.textContent =
     locations.length === 0
-      ? "Choose at least one location to continue."
-      : `${locations.length.toLocaleString()} location${
+      ? "Choose at least one folder to continue."
+      : `${locations.length.toLocaleString()} folder${
           locations.length === 1 ? "" : "s"
-        } approved. Nothing has been scanned yet.`;
+        } chosen. Nothing has been looked at yet.`;
 }
 
 async function chooseLocations() {
@@ -260,14 +260,14 @@ async function chooseSkippedFolders() {
       notes.push(
         `${choice.outside.toLocaleString()} ${
           choice.outside === 1 ? "folder is" : "folders are"
-        } not inside an approved location, so ${
+        } not inside a folder you chose, so ${
           choice.outside === 1 ? "it was" : "they were"
         } not added.`,
       );
     }
     if (choice.refusedWholeLocation > 0) {
       notes.push(
-        "A whole approved location cannot be skipped — remove the location instead.",
+        "You cannot skip a whole folder you chose — remove it instead.",
       );
     }
     if (notes.length > 0) {
@@ -290,7 +290,7 @@ async function clearSkippedFolders() {
     elements.clearSkipped.hidden = true;
     elements.setupStatus.textContent = `${cleared.toLocaleString()} skipped folder${
       cleared === 1 ? "" : "s"
-    } restored. Every approved location will be read whole.`;
+    } restored. Every folder you chose will be read whole.`;
     lastReport = null;
     vaultReport = null;
   } catch (error) {
@@ -378,10 +378,10 @@ function renderReport(report) {
   elements.resultStatus.dataset.status = report.status;
   elements.resultSummary.textContent =
     report.status === "complete"
-      ? "The approved locations were counted without reading document contents."
+      ? "Your folders were counted without opening a single document."
       : report.status === "cancelled"
-        ? "The census was cancelled. Partial counts were discarded from export."
-        : "The census stopped at a safety boundary. Review the aggregate signals.";
+        ? "Cancelled. The partial counts were thrown away."
+        : "Counting stopped at a safety limit, so these totals are incomplete. See what needs attention.";
 
   renderBuildForecast(report);
   elements.metricArtifacts.textContent = report.summary.artifacts.toLocaleString();
@@ -412,21 +412,21 @@ function renderReport(report) {
   if (categories.length === 0) {
     const empty = document.createElement("p");
     empty.className = "status";
-    empty.textContent = "No file or package artifacts were found.";
+    empty.textContent = "No files were found.";
     elements.categoryList.append(empty);
   }
 
   elements.signalsList.replaceChildren(
     createSignal(
-      "Likely OCR candidates",
+      "Scans that need reading",
       report.categories.find((item) => item.category === "image_or_scan")?.artifacts ?? 0,
     ),
     createSignal("iCloud placeholders", report.signals.icloud_placeholders),
-    createSignal("Apple packages", report.summary.packages),
-    createSignal("Unreadable by mode", report.signals.permission_mode_unreadable),
-    createSignal("Links skipped", report.signals.symlinks_skipped),
+    createSignal("Pages, Numbers, Keynote", report.summary.packages),
+    createSignal("Blocked by permissions", report.signals.permission_mode_unreadable),
+    createSignal("Shortcuts skipped", report.signals.symlinks_skipped),
     createSignal(
-      "Metadata errors",
+      "Could not be examined",
       report.signals.metadata_errors + report.signals.directory_errors,
     ),
   );
@@ -447,7 +447,7 @@ async function runCensus() {
     if (report.status === "cancelled") {
       lastReport = null;
       showView("setup");
-      elements.setupStatus.textContent = "Census cancelled. No report was retained.";
+      elements.setupStatus.textContent = "Cancelled. Nothing was kept.";
       return;
     }
     renderReport(report);
@@ -477,7 +477,7 @@ async function exportReport() {
   elements.exportStatus.textContent = "Preparing report…";
   try {
     const saved = await invoke("export_archive_census");
-    elements.exportStatus.textContent = saved ? "Aggregate report saved." : "";
+    elements.exportStatus.textContent = saved ? "Report saved." : "";
   } catch (error) {
     elements.exportStatus.textContent = "";
     showError(error);
@@ -493,9 +493,9 @@ function renderVaultSummary(report) {
   // screen needs to know in one glance what is searchable, and then be able to
   // find the caveat that applies to them. Nothing is dropped, and the warnings
   // that change whether a negative result can be trusted are marked as such.
-  const lead = `${report.indexed_documents.toLocaleString()} supported document${
+  const lead = `${report.indexed_documents.toLocaleString()} document${
     report.indexed_documents === 1 ? "" : "s"
-  } indexed (${formatBytes(report.indexed_bytes)}). All indexes exist only in memory.`;
+  } ready to search (${formatBytes(report.indexed_bytes)}). Held in memory only — nothing was saved to disk.`;
 
   const notes = [];
   const formatBreakdown = [
@@ -504,7 +504,7 @@ function renderVaultSummary(report) {
     // to counsel is how much became searchable, not which container it arrived in.
     `${report.docx_documents.toLocaleString()} Word or OpenDocument`,
   ].join(", ");
-  notes.push({ text: `Searchable formats: ${formatBreakdown}.` });
+  notes.push({ text: `You can search: ${formatBreakdown}.` });
 
   // Its own line. A scan that was read is searchable, but only as a
   // transcription, and folding it into the indexed total would say the archive
@@ -513,7 +513,7 @@ function renderVaultSummary(report) {
     notes.push({
       text: `${report.transcribed_documents.toLocaleString()} scanned page${
         report.transcribed_documents === 1 ? "" : "s"
-      } read by text recognition — searchable as transcriptions, never quoted as source text.`,
+      } read by the text reader — you can search these, but they are a machine reading a picture, so they are never quoted as the document\u0027s own words.`,
     });
   }
   if (report.unsupported_files_skipped > 0 || report.ocr_required_files > 0) {
@@ -522,7 +522,7 @@ function renderVaultSummary(report) {
         report.unsupported_files_skipped === 1 ? "" : "s"
       } skipped; ${report.ocr_required_files.toLocaleString()} PDF${
         report.ocr_required_files === 1 ? "" : "s"
-      } are images of pages and carry no text to read.`,
+      } are pictures of pages with no text to read.`,
     });
   }
   // Folders the owner told the build not to enter. Deliberate, so not a
@@ -543,15 +543,15 @@ function renderVaultSummary(report) {
     notes.push({
       text: `${inferredBoundaryDocuments.toLocaleString()} indexed document${
         inferredBoundaryDocuments === 1 ? "" : "s"
-      } cannot answer same-clause questions because the file does not record where a clause ends.`,
+      } cannot answer "in the same clause" questions, because the file does not record where one clause ends and the next begins.`,
     });
   }
   notes.push({
     text: report.semantic_retrieval_enabled
-      ? `${report.semantic_provisions_indexed.toLocaleString()} provision suggestion vector${
+      ? `Suggestions are on: ${report.semantic_provisions_indexed.toLocaleString()} passage${
           report.semantic_provisions_indexed === 1 ? "" : "s"
-        } built with the pinned macOS model inside its network-denied worker.`
-      : "Semantic suggestions are unavailable on this Mac.",
+        } were prepared using the language model built into macOS, on this Mac.`
+      : "Suggestions by meaning are not available on this Mac. Exact search still works.",
   });
   // Partial suggestion coverage is not the same as none. Exact search is
   // complete either way; a reader who assumes the suggestions swept the whole
@@ -559,7 +559,7 @@ function renderVaultSummary(report) {
   if (report.semantic_coverage_partial) {
     notes.push({
       warning: true,
-      text: "The on-device suggestion model stopped partway through this build, so meaning-based suggestions cover only part of the archive. Exact search covers all of it.",
+      text: "The suggestion model stopped partway through, so suggestions cover only part of your documents. Exact search covers all of them.",
     });
   }
   const dropped = describeDroppedSources(report).trim();
@@ -611,46 +611,49 @@ function renderVaultSummary(report) {
 // visible to be acted on.
 function describeDroppedSources(report) {
   const dropped = [
-    [report.conversion_failures, "could not be converted"],
-    [report.malformed_text_files_skipped, "were malformed"],
-    [report.oversized_files_skipped, "exceeded the size budget"],
-    [report.duplicate_files_skipped, "were duplicates"],
+    [report.conversion_failures, "could not be opened by the converter"],
+    [report.malformed_text_files_skipped, "damaged"],
+    [report.oversized_files_skipped, "too large"],
+    [report.duplicate_files_skipped, "duplicates"],
     // Both link counters were tallied and never shown. On de-duplicated or
     // linked storage every file can carry a second name, so the whole archive
     // is refused and counsel is told only that fewer documents were indexed
     // than the folder holds -- a silent, total coverage loss.
-    [report.symlinks_skipped, "were aliases or shortcuts"],
+    [report.symlinks_skipped, "aliases or shortcuts"],
     [report.hard_links_skipped, "have a second name elsewhere on the disk"],
     // Split five ways after a real archive reported 10,429 of ~16,600
     // documents "could not be read" and the number could not be acted on.
     // Permission denied is a thing a reader can fix; a file changing mid-read
     // is not the same problem at all.
-    [report.permission_denied, "were blocked by macOS permissions"],
-    [report.unopenable, "could not be opened for another reason"],
+    [report.permission_denied, "blocked by macOS permissions"],
+    [report.unopenable, "could not be opened for some other reason"],
     [
       report.open_file_limit_reached,
-      "were not reached before the app ran out of open files (restart and index a smaller folder)",
+      "not reached because the app ran out of open files (restart it and try a smaller folder)",
     ],
-    [report.scans_unreadable, "were scans the text recognizer could not read"],
+    [report.scans_unreadable, "scans the text reader could not make out"],
     [report.entries_unstattable, "could not be examined at all"],
-    [report.identity_unavailable, "had no stable identity to pin"],
+    [report.identity_unavailable, "could not be tracked reliably"],
     [report.changed_while_reading, "changed while being read"],
-    [report.directory_errors, "were in unreadable folders"],
+    [report.directory_errors, "inside folders that could not be read"],
   ].filter(([count]) => count > 0);
   if (dropped.length === 0) {
-    return "No supported document was dropped. ";
+    return "Every supported document was read. ";
   }
   const total = dropped.reduce((sum, [count]) => sum + count, 0);
+  // "reason (count)", not "count reason": the reasons are phrases that cannot
+  // agree with every number, and "1 were aliases or shortcuts" is the kind of
+  // sentence that makes a reader distrust the number beside it.
   const detail = dropped
-    .map(([count, reason]) => `${count.toLocaleString()} ${reason}`)
+    .map(([count, reason]) => `${reason} (${count.toLocaleString()})`)
     .join(", ");
   // "items", not "documents": `directory_errors` counts folders, and an alias
   // can point at one, so the aggregate spans more than files. Calling it a
   // document count would overstate how many documents are missing.
   return (
     `${total.toLocaleString()} item${total === 1 ? "" : "s"} ` +
-    `${total === 1 ? "was" : "were"} not indexed and cannot be searched ` +
-    `(${detail}). Review these before relying on a negative result. `
+    `could not be read, so ${total === 1 ? "it is" : "they are"} not searchable: ` +
+    `${detail}. Check these before you trust a "nothing found" result. `
   );
 }
 
@@ -805,7 +808,7 @@ function evidenceCard(card, compact = false, semantic = false) {
   titleBlock.append(kicker, title);
   const fresh = document.createElement("span");
   fresh.className = "metadata-pill";
-  fresh.textContent = card.index_fresh ? "Source verified" : "Unavailable";
+  fresh.textContent = card.index_fresh ? "Checked against the file" : "Unavailable";
   header.append(titleBlock, fresh);
 
   const excerpt = document.createElement("blockquote");
@@ -863,7 +866,7 @@ function documentCard(card) {
   const titleBlock = document.createElement("div");
   const kicker = document.createElement("span");
   kicker.className = "evidence-kicker";
-  kicker.textContent = "Document-level conjunction";
+  kicker.textContent = "Found across the whole document";
   const title = document.createElement("strong");
   title.className = "evidence-title";
   title.textContent = card.document_title;
@@ -902,7 +905,7 @@ function transcribedCard(card) {
 
   const anchor = document.createElement("p");
   anchor.className = "transcription-anchor";
-  anchor.textContent = `${card.page_anchor} · read by ${card.transcriber}`;
+  anchor.textContent = `${card.page_anchor} · read from a scan`;
   article.append(anchor);
 
   const text = document.createElement("blockquote");
@@ -913,7 +916,7 @@ function transcribedCard(card) {
   const confidence = document.createElement("p");
   confidence.className = "transcription-confidence";
   const percent = Math.round((card.lowest_line_confidence ?? 0) * 100);
-  confidence.textContent = `Lowest line confidence ${percent}%. Check this against the page before relying on it.`;
+  confidence.textContent = `The text reader was least sure here: ${percent}%. Check this against the page before relying on it.`;
   article.append(confidence);
 
   const why = document.createElement("p");
@@ -938,7 +941,7 @@ function renderSearchResponse(response) {
   if (response.semantic_suggestions.length > 0) {
     const heading = document.createElement("p");
     heading.className = "semantic-heading";
-    heading.textContent = "Broader recall · review, not verified legal matches";
+    heading.textContent = "Similar wording — read these yourself; they are not exact matches";
     elements.searchResults.append(heading);
     for (const card of response.semantic_suggestions) {
       elements.searchResults.append(evidenceCard(card, false, true));
@@ -964,7 +967,7 @@ function renderSearchResponse(response) {
     empty.className = "empty-results";
     empty.textContent =
       response.stale_evidence_withdrawn > 0
-        ? "The indexed match is no longer current. It was withdrawn; rebuild the document index before relying on it."
+        ? "This match is out of date, so it was withheld. Open your documents again before relying on it."
         : "No current source satisfied every visible constraint. Try removing one constraint or search for a different legal concept.";
     elements.searchResults.append(empty);
   }
@@ -973,7 +976,7 @@ function renderSearchResponse(response) {
     response.stale_evidence_withdrawn > 0
       ? ` ${response.stale_evidence_withdrawn.toLocaleString()} stale source${
           response.stale_evidence_withdrawn === 1 ? " was" : "s were"
-        } withdrawn.`
+        } withheld because the file changed.`
       : "";
   const boundaryNote =
     (response.inferred_boundary_evidence_withdrawn ?? 0) > 0
@@ -996,7 +999,7 @@ async function searchVault(event) {
   hideError();
   const query = elements.searchQuery.value.trim();
   if (!query) {
-    elements.searchStatus.textContent = "Enter a legal retrieval question first.";
+    elements.searchStatus.textContent = "Type what you are looking for first.";
     elements.searchQuery.focus();
     return;
   }
@@ -1007,7 +1010,7 @@ async function searchVault(event) {
     const response = await invoke("search_archive_text_vault", { query });
     renderSearchResponse(response);
   } catch (error) {
-    elements.searchStatus.textContent = "No evidence was returned.";
+    elements.searchStatus.textContent = "Nothing matched.";
     showError(error);
   } finally {
     elements.searchSubmit.disabled = false;
@@ -1029,9 +1032,9 @@ async function startOver() {
     // to change locations and must still land somewhere he can.
     showError(String(error));
   }
-  elements.setupStatus.textContent = `${locations.length.toLocaleString()} approved location${
+  elements.setupStatus.textContent = `${locations.length.toLocaleString()} folder${
     locations.length === 1 ? "" : "s"
-  }. Change locations or run the metadata census again.`;
+  } chosen. Change them, or count what is there again.`;
 }
 
 function backToCensus() {
@@ -1047,7 +1050,7 @@ async function bootstrap() {
     // where a support conversation starts. Two candidates once carried the
     // same version number and only one of them could index anything.
     if (state.buildIdentity) {
-      elements.buildIdentity.textContent = `Private evidence build · ${state.buildIdentity}`;
+      elements.buildIdentity.textContent = `Minutes Archive ${state.buildIdentity}`;
     }
     renderLocations(state.locations);
     lastReport = state.report;

--- a/archive/src/index.html
+++ b/archive/src/index.html
@@ -195,7 +195,7 @@
                 <div class="card-title">
                   <div>
                     <p class="section-label">File types</p>
-                    <h3 id="coverage-title">What the archive contains</h3>
+                    <h3 id="coverage-title">What kinds of files you have</h3>
                   </div>
                   <span class="metadata-pill">Counts only</span>
                 </div>
@@ -237,7 +237,7 @@
                 </p>
               </div>
               <button id="build-text-vault" class="button button-primary" type="button">
-                Build document pilot
+                Open my documents
                 <span aria-hidden="true">→</span>
               </button>
             </div>
@@ -289,7 +289,7 @@
                 </div>
               </div>
               <button id="back-to-census" class="button button-secondary" type="button">
-                Census &amp; locations
+                Folders &amp; totals
               </button>
             </div>
 
@@ -307,10 +307,10 @@
                 </button>
               </div>
               <p class="search-help">
-                Try “Find documents containing assignment, governing law, and a
-                BAA reference” for document-level conjunction, or describe a
-                clause in ordinary language for separately labeled semantic
-                suggestions.
+                You can ask for several things at once — “documents with
+                assignment, governing law, and a BAA reference” — or just
+                describe a clause in your own words. Close matches are listed
+                separately from exact ones.
               </p>
             </form>
 
@@ -323,8 +323,8 @@
             </div>
 
             <p id="search-status" class="status search-status" role="status">
-              Enter a legal retrieval question. Results are exact source
-              excerpts, not generated answers.
+              Type what you are looking for. You get exact quotes from your
+              own documents, not an answer written by an AI.
             </p>
             <div id="search-results" class="search-results"></div>
 

--- a/archive/src/index.html
+++ b/archive/src/index.html
@@ -25,12 +25,13 @@
       </header>
 
       <section id="main-content" class="hero">
-        <p class="eyebrow">Private legal work product</p>
+        <p class="eyebrow">Local only · nothing is uploaded</p>
         <h1>Map first. Then find the exact language.</h1>
         <p class="hero-copy">
-          Start with a metadata-only census. If the coverage looks right, build
-          a local, in-memory document index and search exact provisions with
-          source evidence. Nothing is uploaded.
+          First count what is in your folders, without opening anything. If
+          that looks right, open the documents so you can search them and get
+          exact quotes that point back to the file they came from. Nothing
+          leaves this Mac.
         </p>
       </section>
 
@@ -40,29 +41,29 @@
             <li class="step is-active" data-step="1">
               <span class="step-number">1</span>
               <div>
-                <strong>Approve locations</strong>
-                <span>Nothing is scanned implicitly.</span>
+                <strong>Choose folders</strong>
+                <span>Nothing is looked at until you pick it.</span>
               </div>
             </li>
             <li class="step" data-step="2">
               <span class="step-number">2</span>
               <div>
-                <strong>Run private census</strong>
-                <span>Metadata only. No filenames exported.</span>
+                <strong>Count what is there</strong>
+                <span>Counts only. Your files stay closed.</span>
               </div>
             </li>
             <li class="step" data-step="3">
               <span class="step-number">3</span>
               <div>
-                <strong>Review coverage</strong>
-                <span>Decide what the pilot should support.</span>
+                <strong>Check the totals</strong>
+                <span>See what is there before opening anything.</span>
               </div>
             </li>
             <li class="step" data-step="4">
               <span class="step-number">4</span>
               <div>
-                <strong>Search exact evidence</strong>
-                <span>Searchable PDF, Word, OpenDocument, RTF, text, and scans read on-device.</span>
+                <strong>Search your documents</strong>
+                <span>PDFs, Word files, text, and scans — all read on this Mac.</span>
               </div>
             </li>
           </ol>
@@ -73,10 +74,11 @@
               <path d="m9.2 12 1.7 1.8 4-4.3" />
             </svg>
             <div>
-              <strong>The census cannot open documents</strong>
+              <strong>This step cannot open your documents</strong>
               <p>
-                Content access is a later, explicit action. No mode follows
-                links, contacts a model, or uploads anything.
+                Opening documents is a separate step that you choose.
+                Nothing here follows shortcuts, sends anything to an AI
+                service, or uploads.
               </p>
             </div>
           </div>
@@ -87,17 +89,17 @@
             <div class="panel-heading">
               <div>
                 <p class="section-label">Step 1</p>
-                <h2 id="locations-title">Approved archive locations</h2>
+                <h2 id="locations-title">Folders you have approved</h2>
                 <p>
-                  Use the macOS picker to approve Documents, iCloud Drive,
-                  external drives, or any other folder. Each location remains
-                  a separate authorization boundary.
+                  Pick folders the way you would in Finder — Documents,
+                  iCloud Drive, an external drive, anything. Each folder is
+                  approved on its own, and you can remove it at any time.
                 </p>
               </div>
               <div class="location-actions">
                 <button id="add-locations" class="button button-secondary" type="button">
                   <span aria-hidden="true">＋</span>
-                  Choose locations
+                  Choose folders
                 </button>
                 <button id="skip-folders" class="button button-secondary" type="button" disabled>
                   <span aria-hidden="true">−</span>
@@ -113,8 +115,8 @@
               <div class="folder-illustration" aria-hidden="true">
                 <span></span>
               </div>
-              <strong>No locations approved</strong>
-              <p>Your home folder and entire filesystem are intentionally refused.</p>
+              <strong>No folders chosen yet</strong>
+              <p>Your whole home folder and your whole disk are refused on purpose.</p>
             </div>
 
             <ul id="location-list" class="location-list" aria-live="polite"></ul>
@@ -122,20 +124,20 @@
             <div class="privacy-strip">
               <span class="privacy-icon" aria-hidden="true">◎</span>
               <div>
-                <strong>Paths stay behind the native boundary</strong>
+                <strong>Reports you save are safe to share</strong>
                 <p>
-                  The interface receives opaque location numbers, not folder
-                  paths. Exported reports contain no paths, filenames, or text.
+                  A saved report is counts only — no folder names, no file
+                  names, and nothing from inside your documents.
                 </p>
               </div>
             </div>
 
             <div class="action-row">
               <p id="setup-status" class="status" role="status">
-                Choose at least one location to continue.
+                Choose at least one folder to continue.
               </p>
               <button id="run-census" class="button button-primary" type="button" disabled>
-                Run private census
+                Count what is there
                 <span aria-hidden="true">→</span>
               </button>
             </div>
@@ -145,45 +147,45 @@
             <div class="scan-orbit" aria-hidden="true">
               <span></span>
             </div>
-            <p class="section-label">Metadata-only census</p>
-            <h2>Inspecting approved locations…</h2>
+            <p class="section-label">Counting only</p>
+            <h2>Looking through your folders…</h2>
             <p>
-              Counting formats, sizes, age bands, packages, and cloud-only
-              placeholders. Document contents remain unopened.
+              Counting file types, sizes, and dates. Not one document is
+              opened.
             </p>
             <div class="progress-track" aria-hidden="true">
               <span></span>
             </div>
             <button id="cancel-census" class="button button-quiet" type="button">
-              Cancel census
+              Stop counting
             </button>
           </div>
 
           <div id="results-view" hidden>
             <div class="results-heading">
               <div>
-                <p class="section-label">Aggregate result</p>
-                <h2>Archive coverage census</h2>
-                <p id="result-summary">The census completed without reading document contents.</p>
+                <p class="section-label">Totals</p>
+                <h2>What is in your folders</h2>
+                <p id="result-summary">Counted without opening a single document.</p>
               </div>
               <div id="result-status" class="result-status">Complete</div>
             </div>
 
             <div class="metrics" aria-label="Census totals">
               <article class="metric">
-                <span>Artifacts</span>
+                <span>Files</span>
                 <strong id="metric-artifacts">—</strong>
               </article>
               <article class="metric">
-                <span>Approved locations</span>
+                <span>Folders</span>
                 <strong id="metric-locations">—</strong>
               </article>
               <article class="metric">
-                <span>Document bytes</span>
+                <span>Total size</span>
                 <strong id="metric-bytes">—</strong>
               </article>
               <article class="metric">
-                <span>Cloud-only items</span>
+                <span>Still in iCloud</span>
                 <strong id="metric-cloud">—</strong>
               </article>
             </div>
@@ -192,16 +194,16 @@
               <section class="coverage-card" aria-labelledby="coverage-title">
                 <div class="card-title">
                   <div>
-                    <p class="section-label">Format mix</p>
+                    <p class="section-label">File types</p>
                     <h3 id="coverage-title">What the archive contains</h3>
                   </div>
-                  <span class="metadata-pill">Aggregate only</span>
+                  <span class="metadata-pill">Counts only</span>
                 </div>
                 <div id="category-list" class="category-list"></div>
               </section>
 
               <section class="signals-card" aria-labelledby="signals-title">
-                <p class="section-label">Coverage signals</p>
+                <p class="section-label">Worth knowing</p>
                 <h3 id="signals-title">What needs attention</h3>
                 <dl id="signals-list" class="signals-list"></dl>
               </section>
@@ -210,33 +212,28 @@
             <div class="verified-strip">
               <span aria-hidden="true">✓</span>
               <div>
-                <strong>No document content was read</strong>
+                <strong>Nothing inside your documents was read</strong>
                 <p>
-                  No filenames or paths were emitted, no hashes were computed,
-                  and no symlinks were followed.
+                  No file names or folder names were recorded, and no
+                  shortcuts were followed.
                 </p>
               </div>
             </div>
 
             <div class="pilot-strip">
               <div>
-                <p class="section-label">Optional next gate</p>
-                <strong>Build a temporary document search index</strong>
+                <p class="section-label">Optional next step</p>
+                <strong>Open your documents so you can search them</strong>
                 <p id="build-forecast" class="build-forecast" hidden></p>
                 <p>
-                  This explicitly opens searchable <code>.pdf</code>,
-                  <code>.docx</code>, <code>.doc</code>, <code>.odt</code>,
-                  <code>.rtf</code>, <code>.txt</code>, <code>.text</code>,
-                  and <code>.md</code> files, and reads scanned images
-                  (<code>.png</code>, <code>.jpg</code>, <code>.tiff</code>,
-                  <code>.heic</code>) with the on-device text recognizer. A
-                  scan's text is a machine's reading and is never quoted as
-                  source language. Every converted byte goes to a
-                  bounded, network-denied converter. Exact search plus the
-                  revision-pinned macOS semantic model run in separate
-                  network-denied workers; source text, FTS rows, and
-                  suggestion vectors stay in memory.
-                  Scans, legacy Word, and email are counted but not searched.
+                  This opens your PDFs, Word, OpenDocument, RTF, text, and
+                  Markdown files, and reads scanned images with the text
+                  reader built into macOS. Text from a scan is a machine
+                  reading a picture, so it is never quoted as the document's
+                  own words. Everything is read on this Mac, by helper
+                  programs that have no network access, and it is all held in
+                  memory — nothing is written to disk. Scans, very old Word
+                  files, and email archives are counted but not searched.
                 </p>
               </div>
               <button id="build-text-vault" class="button button-primary" type="button">
@@ -262,15 +259,14 @@
             <div class="scan-orbit" aria-hidden="true">
               <span></span>
             </div>
-            <p class="section-label">Explicit content step</p>
-            <h2>Building the private document index…</h2>
+            <p class="section-label">You chose this step</p>
+            <h2>Reading your documents…</h2>
             <p>
-              Reading bounded supported files from the approved locations.
-              All document conversion runs in the network-denied worker. The
-              index stays in memory, links remain excluded, and the built-in
-              macOS sentence model creates suggestion vectors in its own
-              network-denied worker. Minutes Archive requests no model download; macOS
-              manages its own on-device assets.
+              Reading the files this app supports from the folders you
+              approved. Everything happens on this Mac, in helper programs
+              with no network access. Shortcuts are skipped, and the result
+              is held in memory only. macOS provides the language model used
+              for suggestions; nothing is downloaded.
             </p>
             <div class="progress-track" aria-hidden="true">
               <span></span>
@@ -286,10 +282,10 @@
           <div id="search-view" hidden>
             <div class="search-heading">
               <div>
-                <p class="section-label">Evidence-first document pilot</p>
-                <h2>Search the approved archive</h2>
+                <p class="section-label">Search</p>
+                <h2>Search your documents</h2>
                 <div id="vault-summary">
-                  <p>The private document index is ready in memory.</p>
+                  <p>Your documents are ready to search. Nothing was saved to disk.</p>
                 </div>
               </div>
               <button id="back-to-census" class="button button-secondary" type="button">
@@ -320,7 +316,7 @@
 
             <div id="query-interpretation" class="query-interpretation" hidden>
               <div>
-                <p class="section-label">Interpreted constraints</p>
+                <p class="section-label">What was searched for</p>
                 <div id="query-chips" class="query-chips"></div>
               </div>
               <span id="candidate-count" class="metadata-pill"></span>
@@ -335,10 +331,10 @@
             <div class="verified-strip search-verification">
               <span aria-hidden="true">✓</span>
               <div>
-                <strong>Every displayed card passed a live source fence</strong>
+                <strong>Every result below was just checked against the real file</strong>
                 <p>
-                  A moved, replaced, changed, inaccessible, or out-of-scope
-                  source is withdrawn before its indexed excerpt is returned.
+                  If a document has moved, changed, or is no longer
+                  available, its quote is withheld rather than shown.
                 </p>
               </div>
             </div>
@@ -353,11 +349,11 @@
       </div>
 
       <footer>
-        <span id="build-identity">Private evidence build</span>
+        <span id="build-identity">Minutes Archive</span>
         <span aria-hidden="true">•</span>
-        <span>Networking disabled by design</span>
+        <span>Networking is switched off</span>
         <span aria-hidden="true">•</span>
-        <span>Closing the window ends the session and discards the index</span>
+        <span>Closing this window forgets everything</span>
       </footer>
     </main>
   </body>

--- a/crates/archive-core/src/lib.rs
+++ b/crates/archive-core/src/lib.rs
@@ -528,6 +528,17 @@ pub struct CensusSignals {
     pub max_depth: u32,
 }
 
+/// What one approved location contributed, in the order the roots were given.
+///
+/// Exists so an owner with several matters approved can tell one opaque
+/// "Approved location" row from another. Counts only -- no name, no path, no
+/// per-format breakdown that could fingerprint a matter.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LocationTotals {
+    pub artifacts: u64,
+    pub regular_file_bytes: u64,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CensusReport {
     pub schema: &'static str,
@@ -539,6 +550,15 @@ pub struct CensusReport {
     pub age_buckets: BTreeMap<String, u64>,
     pub size_buckets: BTreeMap<String, u64>,
     pub signals: CensusSignals,
+    /// Per-location totals, positional against the approved roots.
+    ///
+    /// Deliberately `serde(skip)`: the interface needs these to distinguish
+    /// its own rows, and the exported report -- which has been through a
+    /// privacy review and carries a versioned schema -- does not. A number
+    /// that nothing asked the export to carry does not get added to it, so
+    /// `minutes.archive-census.v1` stays byte-identical to what was reviewed.
+    #[serde(skip)]
+    pub per_location: Vec<LocationTotals>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -562,6 +582,9 @@ struct CensusAccumulator {
     age_buckets: BTreeMap<String, u64>,
     size_buckets: BTreeMap<String, u64>,
     signals: CensusSignals,
+    /// Positional against the approved roots, so a total can be attributed
+    /// without the walk carrying anything that names a folder.
+    per_location: Vec<LocationTotals>,
 }
 
 impl CensusAccumulator {
@@ -579,6 +602,20 @@ impl CensusAccumulator {
             age_buckets: BTreeMap::new(),
             size_buckets: BTreeMap::new(),
             signals: CensusSignals::default(),
+            per_location: vec![LocationTotals::default(); approved_locations],
+        }
+    }
+
+    /// Attribute one artifact to the root it was found under.
+    ///
+    /// A root index past the end is dropped rather than panicking: the walk
+    /// is the only producer and always passes a real index, but a census
+    /// that aborted on an accounting slip would lose a whole archive read to
+    /// a cosmetic number.
+    fn credit_location(&mut self, root_index: usize, bytes: u64) {
+        if let Some(totals) = self.per_location.get_mut(root_index) {
+            totals.artifacts = totals.artifacts.saturating_add(1);
+            totals.regular_file_bytes = totals.regular_file_bytes.saturating_add(bytes);
         }
     }
 
@@ -592,11 +629,12 @@ impl CensusAccumulator {
         }
     }
 
-    fn record_file(&mut self, name: &OsStr, metadata: &CapMetadata) {
+    fn record_file(&mut self, name: &OsStr, metadata: &CapMetadata, root_index: usize) {
         let extension = extension_for_name(name);
         let category = category_for_extension(&extension).to_string();
         let size = metadata.len();
 
+        self.credit_location(root_index, size);
         self.regular_files += 1;
         self.regular_file_bytes = self.regular_file_bytes.saturating_add(size);
         let format = self.formats.entry(extension.clone()).or_default();
@@ -628,7 +666,8 @@ impl CensusAccumulator {
         }
     }
 
-    fn record_package(&mut self, name: &OsStr, extension: &str, category: &str) {
+    fn record_package(&mut self, name: &OsStr, extension: &str, category: &str, root_index: usize) {
+        self.credit_location(root_index, 0);
         self.packages += 1;
         self.formats
             .entry(extension.to_string())
@@ -691,6 +730,7 @@ impl CensusAccumulator {
             age_buckets: self.age_buckets,
             size_buckets: self.size_buckets,
             signals: self.signals,
+            per_location: self.per_location,
         }
     }
 }
@@ -699,6 +739,10 @@ impl CensusAccumulator {
 struct PendingDirectory {
     directory: Dir,
     depth: u32,
+    /// Which approved root this directory descends from. Inherited by every
+    /// child, so an artifact found ten levels down is still attributed to the
+    /// location the owner actually approved.
+    root_index: usize,
 }
 
 /// Scans approved roots without opening a regular file.
@@ -726,11 +770,12 @@ pub fn scan_approved_roots(
     validate_approved_roots(roots)?;
     let mut stack = Vec::with_capacity(roots.len());
 
-    for root in roots {
+    for (root_index, root) in roots.iter().enumerate() {
         let directory = open_approved_root(root)?;
         stack.push(PendingDirectory {
             directory,
             depth: 0,
+            root_index,
         });
     }
 
@@ -797,7 +842,7 @@ pub fn scan_approved_roots(
             if metadata.is_dir() {
                 let extension = extension_for_name(&name);
                 if let Some(category) = package_category(&extension) {
-                    census.record_package(&name, &extension, category);
+                    census.record_package(&name, &extension, category, current.root_index);
                     continue;
                 }
                 if current.depth >= limits.max_depth {
@@ -834,9 +879,10 @@ pub fn scan_approved_roots(
                 stack.push(PendingDirectory {
                     directory: child,
                     depth: current.depth + 1,
+                    root_index: current.root_index,
                 });
             } else if metadata.is_file() {
-                census.record_file(&name, &metadata);
+                census.record_file(&name, &metadata, current.root_index);
             } else {
                 census.signals.special_files_skipped += 1;
             }

--- a/scripts/archive-ui-smoke.mjs
+++ b/scripts/archive-ui-smoke.mjs
@@ -370,7 +370,7 @@ try {
         if (!document.querySelector("#setup-status").textContent.includes("3 folders")) {
           throw new Error("The skipped count came from the interface, not the native side");
         }
-        if (!document.querySelector("#setup-status").textContent.includes("not inside an approved location")) {
+        if (!document.querySelector("#setup-status").textContent.includes("not inside a folder you chose")) {
           throw new Error("A folder outside every approved location was dropped silently");
         }
         // The way back must be visible once something is skipped.
@@ -384,7 +384,7 @@ try {
         );
         document.querySelector("#run-census").click();
         await waitFor(() => !document.querySelector("#results-view").hidden, "census result");
-        if (!document.querySelector("#result-summary").textContent.includes("without reading")) {
+        if (!document.querySelector("#result-summary").textContent.includes("without opening")) {
           throw new Error("Census privacy copy is missing");
         }
         document.querySelector("#build-text-vault").click();
@@ -398,9 +398,9 @@ try {
         const body = document.body.innerText;
         if (
           !body.includes("Synthetic Agreement") ||
-          !body.includes("Source verified") ||
-          !body.toLowerCase().includes("review, not verified legal matches") ||
-          !body.includes("Closing the window ends the session and discards the index")
+          !body.includes("Checked against the file") ||
+          !body.toLowerCase().includes("not exact matches") ||
+          !body.includes("Closing this window forgets everything")
         ) {
           throw new Error("Evidence provenance or session-disposal notice did not render");
         }
@@ -448,16 +448,16 @@ try {
 
         const vaultSummary = document.querySelector("#vault-summary").textContent;
         if (
-          !vaultSummary.includes("2 were aliases or shortcuts") ||
-          !vaultSummary.includes("3 have a second name elsewhere on the disk") ||
-          !vaultSummary.includes("9,023 items were not indexed") ||
-          !vaultSummary.includes("4 scanned pages read by text recognition") ||
+          !vaultSummary.includes("aliases or shortcuts (2)") ||
+          !vaultSummary.includes("have a second name elsewhere on the disk (3)") ||
+          !vaultSummary.includes("9,023 items could not be read") ||
+          !vaultSummary.includes("4 scanned pages read by the text reader") ||
           !vaultSummary.includes("This index is PARTIAL") ||
           !vaultSummary.includes("5,000 documents were not read") ||
           !vaultSummary.includes("3 folders were too deep to enter") ||
-          !vaultSummary.includes("9,000 were blocked by macOS permissions") ||
-          !vaultSummary.includes("12 were scans the text recognizer could not read") ||
-          !vaultSummary.includes("2 changed while being read") ||
+          !vaultSummary.includes("blocked by macOS permissions (9,000)") ||
+          !vaultSummary.includes("scans the text reader could not make out (12)") ||
+          !vaultSummary.includes("changed while being read (2)") ||
           !vaultSummary.includes("suggestion model stopped partway") ||
           !vaultSummary.includes("2 folders were skipped at your request")
         ) {


### PR DESCRIPTION
Two changes, both found by driving the built app rather than reading the code.

## Per-location counts

The approved-location rows are deliberately unnameable, which leaves an owner with several matters approved unable to tell them apart. Counts separate them without naming anything: *"16,636 items · 4.9 GiB"* beside *"12 items · 40 KB"* is the difference between a matter archive and a folder of exhibits, and neither number says whose.

- The census walk now carries the approved root each directory descends from, so an artifact ten levels down is attributed to the location the owner actually approved.
- Totals ride on `CensusReport` but are `serde(skip)`. The interface needs them; the exported report — privacy-reviewed, versioned schema — does not, so `minutes.archive-census.v1` stays **byte-identical** to what was reviewed. A test asserts the export contains no per-location data.
- Totals from a report taken against a *different* set of locations are dropped rather than shown against the wrong rows.

Two bugs surfaced only by running it: the setup view re-rendered from the state it was left in — exactly the state before the census — so rows stayed unlabelled all session; and the interface read `regular_file_bytes` while serde emits `regularFileBytes`, so every row showed a correct item count beside "0 B". A half-correct row reads as a real number. Both fixed, the casing now pinned by a test.

## Plain-language sweep

The app talked to an attorney like a design document: *"Paths stay behind the native boundary"*, *"the interface receives opaque location numbers"*, *"aggregate result"*, *"evidence-first document pilot"*, *"3 lexical candidates checked · 12 semantic vectors ranked"*, *"provision suggestion vectors built with the pinned macOS model inside its network-denied worker"*. Copy the reader cannot parse is copy that cannot reassure him.

Rewritten throughout — census → counting, locations → folders, artifacts → files, in-memory index → held in memory, never saved to disk. **The claims are unchanged; only the language is.**

Two changes went past wording:

- **"Private legal work product"** → **"Local only · nothing is uploaded"**. "Work product" is a term of art tied to the discovery doctrine; a search tool asserting privilege status is making a claim it cannot back — the same failure mode as quoting an OCR guess as the source's own words.
- **"This window never sees where your folders are"** → **"Reports you save are safe to share"**. The old panel was framed as a benefit but described a *mechanism*, and that mechanism's only user-visible effect is that the rows cannot be told apart — it announced an annoyance as a feature. What the reader actually gets from that machinery is that a saved report is safe to hand to someone, so that is what it says now.

Also fixes `"1 were aliases or shortcuts"` — reasons now read `"aliases or shortcuts (1)"`, which parses at any count.

## Verification

Every screen driven end to end in the installed dev app (choose → count → open → search) with the rendered pixels read back. Per-location counts confirmed against the aggregate on a real 16,636-file folder. 5 test suites green, strict clippy, fmt, and the UI smoke updated to assert the new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjmKq74A9UFXTYAUbYEjbx