### PR TITLE
fix(sdk,mcp): report why a corpus lease was denied

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -616,6 +616,48 @@ describe("stable corpus lease", () => {
     });
   });
 
+  it("still denies cleanly when the diagnostic sink is broken", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "stderr canary");
+      // A denial writes its reason to stderr. That write happens after the
+      // lease has settled precisely so it cannot matter, and this pins it: with
+      // a stderr that throws on every write, the denial must still reject
+      // normally rather than stranding the promise. The earlier arrangement,
+      // which wrote before rejecting, would hang here forever.
+      const original = process.stderr.write;
+      let attempted = 0;
+      (process.stderr as unknown as { write: unknown }).write = () => {
+        attempted += 1;
+        throw new Error("stderr is gone");
+      };
+      try {
+        let forceOperationDeadline!: () => void;
+        const operationDeadline = new Promise<void>((resolve) => {
+          forceOperationDeadline = resolve;
+        });
+        await expect(
+          withStableCorpusLease(
+            root,
+            (_snapshot, _attempt, signal) =>
+              new Promise((_resolve, reject) => {
+                signal.addEventListener("abort", () => reject(signal.reason), {
+                  once: true,
+                });
+                forceOperationDeadline();
+              }),
+            { timeoutMs: 10_000, operationDeadlineForTest: operationDeadline }
+          )
+        ).rejects.toThrow("stable meeting corpus authorization failed");
+        // The write is deferred so it cannot delay the denial, so let the
+        // scheduled diagnostic run before asserting it was attempted.
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(attempted).toBeGreaterThan(0);
+      } finally {
+        (process.stderr as unknown as { write: unknown }).write = original;
+      }
+    });
+  });
+
   it("aborts an asynchronous operation at the cumulative authorization deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "operation deadline canary");

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -1878,9 +1878,51 @@ async function dispatchStableCorpusLease<T>(
       const fail = (message: string): void => {
         if (settled) return;
         settled = true;
+        // Sampled before the teardown below so the number reflects the moment
+        // of denial, not how long cleanup took.
+        const remainingNs = deadline - process.hrtime.bigint();
+
         operationAbort.abort(new CorpusLeaseChangedError(message));
         killCorpusWorker(child);
         reject(new Error("Access denied: stable meeting corpus authorization failed"));
+
+        // Diagnostics run last and cannot affect the lease. `settled` is already
+        // true, so anything thrown here would strand the promise forever: no
+        // later fail() would get past the guard, and the abort/kill/reject above
+        // would never have run. Same shape as the bug that made the first
+        // version of this call `remainingAuthorizationMs`, which throws once the
+        // deadline has passed.
+        //
+        // The rejection above stays a single uniform denial on purpose: callers
+        // must not learn why authorization failed. The reason goes to stderr,
+        // which is operator-visible only. Every reason is a fixed internal
+        // string, so no corpus path or content is disclosed.
+        // Deferred as well as guarded. `fail()` must return before promise
+        // handlers can run, so writing inline would let a blocked stderr, a
+        // full pipe for instance, delay the caller's observation of a denial
+        // that has already been decided.
+        //
+        // Not a total guarantee, and deliberately not chased further: the
+        // scheduled write can still land during the lease's own async cleanup,
+        // so a genuinely blocked stderr could delay the public rejection by
+        // however long it blocks. Node writes to pipes asynchronously, leaving
+        // only a wedged TTY or file, which is a broken host rather than a
+        // failure mode this diagnostic should contort itself around.
+        setImmediate(() => {
+          try {
+            // Sign is taken from nanoseconds: BigInt division truncates toward
+            // zero, so a sub-millisecond overrun would otherwise render as
+            // "0ms remained" rather than an overrun.
+            const overran = remainingNs < 0n;
+            const magnitudeMs = Number((overran ? -remainingNs : remainingNs) / 1_000_000n);
+            const budget = overran
+              ? `authorization budget overrun by ${magnitudeMs}ms`
+              : `${magnitudeMs}ms of authorization budget remained`;
+            process.stderr.write(`[corpus-lease] denied: ${message} (${budget})\n`);
+          } catch {
+            // A broken stderr must never turn a clean denial into a crash.
+          }
+        });
       };
       const timer = setTimeout(
         () => fail("meeting corpus authorization deadline elapsed"),

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -648,6 +648,9 @@ describe("stable corpus lease", () => {
             { timeoutMs: 10_000, operationDeadlineForTest: operationDeadline }
           )
         ).rejects.toThrow("stable meeting corpus authorization failed");
+        // The write is deferred so it cannot delay the denial, so let the
+        // scheduled diagnostic run before asserting it was attempted.
+        await new Promise((resolve) => setImmediate(resolve));
         expect(attempted).toBeGreaterThan(0);
       } finally {
         (process.stderr as unknown as { write: unknown }).write = original;

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -616,6 +616,45 @@ describe("stable corpus lease", () => {
     });
   });
 
+  it("still denies cleanly when the diagnostic sink is broken", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "stderr canary");
+      // A denial writes its reason to stderr. That write happens after the
+      // lease has settled precisely so it cannot matter, and this pins it: with
+      // a stderr that throws on every write, the denial must still reject
+      // normally rather than stranding the promise. The earlier arrangement,
+      // which wrote before rejecting, would hang here forever.
+      const original = process.stderr.write;
+      let attempted = 0;
+      (process.stderr as unknown as { write: unknown }).write = () => {
+        attempted += 1;
+        throw new Error("stderr is gone");
+      };
+      try {
+        let forceOperationDeadline!: () => void;
+        const operationDeadline = new Promise<void>((resolve) => {
+          forceOperationDeadline = resolve;
+        });
+        await expect(
+          withStableCorpusLease(
+            root,
+            (_snapshot, _attempt, signal) =>
+              new Promise((_resolve, reject) => {
+                signal.addEventListener("abort", () => reject(signal.reason), {
+                  once: true,
+                });
+                forceOperationDeadline();
+              }),
+            { timeoutMs: 10_000, operationDeadlineForTest: operationDeadline }
+          )
+        ).rejects.toThrow("stable meeting corpus authorization failed");
+        expect(attempted).toBeGreaterThan(0);
+      } finally {
+        (process.stderr as unknown as { write: unknown }).write = original;
+      }
+    });
+  });
+
   it("aborts an asynchronous operation at the cumulative authorization deadline", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "operation deadline canary");

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -1901,6 +1901,13 @@ async function dispatchStableCorpusLease<T>(
         // handlers can run, so writing inline would let a blocked stderr, a
         // full pipe for instance, delay the caller's observation of a denial
         // that has already been decided.
+        //
+        // Not a total guarantee, and deliberately not chased further: the
+        // scheduled write can still land during the lease's own async cleanup,
+        // so a genuinely blocked stderr could delay the public rejection by
+        // however long it blocks. Node writes to pipes asynchronously, leaving
+        // only a wedged TTY or file, which is a broken host rather than a
+        // failure mode this diagnostic should contort itself around.
         setImmediate(() => {
           try {
             // Sign is taken from nanoseconds: BigInt division truncates toward

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -1880,7 +1880,7 @@ async function dispatchStableCorpusLease<T>(
         settled = true;
         // Sampled before the teardown below so the number reflects the moment
         // of denial, not how long cleanup took.
-        const remainingMs = Number((deadline - process.hrtime.bigint()) / 1_000_000n);
+        const remainingNs = deadline - process.hrtime.bigint();
 
         operationAbort.abort(new CorpusLeaseChangedError(message));
         killCorpusWorker(child);
@@ -1897,15 +1897,25 @@ async function dispatchStableCorpusLease<T>(
         // must not learn why authorization failed. The reason goes to stderr,
         // which is operator-visible only. Every reason is a fixed internal
         // string, so no corpus path or content is disclosed.
-        try {
-          const budget =
-            remainingMs >= 0
-              ? `${remainingMs}ms of authorization budget remained`
-              : `authorization budget overrun by ${-remainingMs}ms`;
-          process.stderr.write(`[corpus-lease] denied: ${message} (${budget})\n`);
-        } catch {
-          // A broken stderr must never turn a clean denial into a crash.
-        }
+        // Deferred as well as guarded. `fail()` must return before promise
+        // handlers can run, so writing inline would let a blocked stderr, a
+        // full pipe for instance, delay the caller's observation of a denial
+        // that has already been decided.
+        setImmediate(() => {
+          try {
+            // Sign is taken from nanoseconds: BigInt division truncates toward
+            // zero, so a sub-millisecond overrun would otherwise render as
+            // "0ms remained" rather than an overrun.
+            const overran = remainingNs < 0n;
+            const magnitudeMs = Number((overran ? -remainingNs : remainingNs) / 1_000_000n);
+            const budget = overran
+              ? `authorization budget overrun by ${magnitudeMs}ms`
+              : `${magnitudeMs}ms of authorization budget remained`;
+            process.stderr.write(`[corpus-lease] denied: ${message} (${budget})\n`);
+          } catch {
+            // A broken stderr must never turn a clean denial into a crash.
+          }
+        });
       };
       const timer = setTimeout(
         () => fail("meeting corpus authorization deadline elapsed"),

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -1878,6 +1878,25 @@ async function dispatchStableCorpusLease<T>(
       const fail = (message: string): void => {
         if (settled) return;
         settled = true;
+        // The rejection stays a single uniform denial on purpose: callers must
+        // not be able to distinguish why authorization failed. But the reason
+        // was being discarded entirely, which left a CI failure reading only
+        // "authorization failed" with no way to tell a deadline overrun from a
+        // dead worker. Report it to stderr, where operators and CI logs can see
+        // it and the caller still cannot.
+        // Remaining budget is the discriminating number: at or below zero means
+        // the deadline actually elapsed, while a large remainder means something
+        // else failed and the budget was never the problem.
+        //
+        // Computed inline rather than through `remainingAuthorizationMs`, which
+        // throws once the deadline has passed. That is correct for its callers,
+        // who must not proceed on an expired lease, but fatal here: this handler
+        // runs *because* the deadline elapsed, and throwing inside it would skip
+        // the abort and the reject below and leave the lease promise unsettled.
+        const remainingMs = Number((deadline - process.hrtime.bigint()) / 1_000_000n);
+        process.stderr.write(
+          `[corpus-lease] denied: ${message} (${remainingMs}ms of authorization budget remained)\n`
+        );
         operationAbort.abort(new CorpusLeaseChangedError(message));
         killCorpusWorker(child);
         reject(new Error("Access denied: stable meeting corpus authorization failed"));

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -1878,28 +1878,34 @@ async function dispatchStableCorpusLease<T>(
       const fail = (message: string): void => {
         if (settled) return;
         settled = true;
-        // The rejection stays a single uniform denial on purpose: callers must
-        // not be able to distinguish why authorization failed. But the reason
-        // was being discarded entirely, which left a CI failure reading only
-        // "authorization failed" with no way to tell a deadline overrun from a
-        // dead worker. Report it to stderr, where operators and CI logs can see
-        // it and the caller still cannot.
-        // Remaining budget is the discriminating number: at or below zero means
-        // the deadline actually elapsed, while a large remainder means something
-        // else failed and the budget was never the problem.
-        //
-        // Computed inline rather than through `remainingAuthorizationMs`, which
-        // throws once the deadline has passed. That is correct for its callers,
-        // who must not proceed on an expired lease, but fatal here: this handler
-        // runs *because* the deadline elapsed, and throwing inside it would skip
-        // the abort and the reject below and leave the lease promise unsettled.
+        // Sampled before the teardown below so the number reflects the moment
+        // of denial, not how long cleanup took.
         const remainingMs = Number((deadline - process.hrtime.bigint()) / 1_000_000n);
-        process.stderr.write(
-          `[corpus-lease] denied: ${message} (${remainingMs}ms of authorization budget remained)\n`
-        );
+
         operationAbort.abort(new CorpusLeaseChangedError(message));
         killCorpusWorker(child);
         reject(new Error("Access denied: stable meeting corpus authorization failed"));
+
+        // Diagnostics run last and cannot affect the lease. `settled` is already
+        // true, so anything thrown here would strand the promise forever: no
+        // later fail() would get past the guard, and the abort/kill/reject above
+        // would never have run. Same shape as the bug that made the first
+        // version of this call `remainingAuthorizationMs`, which throws once the
+        // deadline has passed.
+        //
+        // The rejection above stays a single uniform denial on purpose: callers
+        // must not learn why authorization failed. The reason goes to stderr,
+        // which is operator-visible only. Every reason is a fixed internal
+        // string, so no corpus path or content is disclosed.
+        try {
+          const budget =
+            remainingMs >= 0
+              ? `${remainingMs}ms of authorization budget remained`
+              : `authorization budget overrun by ${-remainingMs}ms`;
+          process.stderr.write(`[corpus-lease] denied: ${message} (${budget})\n`);
+        } catch {
+          // A broken stderr must never turn a clean denial into a crash.
+        }
       };
       const timer = setTimeout(
         () => fail("meeting corpus authorization deadline elapsed"),


### PR DESCRIPTION
Groundwork for the flaky-test investigation, and useful on its own.

## Why

A denied corpus lease threw one fixed string and discarded the reason it was constructed with. In CI that leaves a failure reading only `Access denied: stable meeting corpus authorization failed`, with no way to tell a deadline overrun from a worker that died on startup. The flaky macOS failures on #716 and #721 were undiagnosable for exactly this reason.

The rejection stays **byte-identical** on purpose: callers must not be able to distinguish why authorization failed. The reason goes to stderr, which is operator-visible only, and every reason is a fixed internal string, so no corpus path or content is disclosed.

## It already found something

Running the suite shows the same reason string reported under two very different conditions:

```
denied: meeting corpus authorization deadline elapsed (-11ms remained)     ← genuine timeout
denied: meeting corpus authorization deadline elapsed (14914ms remained)   ← ~15s of budget left
```

Indistinguishable by message alone. Worth following up, and only visible because the numbers are printed now.

## Four review rounds, all earned

1. **The naive version failed 30 of 48 tests.** It called `remainingAuthorizationMs`, which *throws* once the deadline has passed. That is right for its normal callers, who must not proceed on an expired lease, and fatal inside a handler that runs *because* the deadline elapsed: it skipped the abort and reject, leaving the lease promise unsettled forever.
2. **The write sat before abort/kill/reject** with `settled` already true, so a throwing stderr could crash the denial or strand the promise. Same shape as (1). Twice in one change is a strong hint: nothing in `fail()` may throw before the lease settles. Now it runs last, wrapped, with the budget sampled before teardown so the number reflects the moment of denial.
3. **A blocking stderr could still delay the caller**, since `fail()` must return before promise handlers run. The write is now scheduled with `setImmediate`. Sub-millisecond overruns also rendered as `0ms remained` because BigInt division truncates toward zero; the sign now comes from nanoseconds.
4. **The mirror gate.** `corpus-lease` is mirrored between `crates/sdk` and `crates/mcp` and CI enforces it. I had edited only the SDK copy, which would have failed CI outright.

## Tests

Adds a regression test using a stderr that throws on every write: the denial must still reject normally. Under the arrangement in (2) that test hangs. 149 sdk tests pass; it passes on both copies.

## Residual, accepted and documented

The scheduled write can still land during the lease's own async cleanup, so a genuinely blocked stderr could delay the public rejection. Node writes to pipes asynchronously, leaving only a wedged TTY or file, which is a broken host rather than something a diagnostic should contort itself around. It can no longer crash the denial or strand the promise, which were the defects that mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)