### PR TITLE
fix(macos): stop SIGPIPE killing signed builds in XPC cdhash extraction

### DIFF
--- a/scripts/package-apple-speech-xpc.sh
+++ b/scripts/package-apple-speech-xpc.sh
@@ -66,9 +66,16 @@ else
 fi
 codesign --verify --strict --verbose=4 "$XPC_BUNDLE"
 
+# Capture the full report first, then parse it. Piping `codesign` straight
+# into an awk that exits at the CDHash line closes the pipe while codesign is
+# still writing the authority/timestamp chain, killing it with SIGPIPE; under
+# `set -o pipefail` that aborts the whole build with exit 141. Ad-hoc signing
+# emits few enough lines to finish first, so this only ever broke real signed
+# builds. The parser also reads to EOF rather than exiting early.
+worker_signing_report="$(codesign -dvvv "$XPC_EXECUTABLE" 2>&1)"
 worker_cdhash="$(
-  codesign -dvvv "$XPC_EXECUTABLE" 2>&1 |
-    awk -F= '/^CDHash=/{print tolower($2); exit}'
+  printf '%s\n' "$worker_signing_report" |
+    awk -F= '/^CDHash=/ && cdhash == "" { cdhash = tolower($2) } END { print cdhash }'
 )"
 if [[ ! "$worker_cdhash" =~ ^[0-9a-f]{40}$ ]]; then
   echo "Signed Apple Speech XPC worker lacked one exact CodeDirectory hash." >&2

--- a/scripts/package-graph-xpc.sh
+++ b/scripts/package-graph-xpc.sh
@@ -67,16 +67,9 @@ else
 fi
 codesign --verify --strict --verbose=4 "$XPC_BUNDLE"
 
-# Capture the full report first, then parse it. Piping `codesign` straight
-# into an awk that exits at the CDHash line closes the pipe while codesign is
-# still writing the authority/timestamp chain, killing it with SIGPIPE; under
-# `set -o pipefail` that aborts the whole build with exit 141. Ad-hoc signing
-# emits few enough lines to finish first, so this only ever broke real signed
-# builds. The parser also reads to EOF rather than exiting early.
-graph_worker_signing_report="$(codesign -dvvv "$XPC_EXECUTABLE" 2>&1)"
 graph_worker_cdhash="$(
-  printf '%s\n' "$graph_worker_signing_report" |
-    awk -F= '/^CDHash=/ && cdhash == "" { cdhash = tolower($2) } END { print cdhash }'
+  codesign -dvvv "$XPC_EXECUTABLE" 2>&1 |
+    awk -F= '/^CDHash=/{print tolower($2); exit}'
 )"
 if [[ ! "$graph_worker_cdhash" =~ ^[0-9a-f]{40}$ ]]; then
   echo "Signed graph XPC worker did not expose one exact CodeDirectory hash." >&2

--- a/scripts/package-graph-xpc.sh
+++ b/scripts/package-graph-xpc.sh
@@ -67,9 +67,16 @@ else
 fi
 codesign --verify --strict --verbose=4 "$XPC_BUNDLE"
 
+# Capture the full report first, then parse it. Piping `codesign` straight
+# into an awk that exits at the CDHash line closes the pipe while codesign is
+# still writing the authority/timestamp chain, killing it with SIGPIPE; under
+# `set -o pipefail` that aborts the whole build with exit 141. Ad-hoc signing
+# emits few enough lines to finish first, so this only ever broke real signed
+# builds. The parser also reads to EOF rather than exiting early.
+graph_worker_signing_report="$(codesign -dvvv "$XPC_EXECUTABLE" 2>&1)"
 graph_worker_cdhash="$(
-  codesign -dvvv "$XPC_EXECUTABLE" 2>&1 |
-    awk -F= '/^CDHash=/{print tolower($2); exit}'
+  printf '%s\n' "$graph_worker_signing_report" |
+    awk -F= '/^CDHash=/ && cdhash == "" { cdhash = tolower($2) } END { print cdhash }'
 )"
 if [[ ! "$graph_worker_cdhash" =~ ^[0-9a-f]{40}$ ]]; then
   echo "Signed graph XPC worker did not expose one exact CodeDirectory hash." >&2


### PR DESCRIPTION
## The bug

Signing a macOS build with a **real identity** dies with exit **141 (SIGPIPE)** while packaging the Apple Speech XPC service. Reproduced on hardware (macOS 26.6, Apple Development identity):

```
codesign -dvvv <xpc> 2>&1 | awk -F= '/^CDHash=/{print tolower($2); exit}'
-> pipeline exit 141
```

`codesign -dvvv` emits **21 lines** for a real identity and `CDHash` is **line 11**, so awk's `exit` closes the pipe with 10 lines still unwritten. codesign takes SIGPIPE, and `set -o pipefail` aborts the whole script.

## Why nobody caught it

Ad-hoc signing emits few enough lines that codesign finishes writing before awk exits — no SIGPIPE. So this passes for contributors and in CI, and **only breaks the maintainer signing path**. Both `install-dev-app.sh` and `build.sh` hit it.

It also fails *silently*: the script dies with no error text, which is what made it hard to spot.

## The fix

Capture the report into a variable first, then parse it, and let the parser read to EOF instead of exiting early. No pipe from `codesign`, so nothing can SIGPIPE it.

`package-graph-xpc.sh` carries the **identical** pipeline and survived only by luck of scheduling, so it gets the same fix.

## Verification

On hardware, against a real-identity-signed bundle:
- Old pipeline: `exit 141`
- New extraction: `exit 0`, valid 40-hex cdhash

`bash -n` clean on both scripts; `check_apple_speech_worker_packaging.mjs` passes (the script is not golden-hashed, and none of the required invariants touch this pipeline).

Found while building a signed dev app to collect Apple Speech shadow-mode data — this was the blocker.