### PR TITLE
feat(apple-speech): hook shadow measurement into the live transcript

### DIFF
--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -56,6 +56,12 @@ pub enum ShadowError {
     XpcInterrupted,
     /// The device/runtime cannot run Apple Speech (`runtime_supported == false`).
     RuntimeUnsupported,
+    /// This process cannot address the worker at all: the worker is only
+    /// reachable from a trusted installed app bundle, so a CLI binary or test
+    /// harness always lands here, as does an installed app whose signing or
+    /// packaging authority fails. Says nothing about the device's Speech
+    /// capability, and must not be counted as a capability failure.
+    WorkerUnavailable,
     /// Speech assets are not installed for the locale.
     AssetsUnavailable,
     /// A Speech-framework or analyzer error.
@@ -71,6 +77,7 @@ impl ShadowError {
             Self::WorkerCrashed => "worker_crashed",
             Self::XpcInterrupted => "xpc_interrupted",
             Self::RuntimeUnsupported => "runtime_unsupported",
+            Self::WorkerUnavailable => "worker_unavailable",
             Self::AssetsUnavailable => "assets_unavailable",
             Self::SpeechError => "speech_error",
             Self::Unknown => "unknown",
@@ -291,12 +298,16 @@ pub fn worker_ok_to_shadow(
 
 /// Map a worker-call transport failure (the `Err` arm of `transcribe_samples`)
 /// into the shadow taxonomy by its `io::ErrorKind`, without reading the message.
-/// `Other` is the XPC/worker layer failing (crash, interruption, or the 180s
-/// budget); the rest are environment or our-side faults (missing worker
-/// authority, over-budget or malformed input/response) with no Speech-capability
-/// signal, recorded as `Unknown`.
+///
+/// `PermissionDenied` is how a failed worker *authority* surfaces — this process
+/// cannot address the worker at all, which is the normal outcome outside an
+/// installed trusted app bundle and says nothing about the device, so it is kept
+/// distinct from a capability failure. `Other` is the XPC/worker layer failing
+/// (crash, interruption, or the 180s budget). The rest are our-side faults
+/// (over-budget or malformed input/response) with no capability signal.
 pub fn transport_error_category(kind: std::io::ErrorKind) -> ShadowError {
     match kind {
+        std::io::ErrorKind::PermissionDenied => ShadowError::WorkerUnavailable,
         std::io::ErrorKind::Other => ShadowError::XpcInterrupted,
         _ => ShadowError::Unknown,
     }
@@ -742,10 +753,11 @@ mod tests {
             transport_error_category(ErrorKind::Other),
             ShadowError::XpcInterrupted
         );
-        // Environment / our-side faults carry no Speech-capability signal.
+        // A failed worker authority: cannot address the worker at all. Distinct
+        // from a capability failure, and the normal outcome outside an app bundle.
         assert_eq!(
             transport_error_category(ErrorKind::PermissionDenied),
-            ShadowError::Unknown
+            ShadowError::WorkerUnavailable
         );
         assert_eq!(
             transport_error_category(ErrorKind::InvalidData),

--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -227,6 +227,24 @@ pub fn log_comparison(source: &str, cmp: &ShadowComparison) -> std::io::Result<(
     result
 }
 
+/// Persist the reason shadow measurement is off for a session that asked for it.
+///
+/// Without this a rollout run with zero shadow rows is indistinguishable from one
+/// where every utterance was ineligible: the desktop app installs no tracing
+/// subscriber, so a `warn!` alone disappears exactly where shadow data is meant to
+/// be collected. Same durable JSONL sink as [`log_comparison`], and equally
+/// failure-isolated.
+pub fn log_shadow_disabled(source: &str, reason: &str) {
+    let entry = serde_json::json!({
+        "event": "apple_speech_shadow_disabled",
+        "ts": chrono::Utc::now().to_rfc3339(),
+        "source": source,
+        "reason": reason,
+    });
+    let _ = crate::logging::append_log(&entry);
+    tracing::warn!(target: "apple_speech_shadow", source, reason, "apple-speech shadow disabled for this session");
+}
+
 /// Whether shadow mode is switched on in config.
 ///
 /// This is only the config intent. An actual shadow attempt additionally

--- a/crates/core/src/apple_speech_shadow.rs
+++ b/crates/core/src/apple_speech_shadow.rs
@@ -426,18 +426,21 @@ impl Drop for ShadowRunner {
     }
 }
 
-/// Build a live-sidecar shadow runner that drives the real Apple Speech worker.
+/// Build a live shadow runner that drives the real Apple Speech worker.
 ///
-/// macOS only, because it calls the XPC worker. The sidecar constructs this once
+/// macOS only, because it calls the XPC worker. The caller constructs this once
 /// per session when [`shadow_enabled`] is true, then feeds it finalized Whisper
-/// utterances via [`ShadowRunner::try_submit`]. A successful call is decoded by
+/// utterances via [`ShadowRunner::try_submit`]. `source` labels the surface in
+/// the log and must use the repository's canonical transcript-source vocabulary
+/// (`"standalone"` / `"recording-sidecar"`) so rollout evidence is attributed to
+/// the surface that actually produced it. A successful call is decoded by
 /// [`worker_ok_to_shadow`]; a transport `Err` is categorized by its
 /// `io::ErrorKind` via [`transport_error_category`]. Returns `None` if the worker
 /// thread cannot be spawned, disabling shadow rather than affecting capture.
 #[cfg(target_os = "macos")]
-pub fn spawn_live_shadow_runner(config: &Config) -> Option<ShadowRunner> {
+pub fn spawn_live_shadow_runner(config: &Config, source: &'static str) -> Option<ShadowRunner> {
     let language = config.transcription.language.clone();
-    ShadowRunner::spawn("live-sidecar", move |samples| {
+    ShadowRunner::spawn(source, move |samples| {
         let locale = crate::apple_speech::live_locale_hint(language.as_deref());
         match crate::apple_speech_worker::transcribe_samples(
             samples,

--- a/crates/core/src/apple_speech_worker.rs
+++ b/crates/core/src/apple_speech_worker.rs
@@ -303,6 +303,18 @@ fn acceptance_canary_samples() -> Vec<f32> {
         .collect()
 }
 
+/// Whether this process can reach the Apple Speech worker at all.
+///
+/// The worker is only addressable from inside a trusted, installed Minutes app
+/// bundle (`Contents/MacOS/...` beside `Contents/XPCServices`), so a plain CLI
+/// binary or a test harness can never reach it. Optional consumers (shadow
+/// measurement) check this up front so they can decline with a clear reason
+/// instead of arming themselves and failing on the first utterance.
+#[cfg(target_os = "macos")]
+pub(crate) fn worker_authority_available() -> bool {
+    authority().is_ok()
+}
+
 #[cfg(target_os = "macos")]
 fn authority() -> Result<MacAppleSpeechWorkerAuthority, String> {
     if let Some(authority) = APPLE_SPEECH_WORKER_AUTHORITY.get() {

--- a/crates/core/src/apple_speech_worker.rs
+++ b/crates/core/src/apple_speech_worker.rs
@@ -303,21 +303,6 @@ fn acceptance_canary_samples() -> Vec<f32> {
         .collect()
 }
 
-/// Why this process cannot reach the Apple Speech worker, or `None` if it can.
-///
-/// Authority can fail for several distinct reasons — not running from a trusted
-/// installed app bundle (`Contents/MacOS/...` beside `Contents/XPCServices`, which
-/// a plain CLI binary or test harness never satisfies), an unavailable
-/// peer-requirement API, a missing worker executable or manifest, or a cdhash
-/// mismatch. Optional consumers (shadow measurement) check this up front so they
-/// can decline with the *actual* reason instead of arming themselves and failing
-/// on the first utterance. The returned string is code-controlled (constants and
-/// bundle paths); it never carries recognized speech.
-#[cfg(target_os = "macos")]
-pub(crate) fn worker_authority_error() -> Option<String> {
-    authority().err()
-}
-
 #[cfg(target_os = "macos")]
 fn authority() -> Result<MacAppleSpeechWorkerAuthority, String> {
     if let Some(authority) = APPLE_SPEECH_WORKER_AUTHORITY.get() {

--- a/crates/core/src/apple_speech_worker.rs
+++ b/crates/core/src/apple_speech_worker.rs
@@ -303,16 +303,19 @@ fn acceptance_canary_samples() -> Vec<f32> {
         .collect()
 }
 
-/// Whether this process can reach the Apple Speech worker at all.
+/// Why this process cannot reach the Apple Speech worker, or `None` if it can.
 ///
-/// The worker is only addressable from inside a trusted, installed Minutes app
-/// bundle (`Contents/MacOS/...` beside `Contents/XPCServices`), so a plain CLI
-/// binary or a test harness can never reach it. Optional consumers (shadow
-/// measurement) check this up front so they can decline with a clear reason
-/// instead of arming themselves and failing on the first utterance.
+/// Authority can fail for several distinct reasons — not running from a trusted
+/// installed app bundle (`Contents/MacOS/...` beside `Contents/XPCServices`, which
+/// a plain CLI binary or test harness never satisfies), an unavailable
+/// peer-requirement API, a missing worker executable or manifest, or a cdhash
+/// mismatch. Optional consumers (shadow measurement) check this up front so they
+/// can decline with the *actual* reason instead of arming themselves and failing
+/// on the first utterance. The returned string is code-controlled (constants and
+/// bundle paths); it never carries recognized speech.
 #[cfg(target_os = "macos")]
-pub(crate) fn worker_authority_available() -> bool {
-    authority().is_ok()
+pub(crate) fn worker_authority_error() -> Option<String> {
+    authority().err()
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -461,7 +461,13 @@ impl LiveTranscriptWriter {
             );
             return;
         }
-        match crate::apple_speech_shadow::spawn_live_shadow_runner(config) {
+        // Attribute the evidence to the surface that produced it, using the
+        // canonical transcript-source vocabulary.
+        let source = match self.source {
+            TranscriptSource::Standalone => "standalone",
+            TranscriptSource::RecordingSidecar => "recording-sidecar",
+        };
+        match crate::apple_speech_shadow::spawn_live_shadow_runner(config, source) {
             Some(runner) => {
                 tracing::info!("apple-speech shadow measurement armed for this live session");
                 self.shadow = Some(LiveShadow {
@@ -504,21 +510,49 @@ impl LiveTranscriptWriter {
     /// Whisper is the shipped engine, so the comparison is always shadow-vs-shipped.
     /// Ownership of the buffer moves to the runner (no copy on this thread), and
     /// the runner drops the job if it is busy — capture is never blocked.
+    ///
+    /// The text is normalized exactly as `write_utterance` normalizes it, so a
+    /// comparison is only recorded for a transcript the user actually received:
+    /// normalization rejects (`[BLANK_AUDIO]` and friends) persist no line, so
+    /// shadow must not count them either. Either way the audio is consumed, so it
+    /// can never bleed into the next utterance.
     #[cfg(target_os = "macos")]
     fn submit_whisper_shadow(&mut self, whisper_text: &str) {
+        let normalized = normalize_live_transcript_text(whisper_text);
         let Some(shadow) = self.shadow.as_mut() else {
             return;
         };
         let samples = std::mem::take(&mut shadow.samples);
         let overflowed = std::mem::replace(&mut shadow.overflowed, false);
+        let Some(text) = normalized else {
+            return;
+        };
         if overflowed || samples.is_empty() {
             return;
         }
-        shadow.runner.try_submit(samples, whisper_text.to_string());
+        shadow.runner.try_submit(samples, text);
     }
 
     #[cfg(not(target_os = "macos"))]
     fn submit_whisper_shadow(&mut self, _whisper_text: &str) {}
+
+    /// Drop any accumulated shadow audio without comparing it.
+    ///
+    /// Called wherever the Whisper stream is reset or discarded without producing
+    /// a finalized utterance (sub-second VAD segments, empty results, transcription
+    /// errors, reconnect discards). Without this the samples would carry into the
+    /// next utterance and Apple Speech would be handed several utterances of audio
+    /// while being scored against only the latest Whisper text.
+    #[cfg(target_os = "macos")]
+    fn discard_shadow_samples(&mut self) {
+        if let Some(shadow) = self.shadow.as_mut() {
+            shadow.samples = Vec::new();
+            shadow.overflowed = false;
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn discard_shadow_samples(&mut self) {}
 
     /// Write the lightweight status file (atomic rename).
     fn write_status(
@@ -1120,6 +1154,9 @@ fn run_inner(
                         }
                     }
                     streaming.reset();
+                    // Whisper's buffer was discarded, so shadow's parallel copy
+                    // must go too or it would bleed into the next utterance.
+                    writer.discard_shadow_samples();
                     #[cfg(target_os = "macos")]
                     apple_utterance_samples.clear();
                     #[cfg(feature = "parakeet")]
@@ -1200,6 +1237,9 @@ fn run_inner(
                             }
                         }
                         streaming.reset();
+                        // Whisper's buffer was discarded, so shadow's parallel
+                        // copy must go too or it would bleed into the next one.
+                        writer.discard_shadow_samples();
                         #[cfg(target_os = "macos")]
                         apple_utterance_samples.clear();
                         #[cfg(feature = "parakeet")]
@@ -2295,6 +2335,10 @@ fn finalize_live_utterance(
                 true
             };
             streaming.reset();
+            // No-op after a successful submit (which consumed the buffer), but
+            // load-bearing when finalize returned None: without it that audio
+            // would join the next utterance and be scored against its text.
+            writer.discard_shadow_samples();
             ok
         }
         Err(error) => {
@@ -2303,6 +2347,7 @@ fn finalize_live_utterance(
                 "failed to load whisper backend for live transcript"
             );
             streaming.reset();
+            writer.discard_shadow_samples();
             false
         }
     };
@@ -2429,6 +2474,9 @@ fn finalize_live_utterance(
     #[cfg(not(target_os = "macos"))]
     let _ = (&apple_live_enabled, &config, source);
     streaming.reset();
+    // No-op after a successful submit; load-bearing when finalize returned None
+    // or the whisper context failed to load.
+    writer.discard_shadow_samples();
     write_ok
 }
 

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -457,15 +457,17 @@ impl LiveTranscriptWriter {
             TranscriptSource::Standalone => "standalone",
             TranscriptSource::RecordingSidecar => "recording-sidecar",
         };
-        // The worker is only reachable from inside a trusted installed app
-        // bundle, so a CLI-run session would fail its first attempt and latch
-        // off, logging a failure that says nothing about device capability.
-        // Decline up front with the actionable reason instead — persisted, so a
-        // run with zero shadow rows is never confused with "no eligible audio".
-        if !crate::apple_speech_worker::worker_authority_available() {
+        // The worker is only reachable from a trusted installed app bundle, so a
+        // CLI-run session would fail its first attempt and latch off, logging a
+        // failure that says nothing about device capability. Decline up front,
+        // carrying the authority layer's own reason (not-an-app-bundle, cdhash
+        // mismatch, missing manifest, unavailable peer API — they are different
+        // diagnoses) and persist it, so a run with zero shadow rows is never
+        // confused with "no eligible audio".
+        if let Some(reason) = crate::apple_speech_worker::worker_authority_error() {
             crate::apple_speech_shadow::log_shadow_disabled(
                 source,
-                "worker unreachable: the Apple Speech worker is only addressable from an installed Minutes app",
+                &format!("worker unreachable: {reason}"),
             );
             return;
         }

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -451,22 +451,24 @@ impl LiveTranscriptWriter {
         if !crate::apple_speech_shadow::shadow_enabled(config) {
             return;
         }
-        // The worker is only reachable from inside a trusted installed app
-        // bundle, so a CLI-run session would fail its first attempt and latch
-        // off, logging a failure that says nothing about device capability.
-        // Decline up front with the actionable reason instead.
-        if !crate::apple_speech_worker::worker_authority_available() {
-            tracing::warn!(
-                "apple-speech shadow requested but this process cannot reach the Apple Speech worker (it is only addressable from an installed Minutes app); shadow stays off for this session"
-            );
-            return;
-        }
         // Attribute the evidence to the surface that produced it, using the
         // canonical transcript-source vocabulary.
         let source = match self.source {
             TranscriptSource::Standalone => "standalone",
             TranscriptSource::RecordingSidecar => "recording-sidecar",
         };
+        // The worker is only reachable from inside a trusted installed app
+        // bundle, so a CLI-run session would fail its first attempt and latch
+        // off, logging a failure that says nothing about device capability.
+        // Decline up front with the actionable reason instead — persisted, so a
+        // run with zero shadow rows is never confused with "no eligible audio".
+        if !crate::apple_speech_worker::worker_authority_available() {
+            crate::apple_speech_shadow::log_shadow_disabled(
+                source,
+                "worker unreachable: the Apple Speech worker is only addressable from an installed Minutes app",
+            );
+            return;
+        }
         match crate::apple_speech_shadow::spawn_live_shadow_runner(config, source) {
             Some(runner) => {
                 tracing::info!("apple-speech shadow measurement armed for this live session");
@@ -476,8 +478,9 @@ impl LiveTranscriptWriter {
                     overflowed: false,
                 });
             }
-            None => tracing::warn!(
-                "apple-speech shadow requested but its worker thread could not start; continuing without shadow"
+            None => crate::apple_speech_shadow::log_shadow_disabled(
+                source,
+                "worker thread could not be spawned",
             ),
         }
     }
@@ -2328,9 +2331,15 @@ fn finalize_live_utterance(
         Ok(whisper_ctx) => {
             let ok = if let Some(sr) = streaming.finalize(whisper_ctx) {
                 // Whisper is the shipped engine here, so this is the one place a
-                // shadow comparison is valid. No-op unless shadow is armed.
-                writer.submit_whisper_shadow(&sr.text);
-                writer.write_utterance(&sr.text, sr.duration_secs)
+                // shadow comparison is valid. Submit only after the line is
+                // actually written: a failed JSONL write means the user never
+                // received this transcript, so it must not appear as evidence.
+                // No-op unless shadow is armed.
+                let written = writer.write_utterance(&sr.text, sr.duration_secs);
+                if written {
+                    writer.submit_whisper_shadow(&sr.text);
+                }
+                written
             } else {
                 true
             };
@@ -2456,9 +2465,15 @@ fn finalize_live_utterance(
         Ok(whisper_ctx) => {
             if let Some(sr) = streaming.finalize(whisper_ctx) {
                 // Whisper is the shipped engine here, so this is the one place a
-                // shadow comparison is valid. No-op unless shadow is armed.
-                writer.submit_whisper_shadow(&sr.text);
-                writer.write_utterance(&sr.text, sr.duration_secs)
+                // shadow comparison is valid. Submit only after the line is
+                // actually written: a failed JSONL write means the user never
+                // received this transcript, so it must not appear as evidence.
+                // No-op unless shadow is armed.
+                let written = writer.write_utterance(&sr.text, sr.duration_secs);
+                if written {
+                    writer.submit_whisper_shadow(&sr.text);
+                }
+                written
             } else {
                 true
             }

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -4236,7 +4236,12 @@ mod tests {
         assert_eq!(backend, "whisper");
         let diagnostic = diagnostic.expect("fallback reason must remain visible");
         assert!(diagnostic.contains("retained apple-speech"));
-        assert!(diagnostic.contains("cannot receive secure private audio"));
+        // Assert against the reason function rather than a copy of its wording:
+        // this assertion previously hardcoded an older phrasing and silently went
+        // stale when the reason was reworded, which no CI job compiles (every
+        // unit-test job runs --no-default-features, so this feature-gated module
+        // is never built there).
+        assert!(diagnostic.contains(crate::pipeline::apple_speech_unavailable_reason()));
         assert!(!diagnostic.contains("applies only to standalone"));
     }
 

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -451,6 +451,16 @@ impl LiveTranscriptWriter {
         if !crate::apple_speech_shadow::shadow_enabled(config) {
             return;
         }
+        // The worker is only reachable from inside a trusted installed app
+        // bundle, so a CLI-run session would fail its first attempt and latch
+        // off, logging a failure that says nothing about device capability.
+        // Decline up front with the actionable reason instead.
+        if !crate::apple_speech_worker::worker_authority_available() {
+            tracing::warn!(
+                "apple-speech shadow requested but this process cannot reach the Apple Speech worker (it is only addressable from an installed Minutes app); shadow stays off for this session"
+            );
+            return;
+        }
         match crate::apple_speech_shadow::spawn_live_shadow_runner(config) {
             Some(runner) => {
                 tracing::info!("apple-speech shadow measurement armed for this live session");

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -311,7 +311,33 @@ struct LiveTranscriptWriter {
     dropped_utterances: u64,
     diagnostic: Option<String>,
     last_status_write: Instant,
+    /// Apple Speech shadow measurement, `None` unless the session opted in
+    /// (`transcription.apple_speech_shadow`). Lives on the writer because the
+    /// writer is already threaded through every finalize path, so hooking it
+    /// here needs no signature churn in the capture code.
+    #[cfg(target_os = "macos")]
+    shadow: Option<LiveShadow>,
 }
+
+/// Per-session Apple Speech shadow state for a live transcript.
+///
+/// `StreamingWhisper` owns its accumulated audio internally and does not hand it
+/// back, so shadow keeps its own parallel copy of the utterance samples. The
+/// buffer is bounded: an utterance past [`SHADOW_MAX_SAMPLES`] marks the session
+/// sample overflowed and is skipped entirely rather than compared on truncated
+/// audio, which would understate Apple Speech and corrupt the measurement.
+#[cfg(target_os = "macos")]
+struct LiveShadow {
+    runner: crate::apple_speech_shadow::ShadowRunner,
+    samples: Vec<f32>,
+    overflowed: bool,
+}
+
+/// Cap on shadow's parallel sample buffer: 120 s at 16 kHz (~7.7 MB). Live
+/// utterances are VAD-segmented and far shorter; anything past this is skipped
+/// rather than truncated, keeping both memory and the measurement honest.
+#[cfg(target_os = "macos")]
+const SHADOW_MAX_SAMPLES: usize = 16_000 * 120;
 
 /// Lightweight sidecar written atomically on each utterance.
 /// Status readers check this instead of reparsing the full JSONL.
@@ -409,10 +435,80 @@ impl LiveTranscriptWriter {
             last_status_write: Instant::now()
                 .checked_sub(SIDECAR_HEARTBEAT_INTERVAL)
                 .unwrap_or_else(Instant::now),
+            #[cfg(target_os = "macos")]
+            shadow: None,
         };
 
         Ok(writer)
     }
+
+    /// Arm Apple Speech shadow measurement for this session when the user opted
+    /// in. No-op when shadow is off (the default), when the runner thread cannot
+    /// be spawned, or on non-macOS. Independent of the product transport gate:
+    /// shadow measures alongside Whisper and never changes what is written.
+    #[cfg(target_os = "macos")]
+    fn enable_shadow(&mut self, config: &Config) {
+        if !crate::apple_speech_shadow::shadow_enabled(config) {
+            return;
+        }
+        match crate::apple_speech_shadow::spawn_live_shadow_runner(config) {
+            Some(runner) => {
+                tracing::info!("apple-speech shadow measurement armed for this live session");
+                self.shadow = Some(LiveShadow {
+                    runner,
+                    samples: Vec::new(),
+                    overflowed: false,
+                });
+            }
+            None => tracing::warn!(
+                "apple-speech shadow requested but its worker thread could not start; continuing without shadow"
+            ),
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn enable_shadow(&mut self, _config: &Config) {}
+
+    /// Accumulate raw utterance samples for the shadow comparison, mirroring what
+    /// `StreamingWhisper` is fed. Bounded by [`SHADOW_MAX_SAMPLES`]; past that the
+    /// utterance is marked overflowed and will be skipped, not truncated.
+    #[cfg(target_os = "macos")]
+    fn push_shadow_samples(&mut self, samples: &[f32]) {
+        if let Some(shadow) = self.shadow.as_mut() {
+            if shadow.samples.len().saturating_add(samples.len()) > SHADOW_MAX_SAMPLES {
+                shadow.overflowed = true;
+                shadow.samples = Vec::new();
+                return;
+            }
+            if !shadow.overflowed {
+                shadow.samples.extend_from_slice(samples);
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn push_shadow_samples(&mut self, _samples: &[f32]) {}
+
+    /// Hand the finished utterance to the shadow runner: the Whisper text that is
+    /// actually shipping, plus the samples that produced it. Called only where
+    /// Whisper is the shipped engine, so the comparison is always shadow-vs-shipped.
+    /// Ownership of the buffer moves to the runner (no copy on this thread), and
+    /// the runner drops the job if it is busy — capture is never blocked.
+    #[cfg(target_os = "macos")]
+    fn submit_whisper_shadow(&mut self, whisper_text: &str) {
+        let Some(shadow) = self.shadow.as_mut() else {
+            return;
+        };
+        let samples = std::mem::take(&mut shadow.samples);
+        let overflowed = std::mem::replace(&mut shadow.overflowed, false);
+        if overflowed || samples.is_empty() {
+            return;
+        }
+        shadow.runner.try_submit(samples, whisper_text.to_string());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn submit_whisper_shadow(&mut self, _whisper_text: &str) {}
 
     /// Write the lightweight status file (atomic rename).
     fn write_status(
@@ -801,6 +897,7 @@ fn run_inner(
     // Only now create the writer (which truncates the JSONL and WAV files)
     let mut writer =
         LiveTranscriptWriter::new(config, context_session_id, TranscriptSource::Standalone)?;
+    writer.enable_shadow(config);
     writer.mark_healthy();
     crate::events::append_event(crate::events::recording_started_event(
         writer.session_id.clone(),
@@ -1168,6 +1265,9 @@ fn run_inner(
                     parakeet_utterance_samples.extend_from_slice(&chunk.samples);
                 }
             } else if let Ok(whisper_ctx) = ensure_live_whisper_ctx(&mut whisper_ctx, config) {
+                // Shadow keeps its own copy of what whisper is fed: StreamingWhisper
+                // does not hand its buffer back. No-op unless shadow is armed.
+                writer.push_shadow_samples(&chunk.samples);
                 if let Some(sr) = streaming.feed(&chunk.samples, whisper_ctx) {
                     if let Some(publisher) = partial_publisher.as_mut() {
                         let _ = publisher
@@ -2177,6 +2277,9 @@ fn finalize_live_utterance(
     let write_ok = match ensure_live_whisper_ctx(whisper_ctx, config) {
         Ok(whisper_ctx) => {
             let ok = if let Some(sr) = streaming.finalize(whisper_ctx) {
+                // Whisper is the shipped engine here, so this is the one place a
+                // shadow comparison is valid. No-op unless shadow is armed.
+                writer.submit_whisper_shadow(&sr.text);
                 writer.write_utterance(&sr.text, sr.duration_secs)
             } else {
                 true
@@ -2297,6 +2400,9 @@ fn finalize_live_utterance(
     let write_ok = match ensure_live_whisper_ctx(whisper_ctx, config) {
         Ok(whisper_ctx) => {
             if let Some(sr) = streaming.finalize(whisper_ctx) {
+                // Whisper is the shipped engine here, so this is the one place a
+                // shadow comparison is valid. No-op unless shadow is armed.
+                writer.submit_whisper_shadow(&sr.text);
                 writer.write_utterance(&sr.text, sr.duration_secs)
             } else {
                 true

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -457,20 +457,12 @@ impl LiveTranscriptWriter {
             TranscriptSource::Standalone => "standalone",
             TranscriptSource::RecordingSidecar => "recording-sidecar",
         };
-        // The worker is only reachable from a trusted installed app bundle, so a
-        // CLI-run session would fail its first attempt and latch off, logging a
-        // failure that says nothing about device capability. Decline up front,
-        // carrying the authority layer's own reason (not-an-app-bundle, cdhash
-        // mismatch, missing manifest, unavailable peer API — they are different
-        // diagnoses) and persist it, so a run with zero shadow rows is never
-        // confused with "no eligible audio".
-        if let Some(reason) = crate::apple_speech_worker::worker_authority_error() {
-            crate::apple_speech_shadow::log_shadow_disabled(
-                source,
-                &format!("worker unreachable: {reason}"),
-            );
-            return;
-        }
+        // No up-front authority probe: the worker is only reachable from a
+        // trusted installed app bundle, and a process that cannot address it
+        // gets PermissionDenied on the first attempt, which the runner records
+        // as ShadowError::WorkerUnavailable and latches off. That is a precise,
+        // durable row and it costs one attempt, whereas probing here would mean
+        // reaching into the signed worker-authority surface for a diagnostic.
         match crate::apple_speech_shadow::spawn_live_shadow_runner(config, source) {
             Some(runner) => {
                 tracing::info!("apple-speech shadow measurement armed for this live session");


### PR DESCRIPTION
## Apple Speech activation — Phase 6: live-transcript shadow hook

Wires the merged `ShadowRunner` (#734) into the standalone live path (`minutes live`), the plan's first surface. **Off unless `transcription.apple_speech_shadow` is set**; product gate stays hard-closed.

### Design: state on the writer, not threaded params
Threading a runner + samples buffer through 4 `finalize_*` definitions and 12 capture-path call sites would be ~21 edits in recording-reliability-sensitive code. `LiveTranscriptWriter` is already passed everywhere, so the state hangs off it instead — **3 call sites**, all no-ops when shadow is off, with no-op non-macOS variants so capture code stays cfg-free.

- `enable_shadow()` at session start. Declines cleanly (with reason) when shadow is off, when the runner thread can't spawn, or when the worker is unreachable.
- `push_shadow_samples()` keeps a parallel copy of what whisper is fed (`StreamingWhisper` doesn't hand its buffer back). Bounded at 120 s; a longer utterance is marked overflowed and **skipped, never truncated** — comparing truncated audio would understate Apple Speech and corrupt the measurement.
- `submit_whisper_shadow()` moves the buffer (no copy) + the shipped whisper text to the runner, at the **two whisper-finalize points only**, so the comparison is always shadow-vs-shipped rather than apple-vs-apple.

### Hardware finding: shadow needs the app bundle
`authority()` requires the process to live inside a trusted installed app bundle (`Contents/MacOS` beside `Contents/XPCServices`), so a CLI binary or test harness **can never reach the worker**. A CLI-run session would fail its first attempt, latch off, and log `outcome=failed` — a capability-looking signal that says nothing about the device. Added `worker_authority_available()` and `enable_shadow()` now declines up front with the actionable reason. **Shadow data must be collected from the desktop app** (which has both bundle authority and mic TCC).

### Drive-by fix: a stale test no CI job compiles
`recording_sidecar_resolves_retained_apple_speech_honestly` has been **failing on main on every platform** — it asserted a hardcoded copy of the unavailable-reason wording that was later reworded. It stayed invisible because every CI unit-test job runs `--no-default-features`, so `live_transcript` (gated on `streaming`+`whisper`) and its 37 tests are never built in CI. Now asserts against `apple_speech_unavailable_reason()` itself so it tracks the source of truth. The coverage gap itself is filed as a separate bead.

### Verification
- **On macOS hardware (mss-macbook-pro, macOS 26.6 arm64)**: `cargo check` + `clippy` clean on the macOS-gated paths; **37/37 live_transcript tests pass**; 18/18 shadow tests pass.
- **On linux**: 37 live_transcript + 41 dictation + 18 shadow pass; fmt + `clippy --no-default-features -D warnings` clean.

Draft pending codex review. Not yet exercised end-to-end with live mic audio — that needs the desktop app and someone speaking, and is the remaining Phase 6 step.