### PR TITLE
feat(apple-speech): shadow-mode measurement scaffolding (Phase 6)

### DIFF
--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -31,10 +31,11 @@ pub enum ShadowOutcome {
 
 /// A fixed failure category for a shadow attempt.
 ///
-/// The raw error string is deliberately discarded: it can embed recognized
-/// speech (names, account details) that must never reach a shadow log, and
-/// truncation is not redaction. Classification reads the message but stores only
-/// this closed set, so no transcript content survives.
+/// `compare` takes this category directly rather than a raw error string. The
+/// caller has the typed failure context (worker exit, XPC status, Speech error),
+/// so it can categorize accurately; and a closed enum makes it *impossible* for a
+/// raw message — which can embed recognized speech — to reach a shadow log. That
+/// is a stronger guarantee than trying to redact free text after the fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShadowError {
     /// The worker process died (crash / abort).
@@ -58,24 +59,6 @@ impl ShadowError {
             Self::AssetsUnavailable => "assets_unavailable",
             Self::SpeechError => "speech_error",
             Self::Unknown => "unknown",
-        }
-    }
-
-    /// Classify a raw error into a fixed category, discarding the message so no
-    /// transcript content it might embed is ever stored or logged. Matching is
-    /// on the worker's own code-controlled status wording, not on user speech.
-    fn classify(msg: &str) -> Self {
-        let m = msg.to_lowercase();
-        if m.contains("interrupt") || m.contains("invalidat") {
-            Self::XpcInterrupted
-        } else if m.contains("crash") || m.contains("abort") || m.contains("signal") {
-            Self::WorkerCrashed
-        } else if m.contains("not subscribed") || m.contains("asset") || m.contains("locale") {
-            Self::AssetsUnavailable
-        } else if m.contains("speech") || m.contains("analyzer") || m.contains("recogni") {
-            Self::SpeechError
-        } else {
-            Self::Unknown
         }
     }
 }
@@ -122,11 +105,13 @@ const SIMILARITY_WORD_CAP: usize = 3000;
 /// Speech attempt result for the same audio.
 ///
 /// `apple` is `Ok(Some(text))` for a usable transcript, `Ok(None)` for an empty
-/// result, or `Err(msg)` when the attempt failed. Whisper is always present
-/// because it is the shipped output. A `Some` value that normalizes to zero
-/// words (e.g. the native bridge's empty-segment `""`) is classified `Empty`,
-/// not `Usable`, so capability-success rates are not inflated.
-pub fn compare(whisper: &str, apple: Result<Option<&str>, &str>) -> ShadowComparison {
+/// result, or `Err(category)` when the attempt failed, where the caller supplies
+/// the typed [`ShadowError`] category (no raw message crosses this boundary).
+/// Whisper is always present because it is the shipped output. A `Some` value
+/// that normalizes to zero words (e.g. the native bridge's empty-segment `""`)
+/// is classified `Empty`, not `Usable`, so capability-success rates are not
+/// inflated.
+pub fn compare(whisper: &str, apple: Result<Option<&str>, ShadowError>) -> ShadowComparison {
     let whisper_words_vec = normalized_words(whisper);
     let whisper_chars = normalized_char_count(whisper);
     let whisper_words = whisper_words_vec.len();
@@ -171,7 +156,7 @@ pub fn compare(whisper: &str, apple: Result<Option<&str>, &str>) -> ShadowCompar
             }
         }
         Ok(None) => non_usable(ShadowOutcome::Empty, None),
-        Err(msg) => non_usable(ShadowOutcome::Failed, Some(ShadowError::classify(msg))),
+        Err(category) => non_usable(ShadowOutcome::Failed, Some(category)),
     }
 }
 
@@ -194,6 +179,10 @@ pub fn log_comparison(source: &str, cmp: &ShadowComparison) -> std::io::Result<(
     };
     let entry = serde_json::json!({
         "event": "apple_speech_shadow",
+        // Each caller injects its own timestamp; append_log does not. Without it
+        // measurements can't be correlated with the OS/app/worker change being
+        // evaluated across sessions (daily rotation gives at most a file date).
+        "ts": chrono::Utc::now().to_rfc3339(),
         "source": source,
         "outcome": outcome,
         "whisper_words": cmp.whisper_words,
@@ -367,25 +356,15 @@ mod tests {
     }
 
     #[test]
-    fn a_failed_attempt_stores_a_fixed_category_not_the_message() {
-        let cmp = compare("whisper had text", Err("worker crashed (XPC interrupted)"));
+    fn a_failed_attempt_records_the_caller_supplied_category() {
+        // The caller passes a typed category; no raw message can cross the API,
+        // so transcript content can never reach the record by construction.
+        let cmp = compare("whisper had text", Err(ShadowError::XpcInterrupted));
         assert_eq!(cmp.outcome, ShadowOutcome::Failed);
         assert_eq!(cmp.apple_words, 0);
         assert_eq!(cmp.similarity, None);
         assert_eq!(cmp.apple_error, Some(ShadowError::XpcInterrupted));
         assert_eq!(cmp.whisper_words, 3);
-    }
-
-    #[test]
-    fn error_classification_discards_any_embedded_text() {
-        // Even if an error embedded recognized speech, only a fixed category is
-        // stored — the raw words never survive. The stored value is a token from
-        // ShadowError's closed set regardless of which category is chosen.
-        let cmp = compare("hi", Err("boom: the secret launch code is hunter2"));
-        let category = cmp.apple_error.expect("failed attempt has a category");
-        assert!(!category.as_str().contains("hunter2"));
-        assert!(!category.as_str().contains("secret"));
-        assert!(!category.as_str().contains("launch"));
     }
 
     #[test]

--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -21,7 +21,8 @@ use crate::config::Config;
 pub enum ShadowOutcome {
     /// Apple Speech returned a non-empty transcript.
     Usable,
-    /// Apple Speech returned successfully but with no text (silence or a blip).
+    /// Apple Speech returned successfully but with no words: silence, a blip, or
+    /// the native bridge's empty-segment `""`.
     Empty,
     /// Apple Speech failed: worker crash, XPC interruption, or a Speech error.
     Failed,
@@ -50,8 +51,8 @@ pub struct ShadowComparison {
     pub similarity: f32,
     /// True when both engines produced the same normalized text.
     pub exact_match: bool,
-    /// Failure detail when `outcome == Failed`; `None` otherwise. This is an
-    /// error string, never transcript content.
+    /// Failure detail when `outcome == Failed`; `None` otherwise. A bounded,
+    /// single-line error category, never transcript content.
     pub apple_error: Option<String>,
 }
 
@@ -61,20 +62,45 @@ pub struct ShadowComparison {
 /// runs are far below this, so the exact metric is what actually gets used.
 const SIMILARITY_WORD_CAP: usize = 3000;
 
+/// Cap on the stored `apple_error` length. Worker errors are structured status
+/// strings, but `compare` accepts an arbitrary `&str`, so the message is
+/// collapsed to one line and truncated to defend the "no transcript content in
+/// shadow logs" guarantee against a caller whose error embeds recognized text.
+const MAX_ERROR_CHARS: usize = 160;
+
 /// Build a shadow comparison from the shipped Whisper transcript and the Apple
 /// Speech attempt result for the same audio.
 ///
 /// `apple` is `Ok(Some(text))` for a usable transcript, `Ok(None)` for an empty
 /// result, or `Err(msg)` when the attempt failed. Whisper is always present
-/// because it is the shipped output.
+/// because it is the shipped output. A `Some` value that normalizes to zero
+/// words (e.g. the native bridge's empty-segment `""`) is classified `Empty`,
+/// not `Usable`, so capability-success rates are not inflated.
 pub fn compare(whisper: &str, apple: Result<Option<&str>, &str>) -> ShadowComparison {
     let whisper_words_vec = normalized_words(whisper);
     let whisper_chars = normalized_char_count(whisper);
     let whisper_words = whisper_words_vec.len();
 
+    let empty = |outcome, apple_error| ShadowComparison {
+        outcome,
+        whisper_chars,
+        whisper_words,
+        apple_chars: 0,
+        apple_words: 0,
+        similarity: 0.0,
+        exact_match: false,
+        apple_error,
+    };
+
     match apple {
         Ok(Some(apple_text)) => {
             let apple_words_vec = normalized_words(apple_text);
+            if apple_words_vec.is_empty() {
+                // A Some("") / whitespace / punctuation-only result is not a
+                // usable transcript — the native bridge returns "" when there
+                // are no segments. Record it as Empty.
+                return empty(ShadowOutcome::Empty, None);
+            }
             ShadowComparison {
                 outcome: ShadowOutcome::Usable,
                 whisper_chars,
@@ -86,61 +112,40 @@ pub fn compare(whisper: &str, apple: Result<Option<&str>, &str>) -> ShadowCompar
                 apple_error: None,
             }
         }
-        Ok(None) => ShadowComparison {
-            outcome: ShadowOutcome::Empty,
-            whisper_chars,
-            whisper_words,
-            apple_chars: 0,
-            apple_words: 0,
-            similarity: 0.0,
-            exact_match: false,
-            apple_error: None,
-        },
-        Err(msg) => ShadowComparison {
-            outcome: ShadowOutcome::Failed,
-            whisper_chars,
-            whisper_words,
-            apple_chars: 0,
-            apple_words: 0,
-            similarity: 0.0,
-            exact_match: false,
-            apple_error: Some(msg.to_string()),
-        },
+        Ok(None) => empty(ShadowOutcome::Empty, None),
+        Err(msg) => empty(ShadowOutcome::Failed, Some(bounded_error(msg))),
     }
 }
 
-/// Emit a shadow comparison to the structured log under the `apple_speech_shadow`
-/// target. Logging only, so it is failure-isolated from capture: a shadow
-/// attempt that crashed still lands here as an event, never as a panic.
+/// Persist a shadow comparison to the structured JSONL log.
+///
+/// Writes through [`crate::logging::append_log`] so the measurement is durable:
+/// the CLI's tracing subscriber only reaches stderr and the Tauri entry point
+/// installs no subscriber at all, so tracing-only events would be dropped on
+/// exactly the desktop path shadow mode most needs to measure. The write is
+/// failure-isolated — a logging error is swallowed so it can never affect
+/// capture — and a `debug` trace is emitted alongside for live tailing.
 pub fn log_comparison(source: &str, cmp: &ShadowComparison) {
-    match cmp.outcome {
-        ShadowOutcome::Usable => tracing::info!(
-            target: "apple_speech_shadow",
-            source,
-            outcome = "usable",
-            whisper_words = cmp.whisper_words,
-            apple_words = cmp.apple_words,
-            whisper_chars = cmp.whisper_chars,
-            apple_chars = cmp.apple_chars,
-            similarity = cmp.similarity,
-            exact_match = cmp.exact_match,
-            "apple-speech shadow comparison"
-        ),
-        ShadowOutcome::Empty => tracing::info!(
-            target: "apple_speech_shadow",
-            source,
-            outcome = "empty",
-            whisper_words = cmp.whisper_words,
-            "apple-speech shadow: empty result while whisper produced text"
-        ),
-        ShadowOutcome::Failed => tracing::warn!(
-            target: "apple_speech_shadow",
-            source,
-            outcome = "failed",
-            error = cmp.apple_error.as_deref().unwrap_or(""),
-            "apple-speech shadow: attempt failed, whisper used"
-        ),
-    }
+    let outcome = match cmp.outcome {
+        ShadowOutcome::Usable => "usable",
+        ShadowOutcome::Empty => "empty",
+        ShadowOutcome::Failed => "failed",
+    };
+    let entry = serde_json::json!({
+        "event": "apple_speech_shadow",
+        "source": source,
+        "outcome": outcome,
+        "whisper_words": cmp.whisper_words,
+        "apple_words": cmp.apple_words,
+        "whisper_chars": cmp.whisper_chars,
+        "apple_chars": cmp.apple_chars,
+        "similarity": cmp.similarity,
+        "exact_match": cmp.exact_match,
+        "apple_error": cmp.apple_error,
+    });
+    // Failure-isolated: a logging failure must never affect capture.
+    let _ = crate::logging::append_log(&entry);
+    tracing::debug!(target: "apple_speech_shadow", source, outcome, "apple-speech shadow comparison");
 }
 
 /// Whether shadow mode is switched on in config.
@@ -154,15 +159,30 @@ pub fn shadow_enabled(config: &Config) -> bool {
     config.transcription.apple_speech_shadow
 }
 
-/// Lowercased whitespace-split words. Casing and spacing differ between the two
-/// engines' formatting, and shadow mode measures word content, not typography,
-/// so both are normalized away before comparison.
+/// Lowercased, punctuation-insensitive words. The two engines format
+/// differently (casing, spacing, and especially punctuation — Whisper writes
+/// `Hello, world!` where Apple Speech may write `hello world`), and shadow mode
+/// measures word content, not typography. Non-alphanumeric, non-whitespace
+/// characters are mapped to spaces before splitting, mirroring
+/// `apple_speech::eval_text_for_compare_punct_insensitive` so the shadow metric
+/// and the offline evaluator agree on what "same words" means.
 fn normalized_words(text: &str) -> Vec<String> {
-    text.split_whitespace().map(|w| w.to_lowercase()).collect()
+    text.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c.is_whitespace() {
+                c
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .map(|w| w.to_lowercase())
+        .collect()
 }
 
-/// Character count of the normalized (lowercased, single-spaced) text. A size
-/// signal for the log, not used in the similarity metric.
+/// Character count of the normalized (lowercased, punctuation-free, single-spaced)
+/// text. A size signal for the log, not used in the similarity metric.
 fn normalized_char_count(text: &str) -> usize {
     normalized_words(text).join(" ").chars().count()
 }
@@ -171,9 +191,6 @@ fn normalized_char_count(text: &str) -> usize {
 /// normalized inverse of the word error rate. Two empty transcripts are treated
 /// as identical (`1.0`); one empty and one not is `0.0`.
 fn word_similarity(a: &[String], b: &[String]) -> f32 {
-    if a.is_empty() && b.is_empty() {
-        return 1.0;
-    }
     let max_len = a.len().max(b.len());
     if max_len == 0 {
         return 1.0;
@@ -211,15 +228,30 @@ fn word_edit_distance(a: &[String], b: &[String]) -> usize {
     prev[short.len()]
 }
 
+/// Collapse an error to a bounded, single-line diagnostic (see `MAX_ERROR_CHARS`).
+fn bounded_error(msg: &str) -> String {
+    let one_line = msg.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.chars().count() > MAX_ERROR_CHARS {
+        let truncated: String = one_line.chars().take(MAX_ERROR_CHARS).collect();
+        format!("{truncated}…")
+    } else {
+        one_line
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn identical_transcripts_are_a_perfect_match() {
-        let cmp = compare("Hello world", Ok(Some("hello   WORLD")));
+    fn punctuation_and_casing_normalize_away_to_a_perfect_match() {
+        // The engines punctuate and case differently; only word content counts.
+        let cmp = compare("Hello, world!", Ok(Some("hello   WORLD")));
         assert_eq!(cmp.outcome, ShadowOutcome::Usable);
-        assert!(cmp.exact_match, "casing/spacing must normalize away");
+        assert!(
+            cmp.exact_match,
+            "punctuation/casing/spacing must normalize away"
+        );
         assert_eq!(cmp.similarity, 1.0);
         assert_eq!(cmp.whisper_words, 2);
         assert_eq!(cmp.apple_words, 2);
@@ -248,7 +280,7 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_apple_result_is_recorded_without_latching_a_failure() {
+    fn an_empty_apple_result_is_recorded_without_a_failure() {
         let cmp = compare("whisper had text", Ok(None));
         assert_eq!(cmp.outcome, ShadowOutcome::Empty);
         assert_eq!(cmp.apple_words, 0);
@@ -257,7 +289,23 @@ mod tests {
     }
 
     #[test]
-    fn a_failed_apple_attempt_carries_the_error_not_the_transcript() {
+    fn a_blank_or_punctuation_only_some_is_empty_not_usable() {
+        // The native bridge returns "" when there are no segments; scoring that
+        // as Usable/1.0 would inflate the capability-success rate.
+        for blank in ["", "   ", " ...!? "] {
+            let cmp = compare("whisper had text", Ok(Some(blank)));
+            assert_eq!(
+                cmp.outcome,
+                ShadowOutcome::Empty,
+                "{blank:?} should classify as Empty"
+            );
+            assert_eq!(cmp.apple_words, 0);
+            assert_eq!(cmp.similarity, 0.0);
+        }
+    }
+
+    #[test]
+    fn a_failed_apple_attempt_carries_a_bounded_error_not_the_transcript() {
         let cmp = compare("whisper had text", Err("worker crashed (XPC interrupted)"));
         assert_eq!(cmp.outcome, ShadowOutcome::Failed);
         assert_eq!(cmp.apple_words, 0);
@@ -270,22 +318,27 @@ mod tests {
     }
 
     #[test]
+    fn a_long_multiline_error_is_bounded_to_one_line() {
+        let huge = format!("failure: {}", "context ".repeat(80));
+        let cmp = compare("hi", Err(&huge));
+        let stored = cmp.apple_error.expect("failed attempt records an error");
+        assert!(!stored.contains('\n'));
+        assert!(
+            stored.chars().count() <= MAX_ERROR_CHARS + 1,
+            "bounded to {} chars, got {}",
+            MAX_ERROR_CHARS,
+            stored.chars().count()
+        );
+        assert!(stored.ends_with('…'), "truncation marker present");
+    }
+
+    #[test]
     fn similarity_is_symmetric_in_edit_distance() {
         let a = compare("one two three four", Ok(Some("one two three")));
         let b = compare("one two three", Ok(Some("one two three four")));
         assert!((a.similarity - b.similarity).abs() < 1e-6);
         // One deletion out of four: 0.75.
         assert!((a.similarity - 0.75).abs() < 1e-6, "got {}", a.similarity);
-    }
-
-    #[test]
-    fn both_empty_is_a_perfect_match() {
-        let cmp = compare("", Ok(Some("")));
-        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
-        assert_eq!(cmp.similarity, 1.0);
-        assert!(cmp.exact_match);
-        assert_eq!(cmp.whisper_words, 0);
-        assert_eq!(cmp.apple_words, 0);
     }
 
     #[test]

--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -239,20 +239,29 @@ pub fn shadow_enabled(config: &Config) -> bool {
 /// and punctuates (`Hello, world!`) where Apple Speech emits plain `hello world`.
 /// Shadow mode measures word content, not typography, so each line is first run
 /// through `pipeline::clean_transcript_line` (stripping `[...]` prefixes, exactly
-/// as the offline evaluator does) and then non-alphanumeric, non-whitespace
-/// characters are mapped to spaces. This keeps the shadow metric and the offline
-/// evaluator (`apple_speech::eval_text_for_compare_punct_insensitive`) in
-/// agreement on what "same words" means.
+/// as the offline evaluator does) and then punctuation is folded:
+///
+/// - word-internal apostrophes and periods are *deleted*, so contractions and
+///   abbreviations survive as one token (`can't` == `cant`, `U.S.` == `us`),
+/// - every other non-alphanumeric character becomes a space (a word boundary).
+///
+/// This follows `apple_speech::eval_text_for_compare_punct_insensitive` but folds
+/// contractions the base evaluator would split. Residual heuristic limits remain
+/// (e.g. hyphenated compounds still split); a shadow similarity is a proxy, not a
+/// ground-truth WER.
 fn normalized_words(text: &str) -> Vec<String> {
     text.lines()
         .filter_map(crate::pipeline::clean_transcript_line)
         .flat_map(|line| {
             line.chars()
-                .map(|c| {
+                .filter_map(|c| {
                     if c.is_alphanumeric() || c.is_whitespace() {
-                        c
+                        Some(c)
+                    } else if c == '\'' || c == '.' {
+                        // Fold word-internal punctuation: can't -> cant, U.S. -> us.
+                        None
                     } else {
-                        ' '
+                        Some(' ')
                     }
                 })
                 .collect::<String>()
@@ -338,6 +347,16 @@ mod tests {
         assert!(cmp.exact_match, "timestamp prefix must be stripped");
         assert_eq!(cmp.similarity, Some(1.0));
         assert_eq!(cmp.whisper_words, 2, "the 0 and 05 must not count as words");
+    }
+
+    #[test]
+    fn contractions_and_abbreviations_fold_to_a_match() {
+        // Engines format contractions/abbreviations differently; word-internal
+        // apostrophes and periods must not create spurious word boundaries.
+        let cmp = compare("I can't visit the U.S.", Ok(Some("i cant visit the us")));
+        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
+        assert!(cmp.exact_match, "can't==cant and U.S.==us");
+        assert_eq!(cmp.similarity, Some(1.0));
     }
 
     #[test]

--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -1,0 +1,311 @@
+//! Apple Speech shadow-mode measurement (activation plan, Phase 6).
+//!
+//! Shadow mode runs Apple Speech alongside Whisper purely to measure the
+//! real-world capability distribution and the transcript quality delta before
+//! any user-facing exposure. It never affects the transcript the user sees or
+//! the recording: the shadow attempt is failure-isolated (RFC 0004), gated
+//! behind an off-by-default config flag, and independent of the product
+//! transport gate (`apple_speech_private_audio_transport_supported`). Shadow
+//! measures; it never exposes.
+//!
+//! This module is the measurement primitive: the pure comparison record and
+//! its logging. It deliberately carries only measurements (counts, a
+//! similarity score, an outcome), never the transcript text, so a shadow log
+//! can never leak sensitive content. Wiring a shadow attempt into a capture
+//! path is a separate step, paired with the on-hardware data run.
+
+use crate::config::Config;
+
+/// What Apple Speech produced for a shadow utterance, relative to Whisper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShadowOutcome {
+    /// Apple Speech returned a non-empty transcript.
+    Usable,
+    /// Apple Speech returned successfully but with no text (silence or a blip).
+    Empty,
+    /// Apple Speech failed: worker crash, XPC interruption, or a Speech error.
+    Failed,
+}
+
+/// One shadow-mode comparison of Whisper (the shipped transcript) against an
+/// Apple Speech attempt for the same audio.
+///
+/// Carries only measurements, never the transcript text, so it is safe to log
+/// to disk under the same privacy rules as the rest of the pipeline.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ShadowComparison {
+    /// Whether Apple Speech produced a usable transcript, an empty one, or failed.
+    pub outcome: ShadowOutcome,
+    /// Character count of the shipped Whisper transcript (post-normalization).
+    pub whisper_chars: usize,
+    /// Word count of the shipped Whisper transcript (post-normalization).
+    pub whisper_words: usize,
+    /// Character count of the Apple Speech transcript; 0 unless `Usable`.
+    pub apple_chars: usize,
+    /// Word count of the Apple Speech transcript; 0 unless `Usable`.
+    pub apple_words: usize,
+    /// Word-level similarity in `[0.0, 1.0]`, `1.0` meaning identical word
+    /// sequences (a normalized inverse word-error-rate). Only meaningful when
+    /// `outcome == Usable`; `0.0` otherwise.
+    pub similarity: f32,
+    /// True when both engines produced the same normalized text.
+    pub exact_match: bool,
+    /// Failure detail when `outcome == Failed`; `None` otherwise. This is an
+    /// error string, never transcript content.
+    pub apple_error: Option<String>,
+}
+
+/// Above this normalized word count, `similarity` uses a cheap length-ratio
+/// proxy instead of an O(n*m) word edit distance, so a full-meeting batch
+/// transcript can never make shadow logging quadratic. Per-utterance shadow
+/// runs are far below this, so the exact metric is what actually gets used.
+const SIMILARITY_WORD_CAP: usize = 3000;
+
+/// Build a shadow comparison from the shipped Whisper transcript and the Apple
+/// Speech attempt result for the same audio.
+///
+/// `apple` is `Ok(Some(text))` for a usable transcript, `Ok(None)` for an empty
+/// result, or `Err(msg)` when the attempt failed. Whisper is always present
+/// because it is the shipped output.
+pub fn compare(whisper: &str, apple: Result<Option<&str>, &str>) -> ShadowComparison {
+    let whisper_words_vec = normalized_words(whisper);
+    let whisper_chars = normalized_char_count(whisper);
+    let whisper_words = whisper_words_vec.len();
+
+    match apple {
+        Ok(Some(apple_text)) => {
+            let apple_words_vec = normalized_words(apple_text);
+            ShadowComparison {
+                outcome: ShadowOutcome::Usable,
+                whisper_chars,
+                whisper_words,
+                apple_chars: normalized_char_count(apple_text),
+                apple_words: apple_words_vec.len(),
+                similarity: word_similarity(&whisper_words_vec, &apple_words_vec),
+                exact_match: whisper_words_vec == apple_words_vec,
+                apple_error: None,
+            }
+        }
+        Ok(None) => ShadowComparison {
+            outcome: ShadowOutcome::Empty,
+            whisper_chars,
+            whisper_words,
+            apple_chars: 0,
+            apple_words: 0,
+            similarity: 0.0,
+            exact_match: false,
+            apple_error: None,
+        },
+        Err(msg) => ShadowComparison {
+            outcome: ShadowOutcome::Failed,
+            whisper_chars,
+            whisper_words,
+            apple_chars: 0,
+            apple_words: 0,
+            similarity: 0.0,
+            exact_match: false,
+            apple_error: Some(msg.to_string()),
+        },
+    }
+}
+
+/// Emit a shadow comparison to the structured log under the `apple_speech_shadow`
+/// target. Logging only, so it is failure-isolated from capture: a shadow
+/// attempt that crashed still lands here as an event, never as a panic.
+pub fn log_comparison(source: &str, cmp: &ShadowComparison) {
+    match cmp.outcome {
+        ShadowOutcome::Usable => tracing::info!(
+            target: "apple_speech_shadow",
+            source,
+            outcome = "usable",
+            whisper_words = cmp.whisper_words,
+            apple_words = cmp.apple_words,
+            whisper_chars = cmp.whisper_chars,
+            apple_chars = cmp.apple_chars,
+            similarity = cmp.similarity,
+            exact_match = cmp.exact_match,
+            "apple-speech shadow comparison"
+        ),
+        ShadowOutcome::Empty => tracing::info!(
+            target: "apple_speech_shadow",
+            source,
+            outcome = "empty",
+            whisper_words = cmp.whisper_words,
+            "apple-speech shadow: empty result while whisper produced text"
+        ),
+        ShadowOutcome::Failed => tracing::warn!(
+            target: "apple_speech_shadow",
+            source,
+            outcome = "failed",
+            error = cmp.apple_error.as_deref().unwrap_or(""),
+            "apple-speech shadow: attempt failed, whisper used"
+        ),
+    }
+}
+
+/// Whether shadow mode is switched on in config.
+///
+/// This is only the config intent. An actual shadow attempt additionally
+/// requires the macOS worker to be available (checked at the call site) and
+/// respects the per-session
+/// [`crate::apple_speech_session::AppleSpeechSession`] latch. It is independent
+/// of the product transport gate: shadow measures, it never exposes.
+pub fn shadow_enabled(config: &Config) -> bool {
+    config.transcription.apple_speech_shadow
+}
+
+/// Lowercased whitespace-split words. Casing and spacing differ between the two
+/// engines' formatting, and shadow mode measures word content, not typography,
+/// so both are normalized away before comparison.
+fn normalized_words(text: &str) -> Vec<String> {
+    text.split_whitespace().map(|w| w.to_lowercase()).collect()
+}
+
+/// Character count of the normalized (lowercased, single-spaced) text. A size
+/// signal for the log, not used in the similarity metric.
+fn normalized_char_count(text: &str) -> usize {
+    normalized_words(text).join(" ").chars().count()
+}
+
+/// Word-level similarity in `[0.0, 1.0]`: `1.0 - editdistance / max(len)`, a
+/// normalized inverse of the word error rate. Two empty transcripts are treated
+/// as identical (`1.0`); one empty and one not is `0.0`.
+fn word_similarity(a: &[String], b: &[String]) -> f32 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let max_len = a.len().max(b.len());
+    if max_len == 0 {
+        return 1.0;
+    }
+    // Guard against a quadratic blow-up on very long (batch) transcripts.
+    if max_len > SIMILARITY_WORD_CAP {
+        let min_len = a.len().min(b.len());
+        return min_len as f32 / max_len as f32;
+    }
+    let distance = word_edit_distance(a, b);
+    1.0 - (distance as f32 / max_len as f32)
+}
+
+/// Levenshtein edit distance over word tokens, two-row DP (O(n*m) time,
+/// O(min(n,m)) space). Inputs are per-utterance word lists, so this is cheap.
+fn word_edit_distance(a: &[String], b: &[String]) -> usize {
+    // Iterate over the longer sequence in the outer loop so the row we allocate
+    // is the shorter of the two.
+    let (long, short) = if a.len() >= b.len() { (a, b) } else { (b, a) };
+    if short.is_empty() {
+        return long.len();
+    }
+    let mut prev: Vec<usize> = (0..=short.len()).collect();
+    let mut curr: Vec<usize> = vec![0; short.len() + 1];
+    for (i, long_word) in long.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, short_word) in short.iter().enumerate() {
+            let cost = usize::from(long_word != short_word);
+            curr[j + 1] = (prev[j + 1] + 1) // deletion
+                .min(curr[j] + 1) // insertion
+                .min(prev[j] + cost); // substitution
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[short.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_transcripts_are_a_perfect_match() {
+        let cmp = compare("Hello world", Ok(Some("hello   WORLD")));
+        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
+        assert!(cmp.exact_match, "casing/spacing must normalize away");
+        assert_eq!(cmp.similarity, 1.0);
+        assert_eq!(cmp.whisper_words, 2);
+        assert_eq!(cmp.apple_words, 2);
+        assert!(cmp.apple_error.is_none());
+    }
+
+    #[test]
+    fn a_one_word_difference_lowers_similarity_but_stays_usable() {
+        let cmp = compare("the quick brown fox", Ok(Some("the quick red fox")));
+        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
+        assert!(!cmp.exact_match);
+        // One substitution out of four words: 1 - 1/4 = 0.75.
+        assert!(
+            (cmp.similarity - 0.75).abs() < 1e-6,
+            "got {}",
+            cmp.similarity
+        );
+    }
+
+    #[test]
+    fn completely_different_text_has_low_similarity() {
+        let cmp = compare("alpha beta gamma", Ok(Some("one two three")));
+        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
+        assert_eq!(cmp.similarity, 0.0);
+        assert!(!cmp.exact_match);
+    }
+
+    #[test]
+    fn an_empty_apple_result_is_recorded_without_latching_a_failure() {
+        let cmp = compare("whisper had text", Ok(None));
+        assert_eq!(cmp.outcome, ShadowOutcome::Empty);
+        assert_eq!(cmp.apple_words, 0);
+        assert_eq!(cmp.whisper_words, 3);
+        assert!(cmp.apple_error.is_none());
+    }
+
+    #[test]
+    fn a_failed_apple_attempt_carries_the_error_not_the_transcript() {
+        let cmp = compare("whisper had text", Err("worker crashed (XPC interrupted)"));
+        assert_eq!(cmp.outcome, ShadowOutcome::Failed);
+        assert_eq!(cmp.apple_words, 0);
+        assert_eq!(
+            cmp.apple_error.as_deref(),
+            Some("worker crashed (XPC interrupted)")
+        );
+        // The Whisper side is still measured so the log shows what shipped.
+        assert_eq!(cmp.whisper_words, 3);
+    }
+
+    #[test]
+    fn similarity_is_symmetric_in_edit_distance() {
+        let a = compare("one two three four", Ok(Some("one two three")));
+        let b = compare("one two three", Ok(Some("one two three four")));
+        assert!((a.similarity - b.similarity).abs() < 1e-6);
+        // One deletion out of four: 0.75.
+        assert!((a.similarity - 0.75).abs() < 1e-6, "got {}", a.similarity);
+    }
+
+    #[test]
+    fn both_empty_is_a_perfect_match() {
+        let cmp = compare("", Ok(Some("")));
+        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
+        assert_eq!(cmp.similarity, 1.0);
+        assert!(cmp.exact_match);
+        assert_eq!(cmp.whisper_words, 0);
+        assert_eq!(cmp.apple_words, 0);
+    }
+
+    #[test]
+    fn shadow_is_off_by_default() {
+        let config = Config::default();
+        assert!(
+            !shadow_enabled(&config),
+            "shadow mode must be off by default — it is a measurement opt-in"
+        );
+    }
+
+    #[test]
+    fn shadow_reads_the_config_flag_when_enabled() {
+        let config = Config {
+            transcription: crate::config::TranscriptionConfig {
+                apple_speech_shadow: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(shadow_enabled(&config));
+    }
+}

--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -10,9 +10,10 @@
 //!
 //! This module is the measurement primitive: the pure comparison record and
 //! its logging. It deliberately carries only measurements (counts, a
-//! similarity score, an outcome), never the transcript text, so a shadow log
-//! can never leak sensitive content. Wiring a shadow attempt into a capture
-//! path is a separate step, paired with the on-hardware data run.
+//! similarity score, an outcome) and a fixed error *category*, never the
+//! transcript text or a raw error message, so a shadow log can never leak
+//! sensitive content. Wiring a shadow attempt into a capture path is a separate
+//! step, paired with the on-hardware data run.
 
 use crate::config::Config;
 
@@ -28,11 +29,63 @@ pub enum ShadowOutcome {
     Failed,
 }
 
+/// A fixed failure category for a shadow attempt.
+///
+/// The raw error string is deliberately discarded: it can embed recognized
+/// speech (names, account details) that must never reach a shadow log, and
+/// truncation is not redaction. Classification reads the message but stores only
+/// this closed set, so no transcript content survives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShadowError {
+    /// The worker process died (crash / abort).
+    WorkerCrashed,
+    /// The XPC connection was interrupted or invalidated.
+    XpcInterrupted,
+    /// Speech assets are not installed for the locale.
+    AssetsUnavailable,
+    /// A Speech-framework or analyzer error.
+    SpeechError,
+    /// Anything else; the raw message is not retained.
+    Unknown,
+}
+
+impl ShadowError {
+    /// Stable log token for this category.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WorkerCrashed => "worker_crashed",
+            Self::XpcInterrupted => "xpc_interrupted",
+            Self::AssetsUnavailable => "assets_unavailable",
+            Self::SpeechError => "speech_error",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Classify a raw error into a fixed category, discarding the message so no
+    /// transcript content it might embed is ever stored or logged. Matching is
+    /// on the worker's own code-controlled status wording, not on user speech.
+    fn classify(msg: &str) -> Self {
+        let m = msg.to_lowercase();
+        if m.contains("interrupt") || m.contains("invalidat") {
+            Self::XpcInterrupted
+        } else if m.contains("crash") || m.contains("abort") || m.contains("signal") {
+            Self::WorkerCrashed
+        } else if m.contains("not subscribed") || m.contains("asset") || m.contains("locale") {
+            Self::AssetsUnavailable
+        } else if m.contains("speech") || m.contains("analyzer") || m.contains("recogni") {
+            Self::SpeechError
+        } else {
+            Self::Unknown
+        }
+    }
+}
+
 /// One shadow-mode comparison of Whisper (the shipped transcript) against an
 /// Apple Speech attempt for the same audio.
 ///
-/// Carries only measurements, never the transcript text, so it is safe to log
-/// to disk under the same privacy rules as the rest of the pipeline.
+/// Carries only measurements and a fixed error category, never the transcript
+/// text, so it is safe to log to disk under the same privacy rules as the rest
+/// of the pipeline.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ShadowComparison {
     /// Whether Apple Speech produced a usable transcript, an empty one, or failed.
@@ -46,27 +99,24 @@ pub struct ShadowComparison {
     /// Word count of the Apple Speech transcript; 0 unless `Usable`.
     pub apple_words: usize,
     /// Word-level similarity in `[0.0, 1.0]`, `1.0` meaning identical word
-    /// sequences (a normalized inverse word-error-rate). Only meaningful when
-    /// `outcome == Usable`; `0.0` otherwise.
-    pub similarity: f32,
+    /// sequences (a normalized inverse word-error-rate). `None` when there is
+    /// nothing to score (`outcome != Usable`) or when the transcripts differ and
+    /// exceed [`SIMILARITY_WORD_CAP`] words, where an exact score is skipped
+    /// rather than faked. Never a placeholder number.
+    pub similarity: Option<f32>,
     /// True when both engines produced the same normalized text.
     pub exact_match: bool,
-    /// Failure detail when `outcome == Failed`; `None` otherwise. A bounded,
-    /// single-line error category, never transcript content.
-    pub apple_error: Option<String>,
+    /// Failure category when `outcome == Failed`; `None` otherwise. A fixed
+    /// category, never transcript content or a raw message.
+    pub apple_error: Option<ShadowError>,
 }
 
-/// Above this normalized word count, `similarity` uses a cheap length-ratio
-/// proxy instead of an O(n*m) word edit distance, so a full-meeting batch
-/// transcript can never make shadow logging quadratic. Per-utterance shadow
-/// runs are far below this, so the exact metric is what actually gets used.
+/// Above this normalized word count, and only when the two transcripts are not
+/// already known-equal, `similarity` is reported as `None` instead of running an
+/// O(n*m) word edit distance, so a pathologically long transcript can never make
+/// shadow logging quadratic. Shadow runs per utterance, far below this cap, so
+/// the exact metric is what actually gets used.
 const SIMILARITY_WORD_CAP: usize = 3000;
-
-/// Cap on the stored `apple_error` length. Worker errors are structured status
-/// strings, but `compare` accepts an arbitrary `&str`, so the message is
-/// collapsed to one line and truncated to defend the "no transcript content in
-/// shadow logs" guarantee against a caller whose error embeds recognized text.
-const MAX_ERROR_CHARS: usize = 160;
 
 /// Build a shadow comparison from the shipped Whisper transcript and the Apple
 /// Speech attempt result for the same audio.
@@ -81,13 +131,13 @@ pub fn compare(whisper: &str, apple: Result<Option<&str>, &str>) -> ShadowCompar
     let whisper_chars = normalized_char_count(whisper);
     let whisper_words = whisper_words_vec.len();
 
-    let empty = |outcome, apple_error| ShadowComparison {
+    let non_usable = |outcome, apple_error| ShadowComparison {
         outcome,
         whisper_chars,
         whisper_words,
         apple_chars: 0,
         apple_words: 0,
-        similarity: 0.0,
+        similarity: None,
         exact_match: false,
         apple_error,
     };
@@ -99,33 +149,44 @@ pub fn compare(whisper: &str, apple: Result<Option<&str>, &str>) -> ShadowCompar
                 // A Some("") / whitespace / punctuation-only result is not a
                 // usable transcript — the native bridge returns "" when there
                 // are no segments. Record it as Empty.
-                return empty(ShadowOutcome::Empty, None);
+                return non_usable(ShadowOutcome::Empty, None);
             }
+            let exact_match = whisper_words_vec == apple_words_vec;
+            // Equality is cheap and definitive, so identical transcripts always
+            // score 1.0 regardless of length; only differing, over-cap ones go None.
+            let similarity = if exact_match {
+                Some(1.0)
+            } else {
+                word_similarity(&whisper_words_vec, &apple_words_vec)
+            };
             ShadowComparison {
                 outcome: ShadowOutcome::Usable,
                 whisper_chars,
                 whisper_words,
                 apple_chars: normalized_char_count(apple_text),
                 apple_words: apple_words_vec.len(),
-                similarity: word_similarity(&whisper_words_vec, &apple_words_vec),
-                exact_match: whisper_words_vec == apple_words_vec,
+                similarity,
+                exact_match,
                 apple_error: None,
             }
         }
-        Ok(None) => empty(ShadowOutcome::Empty, None),
-        Err(msg) => empty(ShadowOutcome::Failed, Some(bounded_error(msg))),
+        Ok(None) => non_usable(ShadowOutcome::Empty, None),
+        Err(msg) => non_usable(ShadowOutcome::Failed, Some(ShadowError::classify(msg))),
     }
 }
 
-/// Persist a shadow comparison to the structured JSONL log.
+/// Persist a shadow comparison to the structured JSONL log, returning the write
+/// result.
 ///
 /// Writes through [`crate::logging::append_log`] so the measurement is durable:
 /// the CLI's tracing subscriber only reaches stderr and the Tauri entry point
 /// installs no subscriber at all, so tracing-only events would be dropped on
-/// exactly the desktop path shadow mode most needs to measure. The write is
-/// failure-isolated — a logging error is swallowed so it can never affect
-/// capture — and a `debug` trace is emitted alongside for live tailing.
-pub fn log_comparison(source: &str, cmp: &ShadowComparison) {
+/// exactly the desktop path shadow mode most needs to measure. A write failure
+/// (unwritable log dir, full disk) is surfaced two ways — a `warn` trace and the
+/// returned `Err` — instead of being silently swallowed behind a success-looking
+/// event. It stays failure-isolated from capture: the caller logs or ignores the
+/// error and keeps recording; this function never panics.
+pub fn log_comparison(source: &str, cmp: &ShadowComparison) -> std::io::Result<()> {
     let outcome = match cmp.outcome {
         ShadowOutcome::Usable => "usable",
         ShadowOutcome::Empty => "empty",
@@ -141,11 +202,25 @@ pub fn log_comparison(source: &str, cmp: &ShadowComparison) {
         "apple_chars": cmp.apple_chars,
         "similarity": cmp.similarity,
         "exact_match": cmp.exact_match,
-        "apple_error": cmp.apple_error,
+        "apple_error": cmp.apple_error.map(ShadowError::as_str),
     });
-    // Failure-isolated: a logging failure must never affect capture.
-    let _ = crate::logging::append_log(&entry);
-    tracing::debug!(target: "apple_speech_shadow", source, outcome, "apple-speech shadow comparison");
+    let result = crate::logging::append_log(&entry);
+    match &result {
+        Ok(()) => tracing::debug!(
+            target: "apple_speech_shadow",
+            source,
+            outcome,
+            "apple-speech shadow comparison persisted"
+        ),
+        Err(error) => tracing::warn!(
+            target: "apple_speech_shadow",
+            source,
+            outcome,
+            %error,
+            "failed to persist apple-speech shadow comparison"
+        ),
+    }
+    result
 }
 
 /// Whether shadow mode is switched on in config.
@@ -188,24 +263,24 @@ fn normalized_char_count(text: &str) -> usize {
 }
 
 /// Word-level similarity in `[0.0, 1.0]`: `1.0 - editdistance / max(len)`, a
-/// normalized inverse of the word error rate. Two empty transcripts are treated
-/// as identical (`1.0`); one empty and one not is `0.0`.
-fn word_similarity(a: &[String], b: &[String]) -> f32 {
+/// normalized inverse of the word error rate. `None` when the inputs differ and
+/// exceed [`SIMILARITY_WORD_CAP`] words, so a pathological input is reported as
+/// unscored rather than approximated with a misleading number. Callers handle
+/// the known-equal case before calling, so this never sees two identical inputs.
+fn word_similarity(a: &[String], b: &[String]) -> Option<f32> {
     let max_len = a.len().max(b.len());
     if max_len == 0 {
-        return 1.0;
+        return Some(1.0);
     }
-    // Guard against a quadratic blow-up on very long (batch) transcripts.
     if max_len > SIMILARITY_WORD_CAP {
-        let min_len = a.len().min(b.len());
-        return min_len as f32 / max_len as f32;
+        return None;
     }
     let distance = word_edit_distance(a, b);
-    1.0 - (distance as f32 / max_len as f32)
+    Some(1.0 - (distance as f32 / max_len as f32))
 }
 
 /// Levenshtein edit distance over word tokens, two-row DP (O(n*m) time,
-/// O(min(n,m)) space). Inputs are per-utterance word lists, so this is cheap.
+/// O(min(n,m)) space). Bounded by [`SIMILARITY_WORD_CAP`] at the call site.
 fn word_edit_distance(a: &[String], b: &[String]) -> usize {
     // Iterate over the longer sequence in the outer loop so the row we allocate
     // is the shorter of the two.
@@ -228,17 +303,6 @@ fn word_edit_distance(a: &[String], b: &[String]) -> usize {
     prev[short.len()]
 }
 
-/// Collapse an error to a bounded, single-line diagnostic (see `MAX_ERROR_CHARS`).
-fn bounded_error(msg: &str) -> String {
-    let one_line = msg.split_whitespace().collect::<Vec<_>>().join(" ");
-    if one_line.chars().count() > MAX_ERROR_CHARS {
-        let truncated: String = one_line.chars().take(MAX_ERROR_CHARS).collect();
-        format!("{truncated}…")
-    } else {
-        one_line
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -252,7 +316,7 @@ mod tests {
             cmp.exact_match,
             "punctuation/casing/spacing must normalize away"
         );
-        assert_eq!(cmp.similarity, 1.0);
+        assert_eq!(cmp.similarity, Some(1.0));
         assert_eq!(cmp.whisper_words, 2);
         assert_eq!(cmp.apple_words, 2);
         assert!(cmp.apple_error.is_none());
@@ -264,18 +328,15 @@ mod tests {
         assert_eq!(cmp.outcome, ShadowOutcome::Usable);
         assert!(!cmp.exact_match);
         // One substitution out of four words: 1 - 1/4 = 0.75.
-        assert!(
-            (cmp.similarity - 0.75).abs() < 1e-6,
-            "got {}",
-            cmp.similarity
-        );
+        let s = cmp.similarity.expect("scored");
+        assert!((s - 0.75).abs() < 1e-6, "got {s}");
     }
 
     #[test]
-    fn completely_different_text_has_low_similarity() {
+    fn completely_different_text_scores_zero() {
         let cmp = compare("alpha beta gamma", Ok(Some("one two three")));
         assert_eq!(cmp.outcome, ShadowOutcome::Usable);
-        assert_eq!(cmp.similarity, 0.0);
+        assert_eq!(cmp.similarity, Some(0.0));
         assert!(!cmp.exact_match);
     }
 
@@ -285,6 +346,7 @@ mod tests {
         assert_eq!(cmp.outcome, ShadowOutcome::Empty);
         assert_eq!(cmp.apple_words, 0);
         assert_eq!(cmp.whisper_words, 3);
+        assert_eq!(cmp.similarity, None);
         assert!(cmp.apple_error.is_none());
     }
 
@@ -300,45 +362,72 @@ mod tests {
                 "{blank:?} should classify as Empty"
             );
             assert_eq!(cmp.apple_words, 0);
-            assert_eq!(cmp.similarity, 0.0);
+            assert_eq!(cmp.similarity, None);
         }
     }
 
     #[test]
-    fn a_failed_apple_attempt_carries_a_bounded_error_not_the_transcript() {
+    fn a_failed_attempt_stores_a_fixed_category_not_the_message() {
         let cmp = compare("whisper had text", Err("worker crashed (XPC interrupted)"));
         assert_eq!(cmp.outcome, ShadowOutcome::Failed);
         assert_eq!(cmp.apple_words, 0);
-        assert_eq!(
-            cmp.apple_error.as_deref(),
-            Some("worker crashed (XPC interrupted)")
-        );
-        // The Whisper side is still measured so the log shows what shipped.
+        assert_eq!(cmp.similarity, None);
+        assert_eq!(cmp.apple_error, Some(ShadowError::XpcInterrupted));
         assert_eq!(cmp.whisper_words, 3);
     }
 
     #[test]
-    fn a_long_multiline_error_is_bounded_to_one_line() {
-        let huge = format!("failure: {}", "context ".repeat(80));
-        let cmp = compare("hi", Err(&huge));
-        let stored = cmp.apple_error.expect("failed attempt records an error");
-        assert!(!stored.contains('\n'));
-        assert!(
-            stored.chars().count() <= MAX_ERROR_CHARS + 1,
-            "bounded to {} chars, got {}",
-            MAX_ERROR_CHARS,
-            stored.chars().count()
-        );
-        assert!(stored.ends_with('…'), "truncation marker present");
+    fn error_classification_discards_any_embedded_text() {
+        // Even if an error embedded recognized speech, only a fixed category is
+        // stored — the raw words never survive. The stored value is a token from
+        // ShadowError's closed set regardless of which category is chosen.
+        let cmp = compare("hi", Err("boom: the secret launch code is hunter2"));
+        let category = cmp.apple_error.expect("failed attempt has a category");
+        assert!(!category.as_str().contains("hunter2"));
+        assert!(!category.as_str().contains("secret"));
+        assert!(!category.as_str().contains("launch"));
     }
 
     #[test]
     fn similarity_is_symmetric_in_edit_distance() {
         let a = compare("one two three four", Ok(Some("one two three")));
         let b = compare("one two three", Ok(Some("one two three four")));
-        assert!((a.similarity - b.similarity).abs() < 1e-6);
+        assert_eq!(a.similarity, b.similarity);
         // One deletion out of four: 0.75.
-        assert!((a.similarity - 0.75).abs() < 1e-6, "got {}", a.similarity);
+        let s = a.similarity.expect("scored");
+        assert!((s - 0.75).abs() < 1e-6, "got {s}");
+    }
+
+    #[test]
+    fn differing_transcripts_over_the_cap_are_unscored_not_faked() {
+        let big_a = (0..=SIMILARITY_WORD_CAP)
+            .map(|i| format!("a{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let big_b = (0..=SIMILARITY_WORD_CAP)
+            .map(|i| format!("b{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let cmp = compare(&big_a, Ok(Some(&big_b)));
+        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
+        assert!(!cmp.exact_match);
+        // The old length-ratio proxy would have reported 1.0 here; honest is None.
+        assert_eq!(cmp.similarity, None);
+    }
+
+    #[test]
+    fn identical_over_the_cap_still_scores_one() {
+        let big = (0..=SIMILARITY_WORD_CAP)
+            .map(|i| format!("w{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let cmp = compare(&big, Ok(Some(&big)));
+        assert!(cmp.exact_match);
+        assert_eq!(
+            cmp.similarity,
+            Some(1.0),
+            "equality is cheap and definitive"
+        );
     }
 
     #[test]

--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -36,12 +36,22 @@ pub enum ShadowOutcome {
 /// so it can categorize accurately; and a closed enum makes it *impossible* for a
 /// raw message — which can embed recognized speech — to reach a shadow log. That
 /// is a stronger guarantee than trying to redact free text after the fact.
+///
+/// The variants cover the known worker outcomes so the wiring step can map onto
+/// them without guessing. That mapping is the wiring increment's job, and it may
+/// need to enrich `apple_speech_worker` to surface a typed outcome: today
+/// transport failures flatten to `MinutesError::Io`, framework failures live in
+/// `AppleSpeechTranscriptionResult.error`, and `runtime_supported == false` is a
+/// bool — so the wiring, not this primitive, owns turning those into the right
+/// [`ShadowError`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShadowError {
     /// The worker process died (crash / abort).
     WorkerCrashed,
     /// The XPC connection was interrupted or invalidated.
     XpcInterrupted,
+    /// The device/runtime cannot run Apple Speech (`runtime_supported == false`).
+    RuntimeUnsupported,
     /// Speech assets are not installed for the locale.
     AssetsUnavailable,
     /// A Speech-framework or analyzer error.
@@ -56,6 +66,7 @@ impl ShadowError {
         match self {
             Self::WorkerCrashed => "worker_crashed",
             Self::XpcInterrupted => "xpc_interrupted",
+            Self::RuntimeUnsupported => "runtime_unsupported",
             Self::AssetsUnavailable => "assets_unavailable",
             Self::SpeechError => "speech_error",
             Self::Unknown => "unknown",
@@ -223,25 +234,32 @@ pub fn shadow_enabled(config: &Config) -> bool {
     config.transcription.apple_speech_shadow
 }
 
-/// Lowercased, punctuation-insensitive words. The two engines format
-/// differently (casing, spacing, and especially punctuation — Whisper writes
-/// `Hello, world!` where Apple Speech may write `hello world`), and shadow mode
-/// measures word content, not typography. Non-alphanumeric, non-whitespace
-/// characters are mapped to spaces before splitting, mirroring
-/// `apple_speech::eval_text_for_compare_punct_insensitive` so the shadow metric
-/// and the offline evaluator agree on what "same words" means.
+/// Lowercased, timestamp- and punctuation-insensitive words. The two engines
+/// format differently: batch Whisper prefixes lines with `[mm:ss]` timestamps
+/// and punctuates (`Hello, world!`) where Apple Speech emits plain `hello world`.
+/// Shadow mode measures word content, not typography, so each line is first run
+/// through `pipeline::clean_transcript_line` (stripping `[...]` prefixes, exactly
+/// as the offline evaluator does) and then non-alphanumeric, non-whitespace
+/// characters are mapped to spaces. This keeps the shadow metric and the offline
+/// evaluator (`apple_speech::eval_text_for_compare_punct_insensitive`) in
+/// agreement on what "same words" means.
 fn normalized_words(text: &str) -> Vec<String> {
-    text.chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c.is_whitespace() {
-                c
-            } else {
-                ' '
-            }
+    text.lines()
+        .filter_map(crate::pipeline::clean_transcript_line)
+        .flat_map(|line| {
+            line.chars()
+                .map(|c| {
+                    if c.is_alphanumeric() || c.is_whitespace() {
+                        c
+                    } else {
+                        ' '
+                    }
+                })
+                .collect::<String>()
+                .split_whitespace()
+                .map(|w| w.to_lowercase())
+                .collect::<Vec<_>>()
         })
-        .collect::<String>()
-        .split_whitespace()
-        .map(|w| w.to_lowercase())
         .collect()
 }
 
@@ -309,6 +327,17 @@ mod tests {
         assert_eq!(cmp.whisper_words, 2);
         assert_eq!(cmp.apple_words, 2);
         assert!(cmp.apple_error.is_none());
+    }
+
+    #[test]
+    fn timestamped_whisper_lines_are_stripped_before_comparison() {
+        // Batch Whisper output carries [mm:ss] prefixes; Apple Speech does not.
+        // Identical speech must still score 1.0, not be penalized for timestamps.
+        let cmp = compare("[0:05] hello world", Ok(Some("hello world")));
+        assert_eq!(cmp.outcome, ShadowOutcome::Usable);
+        assert!(cmp.exact_match, "timestamp prefix must be stripped");
+        assert_eq!(cmp.similarity, Some(1.0));
+        assert_eq!(cmp.whisper_words, 2, "the 0 and 05 must not count as words");
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -367,6 +367,15 @@ pub struct TranscriptionConfig {
     /// Post-pass person-name correction mode. Off by default.
     #[serde(default)]
     pub name_correction: NameCorrectionMode,
+    /// Apple Speech shadow mode: attempt Apple Speech alongside Whisper for
+    /// measurement only, log the comparison, and never affect the user-visible
+    /// transcript or recording. Off by default and independent of the product
+    /// transport gate (`apple_speech_private_audio_transport_supported`) — this
+    /// is the activation plan's Phase 6 shadow switch, not an activation. Even
+    /// when true, an attempt only happens on capable macOS where the worker is
+    /// available; everywhere else it is a no-op.
+    #[serde(default)]
+    pub apple_speech_shadow: bool,
 }
 
 pub const VALID_PARAKEET_MODELS: &[&str] = &["tdt-ctc-110m", "tdt-600m"];
@@ -1363,6 +1372,7 @@ impl Default for TranscriptionConfig {
             parakeet_vocab: "tdt-600m.tokenizer.vocab".into(),
             partial_max_secs: 30,
             name_correction: NameCorrectionMode::Off,
+            apple_speech_shadow: false,
         }
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod apple_fm;
 pub mod apple_speech;
 pub mod apple_speech_session;
+pub mod apple_speech_shadow;
 pub mod apple_speech_worker;
 pub(crate) mod audio_budget;
 pub mod audio_decode_worker;


### PR DESCRIPTION
## Apple Speech activation — Phase 6 groundwork: shadow-mode measurement

Shadow mode (from the [activation plan](docs/plans/apple-speech-activation-2026-08-10.md), Phase 6) runs Apple Speech alongside Whisper purely to measure the real-world capability distribution and the transcript quality delta **before any user-facing exposure**. Whisper stays the shipped transcript; the shadow attempt is failure-isolated (RFC 0004) and never affects output or recording.

This PR lands the **measurement primitive** and its config switch. It does **not** wire a shadow attempt into a capture path yet — that step pairs with the on-hardware data run on the tailnet Apple device, where it can actually be validated. Building untestable capture plumbing now would be premature.

### What this adds

1. **Config flag** `transcription.apple_speech_shadow` (default `false`) — a measurement opt-in, **independent of the product transport gate**. Even when true, an attempt only happens on capable macOS where the worker is available, and it respects the `AppleSpeechSession` latch from Phase 1.
2. **`apple_speech_shadow.rs`** — `ShadowComparison` record + pure `compare()` + a failure-isolated `tracing` log. Design choices that matter:
   - **Privacy**: the record carries only measurements (char/word counts, a similarity score, an outcome, an error string) — **never transcript text**, so a shadow log can't leak sensitive content.
   - **Metric**: `similarity` is a normalized inverse word-error-rate (word-level Levenshtein / max length), with a length guard so a full-meeting batch transcript can't make it quadratic.
   - **Isolation**: logging is `tracing`-only, so a crashed shadow attempt lands as an event, never a panic that touches capture.

### Invariants held
- Product gate stays hard-closed (`apple_speech_private_audio_transport_supported()` unchanged); no user-facing default changed.
- Shadow is off by default; a test asserts it.

### Verification (linux)
- 9 unit tests pass (similarity math, outcomes, privacy of the record, off-by-default).
- `cargo fmt` clean; `cargo clippy -p minutes-core --no-default-features -- -D warnings` clean; the new file trips no `--tests` clippy lint.
- New config field: all `TranscriptionConfig` constructors across the workspace (core, tauri, integration tests) spread `..default()`/`..existing`, so it breaks no build.

Draft pending codex adversarial review.