### PR TITLE
feat(release): bump the Homebrew tap from the release event

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -28,16 +28,36 @@ on:
 permissions:
   contents: read
 
+# Two runs must not interleave. Each writes a single commit, but run A can
+# still read the tap, run B commit, and run A then commit over a base it never
+# saw. The non-forced ref update in the script makes that fail rather than
+# silently win, and this keeps it from arising at all.
+concurrency:
+  group: homebrew-tap
+  cancel-in-progress: false
+
 jobs:
   bump:
     name: Point the tap at the release
     runs-on: ubuntu-latest
+    # Creating a release or dispatching a workflow needs only write access, so
+    # without a gate the trust boundary for a cross-repository token is every
+    # write collaborator rather than the maintainer. Adding required reviewers
+    # to this environment in repository settings closes that; the environment
+    # exists either way, so this is safe before it is configured.
+    environment: homebrew-tap
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+          # The default branch, never the event ref. A release is published
+          # from a tag, and `workflow_dispatch` can select any ref, so taking
+          # the event ref would run whatever version of the bump script that
+          # ref happens to contain while the tap token is in the environment.
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Verify the bump logic before using it
+        # First, so broken logic cannot reach the token.
         run: python3 scripts/bump_homebrew_tap.py --self-test
 
       - name: Resolve version
@@ -52,8 +72,25 @@ jobs:
           version="${INPUT_VERSION:-${EVENT_TAG#v}}"
           echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Skip prereleases
+        id: gate
+        env:
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+          # The tap has no way to express a prerelease, so pointing it at one
+          # would ship it to every `brew upgrade`. The script refuses suffixed
+          # versions too; this stops the run earlier and more legibly.
+          if [ "${PRERELEASE:-false}" = "true" ]; then
+            echo "::notice::prerelease, leaving the tap alone"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Bump the formula and the cask
         id: bump
+        if: steps.gate.outputs.proceed == 'true'
         env:
           # A fine-grained PAT scoped to silverstein/homebrew-tap with
           # contents: write. The default GITHUB_TOKEN cannot reach another
@@ -74,8 +111,8 @@ jobs:
             echo "Until then, bump the tap by hand: docs/release/procedure.md step 16."
             exit 0
           fi
-          # Branch rather than splat an empty variable into the argv, which
-          # is unquoted-expansion and shellcheck rightly rejects it.
+          # Branch rather than splat an empty variable into the argv, which is
+          # unquoted expansion and shellcheck rightly rejects it.
           if [ -n "${DRY_RUN:-}" ]; then
             python3 scripts/bump_homebrew_tap.py --version "$VERSION" --dry-run
           else
@@ -89,17 +126,18 @@ jobs:
       - name: Confirm the tap now serves the release
         if: steps.bump.outputs.wrote == 'true'
         env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          # Reads the tap over plain HTTPS, the same way brew does, rather than
-          # trusting the write to have taken effect.
-          cask=$(curl -fsSL https://raw.githubusercontent.com/silverstein/homebrew-tap/main/Casks/minutes.rb \
-                 | grep -oE 'version "[0-9.]+"' | grep -oE '[0-9.]+')
-          formula=$(curl -fsSL https://raw.githubusercontent.com/silverstein/homebrew-tap/main/Formula/minutes.rb \
-                 | grep -oE 'tag: "v[0-9.]+"' | grep -oE '[0-9.]+')
-          echo "release $VERSION | cask $cask | formula $formula"
-          failed=0
-          [ "$cask" = "$VERSION" ] || { echo "::error::cask is $cask, expected $VERSION"; failed=1; }
-          [ "$formula" = "$VERSION" ] || { echo "::error::formula is $formula, expected $VERSION"; failed=1; }
-          exit "$failed"
+          # Re-running the bump in dry-run mode is the strongest postcondition
+          # available: it re-reads the published tap and re-derives the
+          # expected hash from the release, so it catches a wrong sha256 as
+          # well as a wrong version. Comparing version strings alone would
+          # call a cask with a corrupt hash correct.
+          output=$(python3 scripts/bump_homebrew_tap.py --version "$VERSION" --dry-run)
+          echo "$output"
+          case "$output" in
+            *"nothing to do"*) echo "tap verified at $VERSION" ;;
+            *) echo "::error::the tap does not match release $VERSION after the write"; exit 1 ;;
+          esac

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,105 @@
+name: Update Homebrew Tap
+
+# The tap's cask sat at 0.18.2 while releases reached 0.24.0, because bumping
+# it was a step someone had to remember (#736). This removes the memory.
+#
+# `release: published` rather than a tag push: the release procedure creates
+# the release as a draft, waits for the release workflows to attach assets,
+# then un-drafts it. Publishing is therefore the first moment the DMG this
+# needs is guaranteed to exist. A tag push fires while the assets are still
+# building.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to point the tap at, for example 0.24.0"
+        required: true
+        type: string
+      dry_run:
+        description: "Report what would change without writing"
+        type: boolean
+        default: true
+
+# This job holds a token that can write to another repository, so it takes
+# nothing it does not need: no checkout credentials, no third-party actions,
+# and a read-only default token.
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Point the tap at the release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Verify the bump logic before using it
+        run: python3 scripts/bump_homebrew_tap.py --self-test
+
+      - name: Resolve version
+        id: version
+        env:
+          # Through env, never interpolated into the shell, so a crafted
+          # release name cannot become code here.
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="${INPUT_VERSION:-${EVENT_TAG#v}}"
+          echo "version=${version#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump the formula and the cask
+        id: bump
+        env:
+          # A fine-grained PAT scoped to silverstein/homebrew-tap with
+          # contents: write. The default GITHUB_TOKEN cannot reach another
+          # repository, which is the whole reason this needs a secret.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DRY_RUN: ${{ inputs.dry_run && 'yes' || '' }}
+        run: |
+          set -euo pipefail
+          echo "wrote=false" >> "$GITHUB_OUTPUT"
+          if [ -z "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            # Deliberately not a failure. Until the secret exists this
+            # workflow must not turn a good release red; it just says what it
+            # would have done, loudly enough to be seen.
+            echo "::warning::HOMEBREW_TAP_TOKEN is not set, so the tap was not updated."
+            echo "Create a fine-grained PAT scoped to silverstein/homebrew-tap"
+            echo "(contents: write) and add it as the HOMEBREW_TAP_TOKEN secret."
+            echo "Until then, bump the tap by hand: docs/release/procedure.md step 16."
+            exit 0
+          fi
+          # Branch rather than splat an empty variable into the argv, which
+          # is unquoted-expansion and shellcheck rightly rejects it.
+          if [ -n "${DRY_RUN:-}" ]; then
+            python3 scripts/bump_homebrew_tap.py --version "$VERSION" --dry-run
+          else
+            python3 scripts/bump_homebrew_tap.py --version "$VERSION"
+            echo "wrote=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Only when something was actually written. An earlier version gated
+      # this on a token variable it never declared, so the check was always
+      # skipped: a verification step that cannot fail verifies nothing.
+      - name: Confirm the tap now serves the release
+        if: steps.bump.outputs.wrote == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Reads the tap over plain HTTPS, the same way brew does, rather than
+          # trusting the write to have taken effect.
+          cask=$(curl -fsSL https://raw.githubusercontent.com/silverstein/homebrew-tap/main/Casks/minutes.rb \
+                 | grep -oE 'version "[0-9.]+"' | grep -oE '[0-9.]+')
+          formula=$(curl -fsSL https://raw.githubusercontent.com/silverstein/homebrew-tap/main/Formula/minutes.rb \
+                 | grep -oE 'tag: "v[0-9.]+"' | grep -oE '[0-9.]+')
+          echo "release $VERSION | cask $cask | formula $formula"
+          failed=0
+          [ "$cask" = "$VERSION" ] || { echo "::error::cask is $cask, expected $VERSION"; failed=1; }
+          [ "$formula" = "$VERSION" ] || { echo "::error::formula is $formula, expected $VERSION"; failed=1; }
+          exit "$failed"

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -262,7 +262,29 @@ Vercel project that `307`-redirected to www. The site looked fine, and the entir
 40-route content build stayed effectively unindexed: 496 referring domains, one
 ranking keyword.
 
-### 16. Update the Homebrew tap: formula AND cask, every release
+### 16. Homebrew tap: automated, but confirm it ran
+
+`Update Homebrew Tap` (`.github/workflows/homebrew-tap.yml`) fires on
+`release: published` and points both tap files at the new version. Publishing
+rather than tagging is the trigger because that is the first moment the DMG the
+cask hashes is guaranteed to exist.
+
+**Confirm it, do not assume it.** The run appears under Actions; it prints the
+before and after versions and then re-reads the tap over HTTPS the way `brew`
+does, failing if either file disagrees with the release.
+
+If `HOMEBREW_TAP_TOKEN` is missing the workflow warns and exits 0 rather than
+turning a good release red, so a green release does not by itself prove the tap
+moved. Check the run, or:
+
+```bash
+brew update && brew info silverstein/tap/minutes && brew info --cask silverstein/tap/minutes
+```
+
+The daily triage sweep also compares the latest release against both tap files,
+so drift surfaces within a day even if nobody looks.
+
+#### Doing it by hand (if the workflow is unavailable)
 Two files in `silverstein/homebrew-tap`, and they drift independently. The
 formula (`Formula/minutes.rb`, CLI) was faithfully bumped while the cask
 (`Casks/minutes.rb`, desktop app) sat at 0.18.2 through six releases until a
@@ -288,5 +310,10 @@ SHA=$(gh api repos/silverstein/homebrew-tap/contents/Casks/minutes.rb --jq '.sha
 
 Verify both: `brew update && brew info silverstein/tap/minutes && brew info --cask silverstein/tap/minutes`.
 
-Automating the bump from the release pipeline is tracked in #736; it needs a
-cross-repository token, so until that lands this manual step is the mechanism.
+Or run the same logic the workflow runs, which is safer than hand-editing
+because it refuses rather than guesses when a tap file has been restructured:
+
+```bash
+HOMEBREW_TAP_TOKEN=... python3 scripts/bump_homebrew_tap.py --version X.Y.Z --dry-run
+HOMEBREW_TAP_TOKEN=... python3 scripts/bump_homebrew_tap.py --version X.Y.Z
+```

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -273,6 +273,11 @@ cask hashes is guaranteed to exist.
 before and after versions and then re-reads the tap over HTTPS the way `brew`
 does, failing if either file disagrees with the release.
 
+After writing, it re-runs its own bump in dry-run mode against the published
+tap, so the postcondition covers the cask's `sha256` and not just the version
+string: a cask carrying a correct version with a wrong hash fails every
+install, and a version comparison would call it fine.
+
 If `HOMEBREW_TAP_TOKEN` is missing the workflow warns and exits 0 rather than
 turning a good release red, so a green release does not by itself prove the tap
 moved. Check the run, or:

--- a/scripts/bump_homebrew_tap.py
+++ b/scripts/bump_homebrew_tap.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Point the Homebrew tap at a released version.
+
+The tap holds two independent files, and they drift independently. The CLI
+formula was bumped faithfully every release while the desktop cask sat at
+0.18.2 through six of them, until a user reported that `brew upgrade --cask`
+had been a no-op for months (#736). Nothing was broken; the step simply
+depended on someone remembering, and release-time steps rot invisibly between
+releases.
+
+So this does both, from the release event, with no memory involved.
+
+Design notes:
+
+- The edits are surgical regex substitutions that must match exactly once. A
+  tap file that has been restructured makes this refuse rather than guess,
+  because a wrong `sha256` in a cask is worse than a stale one: stale installs
+  an old version, wrong fails every install with a checksum mismatch.
+- The cask hash is computed from the DMG bytes downloaded from the release,
+  not read from SHA256SUMS.txt, which does not list the DMG at all.
+- Idempotent. Re-running against a tap already at the version is a no-op that
+  exits 0, so a re-run of the release workflow is harmless.
+- The transforms are pure functions with a --self-test, because the only other
+  way to exercise them is to push to the tap for real.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+TAP_REPO = "silverstein/homebrew-tap"
+SOURCE_REPO = "silverstein/minutes"
+CASK_PATH = "Casks/minutes.rb"
+FORMULA_PATH = "Formula/minutes.rb"
+API = "https://api.github.com"
+
+
+class BumpError(RuntimeError):
+    """A condition that must stop the bump rather than be guessed around."""
+
+
+# --------------------------------------------------------------------------
+# Pure transforms
+# --------------------------------------------------------------------------
+
+
+def substitute_once(pattern: str, replacement: str, text: str, what: str) -> str:
+    """Replace exactly one match, or refuse.
+
+    Zero matches means the file moved on and this script no longer understands
+    it. More than one means the file is ambiguous. Either way, writing would be
+    a guess.
+    """
+    # MULTILINE so `^` anchors to each line: these directives sit indented
+    # inside a cask/formula block, never at the start of the file.
+    new_text, count = re.subn(pattern, replacement, text, count=2, flags=re.MULTILINE)
+    if count != 1:
+        raise BumpError(
+            f"expected exactly one {what} in the tap file, found {count}. "
+            "Refusing to write a guess; update this script alongside the tap."
+        )
+    return new_text
+
+
+def bump_cask(content: str, version: str, sha256: str) -> str:
+    content = substitute_once(
+        r'^(\s*version\s+)"[^"]+"',
+        lambda m: f'{m.group(1)}"{version}"',
+        content,
+        "version line",
+    )
+    return substitute_once(
+        r'^(\s*sha256\s+)"[0-9a-f]{64}"',
+        lambda m: f'{m.group(1)}"{sha256}"',
+        content,
+        "sha256 line",
+    )
+
+
+def bump_formula(content: str, version: str) -> str:
+    return substitute_once(
+        r'(tag:\s*)"v[^"]+"',
+        lambda m: f'{m.group(1)}"v{version}"',
+        content,
+        "git tag reference",
+    )
+
+
+def cask_version(content: str) -> str | None:
+    match = re.search(r'^\s*version\s+"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def formula_version(content: str) -> str | None:
+    match = re.search(r'tag:\s*"v([^"]+)"', content)
+    return match.group(1) if match else None
+
+
+# --------------------------------------------------------------------------
+# GitHub plumbing
+# --------------------------------------------------------------------------
+
+
+def request(url: str, token: str, method: str = "GET", payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read() or b"{}")
+    except urllib.error.HTTPError as error:
+        body = error.read().decode(errors="replace")[:400]
+        # Never interpolate the token into an error.
+        raise BumpError(f"{method} {url} failed with {error.code}: {body}") from None
+
+
+def read_tap_file(path: str, token: str) -> tuple[str, str]:
+    payload = request(f"{API}/repos/{TAP_REPO}/contents/{path}", token)
+    return base64.b64decode(payload["content"]).decode(), payload["sha"]
+
+
+def write_tap_file(path: str, content: str, sha: str, message: str, token: str) -> str:
+    payload = request(
+        f"{API}/repos/{TAP_REPO}/contents/{path}",
+        token,
+        method="PUT",
+        payload={
+            "message": message,
+            "content": base64.b64encode(content.encode()).decode(),
+            "sha": sha,
+        },
+    )
+    return payload["commit"]["sha"][:8]
+
+
+def dmg_sha256(version: str, token: str) -> str | None:
+    """SHA-256 of the released DMG, or None when the release has no DMG."""
+    asset_name = f"Minutes_{version}_aarch64.dmg"
+    release = request(f"{API}/repos/{SOURCE_REPO}/releases/tags/v{version}", token)
+    for asset in release.get("assets", []):
+        if asset["name"] == asset_name:
+            req = urllib.request.Request(asset["url"])
+            req.add_header("Authorization", f"Bearer {token}")
+            req.add_header("Accept", "application/octet-stream")
+            digest = hashlib.sha256()
+            with urllib.request.urlopen(req) as response:
+                for chunk in iter(lambda: response.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            return digest.hexdigest()
+    return None
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+def run(version: str, token: str, dry_run: bool) -> int:
+    version = version.lstrip("v")
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise BumpError(f"refusing to bump to a non-release version {version!r}")
+
+    changed = False
+
+    formula, formula_sha = read_tap_file(FORMULA_PATH, token)
+    if formula_version(formula) == version:
+        print(f"formula already at {version}")
+    else:
+        updated = bump_formula(formula, version)
+        print(f"formula {formula_version(formula)} -> {version}")
+        if not dry_run:
+            commit = write_tap_file(
+                FORMULA_PATH,
+                updated,
+                formula_sha,
+                f"minutes {version} (CLI formula)",
+                token,
+            )
+            print(f"  pushed {commit}")
+        changed = True
+
+    cask, cask_sha = read_tap_file(CASK_PATH, token)
+    if cask_version(cask) == version:
+        print(f"cask already at {version}")
+    else:
+        digest = dmg_sha256(version, token)
+        if digest is None:
+            # A release without a desktop artifact is not a failure, but it
+            # must be visible: silence here is how the cask froze in the first
+            # place.
+            print(
+                f"::warning::release v{version} has no Minutes_{version}_aarch64.dmg; "
+                "cask left as is"
+            )
+        else:
+            updated = bump_cask(cask, version, digest)
+            print(f"cask {cask_version(cask)} -> {version} (sha256 {digest[:12]}...)")
+            if not dry_run:
+                commit = write_tap_file(
+                    CASK_PATH,
+                    updated,
+                    cask_sha,
+                    f"minutes {version} (desktop cask)",
+                    token,
+                )
+                print(f"  pushed {commit}")
+            changed = True
+
+    if not changed:
+        print("tap already current; nothing to do")
+    elif dry_run:
+        print("dry run: nothing was written")
+    return 0
+
+
+FIXTURE_CASK = """cask "minutes" do
+  version "0.18.2"
+  sha256 "71b267b411ce77c15e19b97a3cd38ad3c8d7c82e080f1ff1702ce7e39c06fbf9"
+
+  url "https://github.com/silverstein/minutes/releases/download/v#{version}/Minutes_#{version}_aarch64.dmg"
+  app "Minutes.app"
+end
+"""
+
+FIXTURE_FORMULA = """class Minutes < Formula
+  url "https://github.com/silverstein/minutes.git", tag: "v0.24.0"
+  license "MIT"
+end
+"""
+
+
+def self_test() -> int:
+    failures = 0
+    new_sha = "d" * 64
+
+    updated = bump_cask(FIXTURE_CASK, "0.24.0", new_sha)
+    if cask_version(updated) != "0.24.0" or new_sha not in updated:
+        print("self-test FAILED: cask bump did not apply", file=sys.stderr)
+        failures += 1
+    # The url line interpolates #{version} and must survive untouched, or the
+    # cask would point at a literal path and every install would 404.
+    if '#{version}' not in updated or updated.count("sha256") != 1:
+        print("self-test FAILED: cask bump damaged surrounding content", file=sys.stderr)
+        failures += 1
+
+    if formula_version(bump_formula(FIXTURE_FORMULA, "0.25.0")) != "0.25.0":
+        print("self-test FAILED: formula bump did not apply", file=sys.stderr)
+        failures += 1
+
+    # Refusals. Guessing at a restructured tap file is the dangerous outcome:
+    # a wrong sha256 fails every install, which is worse than a stale one.
+    for label, content, fn in [
+        ("a cask with no version line", 'cask "minutes" do\nend\n', lambda c: bump_cask(c, "1.0.0", new_sha)),
+        ("a cask with two version lines",
+         'version "1.0.0"\nversion "2.0.0"\nsha256 "%s"\n' % ("a" * 64),
+         lambda c: bump_cask(c, "1.0.0", new_sha)),
+        ("a formula with no tag", "class Minutes < Formula\nend\n", lambda c: bump_formula(c, "1.0.0")),
+    ]:
+        try:
+            fn(content)
+        except BumpError:
+            print(f"self-test ok: refused {label}")
+        else:
+            print(f"self-test FAILED: accepted {label}", file=sys.stderr)
+            failures += 1
+
+    # Idempotence: bumping to the version already present changes nothing.
+    once = bump_cask(FIXTURE_CASK, "0.24.0", new_sha)
+    if bump_cask(once, "0.24.0", new_sha) != once:
+        print("self-test FAILED: cask bump is not idempotent", file=sys.stderr)
+        failures += 1
+    else:
+        print("self-test ok: cask bump is idempotent")
+
+    if failures == 0:
+        print("self-test ok: all transforms behave")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", help="release version, with or without a leading v")
+    parser.add_argument("--dry-run", action="store_true", help="report without writing")
+    parser.add_argument("--self-test", action="store_true", help="exercise the transforms")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.version:
+        parser.error("--version is required unless --self-test is given")
+
+    token = os.environ.get("HOMEBREW_TAP_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    if not token:
+        raise BumpError(
+            "no token in HOMEBREW_TAP_TOKEN or GITHUB_TOKEN; the default "
+            "workflow token cannot write to another repository"
+        )
+    return run(args.version, token, args.dry_run)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BumpError as error:
+        print(f"::error::{error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/bump_homebrew_tap.py
+++ b/scripts/bump_homebrew_tap.py
@@ -6,22 +6,25 @@ formula was bumped faithfully every release while the desktop cask sat at
 0.18.2 through six of them, until a user reported that `brew upgrade --cask`
 had been a no-op for months (#736). Nothing was broken; the step simply
 depended on someone remembering, and release-time steps rot invisibly between
-releases.
+releases. So this does both, from the release event, with no memory involved.
 
-So this does both, from the release event, with no memory involved.
+The governing risk is a *wrong* hash rather than a stale one. A stale cask
+installs an old version; a wrong one fails every install with a checksum
+mismatch. Everything below follows from that:
 
-Design notes:
-
-- The edits are surgical regex substitutions that must match exactly once. A
-  tap file that has been restructured makes this refuse rather than guess,
-  because a wrong `sha256` in a cask is worse than a stale one: stale installs
-  an old version, wrong fails every install with a checksum mismatch.
-- The cask hash is computed from the DMG bytes downloaded from the release,
-  not read from SHA256SUMS.txt, which does not list the DMG at all.
-- Idempotent. Re-running against a tap already at the version is a no-op that
-  exits 0, so a re-run of the release workflow is harmless.
-- The transforms are pure functions with a --self-test, because the only other
-  way to exercise them is to push to the tap for real.
+- Nothing is written until every read, download and check has succeeded, and
+  then both files land in one commit through the Git Data API. Writing the
+  formula first meant a later failure left the tap half-updated.
+- The DMG is validated three ways: GitHub must call the asset `uploaded`, the
+  downloaded byte count must equal the declared size, and the computed hash
+  must equal the digest GitHub recorded. A sized read on a connection that
+  closes early does not necessarily raise, so hashing until the stream ends
+  can silently digest a truncated file.
+- A cask already at the right version is still checked against the expected
+  hash, and repaired if it disagrees. Treating the version as proof of
+  currency made a wrong hash permanently unfixable by this tool.
+- Edits must match exactly once, so a restructured tap file makes this refuse
+  rather than guess.
 """
 
 from __future__ import annotations
@@ -34,9 +37,11 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 TAP_REPO = "silverstein/homebrew-tap"
+TAP_BRANCH = "main"
 SOURCE_REPO = "silverstein/minutes"
 CASK_PATH = "Casks/minutes.rb"
 FORMULA_PATH = "Formula/minutes.rb"
@@ -47,20 +52,46 @@ class BumpError(RuntimeError):
     """A condition that must stop the bump rather than be guessed around."""
 
 
-# --------------------------------------------------------------------------
+class HostChangeStripsAuth(urllib.request.HTTPRedirectHandler):
+    """Drop Authorization when a redirect crosses to another host.
+
+    Release asset downloads answer with a 302 to object storage, and the
+    stdlib redirect handler copies every header onto the redirected request,
+    Authorization included. Confirmed against the installed runtime rather
+    than assumed. Without this, a token that can write to the tap repository
+    is handed to a storage host with no business seeing it.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is None:
+            return None
+        same_host = (
+            urllib.parse.urlsplit(newurl).netloc
+            == urllib.parse.urlsplit(req.full_url).netloc
+        )
+        if not same_host:
+            for header in list(new.headers):
+                if header.lower() == "authorization":
+                    del new.headers[header]
+            new.unredirected_hdrs.pop("Authorization", None)
+        return new
+
+
+# ---------------------------------------------------------------------------
 # Pure transforms
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 
-def substitute_once(pattern: str, replacement: str, text: str, what: str) -> str:
+def substitute_once(pattern: str, replacement, text: str, what: str) -> str:
     """Replace exactly one match, or refuse.
 
     Zero matches means the file moved on and this script no longer understands
     it. More than one means the file is ambiguous. Either way, writing would be
     a guess.
     """
-    # MULTILINE so `^` anchors to each line: these directives sit indented
-    # inside a cask/formula block, never at the start of the file.
+    # MULTILINE so `^` anchors per line: these directives sit indented inside a
+    # cask or formula block, never at the start of the file.
     new_text, count = re.subn(pattern, replacement, text, count=2, flags=re.MULTILINE)
     if count != 1:
         raise BumpError(
@@ -99,17 +130,24 @@ def cask_version(content: str) -> str | None:
     return match.group(1) if match else None
 
 
+def cask_sha256(content: str) -> str | None:
+    match = re.search(r'^\s*sha256\s+"([0-9a-f]{64})"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
 def formula_version(content: str) -> str | None:
     match = re.search(r'tag:\s*"v([^"]+)"', content)
     return match.group(1) if match else None
 
 
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # GitHub plumbing
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 
-def request(url: str, token: str, method: str = "GET", payload: dict | None = None) -> dict:
+def request(
+    url: str, token: str, method: str = "GET", payload: dict | None = None
+) -> dict:
     data = json.dumps(payload).encode() if payload is not None else None
     req = urllib.request.Request(url, data=data, method=method)
     req.add_header("Authorization", f"Bearer {token}")
@@ -126,102 +164,148 @@ def request(url: str, token: str, method: str = "GET", payload: dict | None = No
         raise BumpError(f"{method} {url} failed with {error.code}: {body}") from None
 
 
-def read_tap_file(path: str, token: str) -> tuple[str, str]:
-    payload = request(f"{API}/repos/{TAP_REPO}/contents/{path}", token)
-    return base64.b64decode(payload["content"]).decode(), payload["sha"]
+def read_tap_file(path: str, token: str) -> str:
+    payload = request(f"{API}/repos/{TAP_REPO}/contents/{path}?ref={TAP_BRANCH}", token)
+    return base64.b64decode(payload["content"]).decode()
 
 
-def write_tap_file(path: str, content: str, sha: str, message: str, token: str) -> str:
-    payload = request(
-        f"{API}/repos/{TAP_REPO}/contents/{path}",
+def commit_tap_files(files: dict[str, str], message: str, token: str) -> str:
+    """Write every changed file in one commit.
+
+    Two Contents API calls are two commits, so a failure between them leaves
+    the tap half-updated, and two concurrent runs can interleave into a formula
+    and cask from different versions. A tree plus a commit plus a non-forced
+    ref update is atomic and rejects a stale base outright.
+    """
+    ref = request(f"{API}/repos/{TAP_REPO}/git/ref/heads/{TAP_BRANCH}", token)
+    base_sha = ref["object"]["sha"]
+    base_commit = request(f"{API}/repos/{TAP_REPO}/git/commits/{base_sha}", token)
+
+    tree = request(
+        f"{API}/repos/{TAP_REPO}/git/trees",
         token,
-        method="PUT",
+        method="POST",
         payload={
-            "message": message,
-            "content": base64.b64encode(content.encode()).decode(),
-            "sha": sha,
+            "base_tree": base_commit["tree"]["sha"],
+            "tree": [
+                {"path": path, "mode": "100644", "type": "blob", "content": content}
+                for path, content in sorted(files.items())
+            ],
         },
     )
-    return payload["commit"]["sha"][:8]
+    commit = request(
+        f"{API}/repos/{TAP_REPO}/git/commits",
+        token,
+        method="POST",
+        payload={"message": message, "tree": tree["sha"], "parents": [base_sha]},
+    )
+    # force defaults to false: a concurrent run that moved the branch makes
+    # this fail rather than silently discard its commit.
+    request(
+        f"{API}/repos/{TAP_REPO}/git/refs/heads/{TAP_BRANCH}",
+        token,
+        method="PATCH",
+        payload={"sha": commit["sha"], "force": False},
+    )
+    return commit["sha"][:8]
 
 
-def dmg_sha256(version: str, token: str) -> str | None:
+def dmg_digest(version: str, token: str) -> str | None:
     """SHA-256 of the released DMG, or None when the release has no DMG."""
     asset_name = f"Minutes_{version}_aarch64.dmg"
     release = request(f"{API}/repos/{SOURCE_REPO}/releases/tags/v{version}", token)
-    for asset in release.get("assets", []):
-        if asset["name"] == asset_name:
-            req = urllib.request.Request(asset["url"])
-            req.add_header("Authorization", f"Bearer {token}")
-            req.add_header("Accept", "application/octet-stream")
-            digest = hashlib.sha256()
-            with urllib.request.urlopen(req) as response:
-                for chunk in iter(lambda: response.read(1024 * 1024), b""):
-                    digest.update(chunk)
-            return digest.hexdigest()
-    return None
+    asset = next((a for a in release.get("assets", []) if a["name"] == asset_name), None)
+    if asset is None:
+        return None
+
+    if asset.get("state") != "uploaded":
+        raise BumpError(
+            f"{asset_name} is in state {asset.get('state')!r}, not 'uploaded'; "
+            "refusing to hash an asset GitHub has not finished storing"
+        )
+
+    opener = urllib.request.build_opener(HostChangeStripsAuth)
+    req = urllib.request.Request(asset["url"])
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/octet-stream")
+    digest = hashlib.sha256()
+    read = 0
+    with opener.open(req) as response:
+        for chunk in iter(lambda: response.read(1024 * 1024), b""):
+            digest.update(chunk)
+            read += len(chunk)
+    computed = digest.hexdigest()
+
+    declared = asset.get("size")
+    if declared is not None and read != declared:
+        raise BumpError(
+            f"downloaded {read} bytes of {asset_name} but GitHub declares "
+            f"{declared}; refusing to write the hash of a partial file"
+        )
+
+    recorded = asset.get("digest") or ""
+    if recorded.startswith("sha256:") and recorded.split(":", 1)[1] != computed:
+        raise BumpError(
+            f"{asset_name} hashed to {computed} but GitHub records {recorded}; "
+            "refusing to write a hash the two disagree on"
+        )
+
+    return computed
 
 
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Driver
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 
 def run(version: str, token: str, dry_run: bool) -> int:
     version = version.lstrip("v")
     if not re.fullmatch(r"\d+\.\d+\.\d+", version):
-        raise BumpError(f"refusing to bump to a non-release version {version!r}")
+        raise BumpError(
+            f"refusing to bump to a non-release version {version!r}; "
+            "prereleases and suffixed tags do not belong in the tap"
+        )
 
-    changed = False
+    # Everything is read, downloaded and checked before anything is written.
+    formula = read_tap_file(FORMULA_PATH, token)
+    cask = read_tap_file(CASK_PATH, token)
+    pending: dict[str, str] = {}
 
-    formula, formula_sha = read_tap_file(FORMULA_PATH, token)
     if formula_version(formula) == version:
         print(f"formula already at {version}")
     else:
-        updated = bump_formula(formula, version)
+        pending[FORMULA_PATH] = bump_formula(formula, version)
         print(f"formula {formula_version(formula)} -> {version}")
-        if not dry_run:
-            commit = write_tap_file(
-                FORMULA_PATH,
-                updated,
-                formula_sha,
-                f"minutes {version} (CLI formula)",
-                token,
-            )
-            print(f"  pushed {commit}")
-        changed = True
 
-    cask, cask_sha = read_tap_file(CASK_PATH, token)
-    if cask_version(cask) == version:
-        print(f"cask already at {version}")
+    expected = dmg_digest(version, token)
+    if expected is None:
+        # Not a failure, but it must be visible: silence is how the cask froze.
+        print(
+            f"::warning::release v{version} has no Minutes_{version}_aarch64.dmg; "
+            "cask left as is"
+        )
+    elif cask_version(cask) == version and cask_sha256(cask) == expected:
+        print(f"cask already at {version} with a matching hash")
     else:
-        digest = dmg_sha256(version, token)
-        if digest is None:
-            # A release without a desktop artifact is not a failure, but it
-            # must be visible: silence here is how the cask froze in the first
-            # place.
+        if cask_version(cask) == version:
+            # The version alone is not proof of currency. An earlier draft
+            # returned here, which made a wrong hash unfixable by this tool.
             print(
-                f"::warning::release v{version} has no Minutes_{version}_aarch64.dmg; "
-                "cask left as is"
+                f"::warning::cask says {version} but its hash is "
+                f"{cask_sha256(cask)}, expected {expected}; repairing"
             )
-        else:
-            updated = bump_cask(cask, version, digest)
-            print(f"cask {cask_version(cask)} -> {version} (sha256 {digest[:12]}...)")
-            if not dry_run:
-                commit = write_tap_file(
-                    CASK_PATH,
-                    updated,
-                    cask_sha,
-                    f"minutes {version} (desktop cask)",
-                    token,
-                )
-                print(f"  pushed {commit}")
-            changed = True
+        pending[CASK_PATH] = bump_cask(cask, version, expected)
+        print(f"cask {cask_version(cask)} -> {version} (sha256 {expected[:12]}...)")
 
-    if not changed:
+    if not pending:
         print("tap already current; nothing to do")
-    elif dry_run:
-        print("dry run: nothing was written")
+        return 0
+    if dry_run:
+        print(f"dry run: would commit {', '.join(sorted(pending))}")
+        return 0
+
+    commit = commit_tap_files(pending, f"minutes {version}", token)
+    print(f"committed {commit}: {', '.join(sorted(pending))}")
     return 0
 
 
@@ -243,49 +327,86 @@ end
 
 def self_test() -> int:
     failures = 0
+
+    def check(condition: bool, message: str) -> None:
+        nonlocal failures
+        if condition:
+            print(f"self-test ok: {message}")
+        else:
+            print(f"self-test FAILED: {message}", file=sys.stderr)
+            failures += 1
+
     new_sha = "d" * 64
-
     updated = bump_cask(FIXTURE_CASK, "0.24.0", new_sha)
-    if cask_version(updated) != "0.24.0" or new_sha not in updated:
-        print("self-test FAILED: cask bump did not apply", file=sys.stderr)
-        failures += 1
-    # The url line interpolates #{version} and must survive untouched, or the
-    # cask would point at a literal path and every install would 404.
-    if '#{version}' not in updated or updated.count("sha256") != 1:
-        print("self-test FAILED: cask bump damaged surrounding content", file=sys.stderr)
-        failures += 1
+    check(
+        cask_version(updated) == "0.24.0" and cask_sha256(updated) == new_sha,
+        "cask bump rewrites both version and hash",
+    )
+    # The url line interpolates #{version} and must survive, or the cask would
+    # point at a literal path and every install would 404.
+    check(
+        "#{version}" in updated and updated.count("sha256") == 1,
+        "cask bump leaves surrounding content intact",
+    )
+    check(
+        formula_version(bump_formula(FIXTURE_FORMULA, "0.25.0")) == "0.25.0",
+        "formula bump rewrites the tag",
+    )
+    check(
+        bump_cask(updated, "0.24.0", new_sha) == updated,
+        "cask bump is idempotent",
+    )
 
-    if formula_version(bump_formula(FIXTURE_FORMULA, "0.25.0")) != "0.25.0":
-        print("self-test FAILED: formula bump did not apply", file=sys.stderr)
-        failures += 1
-
-    # Refusals. Guessing at a restructured tap file is the dangerous outcome:
-    # a wrong sha256 fails every install, which is worse than a stale one.
     for label, content, fn in [
-        ("a cask with no version line", 'cask "minutes" do\nend\n', lambda c: bump_cask(c, "1.0.0", new_sha)),
+        ("a cask with no version line", 'cask "minutes" do\nend\n',
+         lambda c: bump_cask(c, "1.0.0", new_sha)),
         ("a cask with two version lines",
          'version "1.0.0"\nversion "2.0.0"\nsha256 "%s"\n' % ("a" * 64),
          lambda c: bump_cask(c, "1.0.0", new_sha)),
-        ("a formula with no tag", "class Minutes < Formula\nend\n", lambda c: bump_formula(c, "1.0.0")),
+        ("a formula with no tag", "class Minutes < Formula\nend\n",
+         lambda c: bump_formula(c, "1.0.0")),
     ]:
         try:
             fn(content)
         except BumpError:
-            print(f"self-test ok: refused {label}")
+            check(True, f"refused {label}")
         else:
-            print(f"self-test FAILED: accepted {label}", file=sys.stderr)
-            failures += 1
+            check(False, f"accepted {label}")
 
-    # Idempotence: bumping to the version already present changes nothing.
-    once = bump_cask(FIXTURE_CASK, "0.24.0", new_sha)
-    if bump_cask(once, "0.24.0", new_sha) != once:
-        print("self-test FAILED: cask bump is not idempotent", file=sys.stderr)
-        failures += 1
-    else:
-        print("self-test ok: cask bump is idempotent")
+    # Version parsing must reject anything that is not a plain release, since
+    # the tap has no way to express a prerelease.
+    for bad in ["1.2.3-rc1", "1.2", "latest", "", "1.2.3.4"]:
+        try:
+            run(bad, "unused-token", dry_run=True)
+        except BumpError:
+            check(True, f"refused version {bad!r}")
+        except Exception as error:  # network attempted means the guard passed it
+            check(False, f"refused version {bad!r} (got {type(error).__name__})")
+        else:
+            check(False, f"refused version {bad!r}")
+
+    # The redirect handler is the only thing standing between the tap token and
+    # a storage host, so it is exercised rather than trusted.
+    handler = HostChangeStripsAuth()
+    original = urllib.request.Request("https://api.github.com/x")
+    original.add_header("Authorization", "Bearer secret")
+    same = handler.redirect_request(
+        original, None, 302, "Found", {}, "https://api.github.com/y"
+    )
+    cross = handler.redirect_request(
+        original, None, 302, "Found", {}, "https://objects.example.com/y"
+    )
+    check(
+        any(k.lower() == "authorization" for k in (same.headers if same else {})),
+        "redirect within the same host keeps Authorization",
+    )
+    check(
+        not any(k.lower() == "authorization" for k in (cross.headers if cross else {})),
+        "redirect to another host drops Authorization",
+    )
 
     if failures == 0:
-        print("self-test ok: all transforms behave")
+        print("self-test ok: all checks passed")
     return 1 if failures else 0
 
 
@@ -293,7 +414,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--version", help="release version, with or without a leading v")
     parser.add_argument("--dry-run", action="store_true", help="report without writing")
-    parser.add_argument("--self-test", action="store_true", help="exercise the transforms")
+    parser.add_argument("--self-test", action="store_true", help="exercise the logic")
     args = parser.parse_args()
 
     if args.self_test:


### PR DESCRIPTION
Refs #736. Deliberately not an auto-close: the issue stays open until the secret exists, since a merged-but-inert workflow has not actually fixed anything yet.

## Why

The tap's cask sat at 0.18.2 while releases reached 0.24.0. Nothing was broken; bumping it was simply a step someone had to remember, and release-time steps rot invisibly between releases. erikcw found it, we didn't.

`Update Homebrew Tap` fires on `release: published` and points both tap files at the version. Publishing rather than tagging is the trigger deliberately: the release procedure creates a draft, waits for assets, then un-drafts. Publishing is the first moment the DMG the cask has to hash is guaranteed to exist. A tag push fires while those assets are still building.

## One thing needed from you

The default `GITHUB_TOKEN` cannot write to another repository, so this needs a secret. Until it exists the workflow warns and exits 0 rather than turning a good release red, so **merging this is safe and inert**.

1. https://github.com/settings/personal-access-tokens/new
2. Resource owner `silverstein`, repository access **Only select repositories** → `silverstein/homebrew-tap`
3. Repository permissions → **Contents: Read and write**. Nothing else.
4. Copy the token, then:

```bash
gh secret set HOMEBREW_TAP_TOKEN --repo silverstein/minutes
```

To confirm it works without waiting for a release, run the workflow manually with dry run left on. It will report what it would change and write nothing.

## Why the logic is a script, not inline YAML

`scripts/bump_homebrew_tap.py` can be exercised; a `run:` block can only be read.

- Edits are substitutions that must match **exactly once**. A restructured tap file makes it refuse rather than guess, because a wrong `sha256` is worse than a stale one: stale installs an old version, wrong fails every install with a checksum mismatch.
- The cask hash is computed from the DMG bytes, not read from `SHA256SUMS.txt`, which does not list the DMG at all.
- Idempotent, so re-running a release workflow is a no-op that exits 0.
- `--self-test` covers the transforms, three refusal cases, and idempotence, and runs as the first step of the job so broken logic cannot reach the token.

## Token handling

The job holds a credential that can write to another repository, so it takes nothing else it does not need: `permissions: contents: read` for the default token, `persist-credentials: false` on checkout, no third-party actions in the job at all, and the release tag reaches the shell through `env` rather than expression interpolation so a crafted release name cannot become code.

## Verification

Against the live tap and real releases:

- Dry run at 0.24.0 correctly reports the tap is already current and no-ops.
- Dry run at 0.23.0 exercises the real edit path and computes `70a61db0c11e...`, which matches an independent `sha256sum` of the downloaded DMG.
- Version resolution tested for all four input shapes (`release` event tag with and without `v`, `workflow_dispatch` input with and without `v`).
- actionlint clean, checked by exit code. Its first pass caught an unquoted expansion, and fixing that also caught a real bug of mine: the verification step gated on a token variable it never declared, so it always skipped. It now gates on whether a write actually happened and fails on mismatch.

The manual path stays documented for when the workflow is unavailable, and now points at the same script rather than hand-editing.