### PR TITLE
fix(macos): Apple Speech worker Swift Concurrency runtime rpath

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -29,4 +29,18 @@ fn main() {
             plist.display()
         );
     }
+
+    // The Apple Speech worker links the Swift Concurrency bridge (Task, async).
+    // Its binary carries a weak @rpath load of libswift_Concurrency, which on
+    // macOS lives only in the dyld shared cache, not on disk, so that @rpath
+    // resolves only with a runtime rpath into the OS Swift libraries. Without
+    // it the weak load is silently skipped, every Concurrency type descriptor
+    // is null, and the worker aborts inside swift_getTypeByMangledName the
+    // instant the analyzer's async types resolve. A cargo:rustc-link-arg from
+    // the minutes-core build script does NOT reach this downstream binary, so
+    // the rpath must be set here, on the worker bin itself. Proven on Apple
+    // Silicon: without this the real worker aborts; with it it transcribes.
+    println!(
+        "cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift"
+    );
 }

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -40,7 +40,5 @@ fn main() {
     // the minutes-core build script does NOT reach this downstream binary, so
     // the rpath must be set here, on the worker bin itself. Proven on Apple
     // Silicon: without this the real worker aborts; with it it transcribes.
-    println!(
-        "cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift"
-    );
+    println!("cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift");
 }

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -53,6 +53,17 @@ fn compile_macos_graph_xpc_authority_bridge() {
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=minutes_macos_graph_xpc_authority");
     println!("cargo:rustc-link-search=native=/usr/lib/swift");
+    // The Apple Speech bridge uses Swift Concurrency (Task, async), so the
+    // linked binary carries a weak @rpath load of libswift_Concurrency. That
+    // dylib lives only in the dyld shared cache, not on disk, so its @rpath
+    // resolves only when the binary has an rpath pointing at /usr/lib/swift.
+    // Without it the weak load is silently skipped, every Concurrency type
+    // descriptor stays null, and the worker aborts inside
+    // swift_getTypeByMangledName the moment the analyzer's async types
+    // resolve. A link search path is not a runtime rpath; this is the runtime
+    // rpath, present on every macOS, and it is what lets the real worker run
+    // Speech at all.
+    println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
     if let Some(swiftc) = engine_process::command("xcrun")
         .args(["--find", "swiftc"])
         .output()

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -53,16 +53,13 @@ fn compile_macos_graph_xpc_authority_bridge() {
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=minutes_macos_graph_xpc_authority");
     println!("cargo:rustc-link-search=native=/usr/lib/swift");
-    // The Apple Speech bridge uses Swift Concurrency (Task, async), so the
-    // linked binary carries a weak @rpath load of libswift_Concurrency. That
-    // dylib lives only in the dyld shared cache, not on disk, so its @rpath
-    // resolves only when the binary has an rpath pointing at /usr/lib/swift.
-    // Without it the weak load is silently skipped, every Concurrency type
-    // descriptor stays null, and the worker aborts inside
-    // swift_getTypeByMangledName the moment the analyzer's async types
-    // resolve. A link search path is not a runtime rpath; this is the runtime
-    // rpath, present on every macOS, and it is what lets the real worker run
-    // Speech at all.
+    // Runtime rpath for the Swift Concurrency dylib (libswift_Concurrency lives
+    // only in the dyld shared cache, so its weak @rpath load resolves only with
+    // an rpath into /usr/lib/swift). cargo:rustc-link-arg applies to
+    // minutes-core's OWN targets only (its tests and examples that exercise the
+    // async Speech bridge), NOT to downstream binaries. The shipping worker
+    // gets its rpath from crates/cli/build.rs on the worker bin; this line is
+    // what lets a minutes-core test or example resolve the same symbols.
     println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
     if let Some(swiftc) = engine_process::command("xcrun")
         .args(["--find", "swiftc"])

--- a/scripts/check_apple_speech_worker_packaging.mjs
+++ b/scripts/check_apple_speech_worker_packaging.mjs
@@ -42,10 +42,11 @@ const files = {
     "tauri/src-tauri/minutes-apple-speech-worker.entitlements",
     "utf8",
   ),
-  // Structural-only (deliberately not golden-hashed): build.rs changes for
+  // Structural-only (deliberately not golden-hashed): build.rs files change for
   // unrelated reasons and should not force a reseal, but the Swift Concurrency
-  // rpath is load-bearing and must not silently regress.
+  // rpaths are load-bearing and must not silently regress.
   coreBuild: readFileSync("crates/core/build.rs", "utf8"),
+  cliBuild: readFileSync("crates/cli/build.rs", "utf8"),
 };
 
 
@@ -177,11 +178,19 @@ function validate(candidate, checkGoldens = true) {
   // Without this runtime rpath the weak libswift_Concurrency load resolves to
   // null and the worker aborts in swift_getTypeByMangledName as soon as it
   // constructs a Speech (async) type. Proven on hardware; the analyzer cannot
-  // run without it.
+  // run without it. The shipping worker binary gets its rpath from
+  // crates/cli/build.rs (a cargo:rustc-link-arg in minutes-core does not reach
+  // a downstream bin); crates/core covers minutes-core's own test/example
+  // targets. Both are load-bearing.
+  requireText(
+    candidate.cliBuild,
+    "cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift",
+    "the Apple Speech worker bin must add the Swift Concurrency runtime rpath",
+  );
   requireText(
     candidate.coreBuild,
     "cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift",
-    "the worker build must add the Swift Concurrency runtime rpath (/usr/lib/swift)",
+    "minutes-core's own targets must add the Swift Concurrency runtime rpath",
   );
 
   for (const value of [

--- a/scripts/check_apple_speech_worker_packaging.mjs
+++ b/scripts/check_apple_speech_worker_packaging.mjs
@@ -42,6 +42,10 @@ const files = {
     "tauri/src-tauri/minutes-apple-speech-worker.entitlements",
     "utf8",
   ),
+  // Structural-only (deliberately not golden-hashed): build.rs changes for
+  // unrelated reasons and should not force a reseal, but the Swift Concurrency
+  // rpath is load-bearing and must not silently regress.
+  coreBuild: readFileSync("crates/core/build.rs", "utf8"),
 };
 
 
@@ -169,6 +173,16 @@ function validate(candidate, checkGoldens = true) {
   ) {
     errors.push("the Apple Speech worker entitlement allowlist must be App Sandbox only");
   }
+
+  // Without this runtime rpath the weak libswift_Concurrency load resolves to
+  // null and the worker aborts in swift_getTypeByMangledName as soon as it
+  // constructs a Speech (async) type. Proven on hardware; the analyzer cannot
+  // run without it.
+  requireText(
+    candidate.coreBuild,
+    "cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift",
+    "the worker build must add the Swift Concurrency runtime rpath (/usr/lib/swift)",
+  );
 
   for (const value of [
     "MINUTES_APPLE_SPEECH_WORKER_CDHASH_V1=",

--- a/scripts/check_apple_speech_worker_packaging.mjs
+++ b/scripts/check_apple_speech_worker_packaging.mjs
@@ -182,13 +182,15 @@ function validate(candidate, checkGoldens = true) {
   // crates/cli/build.rs (a cargo:rustc-link-arg in minutes-core does not reach
   // a downstream bin); crates/core covers minutes-core's own test/example
   // targets. Both are load-bearing.
+  // activeCode strips comments first, so a commented-out or dead-code println!
+  // does not satisfy the check (raw source.includes would pass it).
   requireText(
-    candidate.cliBuild,
+    activeCode(candidate.cliBuild),
     "cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift",
     "the Apple Speech worker bin must add the Swift Concurrency runtime rpath",
   );
   requireText(
-    candidate.coreBuild,
+    activeCode(candidate.coreBuild),
     "cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift",
     "minutes-core's own targets must add the Swift Concurrency runtime rpath",
   );
@@ -440,6 +442,21 @@ function validate(candidate, checkGoldens = true) {
 
 if (process.argv.includes("--self-test")) {
   const mutations = [
+    ["worker Concurrency rpath commented out", "cliBuild", (value) =>
+      value.replace(
+        '"cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift"',
+        '// "cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift"',
+      ), false],
+    ["worker Concurrency rpath removed", "cliBuild", (value) =>
+      value.replace(
+        '"cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift"',
+        '"cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-sectcreate,__TEXT,__foo,/dev/null"',
+      ), false],
+    ["core Concurrency rpath commented out", "coreBuild", (value) =>
+      value.replace(
+        '"cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift"',
+        '// "cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift"',
+      ), false],
     ["xpc_main aliased to a block declaration", "xpc", (value) =>
       value.replace(
         "fn xpc_main(handler: XpcConnectionHandler) -> !;",


### PR DESCRIPTION
## What

The Apple Speech worker links the Swift Concurrency bridge (Task, async). Its binary carries a weak `@rpath` load of `libswift_Concurrency`, which on macOS lives only in the dyld shared cache, not on disk, so that `@rpath` resolves only with a runtime rpath into `/usr/lib/swift`. build.rs added `/usr/lib/swift` as a link *search* path but never as a runtime rpath, so the weak load was silently skipped, every Concurrency type descriptor stayed null, and the worker aborted inside `swift_getTypeByMangledName` the instant the analyzer's async types resolved.

## Why this is the real root cause

This is the true cause of every prior signed-acceptance runtime crash. Across the investigation it was misattributed to the hosted VM and to missing Speech assets, because the only thing ever run on real hardware was a clang-linked C-driver harness, and clang links the Swift concurrency rpath automatically. The Rust-linked worker never got it. Running the real Rust-linked worker on hardware is what exposed it.

## The fix

- `crates/cli/build.rs`: add `cargo:rustc-link-arg-bin=minutes-apple-speech-worker=-Wl,-rpath,/usr/lib/swift`. This is the shipping fix; a `cargo:rustc-link-arg` in the minutes-core library build script does NOT reach a downstream binary (that mistake was caught by an `otool` check on the actual binary).
- `crates/core/build.rs`: the same rpath for minutes-core's own test/example targets.
- `check_apple_speech_worker_packaging.mjs`: structural guards for both, proven to fail when either is removed. build.rs is deliberately not golden-hashed so unrelated build edits need no reseal.

## Proof (Apple Silicon, macOS 26.6)

- The real Rust-linked worker path (`process_private_audio_request`, non-echo, real demo audio) transcribes 28 words, `runtimeSupported=true`, where it aborted before.
- `otool -l` confirms the shipping `minutes-apple-speech-worker` binary now carries `path /usr/lib/swift`; the graph worker is unaffected.
- clippy `-D warnings` clean, fmt clean, all packaging guards + self-tests pass.

## Scope

The product gate stays hard false: this makes the still-dormant worker capable of running Speech, it does not activate anything. Unblocks the Apple Speech activation epic (beads minutes-i279, minutes-uyc8; plan PR #726).