### PR TITLE
fix(sdk,mcp): recover the corpus worker once a stranded child is reaped

### DIFF
--- a/crates/mcp/src/corpus-lease-hazard-window.test.ts
+++ b/crates/mcp/src/corpus-lease-hazard-window.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// This case ends with a projection that ignores cancellation and therefore
+// never confirms, so the process is left refusing every later lease. Like
+// corpus-lease-poisoning.test.ts it must stay a file of exactly one test.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-hazard-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+describe("stable corpus lease hazard window", () => {
+  it("never reopens between the worker's reap and the projection's hold", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "window canary");
+
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
+
+      // Two hazards from one lease: a worker whose death is not confirmed
+      // inside its grace, and a projection that ignores cancellation. They are
+      // decided in separate branches with an await between them, which is the
+      // gap this test exists to close.
+      const lease = withStableCorpusLease(
+        root,
+        () => {
+          markStarted();
+          return new Promise<never>(() => {});
+        },
+        {
+          timeoutMs: 15_000,
+          operationDeadlineForTest: operationDeadline,
+          forceUnconfirmedTerminationForTest: true,
+          // Settles the worker hazard at the earliest moment it can exist, so
+          // the interval this test samples is the whole projection grace
+          // rather than whatever is left after a real reap lands. It is ANDed
+          // with the real termination, so it cannot open a window that
+          // production would keep shut.
+          confirmTerminationForTest: Promise.resolve(),
+        }
+      );
+      await started;
+
+      // Runs continuously from before the failure until well after both
+      // branches have been decided. While the lease is healthy this is refused
+      // for memory, since two default reservations exceed the process cap;
+      // once the lease fails it must be refused because the hazards hold the
+      // process closed. An accounting that releases per hazard instead of per
+      // lease drops to zero when the worker is reaped inside the projection's
+      // grace, and this poller is admitted in that gap.
+      let admitted = false;
+      let polling = true;
+      const poller = (async () => {
+        while (polling) {
+          try {
+            await withStableCorpusLease(root, () => "admitted");
+            admitted = true;
+            return;
+          } catch {
+            // Refusal is the expected answer at every instant.
+          }
+          await new Promise((resolve) => setTimeout(resolve, 2));
+        }
+      })();
+
+      forceOperationDeadline();
+      await expect(lease).rejects.toThrow(
+        "stable meeting corpus authorization failed"
+      );
+      // Comfortably longer than the projection confirmation grace, so the
+      // poller spans the whole interval between the two branches.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      polling = false;
+      await poller;
+
+      expect(admitted).toBe(false);
+    });
+  }, 20_000);
+});

--- a/crates/mcp/src/corpus-lease-poisoning.test.ts
+++ b/crates/mcp/src/corpus-lease-poisoning.test.ts
@@ -6,16 +6,20 @@ import { join } from "node:path";
 import { withStableCorpusLease } from "./corpus-lease.js";
 import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
 
-// This file deliberately poisons the worker path and leaves the process
-// unusable, so it must stay a file of exactly one test.
+// This file deliberately strands a child whose death is never confirmed and
+// leaves the process refusing every later lease, so it must stay a file of
+// exactly one test.
 //
 // An earlier version kept this beside the recovery test with a comment saying
 // it must run last, plus an opening assertion that the process was still
-// clean. That only catches poison arriving from earlier tests; a test added
-// after it would inherit the poison and could pass for the wrong reason, since
-// most assertions here are of the shape "the lease is refused". Vitest runs
-// each file in its own process, so a file boundary enforces what a comment
-// could only request.
+// clean. That only catches refusal arriving from earlier tests; a test added
+// after it would inherit the refusal and could pass for the wrong reason,
+// since most assertions here are of the shape "the lease is refused". Vitest
+// runs each file in its own process, so a file boundary enforces what a
+// comment could only request.
+//
+// The recovering half of the same contract lives in
+// corpus-lease-recovery.test.ts, which cannot share a process with this one.
 function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
   const root = mkdtempSync(join(tmpdir(), "minutes-corpus-poisoning-"));
   return run(root).finally(async () => {
@@ -25,28 +29,32 @@ function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
 }
 
 describe("stable corpus lease poisoning", () => {
-  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
+  it("keeps failing closed while a disclosed worker's death stays unconfirmed", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "disclosed canary");
       // The counterpart to the never-fed recovery case in
-      // corpus-lease-refusal.test.ts, and the regression that fix must not
-      // introduce. A generous budget lets `begin` reach the child, so the
-      // worker knows which directory to read; stalling it forces the kill.
+      // corpus-lease-refusal.test.ts. A generous budget lets `begin` reach the
+      // child, so the worker knows which directory to read; stalling it forces
+      // the kill.
       //
-      // Once the corpus root has been disclosed, an unconfirmed kill has to
-      // keep failing closed: the child may still be reading, and refusing
-      // every later lease is the intended answer to that.
+      // While the corpus root has been disclosed and the child is unreaped,
+      // every later lease has to be refused: the child may still be reading.
+      // The never-settled hold below is what makes that "while" testable, by
+      // standing in for a reap that has not happened yet. Without it the real
+      // SIGKILLed child is reaped in milliseconds and the assertion would race
+      // the recovery it is supposed to exclude.
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
           timeoutMs: 2_000,
           workerStallPhaseForTest: "before-baseline",
           forceUnconfirmedTerminationForTest: true,
+          confirmTerminationForTest: new Promise<void>(() => {}),
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
 
       await expect(
         withStableCorpusLease(root, () => "must not run")
-      ).rejects.toThrow("requires a process restart");
+      ).rejects.toThrow("killed without confirming it died");
     });
   });
 });

--- a/crates/mcp/src/corpus-lease-recovery.test.ts
+++ b/crates/mcp/src/corpus-lease-recovery.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// The recovering half of the contract whose failing-closed half lives in
+// corpus-lease-poisoning.test.ts. That file strands a child forever on
+// purpose, so these cases cannot share a process with it.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-recovery-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+const REFUSAL = "killed without confirming it died";
+
+/**
+ * Recovery waits on the real reap as well as any test confirmation, so it
+ * lands after a real interval rather than on the next microtask. Polling for
+ * the condition is what keeps that from being a timing guess.
+ */
+async function recoverWithin(root: string, budgetMs: number): Promise<unknown> {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    try {
+      return await withStableCorpusLease(root, () => "recovered");
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes(REFUSAL) ||
+        Date.now() > deadline
+      ) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
+/**
+ * Long enough for a reap and its continuation to have been applied, so that a
+ * following "still refused" assertion reflects a release that really happened
+ * rather than one that has not run yet. Erring long only ever weakens
+ * detection on a slow machine; it cannot turn a correct implementation red.
+ */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+// Small enough that two leases fit under the process memory cap at once. The
+// default budgets reserve enough that a second concurrent lease is refused for
+// memory before it can spawn a child, which would leave the multi-child case
+// below quietly exercising one child.
+const STRAND_BUDGETS = {
+  maxFileBytes: 1024 * 1024,
+  maxCorpusBytes: 8 * 1024 * 1024,
+  maxRetainedPathBytes: 256 * 1024,
+  maxFileCount: 8,
+  maxDirectoryCount: 4,
+  maxDirectoryEntries: 16,
+  maxWatcherCount: 4,
+  maxReaderCount: 2,
+};
+
+/** One lease whose child is killed with its death deliberately unconfirmed. */
+function strandOneWorker(
+  root: string,
+  confirmTerminationForTest: Promise<void>
+): Promise<unknown> {
+  return withStableCorpusLease(root, () => "unreachable", {
+    timeoutMs: 2_000,
+    budgets: STRAND_BUDGETS,
+    workerStallPhaseForTest: "before-baseline",
+    forceUnconfirmedTerminationForTest: true,
+    confirmTerminationForTest,
+  });
+}
+
+describe("stable corpus lease recovery", () => {
+  it("reopens the process once the stranded child is confirmed reaped", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "recovery canary");
+      let confirmReap!: () => void;
+      const reaped = new Promise<void>((resolve) => {
+        confirmReap = resolve;
+      });
+
+      await expect(strandOneWorker(root, reaped)).rejects.toThrow(
+        "stable meeting corpus authorization failed"
+      );
+
+      // Unconfirmed: the child may still be reading, so nothing may run.
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow(REFUSAL);
+
+      confirmReap();
+      // A reaped child reads nothing, so the reason for the refusal is gone.
+      await expect(recoverWithin(root, 10_000)).resolves.toBe("recovered");
+    });
+  });
+
+  it("keeps refusing until the last of several stranded children is reaped", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "two canaries");
+      let confirmFirst!: () => void;
+      const firstReaped = new Promise<void>((resolve) => {
+        confirmFirst = resolve;
+      });
+      let confirmSecond!: () => void;
+      const secondReaped = new Promise<void>((resolve) => {
+        confirmSecond = resolve;
+      });
+
+      // Concurrently, because the first strand refuses every later lease: a
+      // second child can only be stranded by one already in flight.
+      const [first, second] = await Promise.allSettled([
+        strandOneWorker(root, firstReaped),
+        strandOneWorker(root, secondReaped),
+      ]);
+      // Both must have been stranded by the kill, not turned away by a
+      // budget before spawning, or the reap-one-of-two assertion below is
+      // measuring a single child.
+      for (const settled of [first, second]) {
+        expect(settled.status).toBe("rejected");
+        expect(
+          settled.status === "rejected" ? (settled.reason as Error).message : ""
+        ).toContain("stable meeting corpus authorization failed");
+      }
+
+      // Reaping one of two must not reopen the process. A flag instead of a
+      // count passes the single-child case above and fails here.
+      confirmFirst();
+      await settle();
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow(REFUSAL);
+
+      confirmSecond();
+      await expect(recoverWithin(root, 10_000)).resolves.toBe("recovered");
+    });
+  });
+
+  it("recovers without help when the real child is reaped, and frees its memory", async () => {
+    await withCorpus(async (root) => {
+      // The corpus stays empty: the budget pair at the end of this test allows
+      // zero files, matching the admission case in corpus-lease.test.ts that it
+      // mirrors. Disclosure does not depend on the contents, since the root
+      // reaches the child in `begin` either way.
+      // No confirmation hook: this is the production path, and the CI flake it
+      // guards. SIGKILL cannot be caught, so the child is reaped a moment
+      // after the grace expires and the process must reopen by itself.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 2_000,
+          budgets: STRAND_BUDGETS,
+          workerStallPhaseForTest: "before-baseline",
+          forceUnconfirmedTerminationForTest: true,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      await expect(recoverWithin(root, 10_000)).resolves.toBe("recovered");
+
+      // The stranded lease also held a 23,724,032 byte reservation. Proving
+      // that was released needs a pair sized to straddle the 256 MiB process
+      // cap: two of these fit together (266,895,360) only while the stranded
+      // bytes are gone, and the second is refused once they are added back.
+      //
+      // An earlier version of this assertion used two copies of the budget
+      // from the admission case in corpus-lease.test.ts. Those exceed the cap
+      // on their own, so the second lease was refused whether or not the
+      // stranded bytes leaked, and the test proved nothing.
+      const halfCapBudgets = {
+        maxFileBytes: 0,
+        maxCorpusBytes: 64_000_000,
+        // Room for the lease's own on-disk fence entry, and a watcher budget
+        // that admits a second concurrent worker: this pair has to be refused
+        // for memory or not at all, never for an unrelated cap.
+        maxRetainedPathBytes: 65_536,
+        maxFileCount: 0,
+        maxDirectoryCount: 1,
+        maxDirectoryEntries: 2,
+        maxWatcherCount: 4,
+        maxReaderCount: 1,
+      };
+      let release!: () => void;
+      const hold = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let ready!: () => void;
+      const retained = new Promise<void>((resolve) => {
+        ready = resolve;
+      });
+      const held = withStableCorpusLease(root, () => "held", {
+        budgets: halfCapBudgets,
+        afterBaseline: async () => {
+          ready();
+          await hold;
+        },
+      });
+      // Racing surfaces an admission failure as its own error. A bare await on
+      // `retained` would hang to the suite timeout instead, because the
+      // baseline hook that resolves it never runs.
+      await Promise.race([retained, held]);
+      await expect(
+        withStableCorpusLease(root, () => "second", { budgets: halfCapBudgets })
+      ).resolves.toBe("second");
+      release();
+      await expect(held).resolves.toBe("held");
+    });
+  });
+});

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -909,7 +909,10 @@ describe("stable corpus lease", () => {
           await hold;
         },
       });
-      await retained;
+      // Racing the lease surfaces an admission failure as its own error. A
+      // bare `await retained` hangs to the suite timeout instead, because the
+      // baseline hook that resolves it never runs.
+      await Promise.race([retained, first]);
       await expect(
         withStableCorpusLease(root, () => "must not allocate", {
           budgets: leanBudgets,
@@ -1512,7 +1515,7 @@ describe("stable corpus lease", () => {
       expect(Date.now() - started).toBeLessThan(2_500);
       await expect(
         withStableCorpusLease(root, () => "must not reuse")
-      ).rejects.toThrow("requires a process restart");
+      ).rejects.toThrow("killed without confirming it died");
     });
   }, 10_000);
 });

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -185,6 +185,22 @@ export type CorpusLeaseHooks = {
    * worker that knew the corpus still poisons.
    */
   forceUnconfirmedTerminationForTest?: boolean;
+
+  /**
+   * Held *in addition to* the real reap before a stranded child counts as
+   * confirmed dead. Without it both halves of the contract race, because the
+   * child is SIGKILLed and so reaped within milliseconds: a test cannot
+   * observe "still refused" before recovery overtakes it.
+   *
+   * A promise the test never settles pins the refusing half; one it settles
+   * pins the recovering half. Because recovery waits for this promise *and*
+   * the real termination, it can only ever delay recovery relative to
+   * production. It cannot unlock the process before the child is genuinely
+   * reaped, so it cannot manufacture a pass out of a parent that fails closed
+   * too weakly. An earlier draft used `??` here, which substituted the hook
+   * for real termination and did exactly that.
+   */
+  confirmTerminationForTest?: Promise<void>;
 };
 
 type RootIdentity = {
@@ -1662,8 +1678,23 @@ type ParentPause = {
   until: Promise<void>;
 };
 
-let corpusWorkerPoisoned = false;
+// How many children were killed without their death being confirmed inside
+// the grace, and are still unreaped. Every one of them may still be alive and
+// reading the corpus, so while this is above zero no further lease may run.
+//
+// A count rather than a flag because two leases can each strand a child, and
+// the first one reaped must not clear the second one's refusal. Only the
+// transition back to zero reopens the process.
+let unconfirmedCorpusWorkers = 0;
 let activeCorpusWorkerCount = 0;
+
+function retainUnconfirmedCorpusWorker(): void {
+  unconfirmedCorpusWorkers += 1;
+}
+
+function releaseUnconfirmedCorpusWorker(): void {
+  unconfirmedCorpusWorkers = Math.max(0, unconfirmedCorpusWorkers - 1);
+}
 let nextPauseId = 1;
 
 function corpusWorkerInvocation(scriptOverride?: string): {
@@ -1794,8 +1825,10 @@ async function dispatchStableCorpusLease<T>(
   if (hooks.beforeSentinelCreate) {
     return withStableCorpusLeaseInProcess(root, operation, hooks);
   }
-  if (corpusWorkerPoisoned) {
-    throw new Error("Access denied: meeting corpus worker requires a process restart");
+  if (unconfirmedCorpusWorkers > 0) {
+    throw new Error(
+      "Access denied: a meeting corpus worker was killed without confirming it died"
+    );
   }
   const budgets = resolveCorpusReadBudgets(hooks.budgets);
   const deadline = authorizationDeadline(hooks.timeoutMs);
@@ -1831,6 +1864,15 @@ async function dispatchStableCorpusLease<T>(
   // Guards the admission slot against a double release when a late-reaped
   // child's termination promise resolves after the cleanup block already ran.
   let workerAdmissionReleased = false;
+  // Everything this lease may have left running that could still be reading
+  // the corpus. The process stays closed until all of them settle.
+  const unconfirmedHazards: Promise<unknown>[] = [];
+  const noteUnconfirmedHazard = (hazard: Promise<unknown>): void => {
+    // The first hazard closes the process; later ones only extend how long it
+    // stays closed, so the hold is taken exactly once per lease.
+    if (unconfirmedHazards.length === 0) retainUnconfirmedCorpusWorker();
+    unconfirmedHazards.push(hazard);
+  };
   // Whether the `begin` message, the only thing that tells the child which
   // corpus to read, was actually handed to the child's stdin. Authority is the
   // write itself, never anything the child echoes back, and never merely
@@ -2269,7 +2311,22 @@ async function dispatchStableCorpusLease<T>(
       // the worker is still starting (issue #689).
       if (!confirmed) {
         if (corpusRootDisclosed) {
-          corpusWorkerPoisoned = true;
+          // Fail closed for as long as the danger is real, which is exactly
+          // as long as the child's death is unconfirmed. Reaping it later
+          // ends that danger definitively: a reaped child reads nothing, and
+          // it cannot have read anything after it died. Holding the refusal
+          // past that point protects nothing and costs the whole process,
+          // which is the same reasoning the admission slot below already
+          // uses, applied to the poison and the reservation.
+          //
+          // SIGKILL cannot be caught, so a child outliving the grace is a
+          // slow reap under load, not a child refusing to die. That is a
+          // recoverable condition and must not require a process restart.
+          noteUnconfirmedHazard(
+            hooks.confirmTerminationForTest
+              ? Promise.all([termination, hooks.confirmTerminationForTest])
+              : termination
+          );
           releaseReservation = false;
           releaseWorkerAdmission = false;
         } else {
@@ -2305,10 +2362,30 @@ async function dispatchStableCorpusLease<T>(
         }),
       ]);
       if (!operationConfirmed) {
-        corpusWorkerPoisoned = true;
+        // Same bargain as the worker above: refuse while the projection may
+        // still be running, recover once it is confirmed finished.
+        noteUnconfirmedHazard(operationTermination);
         releaseReservation = false;
         releaseWorkerAdmission = false;
       }
+    }
+    if (unconfirmedHazards.length > 0) {
+      // One hold for the whole lease, released only when every hazard it left
+      // behind has settled. Retaining and releasing per hazard would let the
+      // count fall to zero between the worker branch and the projection branch
+      // above, which are separated by an await: the worker's reap can land
+      // inside that window, and a lease admitted there would run while this
+      // lease's projection still holds corpus data.
+      //
+      // allSettled, not all: a hazard that rejects is still a hazard that
+      // finished, and a rejection here must not strand the process closed.
+      void Promise.allSettled(unconfirmedHazards).then(() => {
+        releaseUnconfirmedCorpusWorker();
+        releaseCorpusMemory(reservation);
+        if (workerAdmissionReleased) return;
+        workerAdmissionReleased = true;
+        activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
+      });
     }
     if (releaseWorkerAdmission && !workerAdmissionReleased) {
       workerAdmissionReleased = true;

--- a/crates/sdk/src/corpus-lease-hazard-window.test.ts
+++ b/crates/sdk/src/corpus-lease-hazard-window.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// This case ends with a projection that ignores cancellation and therefore
+// never confirms, so the process is left refusing every later lease. Like
+// corpus-lease-poisoning.test.ts it must stay a file of exactly one test.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-hazard-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+describe("stable corpus lease hazard window", () => {
+  it("never reopens between the worker's reap and the projection's hold", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "window canary");
+
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      let forceOperationDeadline!: () => void;
+      const operationDeadline = new Promise<void>((resolve) => {
+        forceOperationDeadline = resolve;
+      });
+
+      // Two hazards from one lease: a worker whose death is not confirmed
+      // inside its grace, and a projection that ignores cancellation. They are
+      // decided in separate branches with an await between them, which is the
+      // gap this test exists to close.
+      const lease = withStableCorpusLease(
+        root,
+        () => {
+          markStarted();
+          return new Promise<never>(() => {});
+        },
+        {
+          timeoutMs: 15_000,
+          operationDeadlineForTest: operationDeadline,
+          forceUnconfirmedTerminationForTest: true,
+          // Settles the worker hazard at the earliest moment it can exist, so
+          // the interval this test samples is the whole projection grace
+          // rather than whatever is left after a real reap lands. It is ANDed
+          // with the real termination, so it cannot open a window that
+          // production would keep shut.
+          confirmTerminationForTest: Promise.resolve(),
+        }
+      );
+      await started;
+
+      // Runs continuously from before the failure until well after both
+      // branches have been decided. While the lease is healthy this is refused
+      // for memory, since two default reservations exceed the process cap;
+      // once the lease fails it must be refused because the hazards hold the
+      // process closed. An accounting that releases per hazard instead of per
+      // lease drops to zero when the worker is reaped inside the projection's
+      // grace, and this poller is admitted in that gap.
+      let admitted = false;
+      let polling = true;
+      const poller = (async () => {
+        while (polling) {
+          try {
+            await withStableCorpusLease(root, () => "admitted");
+            admitted = true;
+            return;
+          } catch {
+            // Refusal is the expected answer at every instant.
+          }
+          await new Promise((resolve) => setTimeout(resolve, 2));
+        }
+      })();
+
+      forceOperationDeadline();
+      await expect(lease).rejects.toThrow(
+        "stable meeting corpus authorization failed"
+      );
+      // Comfortably longer than the projection confirmation grace, so the
+      // poller spans the whole interval between the two branches.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      polling = false;
+      await poller;
+
+      expect(admitted).toBe(false);
+    });
+  }, 20_000);
+});

--- a/crates/sdk/src/corpus-lease-poisoning.test.ts
+++ b/crates/sdk/src/corpus-lease-poisoning.test.ts
@@ -6,16 +6,20 @@ import { join } from "node:path";
 import { withStableCorpusLease } from "./corpus-lease.js";
 import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
 
-// This file deliberately poisons the worker path and leaves the process
-// unusable, so it must stay a file of exactly one test.
+// This file deliberately strands a child whose death is never confirmed and
+// leaves the process refusing every later lease, so it must stay a file of
+// exactly one test.
 //
 // An earlier version kept this beside the recovery test with a comment saying
 // it must run last, plus an opening assertion that the process was still
-// clean. That only catches poison arriving from earlier tests; a test added
-// after it would inherit the poison and could pass for the wrong reason, since
-// most assertions here are of the shape "the lease is refused". Vitest runs
-// each file in its own process, so a file boundary enforces what a comment
-// could only request.
+// clean. That only catches refusal arriving from earlier tests; a test added
+// after it would inherit the refusal and could pass for the wrong reason,
+// since most assertions here are of the shape "the lease is refused". Vitest
+// runs each file in its own process, so a file boundary enforces what a
+// comment could only request.
+//
+// The recovering half of the same contract lives in
+// corpus-lease-recovery.test.ts, which cannot share a process with this one.
 function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
   const root = mkdtempSync(join(tmpdir(), "minutes-corpus-poisoning-"));
   return run(root).finally(async () => {
@@ -25,28 +29,32 @@ function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
 }
 
 describe("stable corpus lease poisoning", () => {
-  it("still fails closed after an unconfirmed kill of a worker that knew the corpus", async () => {
+  it("keeps failing closed while a disclosed worker's death stays unconfirmed", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "disclosed canary");
       // The counterpart to the never-fed recovery case in
-      // corpus-lease-refusal.test.ts, and the regression that fix must not
-      // introduce. A generous budget lets `begin` reach the child, so the
-      // worker knows which directory to read; stalling it forces the kill.
+      // corpus-lease-refusal.test.ts. A generous budget lets `begin` reach the
+      // child, so the worker knows which directory to read; stalling it forces
+      // the kill.
       //
-      // Once the corpus root has been disclosed, an unconfirmed kill has to
-      // keep failing closed: the child may still be reading, and refusing
-      // every later lease is the intended answer to that.
+      // While the corpus root has been disclosed and the child is unreaped,
+      // every later lease has to be refused: the child may still be reading.
+      // The never-settled hold below is what makes that "while" testable, by
+      // standing in for a reap that has not happened yet. Without it the real
+      // SIGKILLed child is reaped in milliseconds and the assertion would race
+      // the recovery it is supposed to exclude.
       await expect(
         withStableCorpusLease(root, () => "unreachable", {
           timeoutMs: 2_000,
           workerStallPhaseForTest: "before-baseline",
           forceUnconfirmedTerminationForTest: true,
+          confirmTerminationForTest: new Promise<void>(() => {}),
         })
       ).rejects.toThrow("stable meeting corpus authorization failed");
 
       await expect(
         withStableCorpusLease(root, () => "must not run")
-      ).rejects.toThrow("requires a process restart");
+      ).rejects.toThrow("killed without confirming it died");
     });
   });
 });

--- a/crates/sdk/src/corpus-lease-recovery.test.ts
+++ b/crates/sdk/src/corpus-lease-recovery.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withStableCorpusLease } from "./corpus-lease.js";
+import { retireBoundReadersForProcessShutdown } from "./secure-read.js";
+
+// The recovering half of the contract whose failing-closed half lives in
+// corpus-lease-poisoning.test.ts. That file strands a child forever on
+// purpose, so these cases cannot share a process with it.
+function withCorpus(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "minutes-corpus-recovery-"));
+  return run(root).finally(async () => {
+    await retireBoundReadersForProcessShutdown();
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+const REFUSAL = "killed without confirming it died";
+
+/**
+ * Recovery waits on the real reap as well as any test confirmation, so it
+ * lands after a real interval rather than on the next microtask. Polling for
+ * the condition is what keeps that from being a timing guess.
+ */
+async function recoverWithin(root: string, budgetMs: number): Promise<unknown> {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    try {
+      return await withStableCorpusLease(root, () => "recovered");
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes(REFUSAL) ||
+        Date.now() > deadline
+      ) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
+/**
+ * Long enough for a reap and its continuation to have been applied, so that a
+ * following "still refused" assertion reflects a release that really happened
+ * rather than one that has not run yet. Erring long only ever weakens
+ * detection on a slow machine; it cannot turn a correct implementation red.
+ */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+// Small enough that two leases fit under the process memory cap at once. The
+// default budgets reserve enough that a second concurrent lease is refused for
+// memory before it can spawn a child, which would leave the multi-child case
+// below quietly exercising one child.
+const STRAND_BUDGETS = {
+  maxFileBytes: 1024 * 1024,
+  maxCorpusBytes: 8 * 1024 * 1024,
+  maxRetainedPathBytes: 256 * 1024,
+  maxFileCount: 8,
+  maxDirectoryCount: 4,
+  maxDirectoryEntries: 16,
+  maxWatcherCount: 4,
+  maxReaderCount: 2,
+};
+
+/** One lease whose child is killed with its death deliberately unconfirmed. */
+function strandOneWorker(
+  root: string,
+  confirmTerminationForTest: Promise<void>
+): Promise<unknown> {
+  return withStableCorpusLease(root, () => "unreachable", {
+    timeoutMs: 2_000,
+    budgets: STRAND_BUDGETS,
+    workerStallPhaseForTest: "before-baseline",
+    forceUnconfirmedTerminationForTest: true,
+    confirmTerminationForTest,
+  });
+}
+
+describe("stable corpus lease recovery", () => {
+  it("reopens the process once the stranded child is confirmed reaped", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "recovery canary");
+      let confirmReap!: () => void;
+      const reaped = new Promise<void>((resolve) => {
+        confirmReap = resolve;
+      });
+
+      await expect(strandOneWorker(root, reaped)).rejects.toThrow(
+        "stable meeting corpus authorization failed"
+      );
+
+      // Unconfirmed: the child may still be reading, so nothing may run.
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow(REFUSAL);
+
+      confirmReap();
+      // A reaped child reads nothing, so the reason for the refusal is gone.
+      await expect(recoverWithin(root, 10_000)).resolves.toBe("recovered");
+    });
+  });
+
+  it("keeps refusing until the last of several stranded children is reaped", async () => {
+    await withCorpus(async (root) => {
+      writeFileSync(join(root, "meeting.md"), "two canaries");
+      let confirmFirst!: () => void;
+      const firstReaped = new Promise<void>((resolve) => {
+        confirmFirst = resolve;
+      });
+      let confirmSecond!: () => void;
+      const secondReaped = new Promise<void>((resolve) => {
+        confirmSecond = resolve;
+      });
+
+      // Concurrently, because the first strand refuses every later lease: a
+      // second child can only be stranded by one already in flight.
+      const [first, second] = await Promise.allSettled([
+        strandOneWorker(root, firstReaped),
+        strandOneWorker(root, secondReaped),
+      ]);
+      // Both must have been stranded by the kill, not turned away by a
+      // budget before spawning, or the reap-one-of-two assertion below is
+      // measuring a single child.
+      for (const settled of [first, second]) {
+        expect(settled.status).toBe("rejected");
+        expect(
+          settled.status === "rejected" ? (settled.reason as Error).message : ""
+        ).toContain("stable meeting corpus authorization failed");
+      }
+
+      // Reaping one of two must not reopen the process. A flag instead of a
+      // count passes the single-child case above and fails here.
+      confirmFirst();
+      await settle();
+      await expect(
+        withStableCorpusLease(root, () => "must not run")
+      ).rejects.toThrow(REFUSAL);
+
+      confirmSecond();
+      await expect(recoverWithin(root, 10_000)).resolves.toBe("recovered");
+    });
+  });
+
+  it("recovers without help when the real child is reaped, and frees its memory", async () => {
+    await withCorpus(async (root) => {
+      // The corpus stays empty: the budget pair at the end of this test allows
+      // zero files, matching the admission case in corpus-lease.test.ts that it
+      // mirrors. Disclosure does not depend on the contents, since the root
+      // reaches the child in `begin` either way.
+      // No confirmation hook: this is the production path, and the CI flake it
+      // guards. SIGKILL cannot be caught, so the child is reaped a moment
+      // after the grace expires and the process must reopen by itself.
+      await expect(
+        withStableCorpusLease(root, () => "unreachable", {
+          timeoutMs: 2_000,
+          budgets: STRAND_BUDGETS,
+          workerStallPhaseForTest: "before-baseline",
+          forceUnconfirmedTerminationForTest: true,
+        })
+      ).rejects.toThrow("stable meeting corpus authorization failed");
+
+      await expect(recoverWithin(root, 10_000)).resolves.toBe("recovered");
+
+      // The stranded lease also held a 23,724,032 byte reservation. Proving
+      // that was released needs a pair sized to straddle the 256 MiB process
+      // cap: two of these fit together (266,895,360) only while the stranded
+      // bytes are gone, and the second is refused once they are added back.
+      //
+      // An earlier version of this assertion used two copies of the budget
+      // from the admission case in corpus-lease.test.ts. Those exceed the cap
+      // on their own, so the second lease was refused whether or not the
+      // stranded bytes leaked, and the test proved nothing.
+      const halfCapBudgets = {
+        maxFileBytes: 0,
+        maxCorpusBytes: 64_000_000,
+        // Room for the lease's own on-disk fence entry, and a watcher budget
+        // that admits a second concurrent worker: this pair has to be refused
+        // for memory or not at all, never for an unrelated cap.
+        maxRetainedPathBytes: 65_536,
+        maxFileCount: 0,
+        maxDirectoryCount: 1,
+        maxDirectoryEntries: 2,
+        maxWatcherCount: 4,
+        maxReaderCount: 1,
+      };
+      let release!: () => void;
+      const hold = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let ready!: () => void;
+      const retained = new Promise<void>((resolve) => {
+        ready = resolve;
+      });
+      const held = withStableCorpusLease(root, () => "held", {
+        budgets: halfCapBudgets,
+        afterBaseline: async () => {
+          ready();
+          await hold;
+        },
+      });
+      // Racing surfaces an admission failure as its own error. A bare await on
+      // `retained` would hang to the suite timeout instead, because the
+      // baseline hook that resolves it never runs.
+      await Promise.race([retained, held]);
+      await expect(
+        withStableCorpusLease(root, () => "second", { budgets: halfCapBudgets })
+      ).resolves.toBe("second");
+      release();
+      await expect(held).resolves.toBe("held");
+    });
+  });
+});

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -909,7 +909,10 @@ describe("stable corpus lease", () => {
           await hold;
         },
       });
-      await retained;
+      // Racing the lease surfaces an admission failure as its own error. A
+      // bare `await retained` hangs to the suite timeout instead, because the
+      // baseline hook that resolves it never runs.
+      await Promise.race([retained, first]);
       await expect(
         withStableCorpusLease(root, () => "must not allocate", {
           budgets: leanBudgets,
@@ -1512,7 +1515,7 @@ describe("stable corpus lease", () => {
       expect(Date.now() - started).toBeLessThan(2_500);
       await expect(
         withStableCorpusLease(root, () => "must not reuse")
-      ).rejects.toThrow("requires a process restart");
+      ).rejects.toThrow("killed without confirming it died");
     });
   }, 10_000);
 });

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -185,6 +185,22 @@ export type CorpusLeaseHooks = {
    * worker that knew the corpus still poisons.
    */
   forceUnconfirmedTerminationForTest?: boolean;
+
+  /**
+   * Held *in addition to* the real reap before a stranded child counts as
+   * confirmed dead. Without it both halves of the contract race, because the
+   * child is SIGKILLed and so reaped within milliseconds: a test cannot
+   * observe "still refused" before recovery overtakes it.
+   *
+   * A promise the test never settles pins the refusing half; one it settles
+   * pins the recovering half. Because recovery waits for this promise *and*
+   * the real termination, it can only ever delay recovery relative to
+   * production. It cannot unlock the process before the child is genuinely
+   * reaped, so it cannot manufacture a pass out of a parent that fails closed
+   * too weakly. An earlier draft used `??` here, which substituted the hook
+   * for real termination and did exactly that.
+   */
+  confirmTerminationForTest?: Promise<void>;
 };
 
 type RootIdentity = {
@@ -1662,8 +1678,23 @@ type ParentPause = {
   until: Promise<void>;
 };
 
-let corpusWorkerPoisoned = false;
+// How many children were killed without their death being confirmed inside
+// the grace, and are still unreaped. Every one of them may still be alive and
+// reading the corpus, so while this is above zero no further lease may run.
+//
+// A count rather than a flag because two leases can each strand a child, and
+// the first one reaped must not clear the second one's refusal. Only the
+// transition back to zero reopens the process.
+let unconfirmedCorpusWorkers = 0;
 let activeCorpusWorkerCount = 0;
+
+function retainUnconfirmedCorpusWorker(): void {
+  unconfirmedCorpusWorkers += 1;
+}
+
+function releaseUnconfirmedCorpusWorker(): void {
+  unconfirmedCorpusWorkers = Math.max(0, unconfirmedCorpusWorkers - 1);
+}
 let nextPauseId = 1;
 
 function corpusWorkerInvocation(scriptOverride?: string): {
@@ -1794,8 +1825,10 @@ async function dispatchStableCorpusLease<T>(
   if (hooks.beforeSentinelCreate) {
     return withStableCorpusLeaseInProcess(root, operation, hooks);
   }
-  if (corpusWorkerPoisoned) {
-    throw new Error("Access denied: meeting corpus worker requires a process restart");
+  if (unconfirmedCorpusWorkers > 0) {
+    throw new Error(
+      "Access denied: a meeting corpus worker was killed without confirming it died"
+    );
   }
   const budgets = resolveCorpusReadBudgets(hooks.budgets);
   const deadline = authorizationDeadline(hooks.timeoutMs);
@@ -1831,6 +1864,15 @@ async function dispatchStableCorpusLease<T>(
   // Guards the admission slot against a double release when a late-reaped
   // child's termination promise resolves after the cleanup block already ran.
   let workerAdmissionReleased = false;
+  // Everything this lease may have left running that could still be reading
+  // the corpus. The process stays closed until all of them settle.
+  const unconfirmedHazards: Promise<unknown>[] = [];
+  const noteUnconfirmedHazard = (hazard: Promise<unknown>): void => {
+    // The first hazard closes the process; later ones only extend how long it
+    // stays closed, so the hold is taken exactly once per lease.
+    if (unconfirmedHazards.length === 0) retainUnconfirmedCorpusWorker();
+    unconfirmedHazards.push(hazard);
+  };
   // Whether the `begin` message, the only thing that tells the child which
   // corpus to read, was actually handed to the child's stdin. Authority is the
   // write itself, never anything the child echoes back, and never merely
@@ -2269,7 +2311,22 @@ async function dispatchStableCorpusLease<T>(
       // the worker is still starting (issue #689).
       if (!confirmed) {
         if (corpusRootDisclosed) {
-          corpusWorkerPoisoned = true;
+          // Fail closed for as long as the danger is real, which is exactly
+          // as long as the child's death is unconfirmed. Reaping it later
+          // ends that danger definitively: a reaped child reads nothing, and
+          // it cannot have read anything after it died. Holding the refusal
+          // past that point protects nothing and costs the whole process,
+          // which is the same reasoning the admission slot below already
+          // uses, applied to the poison and the reservation.
+          //
+          // SIGKILL cannot be caught, so a child outliving the grace is a
+          // slow reap under load, not a child refusing to die. That is a
+          // recoverable condition and must not require a process restart.
+          noteUnconfirmedHazard(
+            hooks.confirmTerminationForTest
+              ? Promise.all([termination, hooks.confirmTerminationForTest])
+              : termination
+          );
           releaseReservation = false;
           releaseWorkerAdmission = false;
         } else {
@@ -2305,10 +2362,30 @@ async function dispatchStableCorpusLease<T>(
         }),
       ]);
       if (!operationConfirmed) {
-        corpusWorkerPoisoned = true;
+        // Same bargain as the worker above: refuse while the projection may
+        // still be running, recover once it is confirmed finished.
+        noteUnconfirmedHazard(operationTermination);
         releaseReservation = false;
         releaseWorkerAdmission = false;
       }
+    }
+    if (unconfirmedHazards.length > 0) {
+      // One hold for the whole lease, released only when every hazard it left
+      // behind has settled. Retaining and releasing per hazard would let the
+      // count fall to zero between the worker branch and the projection branch
+      // above, which are separated by an await: the worker's reap can land
+      // inside that window, and a lease admitted there would run while this
+      // lease's projection still holds corpus data.
+      //
+      // allSettled, not all: a hazard that rejects is still a hazard that
+      // finished, and a rejection here must not strand the process closed.
+      void Promise.allSettled(unconfirmedHazards).then(() => {
+        releaseUnconfirmedCorpusWorker();
+        releaseCorpusMemory(reservation);
+        if (workerAdmissionReleased) return;
+        workerAdmissionReleased = true;
+        activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
+      });
     }
     if (releaseWorkerAdmission && !workerAdmissionReleased) {
       workerAdmissionReleased = true;


### PR DESCRIPTION
## The bug

A corpus worker killed without its death being confirmed inside the 2 second grace set a permanent process-global flag. Every later lease was refused with "requires a process restart", and its memory reservation was leaked for the life of the process.

The exposure is much wider than it looks, because `corpusRootDisclosed` is set the moment the `begin` request reaches the pipe. Every lease discloses. So any single slow reap under load bricks corpus reads until the process restarts, with no operator-visible cause.

That is a production availability bug in a long-lived MCP server, not only a test problem. It is also the cause of the CI flake that failed the docs-only PR #726: `corpus-lease.test.ts:883` timed out at 15s because an earlier test in the file had stranded a child, the refusal is thrown before `afterBaseline` can run, and the test then waits forever on a baseline that never arrives.

Reproduced deterministically before writing any fix: strand one child, then run that test body, and it times out at 15s with `requires a process restart`.

## The change

Refuse while the danger is real, recover when it provably ends. SIGKILL cannot be caught, so a child outliving the grace is a slow reap, not a child refusing to die. Reaping it ends the hazard definitively: a dead child reads nothing, and it cannot have read anything after it died. This is the same bargain the admission slot already struck for the undisclosed case, applied now to the refusal and the reservation.

The flag becomes a count, because two leases can each strand a child and the first reaped must not clear the second's refusal.

The hold is taken once per lease and released only when every hazard that lease left behind has settled. Retaining per hazard would let the count fall to zero between the worker branch and the projection branch, which are separated by an await: the worker's reap can land inside that window, and a lease admitted there would run while the previous projection still held corpus data.

A projection that ignores cancellation still never confirms, so that case stays closed exactly as before.

## Please look at this part specifically

**This changes a documented fail-closed posture, so it is yours to approve rather than mine to merge.** The previous behavior was deliberate and had a test asserting it, with a comment saying refusing every later lease is the intended answer to an unconfirmed kill. I believe this is a refinement rather than a reversal, since the safety property is preserved exactly while the child may still be reading and only the permanent penalty is dropped. But that is a judgment call about the security posture, not a mechanical fix, so it should be your call.

Also worth your eye: the user-visible error message changed from "requires a process restart" to "a meeting corpus worker was killed without confirming it died", since the old wording is now false for the recoverable case.

## Verification

Each assertion was checked against the specific defect it claims to catch, because a test that passes without the fix proves nothing.

| Mutation | Expected to fail | Result |
|---|---|---|
| Revert the whole fix | all three recovery cases | 3/3 failed |
| Count degraded to a flag | the multi-child case | failed |
| Release per hazard instead of per lease | the window case | 6/6 runs failed |
| Reopen but keep the reservation charged | the memory case | failed |

The window test also passed 6/6 runs against the correct implementation, so it detects the defect reliably without being flaky in the other direction.

SDK 153 passed, MCP 286 passed, both `tsc --noEmit` clean, and the sdk/mcp copies of `corpus-lease.ts` plus all five `corpus-lease*.test.ts` files are byte-identical.

## Adversarial review

Two codex passes. The first found three real defects in my own draft, all fixed here and all now covered by the mutation table above:

1. The worker's recovery could reopen admission during the projection confirmation grace, because each hazard released independently. This is what the per-lease hold and the new `corpus-lease-hazard-window.test.ts` exist to close.
2. `confirmTerminationForTest` used `??`, substituting for real termination rather than adding to it, which made its own doc comment false and would have let a non-test caller unlock early. It now requires `Promise.all([termination, hook])`, so it can only ever delay recovery.
3. The memory assertion used two budgets that each exceed the process cap, so the second lease was refused whether or not the stranded bytes leaked. It now uses a pair sized to straddle the 256 MiB cap: two fit together only once the stranded 23,724,032 bytes are released.

The second pass confirmed fixes 1 and 3 sound, verified mirror parity, and flagged the window test's sampling as timing-dependent. That is addressed by settling the worker hazard at the earliest moment it can exist, which makes the sampled interval the whole projection grace rather than whatever remains after a real reap.

One honest gap: no test catches a regression of fix 2 back to `??`. The requirement is structural in `Promise.all` and visible on review, but exercising it would need a child that survives SIGKILL, which I cannot arrange.

Fixes the `corpus-lease.test.ts:883` flake. Related to #617, which is the Windows budget variant of the same file.