### PR TITLE
feat(macos): Apple Speech activation Phase 1 — safe runtime fallback

### DIFF
--- a/crates/core/src/apple_speech_session.rs
+++ b/crates/core/src/apple_speech_session.rs
@@ -1,17 +1,18 @@
-//! Session-scoped safe fallback for Apple Speech transcription.
+//! Session-scoped safe-fallback latch for Apple Speech transcription.
 //!
 //! Apple Speech runs in a separate XPC worker process, so a worker crash is
-//! failure-isolated: the parent observes an error and can fall back to Whisper
-//! for that utterance without losing it. This is the RFC 0004 failure-isolation
+//! failure-isolated: the parent observes an error and falls back to Whisper for
+//! that utterance without losing it. This is the RFC 0004 failure-isolation
 //! boundary and the standing "recording must never be degraded by an optional
 //! consumer" decision, applied to engine selection.
 //!
 //! Runtime capability cannot be predicted before attempting (a device may lack
-//! Speech assets, or abort constructing the analyzer), so this attempts once
-//! and caches the verdict: the first failure marks Apple Speech unavailable for
-//! the rest of the session, so the worker is never re-spawned only to crash
-//! again. The orchestrator is generic over the transcribe closures so it is
-//! unit-testable without a real Speech runtime.
+//! Speech assets, or abort while constructing the analyzer), so callers attempt
+//! once and cache the verdict here: the first failure latches the session onto
+//! Whisper, so the worker is never re-spawned only to crash again for the same
+//! reason. The latch uses interior mutability (an atomic) so a shared `&self`
+//! reference threads cleanly through a per-utterance loop without `&mut`
+//! plumbing.
 
 use std::sync::atomic::{AtomicU8, Ordering};
 
@@ -47,7 +48,11 @@ impl AppleSpeechSession {
 
     /// Record that Apple Speech produced a usable transcript this session.
     pub fn record_success(&self) {
-        self.state.store(USABLE, Ordering::Release);
+        // Never overwrite a latched failure: a mid-session recovery claim must
+        // not re-arm a worker that already crashed once this session.
+        let _ = self
+            .state
+            .compare_exchange(UNKNOWN, USABLE, Ordering::AcqRel, Ordering::Acquire);
     }
 
     /// Record that Apple Speech failed (crash, error, or unusable result).
@@ -62,126 +67,47 @@ impl AppleSpeechSession {
     }
 }
 
-/// Outcome of a fallback-orchestrated utterance: which engine produced the
-/// transcript, so callers can surface the honest backend and log shadow deltas.
-#[derive(Debug, PartialEq, Eq)]
-pub enum Engine {
-    AppleSpeech,
-    Whisper,
-}
-
-/// Attempt Apple Speech for one utterance, falling back to Whisper on any
-/// failure, and never losing the utterance.
-///
-/// `attempt_apple` returns `Ok(t)` only when the worker returned a response; a
-/// worker crash or XPC interruption is an `Err`. `is_usable` decides whether an
-/// `Ok` response is a real transcript (runtime supported and non-empty) versus a
-/// structured "unsupported" result that must still fall back. `whisper` is
-/// infallible from the caller's perspective: it is the guaranteed transcript, so
-/// the utterance is never dropped.
-///
-/// A failure (error or unusable result) latches the session onto Whisper for
-/// every later utterance.
-pub fn transcribe_or_fall_back<T, E>(
-    session: &AppleSpeechSession,
-    attempt_apple: impl FnOnce() -> Result<T, E>,
-    is_usable: impl FnOnce(&T) -> bool,
-    whisper: impl FnOnce() -> T,
-) -> (Engine, T) {
-    if session.should_attempt() {
-        if let Ok(result) = attempt_apple() {
-            if is_usable(&result) {
-                session.record_success();
-                return (Engine::AppleSpeech, result);
-            }
-        }
-        // Error or unusable result: latch the session onto Whisper.
-        session.record_failure();
-    }
-    (Engine::Whisper, whisper())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn a_usable_apple_result_is_returned_and_keeps_the_session_usable() {
+    fn a_fresh_session_attempts_apple_speech() {
         let session = AppleSpeechSession::new();
-        let (engine, text) = transcribe_or_fall_back(
-            &session,
-            || Ok::<_, ()>("apple transcript".to_string()),
-            |t| !t.is_empty(),
-            || "whisper transcript".to_string(),
-        );
-        assert_eq!(engine, Engine::AppleSpeech);
-        assert_eq!(text, "apple transcript");
         assert!(session.should_attempt());
         assert!(!session.is_unavailable());
     }
 
     #[test]
-    fn a_worker_error_falls_back_to_whisper_and_latches_unavailable() {
+    fn a_failure_latches_the_session_off_apple_speech() {
         let session = AppleSpeechSession::new();
-        let (engine, text) = transcribe_or_fall_back(
-            &session,
-            || Err::<String, _>("worker crashed (XPC interrupted)"),
-            |t| !t.is_empty(),
-            || "whisper transcript".to_string(),
-        );
-        assert_eq!(engine, Engine::Whisper);
-        assert_eq!(text, "whisper transcript");
+        session.record_failure();
+        assert!(!session.should_attempt());
+        assert!(session.is_unavailable());
+    }
+
+    #[test]
+    fn a_success_keeps_the_session_attempting() {
+        let session = AppleSpeechSession::new();
+        session.record_success();
+        assert!(session.should_attempt());
+        assert!(!session.is_unavailable());
+    }
+
+    #[test]
+    fn a_latched_failure_is_not_undone_by_a_later_success() {
+        // A worker that crashed once this session must stay latched off, even if
+        // some later code path reports a stray success: never re-spawn a crasher.
+        let session = AppleSpeechSession::new();
+        session.record_failure();
+        session.record_success();
         assert!(session.is_unavailable());
         assert!(!session.should_attempt());
     }
 
     #[test]
-    fn an_unusable_apple_result_falls_back_and_latches_unavailable() {
-        // runtimeSupported=false comes back as Ok but not usable.
-        let session = AppleSpeechSession::new();
-        let (engine, text) = transcribe_or_fall_back(
-            &session,
-            || Ok::<_, ()>(String::new()),
-            |t| !t.is_empty(),
-            || "whisper transcript".to_string(),
-        );
-        assert_eq!(engine, Engine::Whisper);
-        assert_eq!(text, "whisper transcript");
-        assert!(session.is_unavailable());
-    }
-
-    #[test]
-    fn after_a_failure_apple_is_not_attempted_again_this_session() {
-        let session = AppleSpeechSession::new();
-        session.record_failure();
-        let mut attempted = false;
-        let (engine, text) = transcribe_or_fall_back(
-            &session,
-            || {
-                attempted = true;
-                Ok::<_, ()>("apple transcript".to_string())
-            },
-            |t| !t.is_empty(),
-            || "whisper transcript".to_string(),
-        );
-        assert!(
-            !attempted,
-            "must not re-spawn the worker after a session failure"
-        );
-        assert_eq!(engine, Engine::Whisper);
-        assert_eq!(text, "whisper transcript");
-    }
-
-    #[test]
-    fn the_utterance_is_never_lost_even_when_both_paths_are_exercised() {
-        // Whisper is the guaranteed transcript, so a caller always gets text.
-        let session = AppleSpeechSession::new();
-        let (_, text) = transcribe_or_fall_back(
-            &session,
-            || Err::<String, _>("crash"),
-            |t| !t.is_empty(),
-            || "whisper fallback".to_string(),
-        );
-        assert!(!text.is_empty());
+    fn the_default_impl_matches_new() {
+        let session = AppleSpeechSession::default();
+        assert!(session.should_attempt());
     }
 }

--- a/crates/core/src/apple_speech_session.rs
+++ b/crates/core/src/apple_speech_session.rs
@@ -1,0 +1,187 @@
+//! Session-scoped safe fallback for Apple Speech transcription.
+//!
+//! Apple Speech runs in a separate XPC worker process, so a worker crash is
+//! failure-isolated: the parent observes an error and can fall back to Whisper
+//! for that utterance without losing it. This is the RFC 0004 failure-isolation
+//! boundary and the standing "recording must never be degraded by an optional
+//! consumer" decision, applied to engine selection.
+//!
+//! Runtime capability cannot be predicted before attempting (a device may lack
+//! Speech assets, or abort constructing the analyzer), so this attempts once
+//! and caches the verdict: the first failure marks Apple Speech unavailable for
+//! the rest of the session, so the worker is never re-spawned only to crash
+//! again. The orchestrator is generic over the transcribe closures so it is
+//! unit-testable without a real Speech runtime.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const UNKNOWN: u8 = 0;
+const USABLE: u8 = 1;
+const UNAVAILABLE: u8 = 2;
+
+/// Per-session Apple Speech capability verdict, learned by attempting.
+#[derive(Debug)]
+pub struct AppleSpeechSession {
+    state: AtomicU8,
+}
+
+impl Default for AppleSpeechSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppleSpeechSession {
+    pub const fn new() -> Self {
+        Self {
+            state: AtomicU8::new(UNKNOWN),
+        }
+    }
+
+    /// Whether an Apple Speech attempt is worth making. False once a failure has
+    /// been recorded this session, so a known-incapable device goes straight to
+    /// Whisper instead of re-spawning a worker that will abort.
+    pub fn should_attempt(&self) -> bool {
+        self.state.load(Ordering::Acquire) != UNAVAILABLE
+    }
+
+    /// Record that Apple Speech produced a usable transcript this session.
+    pub fn record_success(&self) {
+        self.state.store(USABLE, Ordering::Release);
+    }
+
+    /// Record that Apple Speech failed (crash, error, or unusable result).
+    /// Latches: once unavailable, the session stays on Whisper.
+    pub fn record_failure(&self) {
+        self.state.store(UNAVAILABLE, Ordering::Release);
+    }
+
+    /// True once a failure has latched this session onto Whisper.
+    pub fn is_unavailable(&self) -> bool {
+        self.state.load(Ordering::Acquire) == UNAVAILABLE
+    }
+}
+
+/// Outcome of a fallback-orchestrated utterance: which engine produced the
+/// transcript, so callers can surface the honest backend and log shadow deltas.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Engine {
+    AppleSpeech,
+    Whisper,
+}
+
+/// Attempt Apple Speech for one utterance, falling back to Whisper on any
+/// failure, and never losing the utterance.
+///
+/// `attempt_apple` returns `Ok(t)` only when the worker returned a response; a
+/// worker crash or XPC interruption is an `Err`. `is_usable` decides whether an
+/// `Ok` response is a real transcript (runtime supported and non-empty) versus a
+/// structured "unsupported" result that must still fall back. `whisper` is
+/// infallible from the caller's perspective: it is the guaranteed transcript, so
+/// the utterance is never dropped.
+///
+/// A failure (error or unusable result) latches the session onto Whisper for
+/// every later utterance.
+pub fn transcribe_or_fall_back<T, E>(
+    session: &AppleSpeechSession,
+    attempt_apple: impl FnOnce() -> Result<T, E>,
+    is_usable: impl FnOnce(&T) -> bool,
+    whisper: impl FnOnce() -> T,
+) -> (Engine, T) {
+    if session.should_attempt() {
+        if let Ok(result) = attempt_apple() {
+            if is_usable(&result) {
+                session.record_success();
+                return (Engine::AppleSpeech, result);
+            }
+        }
+        // Error or unusable result: latch the session onto Whisper.
+        session.record_failure();
+    }
+    (Engine::Whisper, whisper())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_usable_apple_result_is_returned_and_keeps_the_session_usable() {
+        let session = AppleSpeechSession::new();
+        let (engine, text) = transcribe_or_fall_back(
+            &session,
+            || Ok::<_, ()>("apple transcript".to_string()),
+            |t| !t.is_empty(),
+            || "whisper transcript".to_string(),
+        );
+        assert_eq!(engine, Engine::AppleSpeech);
+        assert_eq!(text, "apple transcript");
+        assert!(session.should_attempt());
+        assert!(!session.is_unavailable());
+    }
+
+    #[test]
+    fn a_worker_error_falls_back_to_whisper_and_latches_unavailable() {
+        let session = AppleSpeechSession::new();
+        let (engine, text) = transcribe_or_fall_back(
+            &session,
+            || Err::<String, _>("worker crashed (XPC interrupted)"),
+            |t| !t.is_empty(),
+            || "whisper transcript".to_string(),
+        );
+        assert_eq!(engine, Engine::Whisper);
+        assert_eq!(text, "whisper transcript");
+        assert!(session.is_unavailable());
+        assert!(!session.should_attempt());
+    }
+
+    #[test]
+    fn an_unusable_apple_result_falls_back_and_latches_unavailable() {
+        // runtimeSupported=false comes back as Ok but not usable.
+        let session = AppleSpeechSession::new();
+        let (engine, text) = transcribe_or_fall_back(
+            &session,
+            || Ok::<_, ()>(String::new()),
+            |t| !t.is_empty(),
+            || "whisper transcript".to_string(),
+        );
+        assert_eq!(engine, Engine::Whisper);
+        assert_eq!(text, "whisper transcript");
+        assert!(session.is_unavailable());
+    }
+
+    #[test]
+    fn after_a_failure_apple_is_not_attempted_again_this_session() {
+        let session = AppleSpeechSession::new();
+        session.record_failure();
+        let mut attempted = false;
+        let (engine, text) = transcribe_or_fall_back(
+            &session,
+            || {
+                attempted = true;
+                Ok::<_, ()>("apple transcript".to_string())
+            },
+            |t| !t.is_empty(),
+            || "whisper transcript".to_string(),
+        );
+        assert!(
+            !attempted,
+            "must not re-spawn the worker after a session failure"
+        );
+        assert_eq!(engine, Engine::Whisper);
+        assert_eq!(text, "whisper transcript");
+    }
+
+    #[test]
+    fn the_utterance_is_never_lost_even_when_both_paths_are_exercised() {
+        // Whisper is the guaranteed transcript, so a caller always gets text.
+        let session = AppleSpeechSession::new();
+        let (_, text) = transcribe_or_fall_back(
+            &session,
+            || Err::<String, _>("crash"),
+            |t| !t.is_empty(),
+            || "whisper fallback".to_string(),
+        );
+        assert!(!text.is_empty());
+    }
+}

--- a/crates/core/src/dictation.rs
+++ b/crates/core/src/dictation.rs
@@ -1,3 +1,4 @@
+use crate::apple_speech_session::AppleSpeechSession;
 use crate::config::Config;
 use crate::dictation_cleanup::{clean_dictation_text, CleanupEngine, CleanupOptions};
 use crate::error::{DictationError, MinutesError, TranscribeError};
@@ -356,6 +357,13 @@ where
     let run_start = Instant::now();
     startup_debug("run_inner_start", Some(&config.dictation.model), None, None);
     let final_backend = dictation_final_backend(config);
+    // Session-scoped Apple Speech capability latch: the worker runs in a separate
+    // XPC process, so a crash on an incapable device is failure-isolated and we
+    // fall back to Whisper. Without this latch each utterance would re-spawn the
+    // worker only to crash again; the first failure switches the rest of the
+    // session to Whisper. Dormant while the transport gate stays closed (the
+    // backend never resolves to apple-speech today), armed for when it opens.
+    let apple_session = AppleSpeechSession::new();
 
     // Try to use preloaded model, fall back to loading on demand
     #[cfg(feature = "whisper")]
@@ -497,6 +505,7 @@ where
                     if let Some(finalized) = finalize_dictation_transcription(
                         config,
                         final_backend,
+                        &apple_session,
                         &final_utterance_samples,
                         &mut streaming,
                         whisper_ctx.as_ref(),
@@ -526,6 +535,7 @@ where
                     if let Some(finalized) = finalize_dictation_transcription(
                         config,
                         final_backend,
+                        &apple_session,
                         &final_utterance_samples,
                         &mut streaming,
                         whisper_ctx.as_ref(),
@@ -626,6 +636,7 @@ where
                     if let Some(finalized) = finalize_dictation_transcription(
                         config,
                         final_backend,
+                        &apple_session,
                         &final_utterance_samples,
                         &mut streaming,
                         whisper_ctx.as_ref(),
@@ -654,6 +665,7 @@ where
                     if let Some(finalized) = finalize_dictation_transcription(
                         config,
                         final_backend,
+                        &apple_session,
                         &final_utterance_samples,
                         &mut streaming,
                         whisper_ctx.as_ref(),
@@ -764,28 +776,51 @@ fn parakeet_dictation_ready(config: &Config) -> bool {
     status.ready
 }
 
+/// Whether this utterance should attempt Apple Speech: the resolved backend is
+/// apple-speech *and* the session has not already latched onto Whisper after a
+/// prior failure. Extracted so the latch decision is unit-testable without the
+/// macOS-only worker (the attempt itself is `target_os = "macos"`).
+#[cfg(any(test, target_os = "macos"))]
+fn dictation_should_attempt_apple(
+    backend: DictationFinalBackend,
+    session: &AppleSpeechSession,
+) -> bool {
+    backend == DictationFinalBackend::AppleSpeech && session.should_attempt()
+}
+
 #[cfg(feature = "whisper")]
 fn finalize_dictation_transcription(
     _config: &Config,
     _final_backend: DictationFinalBackend,
+    apple_session: &AppleSpeechSession,
     _final_utterance_samples: &[f32],
     streaming: &mut StreamingWhisper,
     whisper_ctx: Option<&whisper_rs::WhisperContext>,
 ) -> Option<FinalizedDictation> {
+    #[cfg(not(target_os = "macos"))]
+    let _ = apple_session;
+
     #[cfg(target_os = "macos")]
-    if _final_backend == DictationFinalBackend::AppleSpeech {
+    if dictation_should_attempt_apple(_final_backend, apple_session) {
         match transcribe_utterance_with_apple_speech(_final_utterance_samples, _config) {
             Ok(Some(transcript)) => {
+                apple_session.record_success();
                 return Some(FinalizedDictation {
                     transcript,
                     backend: DictationFinalBackend::AppleSpeech,
                 });
             }
+            // Empty result (e.g. sub-1s blip): not a failure, so don't latch the
+            // session off Apple Speech; just yield nothing for this utterance.
             Ok(None) => {}
             Err(error) => {
+                // Worker crash or Speech error: latch this session to Whisper so
+                // the next utterance doesn't re-spawn a worker that will crash
+                // again, and fall through to the Whisper path below.
+                apple_session.record_failure();
                 tracing::warn!(
                     error = %error,
-                    "apple-speech dictation failed; using whisper fallback for this utterance"
+                    "apple-speech dictation failed; latching this session to whisper fallback"
                 );
             }
         }
@@ -1456,6 +1491,31 @@ mod tests {
             },
             ..Config::default()
         }
+    }
+
+    #[test]
+    fn dictation_latches_off_apple_speech_after_a_failure() {
+        let session = AppleSpeechSession::new();
+        // Fresh session with the apple-speech backend selected: attempt it.
+        assert!(dictation_should_attempt_apple(
+            DictationFinalBackend::AppleSpeech,
+            &session
+        ));
+
+        // A worker failure latches the session: the next utterance must not
+        // re-attempt apple-speech (which would re-spawn a crashing worker).
+        session.record_failure();
+        assert!(!dictation_should_attempt_apple(
+            DictationFinalBackend::AppleSpeech,
+            &session
+        ));
+
+        // A whisper session never routes through apple-speech, latch or not.
+        let whisper_session = AppleSpeechSession::new();
+        assert!(!dictation_should_attempt_apple(
+            DictationFinalBackend::Whisper,
+            &whisper_session
+        ));
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod apple_fm;
 pub mod apple_speech;
+pub mod apple_speech_session;
 pub mod apple_speech_worker;
 pub(crate) mod audio_budget;
 pub mod audio_decode_worker;


### PR DESCRIPTION
Phase 1 of the Apple Speech activation epic (bead minutes-oqv5, epic minutes-uyc8, plan #726). **Draft / WIP** — building in verified increments.

**Increment 1 (this push): the safe-fallback primitive.** A session-scoped capability cache plus a fallback orchestrator (`crates/core/src/apple_speech_session.rs`). It attempts Apple Speech for one utterance and falls back to Whisper on any failure (worker crash / XPC interruption / Speech error / `runtimeSupported=false`) without losing the utterance, and latches the session onto Whisper after the first failure so an incapable device never re-spawns a worker that will abort. Generic over the transcribe closures, unit-tested (5 tests) without a real Speech runtime. clippy `-D warnings` clean with and without `whisper`, fmt clean.

**Safety:** the product gate stays hard false. This does not activate anything or flip any default; per the plan (shadow-first) the gate flip is a later, Mat-gated step. This lands the machinery that later increments route utterances through.

**Next increments (planned):** wire the primitive into the live-transcript path (first surface), then batch and dictation; make the gate reflect real runtime capability via attempt-once-and-cache; honest health/docs. Kept out of scope here: the gate flip itself.