### PR TITLE
docs(release): correct why macOS holds sherpa out, and reseal

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -193,7 +193,12 @@ jobs:
       # it). build.rs stages it from target/release/minutes, so the CLI must be
       # built first or the bundle ships a placeholder stub (#324).
       - name: Build release CLI for bundling
-        # engine-sherpa held out per #683 (conflicts with diarize on macOS; see crates/core/src/lib.rs guard)
+        # engine-sherpa held out pending packaging (#369), not because it
+        # conflicts. #685 moved sherpa into a dlopened plugin with its own
+        # ONNX Runtime, so it coexists with diarize now and CI compiles the
+        # pair on purpose. What is missing is a signed, notarized plugin
+        # beside the binary; an unsigned dylib loaded by this hardened,
+        # notarized app is refused at load.
         run: cargo build --release -p minutes-cli --features parakeet,metal
 
       - name: Build signed bundle (helper identity is repaired before notarization)
@@ -207,7 +212,11 @@ jobs:
         # workspace, so cargo resolves --features against every member, and
         # minutes-archive-app has neither parakeet nor metal.
         working-directory: tauri/src-tauri
-        # engine-sherpa held out per #683 (the app hard-enables diarize; see crates/core/src/lib.rs guard)
+        # engine-sherpa held out pending packaging (#369). The #683 conflict
+        # that once justified this is gone: #685 put sherpa in its own
+        # dlopened image, so the app can hard-enable diarize and still load
+        # it. The plugin just is not signed and shipped inside the bundle
+        # yet.
         run: cargo tauri build --features parakeet,metal --bundles app
 
       - name: Sign graph helper inside-out and notarize the final exact app

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from "node:fs";
 // These whole-file hashes prevent dead/comment-only duplicate code from
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
-  release: "a64fa59520223c3b2c5ba44f9321d807eec045196ee630b03f9a14dc4f11c8dd",
+  release: "e17a89af9635b4769952a2b7e27ddb614dfd68abfece6e76ce03e806799025ee",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   build: "24fca291f683c7c6cc0599e7e88514f4f3374e357983298b857b4fef0acada9f",
   dev: "f5376e40b3bdb57866d9fd675a14ea86d6825a5e3496e097502d2c193add1cf3",


### PR DESCRIPTION
The deferred item from #733, done deliberately rather than as a drive-by.

## The problem

Two comments in `release-macos.yml` say `engine-sherpa` is held out because it "conflicts with diarize on macOS", and point at a guard in `crates/core/src/lib.rs`. Both halves are false as of #725: that guard was deleted, and sherpa now lives in a dlopened plugin with its own ONNX Runtime, so the two coexist. CI compiles `diarize,engine-sherpa` together on purpose to keep it that way.

Left alone, these send the next reader to re-litigate a resolved conflict. That matters right now, because #369 is an open thread about exactly whether macOS can ship sherpa, and the honest answer is "yes, once the plugin is signed" rather than "no, it conflicts".

The real reason it is held out is packaging: an unsigned dylib loaded by a hardened, notarized app is refused at load, and the plugin is not signed and shipped in the bundle yet.

## Why this needed its own PR

`release-macos.yml` is hash-sealed as packaging authority by `check_graph_worker_packaging.mjs`, whose own comment says to update the golden hash "only after line-by-line review of the complete authority boundary". Editing a comment there means resealing, and resealing casually is precisely what the seal exists to prevent. So I left it out of #733 and did it here on purpose.

## Evidence the reseal is safe

**The change is comment-only**, proven rather than asserted: stripping every comment line from both revisions and diffing gives zero differing lines.

**The seal behaved correctly.** Before updating the hash the guard failed with `complete release graph-XPC authority changed; review it and update its golden hash`. After, it passes.

**The structural checks are untouched.** What the guard actually enforces on this file is the graph-XPC ordering (`package-graph-xpc.sh` → XPC bundle path → outer sign → `codesign --verify` → `notarytool submit` → `stapler staple`). None of that is near the edited lines.

All three packaging guards pass with their self-tests: graph worker, Apple Speech worker, and sherpa.