### PR TITLE
ci(windows): catch a missing packaged runtime on the PR, not the tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,48 @@ jobs:
           GGML_AVX512_VNNI: "OFF"
           GGML_AVX512_BF16: "OFF"
 
+      - name: The desktop binary must not outgrow its packaged runtime (#657)
+        # release-windows-desktop.yml refuses to zip a desktop build whose
+        # runtime DLLs build.rs did not stage, and release-cli.yml refuses an
+        # archive missing a DLL the binary actually imports. Both live only in
+        # tag-triggered workflows, so the condition they guard is first
+        # observed during a release. #657 is what that looks like when it gets
+        # out, and #733 was the same shape reaching a different artifact.
+        #
+        # Asserted here instead, on the Windows build the pull request already
+        # pays for.
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # build.rs must have staged the runtime beside the crate; the release
+          # zip copies exactly these.
+          $staged = Get-ChildItem 'tauri/src-tauri/vcruntime140*.dll','tauri/src-tauri/msvcp140*.dll' -ErrorAction SilentlyContinue
+          if (-not $staged) {
+            throw 'build.rs staged no runtime DLLs; a release would ship a desktop build that cannot start (#657)'
+          }
+          Write-Host "staged: $(($staged | ForEach-Object { $_.Name }) -join ', ')"
+
+          # And the binary must not import a runtime DLL that is not staged.
+          # Read from the import table rather than a fixed list, because the
+          # failure mode is a dependency adding an import such as MSVCP140_2.dll
+          # (C++17 special math) that nobody thought to package.
+          $exe = 'target/release/minutes-app.exe'
+          if (-not (Test-Path $exe)) { throw "expected $exe from the bundle build" }
+          $dumpbin = Get-ChildItem 'C:\Program Files*\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $dumpbin) { throw 'dumpbin.exe not found; cannot verify the import table' }
+          $imports = & $dumpbin.FullName /dependents $exe |
+                     Select-String -Pattern '^\s+(\S+\.dll)$' |
+                     ForEach-Object { $_.Matches[0].Groups[1].Value }
+          $needed = $imports | Where-Object { $_ -match '^(vcruntime|msvcp|concrt)' }
+          if (-not $needed) { throw 'no VC runtime imports detected; the import scan is probably broken' }
+          Write-Host "runtime imports: $($needed -join ', ')"
+          $stagedNames = $staged | ForEach-Object { $_.Name }
+          $missing = $needed | Where-Object { $stagedNames -notcontains $_ }
+          if ($missing) {
+            throw "minutes-app.exe imports runtime DLLs that are not staged: $($missing -join ', '). Add them to RUNTIME_DLLS in tauri/src-tauri/build.rs and to the release packaging lists (#657)."
+          }
+          Write-Host 'every runtime import is staged for packaging'
+
   mcp:
     name: MCP Server
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,18 @@ jobs:
           if (-not $needed) { throw 'no VC runtime imports detected; the import scan is probably broken' }
           Write-Host "runtime imports: $($needed -join ', ')"
           $stagedNames = $staged | ForEach-Object { $_.Name }
+
+          # Negative control. dumpbin reports MSVCP140.dll while build.rs
+          # stages msvcp140.dll, so this comparison only works because
+          # -notcontains is case-insensitive, and it has never been observed
+          # rejecting anything. Proving it can fail costs three lines and is
+          # the difference between a check and a decoration.
+          $control = @('MSVCP140.dll', 'definitely-not-staged.dll') |
+                     Where-Object { $stagedNames -notcontains $_ }
+          if ($control -ne 'definitely-not-staged.dll') {
+            throw "the import comparison is broken: it flagged '$control' instead of the one absent DLL"
+          }
+
           $missing = $needed | Where-Object { $stagedNames -notcontains $_ }
           if ($missing) {
             throw "minutes-app.exe imports runtime DLLs that are not staged: $($missing -join ', '). Add them to RUNTIME_DLLS in tauri/src-tauri/build.rs and to the release packaging lists (#657)."


### PR DESCRIPTION
Result of auditing every workflow that never runs on a pull request, which is the thing I said I'd pick up after today's third release-time-only failure.

## What the audit found

Nine workflows never see a PR. Four of them (`release-*`) ship artifacts.

**Two things came back clean.** Every `--features` flag used in a release workflow still exists in the crate that declares it, so there is no feature drift. And macOS packaging is already hash-gated on PRs by `check_graph_worker_packaging.mjs` and `check_apple_speech_worker_packaging.mjs`.

**The gap is Windows, and it is about *when* a failure is observed rather than whether it is loud.** Two guards exist only inside tag-triggered workflows:

- `release-windows-desktop.yml` throws if `build.rs` staged no runtime DLLs
- `release-cli.yml` refuses an archive missing a DLL the binary actually imports, derived from the import table rather than a fixed list, which is a genuinely good check

Neither has a pull-request equivalent. CI's `desktop_windows` job builds the Tauri app on every rust-touching PR and never looks at the staged DLLs. So a change that breaks either is first observed during a release, which is exactly how #657 escaped and the same shape as #733.

## The change

CI already pays for a Windows Tauri build, so both conditions are now asserted there, against the same `target/release/minutes-app.exe` path and the same `tauri/src-tauri/vcruntime140*.dll` glob the release step uses. A new runtime import fails the PR that introduces it, naming the file and where to add it:

```
minutes-app.exe imports runtime DLLs that are not staged: MSVCP140_2.dll.
Add them to RUNTIME_DLLS in tauri/src-tauri/build.rs and to the release packaging lists (#657).
```

## Honest limits

**Not a complete mirror.** The release desktop build passes `--features parakeet` and CI does not, so the two import tables can differ. This catches an import added by a shared dependency, which is the common case; the release guard remains the backstop for anything only the release feature set pulls in. Making CI match exactly would mean adding `parakeet` to an existing job's build, which costs real minutes on every PR for a narrower slice of risk.

**The CLI artifact is covered only indirectly.** `release-cli.yml`'s import check runs against a release CLI built with `--features parakeet`, which CI does not produce on Windows. The desktop check exercises the same `build.rs` staging logic, so a broken stage is caught, but a CLI-only import is not.

**It cannot pass vacuously.** A missing exe, a missing dumpbin, or an empty import scan all throw rather than silently succeeding, which was the specific defect in my first sherpa guard.

## Verification

`.github/workflows/ci.yml` is in CI's own `rust` paths-filter, so this PR triggers `desktop_windows` and the new step actually executes on `windows-latest` rather than being skipped. That run is the first real execution: there is no pwsh on my machine, so I am not claiming local verification of the PowerShell.

actionlint clean, checked by exit code. An earlier attempt inserted the step into the `mcp` job by mistake, where actionlint parsed the PowerShell as bash and rejected it, which is how the misplacement was caught.