### PR TITLE
Ship Archive DMG updater notification

### DIFF
--- a/.github/workflows/archive-pilot-private.yml
+++ b/.github/workflows/archive-pilot-private.yml
@@ -210,7 +210,11 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-          sparse-checkout: scripts/archive-bundle-integrity.py
+          sparse-checkout: |
+            scripts/archive-bundle-integrity.py
+            scripts/create-branded-dmg.sh
+            tauri/src-tauri/dmg-background.png
+            tauri/src-tauri/icons/icon.icns
           sparse-checkout-cone-mode: false
 
       - name: Download exact unsigned Archive candidate
@@ -388,6 +392,38 @@ jobs:
             printf 'notarized=true\nstapled=true\n'
           } > signed-archive-provenance.txt
 
+      - name: Create, notarize, and staple Archive DMG
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+            'signed/Minutes Archive.app/Contents/Info.plist')"
+          dmg="Minutes_Archive_${version}_aarch64.dmg"
+          scripts/create-branded-dmg.sh \
+            --app "signed/Minutes Archive.app" \
+            --version "$version" \
+            --output "$dmg"
+          submit_json="$RUNNER_TEMP/archive-dmg-notary-submit.json"
+          xcrun notarytool submit "$dmg" \
+            --key "$ARCHIVE_API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait --timeout 30m \
+            --output-format json > "$submit_json"
+          status="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("status",""))' "$submit_json")"
+          if [ "$status" != "Accepted" ]; then
+            echo "DMG notarization did not return Accepted; refusing candidate" >&2
+            exit 1
+          fi
+          xcrun stapler staple "$dmg"
+          xcrun stapler validate "$dmg"
+          spctl --assess --type open --context context:primary-signature \
+            --verbose=4 "$dmg"
+          shasum -a 256 "$dmg" >> signed-archive-provenance.txt
+          echo "ARCHIVE_DMG=$dmg" >> "$GITHUB_ENV"
+
       - name: Encrypt pilot artifact to its single recipient
         env:
           AGE_RECIPIENT: ${{ vars.ARCHIVE_PILOT_AGE_RECIPIENT }}
@@ -420,10 +456,14 @@ jobs:
           age -R "$recipients" \
             -o minutes-archive-pilot-notarized.zip.age \
             minutes-archive-pilot-notarized.zip
-          rm -f minutes-archive-pilot-notarized.zip
+          age -R "$recipients" \
+            -o "${ARCHIVE_DMG}.age" \
+            "$ARCHIVE_DMG"
+          rm -f minutes-archive-pilot-notarized.zip "$ARCHIVE_DMG"
           test -s minutes-archive-pilot-notarized.zip.age
+          test -s "${ARCHIVE_DMG}.age"
           # Fail closed if the plaintext build survived into the upload set.
-          if [ -e minutes-archive-pilot-notarized.zip ]; then
+          if [ -e minutes-archive-pilot-notarized.zip ] || [ -e "$ARCHIVE_DMG" ]; then
             echo "plaintext signed build still present; refusing to upload" >&2
             exit 1
           fi
@@ -437,7 +477,8 @@ jobs:
           rm -f \
             "$RUNNER_TEMP/minutes-archive-pilot.p12" \
             "${ARCHIVE_API_KEY_PATH:-}" \
-            "$RUNNER_TEMP/Minutes-Archive-notary.zip"
+            "$RUNNER_TEMP/Minutes-Archive-notary.zip" \
+            "$RUNNER_TEMP/archive-dmg-notary-submit.json"
 
       - name: Upload encrypted Archive pilot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -445,6 +486,7 @@ jobs:
           name: minutes-archive-pilot-${{ needs.authorize-candidate.outputs.candidate_sha }}
           path: |
             minutes-archive-pilot-notarized.zip.age
+            Minutes_Archive_*_aarch64.dmg.age
             signed-archive-provenance.txt
             archive-bundle-report.txt
           if-no-files-found: error

--- a/.github/workflows/archive-stable-promotion.yml
+++ b/.github/workflows/archive-stable-promotion.yml
@@ -40,7 +40,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_TAG: ${{ inputs.release_tag }}
     steps:
-      - name: Bind promotion to the exact protected tag and private draft
+      - name: Bind promotion to the exact protected tag and staged release
         run: |
           set -euo pipefail
           if [[ ! "$RELEASE_TAG" =~ ^archive-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -86,10 +86,8 @@ jobs:
           import os
 
           release = json.loads(os.environ["RELEASE_JSON"])
-          if not release.get("draft"):
-              raise SystemExit("Versioned release is not a private draft")
           if release.get("tag_name") != os.environ["RELEASE_TAG"]:
-              raise SystemExit("Draft release tag does not match the requested tag")
+              raise SystemExit("Staged release tag does not match the requested tag")
           PY
 
       - name: Download and verify the exact independently reviewed asset set
@@ -211,7 +209,12 @@ jobs:
       - name: Publish draft, verify public bytes, then advance stable manifest last
         run: |
           set -euo pipefail
-          gh release edit "$RELEASE_TAG" --draft=false
+          # A retry after a partial run may find that the exact reviewed release
+          # is already public but `archive-stable` was never advanced. The
+          # checksum-bound steps above make that state safe to resume.
+          if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --draft=false --latest=false
+          fi
 
           mkdir public
           while IFS= read -r asset; do

--- a/.github/workflows/archive-stable-promotion.yml
+++ b/.github/workflows/archive-stable-promotion.yml
@@ -1,0 +1,252 @@
+name: Promote Reviewed Archive Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Reviewed draft tag in archive-vX.Y.Z form
+        required: true
+        type: string
+      candidate_sha:
+        description: Full commit SHA resolved by the protected release tag
+        required: true
+        type: string
+      release_sums_sha256:
+        description: Independently recorded SHA-256 of archive-release-SHA256SUMS.txt
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: archive-stable-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote-reviewed-release:
+    name: Publish exact reviewed bytes and advance Archive stable
+    if: >-
+      github.actor == 'silverstein' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: archive-stable-release
+    permissions:
+      contents: write
+    env:
+      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      EXPECTED_SUMS_SHA256: ${{ inputs.release_sums_sha256 }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Bind promotion to the exact protected tag and private draft
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^archive-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release_tag must be archive-vX.Y.Z" >&2
+            exit 1
+          fi
+          if [[ ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "candidate_sha must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_SUMS_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "release_sums_sha256 must be a lowercase SHA-256" >&2
+            exit 1
+          fi
+
+          remote="https://github.com/${GITHUB_REPOSITORY}.git"
+          refs="$(
+            git ls-remote --tags "$remote" \
+              "refs/tags/$RELEASE_TAG" "refs/tags/$RELEASE_TAG^{}" || true
+          )"
+          exact="$(
+            printf '%s\n' "$refs" |
+              awk -v t="refs/tags/$RELEASE_TAG" '$2 == t {print $1}'
+          )"
+          peeled="$(
+            printf '%s\n' "$refs" |
+              awk -v t="refs/tags/$RELEASE_TAG^{}" '$2 == t {print $1}'
+          )"
+          if [ "$(printf '%s\n' "$exact" | grep -c .)" -ne 1 ] ||
+             [ "$(printf '%s\n' "$peeled" | grep -c .)" -gt 1 ]; then
+            echo "Protected tag $RELEASE_TAG does not resolve unambiguously" >&2
+            exit 1
+          fi
+          resolved="${peeled:-$exact}"
+          if [ "$resolved" != "$CANDIDATE_SHA" ]; then
+            echo "Protected tag $RELEASE_TAG does not resolve exactly to $CANDIDATE_SHA" >&2
+            exit 1
+          fi
+
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+          RELEASE_JSON="$release_json" python3 <<'PY'
+          import json
+          import os
+
+          release = json.loads(os.environ["RELEASE_JSON"])
+          if not release.get("draft"):
+              raise SystemExit("Versioned release is not a private draft")
+          if release.get("tag_name") != os.environ["RELEASE_TAG"]:
+              raise SystemExit("Draft release tag does not match the requested tag")
+          PY
+
+      - name: Download and verify the exact independently reviewed asset set
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#archive-v}"
+          dmg="Minutes_Archive_${version}_aarch64.dmg"
+          updater="Minutes.Archive_${version}_aarch64.app.tar.gz"
+          mkdir payload
+          gh release download "$RELEASE_TAG" --dir payload
+
+          printf '%s\n' \
+            "$dmg" \
+            "$updater" \
+            "${updater}.sig" \
+            archive-release-SHA256SUMS.txt \
+            latest-archive.json \
+            signed-archive-provenance.txt | sort > expected-assets.txt
+          find payload -maxdepth 1 -type f -printf '%f\n' | sort > actual-assets.txt
+          diff -u expected-assets.txt actual-assets.txt
+
+          actual_sums_sha256="$(sha256sum payload/archive-release-SHA256SUMS.txt | awk '{print $1}')"
+          if [ "$actual_sums_sha256" != "$EXPECTED_SUMS_SHA256" ]; then
+            echo "Draft asset checksum record is not the independently reviewed record" >&2
+            exit 1
+          fi
+          printf '%s\n' \
+            "$dmg" \
+            "$updater" \
+            "${updater}.sig" \
+            latest-archive.json \
+            signed-archive-provenance.txt | sort > expected-checksums.txt
+          awk '{name=$2; sub(/^\*/, "", name); print name}' \
+            payload/archive-release-SHA256SUMS.txt | sort > actual-checksums.txt
+          diff -u expected-checksums.txt actual-checksums.txt
+          (cd payload && sha256sum -c archive-release-SHA256SUMS.txt)
+
+          CANDIDATE_SHA="$CANDIDATE_SHA" \
+          RELEASE_TAG="$RELEASE_TAG" \
+          REPOSITORY="$GITHUB_REPOSITORY" \
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          tag = os.environ["RELEASE_TAG"]
+          version = tag.removeprefix("archive-v")
+          updater = f"Minutes.Archive_{version}_aarch64.app.tar.gz"
+          manifest = json.loads(Path("payload/latest-archive.json").read_text())
+          platform = manifest.get("platforms", {}).get("darwin-aarch64", {})
+          expected_url = (
+              f"https://github.com/{os.environ['REPOSITORY']}/releases/"
+              f"download/{tag}/{updater}"
+          )
+          if manifest.get("version") != version:
+              raise SystemExit("Manifest version does not match release tag")
+          if platform.get("url") != expected_url:
+              raise SystemExit("Manifest updater URL does not match the versioned asset")
+          signature = Path(f"payload/{updater}.sig").read_text().strip()
+          if not signature or platform.get("signature") != signature:
+              raise SystemExit("Manifest signature does not match the reviewed signature asset")
+
+          provenance = dict(
+              line.split("=", 1)
+              for line in Path("payload/signed-archive-provenance.txt").read_text().splitlines()
+              if "=" in line
+          )
+          required = {
+              "candidate": os.environ["CANDIDATE_SHA"],
+              "team_id": "63TMLKT8HN",
+              "identifier": "com.useminutes.archive",
+              "notarized": "true",
+              "stapled": "true",
+          }
+          if any(provenance.get(key) != value for key, value in required.items()):
+              raise SystemExit("Signed provenance does not match the reviewed candidate")
+          PY
+
+      - name: Refuse an accidental downgrade or same-version byte replacement
+        run: |
+          set -euo pipefail
+          if ! gh release view archive-stable >/dev/null 2>&1; then
+            exit 0
+          fi
+          mkdir current-stable
+          gh release download archive-stable \
+            --pattern latest-archive.json \
+            --dir current-stable
+          NEW_MANIFEST=payload/latest-archive.json \
+          OLD_MANIFEST=current-stable/latest-archive.json \
+          python3 <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          old_path = Path(os.environ["OLD_MANIFEST"])
+          new_path = Path(os.environ["NEW_MANIFEST"])
+          old = json.loads(old_path.read_text())
+          new = json.loads(new_path.read_text())
+
+          def version_tuple(value):
+              parts = value.split(".")
+              if len(parts) != 3 or not all(part.isdigit() for part in parts):
+                  raise SystemExit(f"Invalid Archive version: {value}")
+              return tuple(int(part) for part in parts)
+
+          old_version = version_tuple(old.get("version", ""))
+          new_version = version_tuple(new.get("version", ""))
+          if new_version < old_version:
+              raise SystemExit("Refusing to move Archive stable to an older version")
+          if new_version == old_version:
+              old_hash = hashlib.sha256(old_path.read_bytes()).hexdigest()
+              new_hash = hashlib.sha256(new_path.read_bytes()).hexdigest()
+              if old_hash != new_hash:
+                  raise SystemExit("Refusing to replace an existing version with different bytes")
+          PY
+
+      - name: Publish draft, verify public bytes, then advance stable manifest last
+        run: |
+          set -euo pipefail
+          gh release edit "$RELEASE_TAG" --draft=false
+
+          mkdir public
+          while IFS= read -r asset; do
+            curl --proto '=https' --tlsv1.2 --fail --location --retry 3 \
+              --output "public/$asset" \
+              "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${asset}"
+          done < actual-assets.txt
+          diff -u \
+            <(cd payload && while IFS= read -r asset; do sha256sum "$asset"; done < ../actual-assets.txt) \
+            <(cd public && while IFS= read -r asset; do sha256sum "$asset"; done < ../actual-assets.txt)
+
+          if ! gh release view archive-stable >/dev/null 2>&1; then
+            gh release create archive-stable \
+              --latest=false \
+              --target "$CANDIDATE_SHA" \
+              --title "Minutes Archive stable update channel" \
+              --notes "Machine-readable stable channel for signed Minutes Archive updates."
+          fi
+          gh release upload archive-stable payload/latest-archive.json --clobber
+
+          expected_manifest_sha="$(sha256sum payload/latest-archive.json | awk '{print $1}')"
+          verified=false
+          for _ in 1 2 3 4 5; do
+            if curl --proto '=https' --tlsv1.2 --fail --location \
+              --output stable-manifest.json \
+              "https://github.com/${GITHUB_REPOSITORY}/releases/download/archive-stable/latest-archive.json"; then
+              actual_manifest_sha="$(sha256sum stable-manifest.json | awk '{print $1}')"
+              if [ "$actual_manifest_sha" = "$expected_manifest_sha" ]; then
+                verified=true
+                break
+              fi
+            fi
+            sleep 2
+          done
+          if [ "$verified" != "true" ]; then
+            echo "Stable manifest URL did not return the exact reviewed manifest" >&2
+            exit 1
+          fi

--- a/.github/workflows/signed-archive-acceptance.yml
+++ b/.github/workflows/signed-archive-acceptance.yml
@@ -35,6 +35,7 @@ jobs:
       candidate_sha: ${{ steps.authorize.outputs.candidate_sha }}
       checkout_ref: ${{ steps.authorize.outputs.checkout_ref }}
       release_tag: ${{ steps.authorize.outputs.release_tag }}
+      tooling_sha: ${{ steps.authorize.outputs.tooling_sha }}
     steps:
       - name: Bind the request to its protected acceptance tag
         id: authorize
@@ -42,6 +43,7 @@ jobs:
           REQUESTED_SHA: ${{ inputs.candidate_sha }}
           REF_NAME: ${{ github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "push" ]; then
@@ -63,6 +65,18 @@ jobs:
           fi
           tag="${CHECKOUT_REF#refs/tags/}"
           remote="https://github.com/${GITHUB_REPOSITORY}.git"
+          TOOLING_SHA="$(
+            git ls-remote --heads "$remote" refs/heads/main |
+              awk '$2 == "refs/heads/main" {print $1}'
+          )"
+          if [[ ! "$TOOLING_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not bind release tooling to one exact main commit" >&2
+            exit 1
+          fi
+          if [ "$EVENT_NAME" != "push" ] && [ "$TOOLING_SHA" != "$WORKFLOW_SHA" ]; then
+            echo "Dispatched workflow definition is not the exact current main commit" >&2
+            exit 1
+          fi
           # `git ls-remote` patterns tail-match across ref namespaces, so a
           # pattern of "refs/tags/<tag>" also matches a branch literally named
           # "refs/tags/<tag>" (full ref refs/heads/refs/tags/<tag>). Restrict
@@ -97,6 +111,10 @@ jobs:
           resolved="${peeled:-$exact}"
           if [ "$EVENT_NAME" = "push" ]; then
             CANDIDATE_SHA="$resolved"
+            if [ "$CANDIDATE_SHA" != "$TOOLING_SHA" ]; then
+              echo "Archive release tag must point to the exact current main commit" >&2
+              exit 1
+            fi
           elif [ "$resolved" != "$CANDIDATE_SHA" ]; then
             echo "Protected tag $tag does not resolve exactly to $CANDIDATE_SHA" >&2
             exit 1
@@ -105,6 +123,7 @@ jobs:
             echo "candidate_sha=$CANDIDATE_SHA"
             echo "checkout_ref=$CHECKOUT_REF"
             echo "release_tag=$RELEASE_TAG"
+            echo "tooling_sha=$TOOLING_SHA"
           } >> "$GITHUB_OUTPUT"
 
   build-unsigned:
@@ -211,12 +230,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      # Release tooling and presentation assets come from reviewed main, not
-      # from candidate-controlled code. They are installed/read before either
-      # the Apple identity or updater signing key is exposed.
-      - name: Check out reviewed release tooling only
+      # Release tooling and presentation assets come from the exact main SHA
+      # resolved by the authorization job, not from the event's implicit tag
+      # checkout. They are installed/read before either the Apple identity or
+      # updater signing key is exposed.
+      - name: Check out exact reviewed-main release tooling only
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          ref: ${{ needs.authorize-candidate.outputs.tooling_sha }}
           fetch-depth: 1
           persist-credentials: false
           sparse-checkout: |
@@ -225,6 +246,11 @@ jobs:
             tauri/src-tauri/icons/icon.icns
             docs/release/notes
           sparse-checkout-cone-mode: false
+
+      - name: Verify exact release-tooling checkout
+        env:
+          TOOLING_SHA: ${{ needs.authorize-candidate.outputs.tooling_sha }}
+        run: test "$(git rev-parse HEAD)" = "$TOOLING_SHA"
 
       - name: Install pinned Tauri signer before credentials unlock
         run: cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
@@ -378,18 +404,6 @@ jobs:
 
           executable="$app/Contents/MacOS/minutes-archive-app"
 
-          # Prove the SIGNED app can run its own workers, before anything is
-          # published. Every other check here is about provenance: is it the
-          # right bytes, signed by the right identity, notarized and stapled.
-          # All of that passed on a build that could not index a single
-          # document, because the workers were copied to a temp directory and a
-          # copy of a bundle-signed binary is killed on exec. Local testing used
-          # an ad-hoc-signed app whose copy runs fine, and the smokes above run
-          # on the unsigned build, so nothing saw it until a human clicked the
-          # button. This is the only step that exercises the artifact as
-          # shipped.
-          "$executable" --archive-signed-worker-selftest
-
           executable_sha="$(shasum -a 256 "$executable" | awk '{print $1}')"
           printf 'candidate=%s\nteam_id=%s\nidentifier=%s\nexecutable_sha256=%s\nnotarized=true\nstapled=true\n' \
             "$CANDIDATE_SHA" "$team_id" "$identifier" "$executable_sha" \
@@ -532,6 +546,16 @@ jobs:
             "${ARCHIVE_API_KEY_PATH:-}" \
             "$RUNNER_TEMP/Minutes-Archive-notary.zip" \
             "$RUNNER_TEMP/archive-dmg-notary-submit.json"
+
+      # Candidate code is exercised only after the Developer ID keychain,
+      # notarization key, and updater signing secret have all left scope. This
+      # proves the shipped signed app can run its workers without giving that
+      # app an opportunity to read release credentials.
+      - name: Exercise exact signed app after credential teardown
+        run: |
+          set -euo pipefail
+          signed/Minutes\ Archive.app/Contents/MacOS/minutes-archive-app \
+            --archive-signed-worker-selftest
 
       - name: Upload short-lived notarized Archive pilot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/signed-archive-acceptance.yml
+++ b/.github/workflows/signed-archive-acceptance.yml
@@ -474,7 +474,12 @@ jobs:
           }
           Path("latest-archive.json").write_text(json.dumps(manifest, indent=2) + "\n")
           PY
-          shasum -a 256 "$dmg" "$updater" "${updater}.sig" latest-archive.json \
+          shasum -a 256 \
+            "$dmg" \
+            "$updater" \
+            "${updater}.sig" \
+            latest-archive.json \
+            signed-archive-provenance.txt \
             > archive-release-SHA256SUMS.txt
           {
             echo "ARCHIVE_VERSION=$version"
@@ -483,7 +488,7 @@ jobs:
             echo "ARCHIVE_UPDATER=$updater"
           } >> "$GITHUB_ENV"
 
-      - name: Publish versioned release and advance stable updater manifest
+      - name: Stage exact versioned assets in a private draft release
         if: needs.authorize-candidate.outputs.release_tag != ''
         env:
           CANDIDATE_SHA: ${{ needs.authorize-candidate.outputs.candidate_sha }}
@@ -492,9 +497,18 @@ jobs:
         run: |
           set -euo pipefail
           notes="docs/release/notes/${RELEASE_TAG}.md"
-          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)"
+            if [ "$is_draft" != "true" ]; then
+              echo "Release $RELEASE_TAG is already public; refusing to replace reviewed assets" >&2
+              exit 1
+            fi
+          else
             gh release create "$RELEASE_TAG" \
               --verify-tag \
+              --draft \
+              --latest=false \
+              --target "$CANDIDATE_SHA" \
               --title "Minutes Archive ${ARCHIVE_VERSION}" \
               --notes-file "$notes"
           fi
@@ -506,18 +520,6 @@ jobs:
             archive-release-SHA256SUMS.txt \
             signed-archive-provenance.txt \
             --clobber
-
-          # The app reads one stable URL. Versioned payloads are uploaded
-          # first; replacing this tiny manifest last makes publication atomic
-          # from the client's point of view and lets an operator stop offering
-          # a bad release without removing prior signed artifacts.
-          if ! gh release view archive-stable >/dev/null 2>&1; then
-            gh release create archive-stable \
-              --target "$CANDIDATE_SHA" \
-              --title "Minutes Archive stable update channel" \
-              --notes "Machine-readable stable channel for signed Minutes Archive updates."
-          fi
-          gh release upload archive-stable latest-archive.json --clobber
 
       - name: Remove ephemeral signing material
         if: always()

--- a/.github/workflows/signed-archive-acceptance.yml
+++ b/.github/workflows/signed-archive-acceptance.yml
@@ -1,6 +1,9 @@
 name: Signed Archive Pilot Acceptance
 
 on:
+  push:
+    tags:
+      - "archive-v*"
   workflow_dispatch:
     inputs:
       candidate_sha:
@@ -23,22 +26,42 @@ env:
 jobs:
   authorize-candidate:
     name: Authorize exact protected Archive candidate
-    if: github.ref == 'refs/heads/main' && github.actor == 'silverstein'
+    if: >-
+      github.actor == 'silverstein' &&
+      ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/archive-v')))
     runs-on: ubuntu-latest
     outputs:
       candidate_sha: ${{ steps.authorize.outputs.candidate_sha }}
+      checkout_ref: ${{ steps.authorize.outputs.checkout_ref }}
+      release_tag: ${{ steps.authorize.outputs.release_tag }}
     steps:
       - name: Bind the request to its protected acceptance tag
         id: authorize
         env:
-          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          REQUESTED_SHA: ${{ inputs.candidate_sha }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          if [[ ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          if [ "$EVENT_NAME" = "push" ]; then
+            if [[ ! "$REF_NAME" =~ ^archive-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Archive release tags must be archive-vX.Y.Z" >&2
+              exit 1
+            fi
+            CANDIDATE_SHA=""
+            CHECKOUT_REF="refs/tags/$REF_NAME"
+            RELEASE_TAG="$REF_NAME"
+          else
+            CANDIDATE_SHA="$REQUESTED_SHA"
+            CHECKOUT_REF="refs/tags/acceptance-$CANDIDATE_SHA"
+            RELEASE_TAG=""
+          fi
+          if [ "$EVENT_NAME" != "push" ] && [[ ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
-          tag="acceptance-$CANDIDATE_SHA"
+          tag="${CHECKOUT_REF#refs/tags/}"
           remote="https://github.com/${GITHUB_REPOSITORY}.git"
           # `git ls-remote` patterns tail-match across ref namespaces, so a
           # pattern of "refs/tags/<tag>" also matches a branch literally named
@@ -72,11 +95,17 @@ jobs:
           # Annotated tag -> the peeled line is the commit.
           # Lightweight tag -> the ref itself is the commit.
           resolved="${peeled:-$exact}"
-          if [ "$resolved" != "$CANDIDATE_SHA" ]; then
+          if [ "$EVENT_NAME" = "push" ]; then
+            CANDIDATE_SHA="$resolved"
+          elif [ "$resolved" != "$CANDIDATE_SHA" ]; then
             echo "Protected tag $tag does not resolve exactly to $CANDIDATE_SHA" >&2
             exit 1
           fi
-          echo "candidate_sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "candidate_sha=$CANDIDATE_SHA"
+            echo "checkout_ref=$CHECKOUT_REF"
+            echo "release_tag=$RELEASE_TAG"
+          } >> "$GITHUB_OUTPUT"
 
   build-unsigned:
     name: Build and exercise Archive without signing secrets
@@ -87,7 +116,7 @@ jobs:
       - name: Check out exact protected candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: refs/tags/acceptance-${{ needs.authorize-candidate.outputs.candidate_sha }}
+          ref: ${{ needs.authorize-candidate.outputs.checkout_ref }}
           fetch-depth: 1
 
       - name: Verify exact candidate checkout
@@ -179,7 +208,36 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     environment: signed-dev-acceptance
+    permissions:
+      contents: write
     steps:
+      # Release tooling and presentation assets come from reviewed main, not
+      # from candidate-controlled code. They are installed/read before either
+      # the Apple identity or updater signing key is exposed.
+      - name: Check out reviewed release tooling only
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/create-branded-dmg.sh
+            tauri/src-tauri/dmg-background.png
+            tauri/src-tauri/icons/icon.icns
+            docs/release/notes
+          sparse-checkout-cone-mode: false
+
+      - name: Install pinned Tauri signer before credentials unlock
+        run: cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
+
+      - name: Validate updater signing key exists
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            echo "Missing required updater signing secret: TAURI_SIGNING_PRIVATE_KEY" >&2
+            exit 1
+          fi
+
       - name: Download exact unsigned Archive candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -341,6 +399,126 @@ jobs:
           shasum -a 256 minutes-archive-pilot-notarized.zip \
             > minutes-archive-pilot-notarized.zip.sha256
 
+      - name: Build signed updater artifact and notarized DMG
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          RELEASE_TAG: ${{ needs.authorize-candidate.outputs.release_tag }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+        run: |
+          set -euo pipefail
+          app="signed/Minutes Archive.app"
+          version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+            "$app/Contents/Info.plist")"
+          expected_tag="archive-v${version}"
+          if [ -n "$RELEASE_TAG" ] && [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Release tag $RELEASE_TAG does not match Archive version $version" >&2
+            exit 1
+          fi
+
+          updater="Minutes.Archive_${version}_aarch64.app.tar.gz"
+          tar -C signed -czf "$updater" "Minutes Archive.app"
+          cargo tauri signer sign "$updater"
+          test -s "${updater}.sig"
+
+          dmg="Minutes_Archive_${version}_aarch64.dmg"
+          scripts/create-branded-dmg.sh \
+            --app "$app" \
+            --version "$version" \
+            --output "$dmg"
+          submit_json="$RUNNER_TEMP/archive-dmg-notary-submit.json"
+          xcrun notarytool submit "$dmg" \
+            --key "$ARCHIVE_API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait --timeout 30m \
+            --output-format json > "$submit_json"
+          status="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("status",""))' "$submit_json")"
+          if [ "$status" != "Accepted" ]; then
+            echo "DMG notarization did not return Accepted; refusing release" >&2
+            exit 1
+          fi
+          xcrun stapler staple "$dmg"
+          xcrun stapler validate "$dmg"
+          spctl --assess --type open --context context:primary-signature \
+            --verbose=4 "$dmg"
+
+          notes="docs/release/notes/${expected_tag}.md"
+          if [ ! -s "$notes" ]; then
+            echo "Missing non-empty Archive release notes: $notes" >&2
+            exit 1
+          fi
+          signature="$(cat "${updater}.sig")"
+          update_url="https://github.com/silverstein/minutes/releases/download/${expected_tag}/${updater}"
+          UPDATE_VERSION="$version" \
+          UPDATE_SIGNATURE="$signature" \
+          UPDATE_URL="$update_url" \
+          UPDATE_NOTES_PATH="$notes" \
+          python3 <<'PY'
+          import datetime
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = {
+              "version": os.environ["UPDATE_VERSION"],
+              "notes": Path(os.environ["UPDATE_NOTES_PATH"]).read_text(),
+              "pub_date": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "platforms": {
+                  "darwin-aarch64": {
+                      "signature": os.environ["UPDATE_SIGNATURE"].strip(),
+                      "url": os.environ["UPDATE_URL"],
+                  }
+              },
+          }
+          Path("latest-archive.json").write_text(json.dumps(manifest, indent=2) + "\n")
+          PY
+          shasum -a 256 "$dmg" "$updater" "${updater}.sig" latest-archive.json \
+            > archive-release-SHA256SUMS.txt
+          {
+            echo "ARCHIVE_VERSION=$version"
+            echo "ARCHIVE_EXPECTED_TAG=$expected_tag"
+            echo "ARCHIVE_DMG=$dmg"
+            echo "ARCHIVE_UPDATER=$updater"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish versioned release and advance stable updater manifest
+        if: needs.authorize-candidate.outputs.release_tag != ''
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize-candidate.outputs.candidate_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.authorize-candidate.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          notes="docs/release/notes/${RELEASE_TAG}.md"
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --title "Minutes Archive ${ARCHIVE_VERSION}" \
+              --notes-file "$notes"
+          fi
+          gh release upload "$RELEASE_TAG" \
+            "$ARCHIVE_DMG" \
+            "$ARCHIVE_UPDATER" \
+            "${ARCHIVE_UPDATER}.sig" \
+            latest-archive.json \
+            archive-release-SHA256SUMS.txt \
+            signed-archive-provenance.txt \
+            --clobber
+
+          # The app reads one stable URL. Versioned payloads are uploaded
+          # first; replacing this tiny manifest last makes publication atomic
+          # from the client's point of view and lets an operator stop offering
+          # a bad release without removing prior signed artifacts.
+          if ! gh release view archive-stable >/dev/null 2>&1; then
+            gh release create archive-stable \
+              --target "$CANDIDATE_SHA" \
+              --title "Minutes Archive stable update channel" \
+              --notes "Machine-readable stable channel for signed Minutes Archive updates."
+          fi
+          gh release upload archive-stable latest-archive.json --clobber
+
       - name: Remove ephemeral signing material
         if: always()
         run: |
@@ -350,7 +528,8 @@ jobs:
           rm -f \
             "$RUNNER_TEMP/minutes-archive-acceptance.p12" \
             "${ARCHIVE_API_KEY_PATH:-}" \
-            "$RUNNER_TEMP/Minutes-Archive-notary.zip"
+            "$RUNNER_TEMP/Minutes-Archive-notary.zip" \
+            "$RUNNER_TEMP/archive-dmg-notary-submit.json"
 
       - name: Upload short-lived notarized Archive pilot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -359,6 +538,11 @@ jobs:
           path: |
             minutes-archive-pilot-notarized.zip
             minutes-archive-pilot-notarized.zip.sha256
+            Minutes_Archive_*_aarch64.dmg
+            Minutes.Archive_*_aarch64.app.tar.gz
+            Minutes.Archive_*_aarch64.app.tar.gz.sig
+            latest-archive.json
+            archive-release-SHA256SUMS.txt
             signed-archive-provenance.txt
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/signed-archive-acceptance.yml
+++ b/.github/workflows/signed-archive-acceptance.yml
@@ -538,20 +538,26 @@ jobs:
       - name: Remove ephemeral signing material
         if: always()
         run: |
+          teardown_status=0
           if [ -n "${ARCHIVE_ACCEPTANCE_KEYCHAIN:-}" ]; then
-            security delete-keychain "$ARCHIVE_ACCEPTANCE_KEYCHAIN" || true
+            security delete-keychain "$ARCHIVE_ACCEPTANCE_KEYCHAIN" || teardown_status=$?
           fi
           rm -f \
             "$RUNNER_TEMP/minutes-archive-acceptance.p12" \
             "${ARCHIVE_API_KEY_PATH:-}" \
             "$RUNNER_TEMP/Minutes-Archive-notary.zip" \
             "$RUNNER_TEMP/archive-dmg-notary-submit.json"
+          if [ "$teardown_status" -ne 0 ]; then
+            echo "Signing keychain deletion failed; refusing candidate execution" >&2
+            exit "$teardown_status"
+          fi
 
       # Candidate code is exercised only after the Developer ID keychain,
       # notarization key, and updater signing secret have all left scope. This
       # proves the shipped signed app can run its workers without giving that
       # app an opportunity to read release credentials.
       - name: Exercise exact signed app after credential teardown
+        if: success()
         run: |
           set -euo pipefail
           signed/Minutes\ Archive.app/Contents/MacOS/minutes-archive-app \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "minutes-archive-app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "minutes-archive-convert",
@@ -3905,6 +3905,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-updater",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,6 +3893,7 @@ dependencies = [
 name = "minutes-archive-app"
 version = "0.2.0"
 dependencies = [
+ "flate2",
  "libc",
  "minutes-archive-convert",
  "minutes-archive-core",
@@ -3902,6 +3903,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/archive/src-tauri/Cargo.toml
+++ b/archive/src-tauri/Cargo.toml
@@ -13,18 +13,18 @@ minutes-archive-core = { path = "../../crates/archive-core" }
 minutes-archive-ocr = { path = "../../crates/archive-ocr" }
 minutes-archive-semantic = { path = "../../crates/archive-semantic" }
 minutes-archive-worker-control = { path = "../../crates/archive-worker-control" }
+flate2 = "1"
 serde = { workspace = true }
 sha2 = "0.10"
 serde_json = { workspace = true }
+tar = "0.4"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
+tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
-
-[dev-dependencies]
-tempfile = "3"

--- a/archive/src-tauri/Cargo.toml
+++ b/archive/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minutes-archive-app"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,6 +18,7 @@ sha2 = "0.10"
 serde_json = { workspace = true }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/archive/src-tauri/src/main.rs
+++ b/archive/src-tauri/src/main.rs
@@ -737,6 +737,13 @@ fn reject_links_in_tree(path: &Path) -> std::io::Result<()> {
 
 #[cfg(target_os = "macos")]
 fn verify_staged_archive_app(app: &Path) -> std::io::Result<()> {
+    // Match Apple's designated requirement for a Developer ID Application
+    // signed by the Minutes team. `codesign --verify` alone proves only that a
+    // signature is internally consistent; this external requirement also
+    // proves that the chain anchors at Apple and carries the Developer ID
+    // Application certificate extensions.
+    const DEVELOPER_ID_REQUIREMENT: &str = r#"=identifier "com.useminutes.archive" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = "63TMLKT8HN""#;
+
     reject_links_in_tree(app)?;
     let executable = app.join("Contents/MacOS/minutes-archive-app");
     if !executable.is_file() {
@@ -746,7 +753,14 @@ fn verify_staged_archive_app(app: &Path) -> std::io::Result<()> {
     }
 
     let verification = std::process::Command::new("/usr/bin/codesign")
-        .args(["--verify", "--deep", "--strict", "--verbose=4"])
+        .args([
+            "--verify",
+            "--deep",
+            "--strict",
+            "--verbose=4",
+            "--test-requirement",
+            DEVELOPER_ID_REQUIREMENT,
+        ])
         .arg(app)
         .output()?;
     if !verification.status.success() {

--- a/archive/src-tauri/src/main.rs
+++ b/archive/src-tauri/src/main.rs
@@ -24,7 +24,7 @@ use minutes_archive_worker_control::LiveWorkerProcesses;
 use serde::Serialize;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{Manager, State};
@@ -102,6 +102,15 @@ struct NetworkWindow {
     /// Spent by the one permitted download, which happens only if the operator
     /// asks for it.
     download_spent: AtomicBool,
+    /// True while either bounded network operation is alive.
+    ///
+    /// The webview disables folder controls during those operations, but the
+    /// Rust boundary must also arbitrate a compromised or racing caller. A
+    /// folder-panel command that arrives while this is true closes the network
+    /// window permanently but does not open the panel; the operator can choose
+    /// the folder after the request finishes, and no archive state can overlap
+    /// the request.
+    operation_in_flight: AtomicBool,
 }
 
 /// The one update this session may install, held between the check and consent.
@@ -186,6 +195,10 @@ const WINDOW_SPENT_REFUSAL: &str =
     "Minutes Archive allows each update step once per session, and this step \
      already ran.";
 
+/// Shown when a folder-panel command races the bounded update operation.
+const NETWORK_BUSY_REFUSAL: &str =
+    "Wait for the update check or installation to finish, then choose folders.";
+
 /// Shown when the request could not be completed, for any reason at all.
 ///
 /// One sentence for offline, endpoint down, DNS failure, malformed JSON, and a
@@ -193,8 +206,8 @@ const WINDOW_SPENT_REFUSAL: &str =
 /// nothing they can act on, and the raw error text is the one place a URL or a
 /// local path could leak into the interface.
 const UPDATE_UNAVAILABLE: &str =
-    "Minutes Archive could not reach the update file. Nothing was sent and \
-     nothing changed.";
+    "Minutes Archive could not complete the update check. No archive-derived \
+     data, query string, or request body was sent, and nothing changed.";
 
 #[derive(Debug)]
 struct ArchiveState {
@@ -395,7 +408,32 @@ fn session_has_seen_archive(session: &SessionState) -> bool {
 
 /// Closes the network window for the rest of the session.
 fn close_network_window(state: &ArchiveState) {
-    state.network.archive_seen.store(true, Ordering::Release);
+    state.network.archive_seen.store(true, Ordering::SeqCst);
+}
+
+/// Starts an archive interaction only when no updater request is alive.
+///
+/// Setting `archive_seen` first makes the race one-sided: either this call wins
+/// and the network claim refuses, or the network claim is already alive and
+/// this call refuses before opening the native panel. They can never both
+/// proceed.
+fn begin_archive_interaction(state: &ArchiveState) -> Result<(), String> {
+    close_network_window(state);
+    if state.network.operation_in_flight.load(Ordering::SeqCst) {
+        return Err(NETWORK_BUSY_REFUSAL.to_string());
+    }
+    Ok(())
+}
+
+/// Releases the exclusive updater-operation claim on every return path.
+struct NetworkOperationClaim<'a> {
+    in_flight: &'a AtomicBool,
+}
+
+impl Drop for NetworkOperationClaim<'_> {
+    fn drop(&mut self) {
+        self.in_flight.store(false, Ordering::SeqCst);
+    }
 }
 
 /// Refuses unless this is still a launch-time, archive-free session.
@@ -404,8 +442,26 @@ fn close_network_window(state: &ArchiveState) {
 /// no second path. `spend` is the one-shot latch for the operation being
 /// claimed, so an interface that is compromised -- or merely looping on a bug
 /// -- cannot turn the launch check or consented download into a poll.
-fn claim_network_window(state: &ArchiveState, spend: &AtomicBool) -> Result<(), String> {
-    if state.network.archive_seen.load(Ordering::Acquire) {
+fn claim_network_window<'a>(
+    state: &'a ArchiveState,
+    spend: &AtomicBool,
+) -> Result<NetworkOperationClaim<'a>, String> {
+    if state.network.archive_seen.load(Ordering::SeqCst) {
+        return Err(WINDOW_CLOSED_REFUSAL.to_string());
+    }
+    state
+        .network
+        .operation_in_flight
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .map_err(|_| NETWORK_BUSY_REFUSAL.to_string())?;
+    let claim = NetworkOperationClaim {
+        in_flight: &state.network.operation_in_flight,
+    };
+
+    // `archive_seen` may have changed between the optimistic read above and
+    // the exclusive claim. A folder command that raced us sets it before it
+    // checks this claim, so this second read decides which side proceeds.
+    if state.network.archive_seen.load(Ordering::SeqCst) {
         return Err(WINDOW_CLOSED_REFUSAL.to_string());
     }
     {
@@ -421,7 +477,14 @@ fn claim_network_window(state: &ArchiveState, spend: &AtomicBool) -> Result<(), 
     spend
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .map_err(|_| WINDOW_SPENT_REFUSAL.to_string())?;
-    Ok(())
+    // One last read closes the interleaving where an archive interaction set
+    // its latch while the live session was being inspected. If it set the
+    // latch after this read, it necessarily observes `operation_in_flight` and
+    // refuses before opening a panel.
+    if state.network.archive_seen.load(Ordering::SeqCst) {
+        return Err(WINDOW_CLOSED_REFUSAL.to_string());
+    }
+    Ok(claim)
 }
 
 /// Records what the operator should see, and returns it for the same reason.
@@ -477,12 +540,15 @@ async fn check_for_archive_update(
     app: tauri::AppHandle,
     state: State<'_, ArchiveState>,
 ) -> Result<UpdateReport, String> {
-    if let Err(reason) = claim_network_window(&state, &state.network.check_spent) {
-        return Ok(publish_update_report(
-            &state,
-            UpdateReport::Refused { reason },
-        ));
-    }
+    let _network_claim = match claim_network_window(&state, &state.network.check_spent) {
+        Ok(claim) => claim,
+        Err(reason) => {
+            return Ok(publish_update_report(
+                &state,
+                UpdateReport::Refused { reason },
+            ));
+        }
+    };
 
     let installed = app.package_info().version.to_string();
     publish_update_report(&state, UpdateReport::Checking);
@@ -502,7 +568,10 @@ async fn check_for_archive_update(
     };
 
     Ok(match outcome {
-        Ok(Some(update)) => {
+        Ok(Some(mut update)) => {
+            // The manifest check is deliberately short; the consented app
+            // download is larger and gets its own bounded request lifetime.
+            update.timeout = Some(std::time::Duration::from_secs(10 * 60));
             let offered = update.version.clone();
             publish_update_offer(
                 &state,
@@ -520,25 +589,30 @@ async fn check_for_archive_update(
     })
 }
 
-/// Downloads and installs the update the operator just asked for.
+/// Downloads, verifies, and atomically swaps in the update the operator asked for.
 ///
-/// `download_and_install` verifies the minisign signature against the public
-/// key in `tauri.conf.json` -- the same key the main Minutes application signs
-/// with -- before a byte is written anywhere. There is deliberately no other
-/// install path in this file: the plugin's `install` alone would take whatever
-/// bytes it was handed, and a second entry point is how an unverified one gets
-/// added later.
+/// `Update::download` verifies the minisign signature against the public key in
+/// `tauri.conf.json` -- the same key the main Minutes application signs with --
+/// before returning bytes. The pinned plugin's macOS installer is deliberately
+/// not used: it moves the current app into a temporary backup and has failure
+/// paths that can delete that backup. The replacement below is first extracted
+/// and code-signature checked in a sibling directory, then exchanged with the
+/// running bundle in one filesystem operation. A failed exchange changes
+/// neither path.
 #[tauri::command]
 async fn install_archive_update(state: State<'_, ArchiveState>) -> Result<UpdateReport, String> {
     // The same window, for the same reasons. Consent does not reopen it: if the
     // operator approved a folder while the offer was on screen, the answer is
     // no, and quitting and reopening is the way to take it.
-    if let Err(reason) = claim_network_window(&state, &state.network.download_spent) {
-        return Ok(publish_update_report(
-            &state,
-            UpdateReport::Refused { reason },
-        ));
-    }
+    let _network_claim = match claim_network_window(&state, &state.network.download_spent) {
+        Ok(claim) => claim,
+        Err(reason) => {
+            return Ok(publish_update_report(
+                &state,
+                UpdateReport::Refused { reason },
+            ));
+        }
+    };
 
     let offered = state
         .update
@@ -557,16 +631,198 @@ async fn install_archive_update(state: State<'_, ArchiveState>) -> Result<Update
 
     let version = offered.0.version.clone();
     publish_update_report(&state, UpdateReport::Installing);
+    let downloaded = offered.0.download(|_, _| {}, || {}).await;
     Ok(
-        match offered.0.download_and_install(|_, _| {}, || {}).await {
+        match downloaded.and_then(|bytes| {
+            install_verified_archive(&bytes).map_err(tauri_plugin_updater::Error::Io)
+        }) {
             Ok(()) => publish_update_report(&state, UpdateReport::Installed { offered: version }),
-            // Includes a signature that does not verify. The old application is
-            // still in place and still works, which is the whole point of refusing.
+            // Includes a signature or local code-signature failure. The atomic
+            // exchange has not happened, so the current application is unchanged.
             Err(_) => {
                 publish_update_report(&state, UpdateReport::InstallFailed { offered: version })
             }
         },
     )
+}
+
+#[cfg(target_os = "macos")]
+fn running_app_bundle_path() -> std::io::Result<PathBuf> {
+    let executable = std::env::current_exe()?.canonicalize()?;
+    let macos = executable
+        .parent()
+        .ok_or_else(|| std::io::Error::other("running executable has no parent"))?;
+    let contents = macos
+        .parent()
+        .ok_or_else(|| std::io::Error::other("running executable is not in an app bundle"))?;
+    let app = contents
+        .parent()
+        .ok_or_else(|| std::io::Error::other("running executable is not in an app bundle"))?;
+    if macos.file_name().and_then(|name| name.to_str()) != Some("MacOS")
+        || contents.file_name().and_then(|name| name.to_str()) != Some("Contents")
+        || app.extension().and_then(|extension| extension.to_str()) != Some("app")
+    {
+        return Err(std::io::Error::other(
+            "running executable is not in a macOS app bundle",
+        ));
+    }
+    Ok(app.to_path_buf())
+}
+
+#[cfg(target_os = "macos")]
+fn extract_update_archive(bytes: &[u8], destination: &Path) -> std::io::Result<PathBuf> {
+    use flate2::read::GzDecoder;
+    use std::ffi::OsStr;
+    use std::io::Cursor;
+
+    let mut archive = tar::Archive::new(GzDecoder::new(Cursor::new(bytes)));
+    let expected_root = OsStr::new("Minutes Archive.app");
+    let mut saw_payload = false;
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?.into_owned();
+        let mut components = path.components();
+        match components.next() {
+            Some(std::path::Component::Normal(component)) if component == expected_root => {}
+            _ => {
+                return Err(std::io::Error::other(
+                    "update archive has an unexpected top-level path",
+                ));
+            }
+        }
+        if components.any(|component| !matches!(component, std::path::Component::Normal(_))) {
+            return Err(std::io::Error::other(
+                "update archive contains an unsafe path",
+            ));
+        }
+        let kind = entry.header().entry_type();
+        if !kind.is_file() && !kind.is_dir() {
+            return Err(std::io::Error::other(
+                "update archive contains a link or special file",
+            ));
+        }
+        if !entry.unpack_in(destination)? {
+            return Err(std::io::Error::other(
+                "update archive tried to escape its staging directory",
+            ));
+        }
+        saw_payload = true;
+    }
+    let staged_app = destination.join(expected_root);
+    if !saw_payload || !staged_app.is_dir() {
+        return Err(std::io::Error::other(
+            "update archive does not contain Minutes Archive.app",
+        ));
+    }
+    Ok(staged_app)
+}
+
+#[cfg(target_os = "macos")]
+fn reject_links_in_tree(path: &Path) -> std::io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Err(std::io::Error::other(
+            "staged update contains a symbolic link",
+        ));
+    }
+    if metadata.is_dir() {
+        for entry in std::fs::read_dir(path)? {
+            reject_links_in_tree(&entry?.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn verify_staged_archive_app(app: &Path) -> std::io::Result<()> {
+    reject_links_in_tree(app)?;
+    let executable = app.join("Contents/MacOS/minutes-archive-app");
+    if !executable.is_file() {
+        return Err(std::io::Error::other(
+            "staged update has no Archive executable",
+        ));
+    }
+
+    let verification = std::process::Command::new("/usr/bin/codesign")
+        .args(["--verify", "--deep", "--strict", "--verbose=4"])
+        .arg(app)
+        .output()?;
+    if !verification.status.success() {
+        return Err(std::io::Error::other(
+            "staged update failed its Developer ID signature check",
+        ));
+    }
+    let identity = std::process::Command::new("/usr/bin/codesign")
+        .args(["-dv", "--verbose=4"])
+        .arg(app)
+        .output()?;
+    if !identity.status.success() {
+        return Err(std::io::Error::other(
+            "staged update identity could not be read",
+        ));
+    }
+    let details = String::from_utf8_lossy(&identity.stderr);
+    if !details
+        .lines()
+        .any(|line| line == "TeamIdentifier=63TMLKT8HN")
+        || !details
+            .lines()
+            .any(|line| line == "Identifier=com.useminutes.archive")
+    {
+        return Err(std::io::Error::other(
+            "staged update is not the signed Minutes Archive application",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn atomic_swap_paths(first: &Path, second: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let first = CString::new(first.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::other("application path contains a null byte"))?;
+    let second = CString::new(second.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::other("staging path contains a null byte"))?;
+    // Both paths are siblings on the same volume. RENAME_SWAP is one atomic
+    // filesystem transaction: success leaves the new app at the original path
+    // and the old app in staging; failure changes neither path.
+    let result = unsafe {
+        libc::renameatx_np(
+            libc::AT_FDCWD,
+            first.as_ptr(),
+            libc::AT_FDCWD,
+            second.as_ptr(),
+            libc::RENAME_SWAP,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn install_verified_archive(bytes: &[u8]) -> std::io::Result<()> {
+    let current_app = running_app_bundle_path()?;
+    let parent = current_app
+        .parent()
+        .ok_or_else(|| std::io::Error::other("application bundle has no parent"))?;
+    let staging = tempfile::Builder::new()
+        .prefix(".minutes-archive-update-")
+        .tempdir_in(parent)?;
+    let staged_app = extract_update_archive(bytes, staging.path())?;
+    verify_staged_archive_app(&staged_app)?;
+    atomic_swap_paths(&current_app, &staged_app)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn install_verified_archive(_bytes: &[u8]) -> std::io::Result<()> {
+    Err(std::io::Error::other(
+        "Minutes Archive updates are supported only on macOS",
+    ))
 }
 
 /// Counts for the build in flight.
@@ -707,7 +963,7 @@ async fn choose_archive_locations(
     // network window closes here rather than after a folder is actually
     // approved. Cancelling the panel does not reopen it: the intent to point
     // this application at an archive is the event, not the outcome.
-    close_network_window(&state);
+    begin_archive_interaction(&state)?;
     let selected = app
         .dialog()
         .file()
@@ -2477,16 +2733,15 @@ mod tests {
     #[test]
     fn a_launch_session_that_has_seen_nothing_may_check_once() {
         let state = ArchiveState::default();
-        assert_eq!(
-            claim_network_window(&state, &state.network.check_spent),
-            Ok(())
-        );
+        let claim = claim_network_window(&state, &state.network.check_spent)
+            .expect("a pristine session may claim its launch check");
+        drop(claim);
         // ...and exactly once. The claim on screen and in Peter's disclosure is
         // "one request", so a second call is refused even though nothing about
         // the session has changed.
         assert_eq!(
-            claim_network_window(&state, &state.network.check_spent),
-            Err(WINDOW_SPENT_REFUSAL.to_string())
+            claim_network_window(&state, &state.network.check_spent).err(),
+            Some(WINDOW_SPENT_REFUSAL.to_string())
         );
     }
 
@@ -2512,8 +2767,8 @@ mod tests {
             });
 
         assert_eq!(
-            claim_network_window(&state, &state.network.check_spent),
-            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            claim_network_window(&state, &state.network.check_spent).err(),
+            Some(WINDOW_CLOSED_REFUSAL.to_string()),
             "an update check was permitted after a folder was approved"
         );
         assert!(
@@ -2523,8 +2778,8 @@ mod tests {
         // The download path is the same gate, so consenting to an install the
         // operator was offered before approving a folder is refused too.
         assert_eq!(
-            claim_network_window(&state, &state.network.download_spent),
-            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            claim_network_window(&state, &state.network.download_spent).err(),
+            Some(WINDOW_CLOSED_REFUSAL.to_string()),
             "an update download was permitted after a folder was approved"
         );
     }
@@ -2567,8 +2822,8 @@ mod tests {
         state.session.lock().expect("session").text_vault = Some(vault);
 
         assert_eq!(
-            claim_network_window(&state, &state.network.check_spent),
-            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            claim_network_window(&state, &state.network.check_spent).err(),
+            Some(WINDOW_CLOSED_REFUSAL.to_string()),
             "an update check was permitted while an index of the operator's documents was open"
         );
     }
@@ -2606,8 +2861,8 @@ mod tests {
         }
 
         assert_eq!(
-            claim_network_window(&state, &state.network.check_spent),
-            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            claim_network_window(&state, &state.network.check_spent).err(),
+            Some(WINDOW_CLOSED_REFUSAL.to_string()),
             "removing the approved location reopened the network window"
         );
     }
@@ -2618,8 +2873,150 @@ mod tests {
         let state = ArchiveState::default();
         state.session.lock().expect("session").scan.running = true;
         assert_eq!(
-            claim_network_window(&state, &state.network.check_spent),
-            Err(WINDOW_CLOSED_REFUSAL.to_string())
+            claim_network_window(&state, &state.network.check_spent).err(),
+            Some(WINDOW_CLOSED_REFUSAL.to_string())
+        );
+    }
+
+    /// A direct IPC race cannot overlap the updater with a native folder panel.
+    ///
+    /// UI buttons are disabled while the request is alive, but that is a
+    /// convenience, not the boundary. This exercises the Rust arbitration
+    /// that a compromised webview cannot bypass.
+    #[test]
+    fn an_archive_interaction_cannot_overlap_a_network_operation() {
+        let state = ArchiveState::default();
+        let claim = claim_network_window(&state, &state.network.check_spent)
+            .expect("the launch check should own the operation slot");
+
+        assert_eq!(
+            begin_archive_interaction(&state),
+            Err(NETWORK_BUSY_REFUSAL.to_string()),
+            "a folder panel could open while update traffic was alive"
+        );
+        assert!(
+            state.network.archive_seen.load(Ordering::SeqCst),
+            "the racing folder request did not close the network window"
+        );
+
+        drop(claim);
+        assert_eq!(
+            claim_network_window(&state, &state.network.download_spent).err(),
+            Some(WINDOW_CLOSED_REFUSAL.to_string()),
+            "the completed update operation reopened the raced window"
+        );
+    }
+
+    #[test]
+    fn a_network_operation_cannot_start_after_archive_interaction_begins() {
+        let state = ArchiveState::default();
+        begin_archive_interaction(&state).expect("an idle launch may open its folder panel");
+        assert_eq!(
+            claim_network_window(&state, &state.network.check_spent).err(),
+            Some(WINDOW_CLOSED_REFUSAL.to_string())
+        );
+        assert!(
+            !state.network.check_spent.load(Ordering::Acquire),
+            "a refused race consumed the one launch check"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    fn synthetic_update_archive(include_link: bool) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Cursor;
+
+        let encoder = GzEncoder::new(Vec::new(), Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        for path in [
+            "Minutes Archive.app/",
+            "Minutes Archive.app/Contents/",
+            "Minutes Archive.app/Contents/MacOS/",
+        ] {
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Directory);
+            header.set_mode(0o755);
+            header.set_size(0);
+            header.set_cksum();
+            archive
+                .append_data(&mut header, path, std::io::empty())
+                .expect("append directory");
+        }
+
+        let payload = b"synthetic signed executable";
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o755);
+        header.set_size(payload.len() as u64);
+        header.set_cksum();
+        archive
+            .append_data(
+                &mut header,
+                "Minutes Archive.app/Contents/MacOS/minutes-archive-app",
+                Cursor::new(payload),
+            )
+            .expect("append executable");
+
+        if include_link {
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_mode(0o777);
+            header.set_size(0);
+            header.set_cksum();
+            archive
+                .append_link(
+                    &mut header,
+                    "Minutes Archive.app/Contents/escape",
+                    "/tmp/outside",
+                )
+                .expect("append link");
+        }
+
+        archive
+            .into_inner()
+            .expect("finish tar")
+            .finish()
+            .expect("finish gzip")
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn updater_extraction_accepts_only_one_link_free_archive_bundle() {
+        let destination = TempDir::new().expect("destination");
+        let app = extract_update_archive(&synthetic_update_archive(false), destination.path())
+            .expect("extract safe update");
+        assert_eq!(
+            fs::read(app.join("Contents/MacOS/minutes-archive-app")).expect("read payload"),
+            b"synthetic signed executable"
+        );
+
+        let refused = TempDir::new().expect("refused destination");
+        assert!(
+            extract_update_archive(&synthetic_update_archive(true), refused.path()).is_err(),
+            "a linked updater archive crossed the staging boundary"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn updater_replacement_is_one_atomic_exchange() {
+        let temp = TempDir::new().expect("temp");
+        let current = temp.path().join("Minutes Archive.app");
+        let staged = temp.path().join("staged.app");
+        fs::create_dir(&current).expect("current app");
+        fs::create_dir(&staged).expect("staged app");
+        fs::write(current.join("identity"), b"current").expect("current marker");
+        fs::write(staged.join("identity"), b"staged").expect("staged marker");
+
+        atomic_swap_paths(&current, &staged).expect("atomic app exchange");
+        assert_eq!(
+            fs::read(current.join("identity")).expect("new app"),
+            b"staged"
+        );
+        assert_eq!(
+            fs::read(staged.join("identity")).expect("old app"),
+            b"current"
         );
     }
 

--- a/archive/src-tauri/src/main.rs
+++ b/archive/src-tauri/src/main.rs
@@ -24,7 +24,9 @@ use minutes_archive_worker_control::LiveWorkerProcesses;
 use serde::Serialize;
 use std::fs;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{Manager, State};

--- a/archive/src-tauri/src/main.rs
+++ b/archive/src-tauri/src/main.rs
@@ -3016,6 +3016,44 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn updater_rejects_an_ad_hoc_signature_without_developer_id_trust() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp");
+        let app = temp.path().join("Minutes Archive.app");
+        let contents = app.join("Contents");
+        let executable = contents.join("MacOS/minutes-archive-app");
+        fs::create_dir_all(executable.parent().expect("executable parent"))
+            .expect("create synthetic app");
+        fs::write(&executable, b"#!/bin/sh\nexit 0\n").expect("write executable");
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))
+            .expect("make executable");
+        fs::write(
+            contents.join("Info.plist"),
+            br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>minutes-archive-app</string>
+<key>CFBundleIdentifier</key><string>com.useminutes.archive</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+</dict></plist>
+"#,
+        )
+        .expect("write plist");
+        let signed = std::process::Command::new("/usr/bin/codesign")
+            .args(["--force", "--deep", "--sign", "-"])
+            .arg(&app)
+            .status()
+            .expect("run ad hoc signing");
+        assert!(signed.success(), "construct the negative-control bundle");
+        assert!(
+            verify_staged_archive_app(&app).is_err(),
+            "an internally valid ad hoc signature crossed the Developer ID boundary"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn updater_replacement_is_one_atomic_exchange() {
         let temp = TempDir::new().expect("temp");
         let current = temp.path().join("Minutes Archive.app");

--- a/archive/src-tauri/src/main.rs
+++ b/archive/src-tauri/src/main.rs
@@ -29,6 +29,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{Manager, State};
 use tauri_plugin_dialog::DialogExt;
+use tauri_plugin_updater::UpdaterExt;
 
 const NATIVE_LIFECYCLE_SELFTEST_MARKER: &str = "--archive-native-lifecycle-selftest";
 /// Proves the SIGNED application can actually run its own workers.
@@ -70,6 +71,131 @@ struct SessionState {
     scan: ScanControl,
 }
 
+/// The single network exception, and the thing that keeps it single.
+///
+/// Minutes Archive is network-denied everywhere it can be: both worker
+/// processes run under a seatbelt profile carrying `(deny network*)`, and the
+/// parent holds no entitlement it could use to reach anywhere. The updater
+/// makes the parent the one exception, because the attorney this is built for
+/// cannot be asked to notice a release and download the application again.
+///
+/// An exception kept by convention becomes a habit. So the window is closed by
+/// the session's own state rather than by remembering not to call: the instant
+/// anything of the operator's archive is in this process -- an approved folder,
+/// a census, an index, a scan in flight -- every network operation is refused
+/// for the rest of the session, and the refusal is what the interface shows.
+#[derive(Debug, Default)]
+struct NetworkWindow {
+    /// Closed the moment this session takes on anything of the archive, and
+    /// never reopened.
+    ///
+    /// Deliberately here rather than in `SessionState`: `purge_session`
+    /// replaces that whole value with a default, and a latch a reset can clear
+    /// is not a latch. Removing an approved location does not un-see it either
+    /// -- approve, remove, then check would otherwise reopen the window.
+    archive_seen: AtomicBool,
+    /// Spent by the one permitted check.
+    ///
+    /// One-shot rather than rate-limited. A repeated check is a beacon whether
+    /// or not it carries anything.
+    check_spent: AtomicBool,
+    /// Spent by the one permitted download, which happens only if the operator
+    /// asks for it.
+    download_spent: AtomicBool,
+}
+
+/// The one update this session may install, held between the check and consent.
+///
+/// Held rather than re-checked. Consent must not cost a second request to the
+/// same file, and re-checking at install time would let the answer change
+/// between what the operator was shown and what gets installed.
+struct OfferedUpdate(tauri_plugin_updater::Update);
+
+impl std::fmt::Debug for OfferedUpdate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The version only. The rest of `Update` carries a download URL and a
+        // signature that have no business in a debug line.
+        formatter
+            .debug_struct("OfferedUpdate")
+            .field("version", &self.0.version)
+            .finish()
+    }
+}
+
+/// What the launch check found, and the update it may install.
+#[derive(Debug, Default)]
+struct UpdateSlot {
+    report: UpdateReport,
+    offered: Option<OfferedUpdate>,
+}
+
+/// What the interface is told about the update check.
+///
+/// Every state is visible: there is no branch here that checks quietly, and no
+/// branch that installs without the operator asking. The only two values that
+/// ever come from the network are `offered` and the presence of an update at
+/// all -- both are semver strings the plugin has already parsed. Release notes
+/// are deliberately not carried: they are remote-controlled prose, and an
+/// attorney reading them inside a tool that promises to show only their own
+/// documents is a worse trade than not showing them.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(tag = "state", rename_all = "camelCase")]
+enum UpdateReport {
+    /// No check has run in this session yet.
+    #[default]
+    NotChecked,
+    Checking,
+    /// The check ran and this build is the current one.
+    Current {
+        installed: String,
+    },
+    /// The check ran and a newer signed build exists. Nothing is downloaded
+    /// until the operator asks.
+    Available {
+        installed: String,
+        offered: String,
+    },
+    /// The window was closed before the check could run. Not an error: this is
+    /// the boundary doing its job, and it says so in those words.
+    Refused {
+        reason: String,
+    },
+    /// The check ran and could not complete. The application is unaffected.
+    Unavailable {
+        reason: String,
+    },
+    Installing,
+    /// A signed build was verified and written into place.
+    Installed {
+        offered: String,
+    },
+    /// Verification or replacement failed. The current app remains intact and
+    /// the notarized DMG is the explicit recovery path.
+    InstallFailed {
+        offered: String,
+    },
+}
+
+/// Shown when the session has already seen the operator's archive.
+const WINDOW_CLOSED_REFUSAL: &str =
+    "Minutes Archive has already opened this session's archive, so it will not \
+     use the network again until you quit and reopen it.";
+
+/// Shown when one of the two bounded update steps is attempted twice.
+const WINDOW_SPENT_REFUSAL: &str =
+    "Minutes Archive allows each update step once per session, and this step \
+     already ran.";
+
+/// Shown when the request could not be completed, for any reason at all.
+///
+/// One sentence for offline, endpoint down, DNS failure, malformed JSON, and a
+/// signature that does not verify. Distinguishing them would tell the operator
+/// nothing they can act on, and the raw error text is the one place a URL or a
+/// local path could leak into the interface.
+const UPDATE_UNAVAILABLE: &str =
+    "Minutes Archive could not reach the update file. Nothing was sent and \
+     nothing changed.";
+
 #[derive(Debug)]
 struct ArchiveState {
     session: Mutex<SessionState>,
@@ -77,6 +203,10 @@ struct ArchiveState {
     /// Every converter, recogniser, and semantic worker alive in this process.
     /// Purge kills their process groups before the desktop process exits.
     live_workers: LiveWorkerProcesses,
+    /// The single network exception. See `NetworkWindow`.
+    network: NetworkWindow,
+    /// What the launch check found, and the update it may install.
+    update: Mutex<UpdateSlot>,
     /// Snapshot directories of workers that are currently alive.
     ///
     /// During a vault build the converter and engine live inside a blocking
@@ -99,6 +229,8 @@ impl Default for ArchiveState {
             session: Mutex::new(SessionState::default()),
             next_location_id: AtomicU64::new(1),
             live_workers: LiveWorkerProcesses::default(),
+            network: NetworkWindow::default(),
+            update: Mutex::new(UpdateSlot::default()),
             live_snapshots: Arc::new(Mutex::new(Vec::new())),
             build_progress: Mutex::new(Arc::new(BuildProgress::default())),
         }
@@ -168,16 +300,18 @@ struct BootstrapState {
     scan_running: bool,
     report: Option<CensusReport>,
     text_vault_report: Option<DocumentVaultBuildReport>,
+    /// Carried here so a reloaded webview shows the result of the check that
+    /// already ran instead of asking for another one. The window would refuse
+    /// the second request anyway; this is what stops the interface from having
+    /// to ask to find that out.
+    update: UpdateReport,
 }
 
 /// Version plus a short digest of the executable that is actually running.
 ///
-/// Reads nothing but its own binary and reaches no network -- the whole point
-/// of this application is that it does not, and knowing which build you have
-/// must not be the exception. Auto-update was considered and deliberately not
-/// wired: docs/investigations/auto-update-evaluation.md holds the decision, and
-/// a shipped updater endpoint sat in the configuration for a while contradicting
-/// the "networking disabled by design" line in this app's own footer.
+/// Reads nothing but its own binary and reaches no network. Update traffic is
+/// handled separately by the one-shot, launch-only window below; identifying
+/// the build itself never depends on that window or on a remote service.
 fn build_identity() -> String {
     let version = env!("CARGO_PKG_VERSION");
     let digest = std::env::current_exe()
@@ -243,6 +377,196 @@ fn ensure_scan_idle(session: &SessionState) -> Result<(), String> {
         return Err("Wait for the current census to finish or cancel it first.".to_string());
     }
     Ok(())
+}
+
+/// True once this session holds anything that came from the operator's archive.
+///
+/// Reads the live session rather than a flag someone has to remember to set, so
+/// a field added to `SessionState` later -- another cache, another report --
+/// closes the window even if whoever adds it never thinks about the updater.
+/// The latch in `NetworkWindow` covers the other direction: state that was
+/// here and has since been cleared.
+fn session_has_seen_archive(session: &SessionState) -> bool {
+    !session.locations.is_empty()
+        || session.last_report.is_some()
+        || session.text_vault.is_some()
+        || session.scan.running
+}
+
+/// Closes the network window for the rest of the session.
+fn close_network_window(state: &ArchiveState) {
+    state.network.archive_seen.store(true, Ordering::Release);
+}
+
+/// Refuses unless this is still a launch-time, archive-free session.
+///
+/// Every network operation in the application goes through here, and there is
+/// no second path. `spend` is the one-shot latch for the operation being
+/// claimed, so an interface that is compromised -- or merely looping on a bug
+/// -- cannot turn the launch check or consented download into a poll.
+fn claim_network_window(state: &ArchiveState, spend: &AtomicBool) -> Result<(), String> {
+    if state.network.archive_seen.load(Ordering::Acquire) {
+        return Err(WINDOW_CLOSED_REFUSAL.to_string());
+    }
+    {
+        let session = state.session.lock().map_err(|_| lock_error())?;
+        if session_has_seen_archive(&session) {
+            // Observing it is enough to close it permanently. Whatever put the
+            // archive into this session, the window does not reopen when it
+            // goes away again.
+            close_network_window(state);
+            return Err(WINDOW_CLOSED_REFUSAL.to_string());
+        }
+    }
+    spend
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .map_err(|_| WINDOW_SPENT_REFUSAL.to_string())?;
+    Ok(())
+}
+
+/// Records what the operator should see, and returns it for the same reason.
+///
+/// Leaves any held offer alone. Reporting a refusal is not a reason to discard
+/// an offer the operator was already shown: the gate decides whether it can be
+/// installed, and it decides that at install time.
+fn publish_update_report(state: &ArchiveState, report: UpdateReport) -> UpdateReport {
+    if let Ok(mut slot) = state.update.lock() {
+        slot.report = report.clone();
+    }
+    report
+}
+
+/// Holds the offer the operator may consent to, alongside the report naming it.
+fn publish_update_offer(
+    state: &ArchiveState,
+    report: UpdateReport,
+    offered: OfferedUpdate,
+) -> UpdateReport {
+    if let Ok(mut slot) = state.update.lock() {
+        slot.report = report.clone();
+        slot.offered = Some(offered);
+    }
+    report
+}
+
+/// What the launch check found, for an interface that has just loaded.
+#[tauri::command]
+fn archive_update_report(state: State<'_, ArchiveState>) -> UpdateReport {
+    state
+        .update
+        .lock()
+        .map(|slot| slot.report.clone())
+        .unwrap_or_default()
+}
+
+/// The one automatic network request Minutes Archive is allowed to make.
+///
+/// A plain GET of a static JSON file. Nothing is appended to it: the configured
+/// endpoint carries none of the `{{current_version}}`, `{{target}}` or
+/// `{{arch}}` placeholders the plugin would otherwise substitute, `clear_headers`
+/// removes anything a caller might have attached, and no identifier, count, or
+/// value derived from a document exists in this process yet to send. The
+/// request is made before the operator has approved a folder, so there is
+/// nothing about their archive to leak even in principle.
+///
+/// Never returns `Err`. A refusal, an unreachable endpoint, a malformed file
+/// and an offline Mac are all ordinary reports the interface renders, because
+/// the application must work exactly as it does today when the check fails.
+#[tauri::command]
+async fn check_for_archive_update(
+    app: tauri::AppHandle,
+    state: State<'_, ArchiveState>,
+) -> Result<UpdateReport, String> {
+    if let Err(reason) = claim_network_window(&state, &state.network.check_spent) {
+        return Ok(publish_update_report(
+            &state,
+            UpdateReport::Refused { reason },
+        ));
+    }
+
+    let installed = app.package_info().version.to_string();
+    publish_update_report(&state, UpdateReport::Checking);
+
+    // Keep launch usable when the release host is slow or unreachable. The
+    // folder controls stay disabled while this request is alive so the app
+    // cannot begin holding archive state while its automatic network request is
+    // still in flight.
+    let outcome = match app
+        .updater_builder()
+        .clear_headers()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(updater) => updater.check().await,
+        Err(error) => Err(error),
+    };
+
+    Ok(match outcome {
+        Ok(Some(update)) => {
+            let offered = update.version.clone();
+            publish_update_offer(
+                &state,
+                UpdateReport::Available { installed, offered },
+                OfferedUpdate(update),
+            )
+        }
+        Ok(None) => publish_update_report(&state, UpdateReport::Current { installed }),
+        Err(_) => publish_update_report(
+            &state,
+            UpdateReport::Unavailable {
+                reason: UPDATE_UNAVAILABLE.to_string(),
+            },
+        ),
+    })
+}
+
+/// Downloads and installs the update the operator just asked for.
+///
+/// `download_and_install` verifies the minisign signature against the public
+/// key in `tauri.conf.json` -- the same key the main Minutes application signs
+/// with -- before a byte is written anywhere. There is deliberately no other
+/// install path in this file: the plugin's `install` alone would take whatever
+/// bytes it was handed, and a second entry point is how an unverified one gets
+/// added later.
+#[tauri::command]
+async fn install_archive_update(state: State<'_, ArchiveState>) -> Result<UpdateReport, String> {
+    // The same window, for the same reasons. Consent does not reopen it: if the
+    // operator approved a folder while the offer was on screen, the answer is
+    // no, and quitting and reopening is the way to take it.
+    if let Err(reason) = claim_network_window(&state, &state.network.download_spent) {
+        return Ok(publish_update_report(
+            &state,
+            UpdateReport::Refused { reason },
+        ));
+    }
+
+    let offered = state
+        .update
+        .lock()
+        .map_err(|_| lock_error())?
+        .offered
+        .take();
+    let Some(offered) = offered else {
+        return Ok(publish_update_report(
+            &state,
+            UpdateReport::Refused {
+                reason: "No update was offered in this session.".to_string(),
+            },
+        ));
+    };
+
+    let version = offered.0.version.clone();
+    publish_update_report(&state, UpdateReport::Installing);
+    Ok(
+        match offered.0.download_and_install(|_, _| {}, || {}).await {
+            Ok(()) => publish_update_report(&state, UpdateReport::Installed { offered: version }),
+            // Includes a signature that does not verify. The old application is
+            // still in place and still works, which is the whole point of refusing.
+            Err(_) => {
+                publish_update_report(&state, UpdateReport::InstallFailed { offered: version })
+            }
+        },
+    )
 }
 
 /// Counts for the build in flight.
@@ -362,6 +686,11 @@ fn archive_bootstrap(state: State<'_, ArchiveState>) -> Result<BootstrapState, S
             .text_vault
             .as_ref()
             .map(|vault| vault.build_report().clone()),
+        update: state
+            .update
+            .lock()
+            .map(|slot| slot.report.clone())
+            .unwrap_or_default(),
     })
 }
 
@@ -374,6 +703,11 @@ async fn choose_archive_locations(
         let session = state.session.lock().map_err(|_| lock_error())?;
         ensure_scan_idle(&session)?;
     }
+    // Launch is over the moment the operator reaches for a folder, so the
+    // network window closes here rather than after a folder is actually
+    // approved. Cancelling the panel does not reopen it: the intent to point
+    // this application at an archive is the event, not the outcome.
+    close_network_window(&state);
     let selected = app
         .dialog()
         .file()
@@ -1308,6 +1642,13 @@ fn main() {
     tauri::Builder::default()
         .manage(ArchiveState::default())
         .plugin(tauri_plugin_dialog::init())
+        // Registered for the Rust side only. `archive-main` deliberately does
+        // not carry `updater:default`, so the plugin's own commands are not
+        // reachable from the webview: the only way to the network is through
+        // the two gated commands below, and the capability file stays the
+        // literal statement the security packet cites -- no updater capability
+        // is exposed to the interface.
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(move |app| {
             // Erase any panel state a PREVIOUS run left behind, before this
             // one can show a window. The erasure after each panel and at
@@ -1375,6 +1716,9 @@ fn main() {
             reveal_archive_document,
             reveal_archive_location,
             search_archive_text_vault,
+            archive_update_report,
+            check_for_archive_update,
+            install_archive_update,
         ])
         .build(tauri::generate_context!())
         .expect("Minutes Archive failed to start")
@@ -1512,6 +1856,16 @@ fn purge_archive_state(state: &ArchiveState) {
     // process group while the desktop process is still alive; each launcher
     // then reaps and deregisters its child as cancellation unwinds the build.
     state.live_workers.terminate_all();
+
+    // The offer holds a download URL and a signature. Neither is privileged,
+    // but nothing here should outlive the session it was fetched in, and the
+    // window is closed by then in any case.
+    let mut update = state
+        .update
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    update.offered = None;
+    drop(update);
 
     let mut snapshots = state
         .live_snapshots
@@ -2113,6 +2467,198 @@ mod tests {
                 0o600
             );
         }
+    }
+
+    /// A pristine session is the only one that may reach the network.
+    ///
+    /// Stated first so the refusal tests below cannot pass vacuously: if the
+    /// window never opened at all they would still be green, and the feature
+    /// would be broken rather than safe.
+    #[test]
+    fn a_launch_session_that_has_seen_nothing_may_check_once() {
+        let state = ArchiveState::default();
+        assert_eq!(
+            claim_network_window(&state, &state.network.check_spent),
+            Ok(())
+        );
+        // ...and exactly once. The claim on screen and in Peter's disclosure is
+        // "one request", so a second call is refused even though nothing about
+        // the session has changed.
+        assert_eq!(
+            claim_network_window(&state, &state.network.check_spent),
+            Err(WINDOW_SPENT_REFUSAL.to_string())
+        );
+    }
+
+    /// An approved location ends the network window for the whole session.
+    #[test]
+    fn an_update_check_is_refused_once_a_location_is_approved() {
+        let temp = TempDir::new().expect("temp");
+        let client = temp.path().join("client-matter");
+        fs::create_dir(&client).expect("client folder");
+        let mut roots = approve_roots(&[client]).expect("approve");
+
+        let state = ArchiveState::default();
+        // Only the approved location closes the window: no census has run and
+        // no index exists, so this test pins that one condition alone.
+        state
+            .session
+            .lock()
+            .expect("session")
+            .locations
+            .push(ApprovedLocation {
+                id: 1,
+                root: roots.remove(0),
+            });
+
+        assert_eq!(
+            claim_network_window(&state, &state.network.check_spent),
+            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            "an update check was permitted after a folder was approved"
+        );
+        assert!(
+            !state.network.check_spent.load(Ordering::Acquire),
+            "a refused check still consumed the session's one request"
+        );
+        // The download path is the same gate, so consenting to an install the
+        // operator was offered before approving a folder is refused too.
+        assert_eq!(
+            claim_network_window(&state, &state.network.download_spent),
+            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            "an update download was permitted after a folder was approved"
+        );
+    }
+
+    /// An existing index ends the network window for the whole session.
+    ///
+    /// Built through the real vault builder rather than by setting a flag: the
+    /// invariant is about the process holding the operator's document text, and
+    /// a test that stubs the vault would keep passing if the field it guards
+    /// were renamed or replaced.
+    #[test]
+    fn an_update_check_is_refused_once_an_index_exists() {
+        use minutes_archive_core::vault::build_authorized_text_vault;
+
+        let temp = TempDir::new().expect("temp");
+        let client = temp.path().join("client-matter");
+        fs::create_dir(&client).expect("client folder");
+        fs::write(
+            client.join("agreement.txt"),
+            b"7. CONFIDENTIALITY\nRecipient shall protect Confidential Information.\n",
+        )
+        .expect("synthetic document");
+        let roots = approve_roots(&[client]).expect("approve");
+        let vault = build_authorized_text_vault(
+            VaultId::parse("gate-probe").expect("vault"),
+            &roots,
+            DocumentVaultLimits::default(),
+            &AtomicBool::new(false),
+        )
+        .expect("index");
+        assert_eq!(
+            vault.build_report().indexed_documents,
+            1,
+            "the fixture built an empty index; this test would prove nothing"
+        );
+
+        let state = ArchiveState::default();
+        // No approved locations recorded and no census report: the index alone
+        // is what must close the window.
+        state.session.lock().expect("session").text_vault = Some(vault);
+
+        assert_eq!(
+            claim_network_window(&state, &state.network.check_spent),
+            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            "an update check was permitted while an index of the operator's documents was open"
+        );
+    }
+
+    /// Removing what closed the window does not reopen it.
+    ///
+    /// The live-state read alone would let approve, remove, then check through,
+    /// because after the removal the session looks untouched again. It is not:
+    /// the operator has pointed this application at an archive, and the process
+    /// has held its roots.
+    #[test]
+    fn removing_an_approved_location_does_not_reopen_the_window() {
+        let temp = TempDir::new().expect("temp");
+        let client = temp.path().join("client-matter");
+        fs::create_dir(&client).expect("client folder");
+        let mut roots = approve_roots(&[client]).expect("approve");
+
+        let state = ArchiveState::default();
+        {
+            let mut session = state.session.lock().expect("session");
+            close_network_window(&state);
+            session.locations.push(ApprovedLocation {
+                id: 1,
+                root: roots.remove(0),
+            });
+            assert_eq!(session.locations.len(), 1);
+            // What `remove_archive_location` does to the session.
+            session.locations.clear();
+            session.last_report = None;
+            session.text_vault = None;
+            assert!(
+                !session_has_seen_archive(&session),
+                "the session no longer looks touched, which is what makes the latch necessary"
+            );
+        }
+
+        assert_eq!(
+            claim_network_window(&state, &state.network.check_spent),
+            Err(WINDOW_CLOSED_REFUSAL.to_string()),
+            "removing the approved location reopened the network window"
+        );
+    }
+
+    /// A running census closes the window even before it has produced a report.
+    #[test]
+    fn an_update_check_is_refused_while_a_census_is_running() {
+        let state = ArchiveState::default();
+        state.session.lock().expect("session").scan.running = true;
+        assert_eq!(
+            claim_network_window(&state, &state.network.check_spent),
+            Err(WINDOW_CLOSED_REFUSAL.to_string())
+        );
+    }
+
+    /// A refusal never reaches the operator as a raw error string.
+    ///
+    /// `UpdateReport` is the only thing that crosses IPC for the updater, and
+    /// the endpoint URL, the download URL and the signature must stay behind
+    /// the boundary the same way document paths do.
+    #[test]
+    fn the_update_report_carries_no_endpoint_or_signature() {
+        let report = UpdateReport::Available {
+            installed: "0.1.0".to_string(),
+            offered: "0.2.0".to_string(),
+        };
+        let serialized = serde_json::to_string(&report).expect("serialize report");
+        assert_eq!(
+            serialized,
+            r#"{"state":"available","installed":"0.1.0","offered":"0.2.0"}"#
+        );
+        for forbidden in ["http", "github", "signature", "/"] {
+            assert!(
+                !serialized.contains(forbidden),
+                "{forbidden} reached the interface"
+            );
+        }
+
+        let refused = serde_json::to_string(&UpdateReport::Refused {
+            reason: WINDOW_CLOSED_REFUSAL.to_string(),
+        })
+        .expect("serialize refusal");
+        assert!(refused.contains("quit and reopen"));
+        assert!(!refused.contains("http"));
+
+        let failed = serde_json::to_string(&UpdateReport::InstallFailed {
+            offered: "0.2.0".to_string(),
+        })
+        .expect("serialize failed install");
+        assert_eq!(failed, r#"{"state":"installFailed","offered":"0.2.0"}"#);
+        assert!(!failed.contains("http"));
     }
 
     #[cfg(unix)]

--- a/archive/src-tauri/tauri.conf.json
+++ b/archive/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Minutes Archive",
   "identifier": "com.useminutes.archive",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "build": {
     "frontendDist": "../src"
   },
@@ -27,15 +27,28 @@
   },
   "bundle": {
     "active": true,
-    "createUpdaterArtifacts": false,
+    "createUpdaterArtifacts": true,
     "icon": [
       "../../tauri/src-tauri/icons/icon.icns",
       "../../tauri/src-tauri/icons/icon.ico",
       "../../tauri/src-tauri/icons/app-icon.png"
     ],
     "macOS": {
-      "minimumSystemVersion": "13.0"
+      "minimumSystemVersion": "13.0",
+      "dmg": {
+        "background": "../../tauri/src-tauri/dmg-background.png",
+        "windowSize": { "width": 660, "height": 400 },
+        "appPosition": { "x": 180, "y": 200 },
+        "applicationFolderPosition": { "x": 480, "y": 200 }
+      }
     }
   },
-  "plugins": {}
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUyMjA0OUE4OTg1RjhCNDYKUldSR2kxK1lxRWtnNHRKQ2ZxenRqN1V6cFhCSUFDT0tZVTBHUk1LdGJuOFJzdTVkd2xsNjZFQTUK",
+      "endpoints": [
+        "https://github.com/silverstein/minutes/releases/download/archive-stable/latest-archive.json"
+      ]
+    }
+  }
 }

--- a/archive/src/app.js
+++ b/archive/src/app.js
@@ -43,6 +43,11 @@ const elements = {
   searchStatus: document.querySelector("#search-status"),
   searchResults: document.querySelector("#search-results"),
   buildIdentity: document.querySelector("#build-identity"),
+  updateStrip: document.querySelector("#update-strip"),
+  updateDot: document.querySelector("#update-dot"),
+  updateHeadline: document.querySelector("#update-headline"),
+  updateDetail: document.querySelector("#update-detail"),
+  installUpdate: document.querySelector("#install-update"),
 };
 
 let locations = [];
@@ -1070,6 +1075,114 @@ function backToCensus() {
   else showView("setup");
 }
 
+// Every state the update flow can be in, written out.
+//
+// Nothing here is a template that interpolates remote text: the only value
+// from the network that reaches this file is a version string the Rust side
+// received as parsed semver, and it goes through `textContent`. Release notes
+// are deliberately not carried across the boundary at all.
+const updateCopy = {
+  notChecked: () => ({
+    headline: "No update check has run",
+    detail:
+      "Minutes Archive checks once when it opens, before any folder is approved.",
+  }),
+  checking: () => ({
+    headline: "Checking for a signed update",
+    detail:
+      "One request for a version file, made before any folder is approved. " +
+      "Nothing about you or your documents is sent.",
+  }),
+  current: (report) => ({
+    headline: `Minutes Archive ${report.installed} is up to date`,
+    detail:
+      "The check is finished. Minutes Archive will not use the network again " +
+      "in this session.",
+  }),
+  available: (report) => ({
+    headline: `Version ${report.offered} is available`,
+    detail:
+      `You have ${report.installed}. Nothing has been downloaded. If you ` +
+      "install it, the download is checked against the Minutes signing key " +
+      "before anything is replaced. You can ignore this and keep your current version.",
+  }),
+  installing: () => ({
+    headline: "Downloading and verifying the update",
+    detail:
+      "The download is refused unless it carries a valid Minutes signature.",
+  }),
+  installed: (report) => ({
+    headline: `Version ${report.offered} is installed`,
+    detail: "Quit Minutes Archive and open it again to use the new version.",
+  }),
+  installFailed: (report) => ({
+    headline: `Version ${report.offered} was not installed`,
+    detail:
+      "Your current app is unchanged. Use the signed Minutes Archive DMG from " +
+      "the release page, or contact the pilot operator.",
+  }),
+  refused: (report) => ({
+    headline: "Update check declined",
+    detail: report.reason,
+  }),
+  unavailable: (report) => ({
+    headline: "No update check was completed",
+    detail: `${report.reason} Minutes Archive works exactly as it did before.`,
+  }),
+};
+
+function renderUpdate(report) {
+  // An unrecognised state must not blank the strip: the operator is entitled
+  // to see that the network surface exists even if this file does not know
+  // what to call the state it is in.
+  const copy = (updateCopy[report?.state] ?? updateCopy.notChecked)(report ?? {});
+  elements.updateStrip.dataset.state = report?.state ?? "notChecked";
+  elements.updateHeadline.textContent = copy.headline;
+  elements.updateDetail.textContent = copy.detail;
+  // The install button appears only against a live offer, so there is no
+  // control on screen that could start a download at any other moment.
+  elements.installUpdate.hidden = report?.state !== "available";
+  elements.installUpdate.disabled = false;
+  elements.updateStrip.hidden = false;
+}
+
+async function checkForUpdate() {
+  // Do not let the operator approve a folder while the automatic check is
+  // still in flight. This is normally a fraction of a second and is bounded
+  // by the Rust-side timeout.
+  setLocationControlsDisabled(true);
+  renderUpdate({ state: "checking" });
+  try {
+    renderUpdate(await invoke("check_for_archive_update"));
+  } catch {
+    // The command is written never to fail, so reaching here means the IPC
+    // call itself did. Either way a failed check is one line of text and
+    // nothing else: no retry, no banner, no interruption to the session.
+    renderUpdate({
+      state: "unavailable",
+      reason: "Minutes Archive could not run the update check.",
+    });
+  } finally {
+    setLocationControlsDisabled(false);
+  }
+}
+
+async function installUpdate() {
+  setLocationControlsDisabled(true);
+  elements.installUpdate.disabled = true;
+  renderUpdate({ state: "installing" });
+  try {
+    renderUpdate(await invoke("install_archive_update"));
+  } catch {
+    renderUpdate({
+      state: "unavailable",
+      reason: "Minutes Archive could not install the update.",
+    });
+  } finally {
+    setLocationControlsDisabled(false);
+  }
+}
+
 async function bootstrap() {
   try {
     const state = await invoke("archive_bootstrap");
@@ -1092,6 +1205,13 @@ async function bootstrap() {
     } else {
       showView("setup");
     }
+    // Asked for once per process, not once per page load. Rust holds the result
+    // and the window that permits the request, so a reloaded webview shows what
+    // the launch check already found instead of asking for another one.
+    renderUpdate(state.update);
+    if (state.update?.state === "notChecked") {
+      await checkForUpdate();
+    }
   } catch (error) {
     showError(error);
   }
@@ -1109,5 +1229,6 @@ elements.buildTextVault.addEventListener("click", buildTextVault);
 elements.backToCensus.addEventListener("click", backToCensus);
 elements.searchForm.addEventListener("submit", searchVault);
 elements.dismissError.addEventListener("click", hideError);
+elements.installUpdate.addEventListener("click", installUpdate);
 
 bootstrap();

--- a/archive/src/app.js
+++ b/archive/src/app.js
@@ -1091,7 +1091,8 @@ const updateCopy = {
     headline: "Checking for a signed update",
     detail:
       "One request for a version file, made before any folder is approved. " +
-      "Nothing about you or your documents is sent.",
+      "No archive data or app-supplied identifier is sent. The server still " +
+      "sees this Mac's IP address and request time.",
   }),
   current: (report) => ({
     headline: `Minutes Archive ${report.installed} is up to date`,
@@ -1170,6 +1171,10 @@ async function checkForUpdate() {
 async function installUpdate() {
   setLocationControlsDisabled(true);
   elements.installUpdate.disabled = true;
+  // The button is about to disappear. Move keyboard and VoiceOver focus to
+  // the atomic live region so the offered version and installation state are
+  // announced together instead of dropping focus into the page.
+  elements.updateStrip.focus();
   renderUpdate({ state: "installing" });
   try {
     renderUpdate(await invoke("install_archive_update"));

--- a/archive/src/index.html
+++ b/archive/src/index.html
@@ -19,10 +19,35 @@
           <span>Minutes Archive</span>
         </a>
         <div class="mode-badges" aria-label="Application protections">
-          <span class="badge badge-local"><span class="dot"></span>Local only</span>
+          <span class="badge badge-local"><span class="dot"></span>Documents stay local</span>
           <span class="badge">Private pilot</span>
         </div>
       </header>
+
+      <!--
+        The one place this application touches the network, stated where it
+        happens rather than in a settings pane nobody opens. It reports the
+        check before, during and after, so "an update check ran" is something
+        the operator saw rather than something they have to take on trust.
+      -->
+      <section
+        id="update-strip"
+        class="update-strip"
+        aria-label="Update check"
+        hidden
+      >
+        <span id="update-dot" class="update-dot" aria-hidden="true"></span>
+        <div>
+          <strong id="update-headline">Checking for a signed update</strong>
+          <p id="update-detail" role="status" aria-live="polite">
+            One request for a version file, made before any folder is approved.
+            Nothing about you or your documents is sent.
+          </p>
+        </div>
+        <button id="install-update" class="button button-secondary" type="button" hidden>
+          Install update
+        </button>
+      </section>
 
       <section id="main-content" class="hero">
         <p class="eyebrow">Local only · nothing is uploaded</p>
@@ -352,7 +377,7 @@
       <footer>
         <span id="build-identity">Minutes Archive</span>
         <span aria-hidden="true">•</span>
-        <span>Networking is switched off</span>
+        <span>Updates only before folders open</span>
         <span aria-hidden="true">•</span>
         <span>Closing this window forgets everything</span>
       </footer>

--- a/archive/src/index.html
+++ b/archive/src/index.html
@@ -34,14 +34,19 @@
         id="update-strip"
         class="update-strip"
         aria-label="Update check"
+        aria-atomic="true"
+        aria-live="polite"
+        role="status"
+        tabindex="-1"
         hidden
       >
         <span id="update-dot" class="update-dot" aria-hidden="true"></span>
         <div>
           <strong id="update-headline">Checking for a signed update</strong>
-          <p id="update-detail" role="status" aria-live="polite">
+          <p id="update-detail">
             One request for a version file, made before any folder is approved.
-            Nothing about you or your documents is sent.
+            No archive data or app-supplied identifier is sent. The server still
+            sees this Mac's IP address and request time.
           </p>
         </div>
         <button id="install-update" class="button button-secondary" type="button" hidden>

--- a/archive/src/styles.css
+++ b/archive/src/styles.css
@@ -206,6 +206,60 @@ a:focus-visible {
   box-shadow: 0 0 0 3px rgba(57, 145, 110, 0.13);
 }
 
+/* Quiet by default and never dismissable. This is the application's one
+   network surface, so it reports itself in the same register as the privacy
+   strips rather than as a notification the operator learns to close. */
+.update-strip {
+  display: grid;
+  grid-template-columns: 27px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+  padding: 11px 14px;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+
+.update-strip strong {
+  display: block;
+  color: var(--ink-2);
+  font-size: 11px;
+}
+
+.update-strip p {
+  margin: 3px 0 0;
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.update-dot {
+  width: 9px;
+  height: 9px;
+  margin-left: 9px;
+  border-radius: 50%;
+  background: var(--line-2);
+}
+
+/* An offer is the only state that earns colour: it is the only one that asks
+   the operator to decide something. */
+.update-strip[data-state="available"] {
+  color: var(--green-muted);
+  border-color: rgba(45, 114, 89, 0.24);
+  background: var(--green-soft);
+}
+
+.update-strip[data-state="available"] strong {
+  color: var(--green);
+}
+
+.update-strip[data-state="available"] .update-dot,
+.update-strip[data-state="installed"] .update-dot,
+.update-strip[data-state="current"] .update-dot {
+  background: var(--green-3);
+}
+
 .hero {
   max-width: 790px;
   padding: 26px 0 20px;

--- a/docs/investigations/auto-update-evaluation.md
+++ b/docs/investigations/auto-update-evaluation.md
@@ -4,6 +4,16 @@ This document evaluates whether Minutes should add in-app update support for the
 desktop app, and if so, how to do it without violating the project’s trust
 model.
 
+**Scope note.** This record is about `tauri/` — the Minutes desktop app. It is
+not about Minutes Archive, which is a separate target with a different trust
+model and a different user. Archive's updater is a single launch-time check
+that is refused for the rest of the session once the app has seen any of the
+operator's documents, with install only on explicit consent; the residual is
+written up for the reviewer in
+`docs/security/archive-pilot-independent-review.md` and disclosed to the pilot
+attorney in `docs/release/archive-peter-acceptance.md`. Nothing in this
+document licenses an ungated updater in either target.
+
 ## Summary
 
 Recommendation:
@@ -210,3 +220,21 @@ them could index a single document.
 Delivering a fix stays a person handing over a signed build. For one user that
 is not a hardship; it is a smaller trust surface than an updater, and it keeps
 the footer honest.
+
+## Minutes Archive decision update (2026-08-11)
+
+The owner superseded the Archive-specific deferral above and authorized a DMG
+plus an in-app update notification. The normal Minutes desktop recommendation
+in this document remains unchanged.
+
+Archive now uses Tauri Updater with narrower behavior than the normal desktop
+app: one bounded check when the process opens, before folder controls become
+available; no automatic download; an explicit install button; signature
+verification; and a monotone network latch that closes when the folder picker
+opens. The webview still has no updater capability of its own.
+
+The release train is separate too. `archive-vX.Y.Z` publishes a notarized DMG
+and versioned signed updater archive, then advances the fixed `archive-stable`
+manifest only after those assets exist. The normal Minutes `latest.json` can
+never offer an Archive update. The signed DMG remains the manual recovery path,
+and a failed in-app install leaves the current app in place and says so.

--- a/docs/release/archive-peter-acceptance.md
+++ b/docs/release/archive-peter-acceptance.md
@@ -12,12 +12,12 @@ downloaded notarized artifact with
 `scripts/verify-archive-pilot-artifact.sh`. An independent reviewer approves the
 security packet in `docs/security/archive-pilot-independent-review.md`. The
 operator then performs the complete installed-app interaction once with
-networking disabled and once with networking enabled under network
-observation. Under observation the expected result is one update check at
-launch, to the configured GitHub endpoint and any GitHub release-asset redirect,
-before any folder is approved, and nothing else for the rest of the session.
-Any second check, or any connection after a folder is approved, is a stop-ship
-finding.
+normal connectivity under network observation. Do not disable the Mac's Wi-Fi
+or alter system-wide connectivity for this test. The expected result is one
+update check at launch, to the configured GitHub endpoint and any GitHub
+release-asset redirect, before any folder is approved, and nothing else for the
+rest of the session. Any second check, or any connection after a folder is
+approved, is a stop-ship finding.
 
 Do not use Peter's documents for those release tests. Use synthetic legal
 fixtures with distinctive canary text. The release operator creates the
@@ -95,10 +95,11 @@ That check happens the moment the app opens, before you have chosen a folder,
 so at that point the app has not seen a single one of your documents and has
 nothing about them it could send. It is the only automatic internet use.
 
-The request sends nothing about you. Not your name, not your Mac, not a licence
-number, not a count of anything, not a folder, not a filename, not a word of
-any document. It asks for one small file on the Minutes download page — the
-same file everybody's copy asks for — and reads a version number out of it.
+The request contains no app-supplied identifier and nothing from the archive:
+not your name, not a licence number, not a count, not a folder, not a filename,
+and not a word of any document. It asks for one small file on the Minutes
+download page — the same file everybody's copy asks for — and reads a version
+number out of it.
 
 What the far end does learn, because every internet request works this way, is
 that some computer at your office's internet address opened Minutes Archive at

--- a/docs/release/archive-peter-acceptance.md
+++ b/docs/release/archive-peter-acceptance.md
@@ -142,7 +142,8 @@ force-quit or crashes.
 
 What could remain is the folder's FULL PATH -- its name, the names of every
 folder above it, and the name and identifier of the disk it is on. It is not any
-document, not any text from a document, and nothing is ever sent anywhere. It
+document, not any text from a document, and that saved path is never sent
+anywhere. It
 sits in the app's own settings file on your Mac. In a law practice those folder
 names are often client names, which is why this is stated rather than left
 unsaid. Opening Minutes Archive again clears it.

--- a/docs/release/archive-peter-acceptance.md
+++ b/docs/release/archive-peter-acceptance.md
@@ -105,8 +105,9 @@ What the far end does learn, because every internet request works this way, is
 that some computer at your office's internet address opened Minutes Archive at
 that minute. Not which folder, not which documents, not who you are — but the
 fact that the app was opened, from your address, at that time. If a request
-like that is unacceptable for a particular matter, disconnect from the internet
-before opening the app; everything the app does still works.
+like that is unacceptable for a particular matter, do not open the app for
+that matter; contact the pilot operator. Do not change the Mac's system-wide
+connectivity for this pilot.
 
 You are told what it found. A line at the top of the window says the check ran
 and whether you already have the current version. If there is a newer one it
@@ -197,10 +198,12 @@ look at the original before you rely on it.
 
 Peter should stop the session if macOS shows an unidentified-developer warning,
 the app uses the network for anything other than the single version check it
-announces at launch, the app requests unrelated privacy permissions, a census
-export contains a filename or path, a result lacks a source anchor, a changed source
-remains available, the app claims to search an unavailable location, or the
-Archive process remains running after its only window closes.
+announces at launch and one update download Peter explicitly starts, either
+network operation begins after a folder is approved, the app requests unrelated
+privacy permissions, a census export contains a filename or path, a result
+lacks a source anchor, a changed source remains available, the app claims to
+search an unavailable location, or the Archive process remains running after
+its only window closes.
 
 No real client document should be sent to support, copied into an email, or
 uploaded to a model to diagnose the issue. Reproduce with a synthetic document

--- a/docs/release/archive-peter-acceptance.md
+++ b/docs/release/archive-peter-acceptance.md
@@ -13,7 +13,11 @@ downloaded notarized artifact with
 security packet in `docs/security/archive-pilot-independent-review.md`. The
 operator then performs the complete installed-app interaction once with
 networking disabled and once with networking enabled under network
-observation.
+observation. Under observation the expected result is one update check at
+launch, to the configured GitHub endpoint and any GitHub release-asset redirect,
+before any folder is approved, and nothing else for the rest of the session.
+Any second check, or any connection after a folder is approved, is a stop-ship
+finding.
 
 Do not use Peter's documents for those release tests. Use synthetic legal
 fixtures with distinctive canary text. The release operator creates the
@@ -22,8 +26,9 @@ review folder with `scripts/make-archive-qa-fixtures.sh` and follows
 
 ## Peter's first session
 
-1. Peter opens the delivered `Minutes Archive` application in Finder. macOS
-   should open it normally without an unidentified-developer override.
+1. Peter opens the delivered `Minutes Archive` DMG in Finder, drags Minutes
+   Archive to Applications, then opens it. macOS should open it normally
+   without an unidentified-developer override.
 2. He selects one small, well-understood pilot folder containing roughly
    100–500 documents. He does not need to reorganize or move them.
 3. He runs **Private census**. The application reports only aggregate format,
@@ -77,13 +82,55 @@ legal conclusions, and Peter reviews the source before use. Meaning-similar
 suggestions are separately labeled and are never presented as proof that a
 clause satisfies the question.
 
-## Two things Peter is told before he starts
+## What Peter is told before he starts
 
-These are accepted, disclosed limitations of the pilot, not defects to be
-discovered. The operator states both in plain language when handing over the
-app. Neither should be softened.
+These are accepted, disclosed properties and limitations of the pilot, not
+defects to be discovered. The operator states each of them in plain language
+when handing over the app. None should be softened.
 
-**1. If the app is force-quit or crashes, the location of the folder you chose
+**1. Minutes Archive uses the internet once, when it opens, to ask whether
+there is a newer version of itself.**
+
+That check happens the moment the app opens, before you have chosen a folder,
+so at that point the app has not seen a single one of your documents and has
+nothing about them it could send. It is the only automatic internet use.
+
+The request sends nothing about you. Not your name, not your Mac, not a licence
+number, not a count of anything, not a folder, not a filename, not a word of
+any document. It asks for one small file on the Minutes download page — the
+same file everybody's copy asks for — and reads a version number out of it.
+
+What the far end does learn, because every internet request works this way, is
+that some computer at your office's internet address opened Minutes Archive at
+that minute. Not which folder, not which documents, not who you are — but the
+fact that the app was opened, from your address, at that time. If a request
+like that is unacceptable for a particular matter, disconnect from the internet
+before opening the app; everything the app does still works.
+
+You are told what it found. A line at the top of the window says the check ran
+and whether you already have the current version. If there is a newer one it
+says so and then waits. Nothing is downloaded unless you press the button, and
+if you press it, the download is refused unless it carries the Minutes
+signature. A tampered or unsigned download is discarded and the app you have
+keeps working.
+
+That download is the only other internet use, and it happens only if you press
+Install update while no folder is open.
+
+If installation fails, the current app stays in place. Peter can keep using it
+and install the newer signed DMG manually; the update notice says so rather
+than leaving him at a dead end.
+
+Then the door shuts. From the moment you open the folder picker — whether or
+not you go through with it — Minutes Archive will not use the internet again
+for the rest of that session, and it will say so on screen if anything asks it
+to. To check again, quit the app and open it.
+
+If you are offline, or the check fails for any other reason, the app says it
+could not check and then behaves exactly as it always does. Nothing about
+searching your archive depends on it.
+
+**2. If the app is force-quit or crashes, the location of the folder you chose
 may remain on your Mac until you next open the app.**
 
 When you click "choose folder", macOS itself remembers the last folder you
@@ -99,7 +146,7 @@ sits in the app's own settings file on your Mac. In a law practice those folder
 names are often client names, which is why this is stated rather than left
 unsaid. Opening Minutes Archive again clears it.
 
-**2. PDFs and RTFs never answer "in the same clause".**
+**3. PDFs and RTFs never answer "in the same clause".**
 
 Word and OpenDocument files record where each section begins. PDF and RTF do
 not. A PDF records only where ink sits on the page; RTF can carry an outline
@@ -129,7 +176,7 @@ Read the excerpt, which is always shown, before relying on such an answer.
 This is deliberate throughout: a wrong "same clause" answer to a lawyer is
 worse than no answer.
 
-**3. Text read from a scan is a reading, not a quotation.**
+**4. Text read from a scan is a reading, not a quotation.**
 
 A scan is a picture. To search it, the app has macOS read the page and tell it
 what the letters appear to say. That reading is usually good and sometimes
@@ -147,8 +194,9 @@ look at the original before you rely on it.
 ## Stop and contact the pilot operator
 
 Peter should stop the session if macOS shows an unidentified-developer warning,
-the app requests network or unrelated privacy permissions, a census export
-contains a filename or path, a result lacks a source anchor, a changed source
+the app uses the network for anything other than the single version check it
+announces at launch, the app requests unrelated privacy permissions, a census
+export contains a filename or path, a result lacks a source anchor, a changed source
 remains available, the app claims to search an unavailable location, or the
 Archive process remains running after its only window closes.
 

--- a/docs/release/archive-pilot-signing-and-handoff.md
+++ b/docs/release/archive-pilot-signing-and-handoff.md
@@ -30,10 +30,12 @@ Recheck this state immediately before a release; it can drift:
 - the active `protect-acceptance-tags` ruleset must cover
   `refs/tags/acceptance-*`;
 - a release-tag ruleset must restrict `refs/tags/archive-v*` to the owner; a
-  pushed Archive version tag publishes public release assets and advances the
-  stable updater channel;
+  pushed Archive version tag creates only a private draft release;
 - the `signed-dev-acceptance` environment must require a reviewer and permit
-  deployment only from `main`; and
+  deployment only from `main` and `archive-v*` tags;
+- the `archive-stable-release` environment must require a reviewer and permit
+  deployment only from `main`; promotion must require the independently
+  recorded SHA-256 of `archive-release-SHA256SUMS.txt`; and
 - the referenced credential names must exist:
   `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`,
   `APPLE_SIGNING_IDENTITY`, `APPLE_API_ISSUER`, `APPLE_API_KEY`, and
@@ -50,18 +52,18 @@ Do not print, download, or inspect credential values during this preflight.
 3. Run `./scripts/verify-archive-dev-app.sh` from that exact checkout.
 4. Make no candidate changes after review. Any change requires a new commit,
    fresh CI, fresh review, and a different acceptance tag.
-5. After explicit owner approval, merge the fixed signing-workflow pull
-   request into `main`. Do not merge the Archive feature pull request merely to
-   make the signing workflow available.
+5. After explicit owner approval, merge the reviewed Archive pull request into
+   `main`. Record the exact resulting commit; if GitHub creates a different
+   commit, independently confirm its tree is identical to the reviewed head.
 
 ## Authorize the exact commit
 
 Set `CANDIDATE_SHA` to the reviewed 40-character Archive commit:
 
 ```sh
-git fetch origin main feat/minutes-archive-discovery
+git fetch origin main
 git cat-file -e "${CANDIDATE_SHA}^{commit}"
-test "$(git rev-parse "origin/feat/minutes-archive-discovery")" = "$CANDIDATE_SHA"
+test "$(git rev-parse origin/main)" = "$CANDIDATE_SHA"
 git tag -a "acceptance-$CANDIDATE_SHA" "$CANDIDATE_SHA" \
   -m "Authorize Minutes Archive private pilot $CANDIDATE_SHA"
 git push origin "refs/tags/acceptance-$CANDIDATE_SHA"
@@ -113,12 +115,39 @@ Record the workflow run URL, candidate SHA, zip SHA-256, executable SHA-256,
 Team ID, bundle identifier, notarization result, staple result, Gatekeeper
 result, verifier output, and verifier Mac details.
 
-After independent approval, create and push the exact version tag shown in the
-Archive config, for example `archive-v0.2.0`. The same protected workflow then
-publishes the versioned DMG and updater archive and advances only
-`archive-stable/latest-archive.json`. Confirm that URL returns 200, that its
-version and asset URL match the reviewed release, and that the DMG downloaded
-from the versioned release has the reviewed SHA-256 before delivery. The normal
+## Stage and promote the exact release bytes
+
+After source approval, create and push the exact version tag shown in the
+Archive config, for example `archive-v0.2.0`. The protected signing workflow
+creates a **private draft release** and stops. It does not make the version
+public and does not touch `archive-stable`.
+
+Download that draft with `gh release download`, run the artifact verifier, and
+complete the independent Finder/security review against its exact DMG. Record
+the SHA-256 of `archive-release-SHA256SUMS.txt` from the reviewed draft. Any
+rerun or asset replacement invalidates that recorded value and requires a new
+artifact review.
+
+Only after the independent decision is `ACCEPT` may the owner dispatch:
+
+```sh
+gh workflow run archive-stable-promotion.yml \
+  --ref main \
+  -f "release_tag=$RELEASE_TAG" \
+  -f "candidate_sha=$CANDIDATE_SHA" \
+  -f "release_sums_sha256=$REVIEWED_SUMS_SHA256"
+```
+
+Approve `archive-stable-release` only after confirming all three inputs match
+the review record. The promotion job refuses a moved tag, changed checksum
+record, unexpected asset, downgrade, or same-version byte replacement. It
+makes the reviewed draft public, downloads and hashes the public bytes, and
+only then advances `archive-stable/latest-archive.json` with the same reviewed
+manifest. Neither the Archive version nor its machine-readable channel replaces
+the normal Minutes release marked “Latest” on GitHub.
+
+Confirm the stable URL returns 200, its version and asset URL match the reviewed
+release, and the public DMG has the reviewed SHA-256 before delivery. The normal
 Minutes `latest.json` channel is not involved.
 
 ## Human and independent acceptance

--- a/docs/release/archive-pilot-signing-and-handoff.md
+++ b/docs/release/archive-pilot-signing-and-handoff.md
@@ -120,7 +120,9 @@ result, verifier output, and verifier Mac details.
 After source approval, create and push the exact version tag shown in the
 Archive config, for example `archive-v0.2.0`. The protected signing workflow
 creates a **private draft release** and stops. It does not make the version
-public and does not touch `archive-stable`.
+public and does not touch `archive-stable`. The tag must point to the exact
+current `main` commit; the workflow resolves that SHA itself and checks out
+release tooling by SHA rather than implicitly trusting the tag checkout.
 
 Download that draft with `gh release download`, run the artifact verifier, and
 complete the independent Finder/security review against its exact DMG. Record
@@ -146,9 +148,24 @@ only then advances `archive-stable/latest-archive.json` with the same reviewed
 manifest. Neither the Archive version nor its machine-readable channel replaces
 the normal Minutes release marked “Latest” on GitHub.
 
+If promotion stops after the versioned draft becomes public but before the
+stable manifest is verified, do not rebuild or replace anything. Rerun the
+promotion with the same three reviewed inputs. It accepts that partial state
+only after rechecking the protected tag, exact asset set, checksum-record hash,
+and every asset digest, then resumes at public-byte verification and stable
+publication.
+
 Confirm the stable URL returns 200, its version and asset URL match the reviewed
 release, and the public DMG has the reviewed SHA-256 before delivery. The normal
 Minutes `latest.json` channel is not involved.
+
+Before Peter receives the first updater-enabled build, exercise the public
+stable channel with a disposable older development copy installed in a
+temporary app folder. It must discover the reviewed version, download only
+after the test operator presses Install, verify the updater signature and
+Developer ID identity, atomically replace only that disposable app, and reopen
+as the reviewed version. Use synthetic fixtures only and compare the installed
+executable hash with the signed provenance record.
 
 ## Human and independent acceptance
 
@@ -170,10 +187,11 @@ folder is approved. The app never wrote outside its own
 space. The leak sweep still has to distinguish the two every time, so keep the
 fixtures off synced volumes and the question does not arise.
 
-The release operator completes the Finder interaction once with networking
-disabled and once with networking enabled under observation. The independent
-reviewer follows `docs/security/archive-pilot-independent-review.md` and owns
-the review decision.
+The release operator completes the Finder interaction with normal connectivity
+under observation. Do not disable the Mac's Wi-Fi or alter system-wide
+connectivity. The independent reviewer follows
+`docs/security/archive-pilot-independent-review.md` and owns the review
+decision.
 
 The app may be handed to Peter only when:
 
@@ -181,7 +199,6 @@ The app may be handed to Peter only when:
 - native folder-picker, cancellation, census export, content authorization,
   exact retrieval, stale-source withdrawal, and close-time purge have been
   click-tested;
-- the offline run succeeds;
 - in the observed online run, no worker opens a network connection at all, and
   the parent performs exactly one launch update check, to the configured
   endpoint and any GitHub-owned release redirect, before any folder is approved,

--- a/docs/release/archive-pilot-signing-and-handoff.md
+++ b/docs/release/archive-pilot-signing-and-handoff.md
@@ -2,7 +2,7 @@
 
 This is the release-operator procedure for producing Peter's private-pilot
 application. Peter does not run these commands. He receives a normal signed and
-notarized `Minutes Archive.app` and uses Finder.
+notarized `Minutes Archive` DMG and uses Finder.
 
 No step in this procedure authorizes use of real client documents. Signing,
 notarization, security review, and operator QA use only the repository's
@@ -29,12 +29,16 @@ Recheck this state immediately before a release; it can drift:
   `acceptance-<sha>` tag and run from `main` as `silverstein`;
 - the active `protect-acceptance-tags` ruleset must cover
   `refs/tags/acceptance-*`;
+- a release-tag ruleset must restrict `refs/tags/archive-v*` to the owner; a
+  pushed Archive version tag publishes public release assets and advances the
+  stable updater channel;
 - the `signed-dev-acceptance` environment must require a reviewer and permit
   deployment only from `main`; and
-- the six referenced credential names must exist:
+- the referenced credential names must exist:
   `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`,
   `APPLE_SIGNING_IDENTITY`, `APPLE_API_ISSUER`, `APPLE_API_KEY`, and
-  `APPLE_API_PRIVATE_KEY`.
+  `APPLE_API_PRIVATE_KEY`, plus `TAURI_SIGNING_PRIVATE_KEY` for updater
+  artifacts.
 
 Do not print, download, or inspect credential values during this preflight.
 
@@ -92,7 +96,10 @@ Download only the artifact named
 `minutes-archive-pilot-notarized-<candidate-sha>`. It must contain exactly:
 
 - `minutes-archive-pilot-notarized.zip`;
-- `minutes-archive-pilot-notarized.zip.sha256`; and
+- `minutes-archive-pilot-notarized.zip.sha256`;
+- one notarized `Minutes_Archive_<version>_aarch64.dmg`;
+- one signed `Minutes.Archive_<version>_aarch64.app.tar.gz` and its `.sig`;
+- `latest-archive.json` and `archive-release-SHA256SUMS.txt`; and
 - `signed-archive-provenance.txt`.
 
 From the exact candidate checkout, verify it on a Mac before opening:
@@ -105,6 +112,14 @@ From the exact candidate checkout, verify it on a Mac before opening:
 Record the workflow run URL, candidate SHA, zip SHA-256, executable SHA-256,
 Team ID, bundle identifier, notarization result, staple result, Gatekeeper
 result, verifier output, and verifier Mac details.
+
+After independent approval, create and push the exact version tag shown in the
+Archive config, for example `archive-v0.2.0`. The same protected workflow then
+publishes the versioned DMG and updater archive and advances only
+`archive-stable/latest-archive.json`. Confirm that URL returns 200, that its
+version and asset URL match the reviewed release, and that the DMG downloaded
+from the versioned release has the reviewed SHA-256 before delivery. The normal
+Minutes `latest.json` channel is not involved.
 
 ## Human and independent acceptance
 
@@ -119,10 +134,12 @@ Do not place the fixture folder anywhere iCloud Drive syncs -- Desktop and
 Documents are synced by default on a Mac with Desktop & Documents enabled. A
 QA run that put fixtures on the Desktop found the canary string in
 `~/Library/Caches/CloudKit/com.apple.bird/`, which is iCloud's own upload
-cache and not the application: the app holds no network sockets and never
-wrote outside its own space. The leak sweep still has to distinguish the two
-every time, so keep the fixtures off synced volumes and the question does not
-arise.
+cache and not the application. Archive workers hold no network sockets; the
+parent's expected operations are the announced launch update check and, only
+when the operator presses Install, one signed download, both before the fixture
+folder is approved. The app never wrote outside its own
+space. The leak sweep still has to distinguish the two every time, so keep the
+fixtures off synced volumes and the question does not arise.
 
 The release operator completes the Finder interaction once with networking
 disabled and once with networking enabled under observation. The independent
@@ -136,12 +153,17 @@ The app may be handed to Peter only when:
   exact retrieval, stale-source withdrawal, and close-time purge have been
   click-tested;
 - the offline run succeeds;
-- no Archive process or worker opens a network connection in the observed
-  online run;
+- in the observed online run, no worker opens a network connection at all, and
+  the parent performs exactly one launch update check, to the configured
+  endpoint and any GitHub-owned release redirect, before any folder is approved,
+  carrying no query string and no body. If Install is pressed, one updater
+  download is additionally expected. A repeated check, repeated download, or
+  any connection after a folder is approved is a failure;
 - no canary, path, filename, content, prompt, or vector leaks to logs, crash
   reports, temporary storage, or the census export;
 - the independent report says approve; and
-- the delivery hash matches the reviewed notarized zip.
+- the delivered DMG hash matches the reviewed notarized DMG; and
+- the stable updater manifest returns 200 and names that exact reviewed version.
 
 Any failure leaves the artifact quarantined. Fixes require a new commit and a
 new acceptance tag; do not mutate or silently replace a reviewed artifact.

--- a/docs/release/notes/archive-v0.2.0.md
+++ b/docs/release/notes/archive-v0.2.0.md
@@ -1,0 +1,15 @@
+# Minutes Archive 0.2.0
+
+This is the first DMG release of the private Minutes Archive pilot.
+
+- Adds a visible, one-time update check when the app opens, before any folder
+  is approved.
+- Downloads nothing unless the user chooses **Install update**.
+- Verifies every in-app update against the Minutes signing key before replacing
+  the installed app.
+- Closes the update network window before the folder picker opens and keeps all
+  archive reading, indexing, and search local to the Mac.
+- Keeps a signed, notarized DMG available as the manual recovery path.
+
+The Archive pilot remains separate from the normal Minutes desktop release
+channel. Its updater reads only the dedicated `archive-stable` manifest.

--- a/docs/security/archive-pilot-independent-review.md
+++ b/docs/security/archive-pilot-independent-review.md
@@ -138,10 +138,13 @@ authority" row above is unchanged. Both workers still run under
 
 **Release and recovery path.** Archive uses its own fixed `archive-stable`
 manifest, never the normal Minutes `latest.json`. An `archive-vX.Y.Z` tag runs
-the protected signing workflow, uploads a versioned signed updater archive and
-notarized DMG, and replaces the stable manifest only after those versioned
-assets exist. The reviewer must confirm the stable manifest returns 200 and
-names the exact reviewed version before delivery. If a release must be stopped,
+the protected signing workflow and stages the signed updater archive and
+notarized DMG in a private draft release. It does not advance the updater feed.
+The reviewer records the checksum-record hash for those exact bytes. A separate
+protected promotion checks that hash, makes the same assets public, verifies
+their public hashes, and replaces the stable manifest last. The reviewer must
+confirm the stable manifest returns 200 and names the exact reviewed version
+before delivery. If a release must be stopped,
 the stable manifest can be replaced or removed so older clients no longer see
 it; clients that already installed it require a higher patch release or a
 manual DMG. The UI states that the installed app stays unchanged after a failed

--- a/docs/security/archive-pilot-independent-review.md
+++ b/docs/security/archive-pilot-independent-review.md
@@ -71,6 +71,9 @@ The reviewer should independently attempt at least these cases:
 | Same, with a signature that is valid but was made over different bytes | the download is refused |
 | Drive `check_for_archive_update` in a loop from the webview console before approving anything | exactly one request leaves the process |
 | Serve a manifest that never finishes, or a 500, or malformed JSON | the app reports that it could not check and is otherwise unaffected |
+| Invoke the folder picker directly while a check or download is in flight | exactly one side proceeds; the other is refused, and no panel/archive access overlaps network traffic |
+| Supply a signed archive with a link, special file, wrong Team ID, or wrong bundle identifier | installation is refused before replacement and the current app is unchanged |
+| Make the same-volume atomic exchange fail | installation is refused and both the current and staged paths remain unchanged |
 | Close the only window after indexing | process exits and cannot answer without rebuilding the vault |
 
 ## The bounded update surface, and what it costs
@@ -122,14 +125,16 @@ compare-exchange with an unconditional store makes
 closed when the folder picker opens, before the operator has chosen anything,
 so cancelling the panel does not restore it.
 
-**Signature verification.** Installation goes through
-`Update::download_and_install`, which verifies the minisign signature against
-the public key in `tauri.conf.json` before writing. That is the same key the
-main Minutes application uses; no second key was introduced. There is no other
-install path in the file -- the plugin's bare `install` would accept whatever
-bytes it was given, and adding a second entry point is how an unverified one
-appears later. A download only happens if the operator presses the button
-against a visible offer.
+**Signature verification and replacement.** The download goes through
+`Update::download`, which verifies the minisign signature against the public
+key in `tauri.conf.json` before returning bytes. That is the same key the main
+Minutes application uses; no second key was introduced. The pinned plugin's
+macOS replacement routine is not used because its rollback is incomplete.
+Archive extracts only one link-free `Minutes Archive.app`, verifies its
+Developer ID Team ID and bundle identifier, and atomically exchanges it with
+the current bundle on the same volume. A failed exchange changes neither path.
+A download only happens if the operator presses the button against a visible
+offer.
 
 **What did not change.** `archive-main` still does not carry `updater:default`,
 so the plugin's own commands remain unreachable from the webview; the "Webview
@@ -152,10 +157,10 @@ update and names the signed DMG as the recovery path.
 
 ## Egress and observation checks
 
-Use synthetic documents only for security testing. With networking disabled,
-exercise census, content authorization, PDF and DOCX conversion, semantic
-suggestions, export, and close. Repeat with networking enabled while observing
-the app and both workers.
+Use synthetic documents only for security testing. Exercise census, content
+authorization, PDF and DOCX conversion, semantic suggestions, export, and close
+with normal connectivity while observing the app and both workers. Do not
+disable the Mac's Wi-Fi or alter system-wide connectivity for this review.
 
 The expected observation without accepting an update is exactly one updater
 check, from the parent process only, to the configured update endpoint, before

--- a/docs/security/archive-pilot-independent-review.md
+++ b/docs/security/archive-pilot-independent-review.md
@@ -65,7 +65,6 @@ The reviewer should independently attempt at least these cases:
 | Ask for three required concepts in one clause | only one-provision conjunctions qualify |
 | Ask for criteria anywhere in one document | each criterion is tied to exact evidence in that same document |
 | Exceed the candidate budget | search fails closed rather than claiming completeness |
-| Disable networking for the entire installed-app session | census, indexing, exact search, and supported semantic suggestions still work |
 | Approve a folder, then remove it, then try to make the app check for updates | the check is refused; removing the location does not reopen the window |
 | Rebuild with the endpoint pointed at a host you control, and serve a manifest signed with your own minisign key | the download is refused and the installed application is unchanged |
 | Same, with a signature that is valid but was made over different bytes | the download is refused |
@@ -293,9 +292,12 @@ that can:
 - return evidence after its source is no longer current and authorized;
 - persist source text or vectors across application exit;
 - execute document text or candidate-controlled code as instructions;
-- use the network at any moment other than the single announced launch check,
-  send anything in that request, repeat it, or make it after a folder has been
-  approved;
+- use the network at any moment other than the single announced launch check
+  and at most one explicitly consented update download, repeat either
+  operation, or start either operation after a folder has been approved;
+- add an application, user, or archive identifier, query string, or request
+  body to the launch check, or disclose archive-derived data in either network
+  operation;
 - install an update whose minisign signature does not verify against the key in
   `tauri.conf.json`, or install one without the operator asking;
 - silently use a network or downloaded model;

--- a/docs/security/archive-pilot-independent-review.md
+++ b/docs/security/archive-pilot-independent-review.md
@@ -12,7 +12,10 @@ The review object is one notarized `Minutes Archive.app` produced from an exact
 `Signed Archive Pilot Acceptance` workflow. The download must contain:
 
 - `minutes-archive-pilot-notarized.zip`;
-- `minutes-archive-pilot-notarized.zip.sha256`; and
+- `minutes-archive-pilot-notarized.zip.sha256`;
+- one notarized `Minutes_Archive_<version>_aarch64.dmg`;
+- one signed `Minutes.Archive_<version>_aarch64.app.tar.gz` and its `.sig`;
+- `latest-archive.json` and `archive-release-SHA256SUMS.txt`; and
 - `signed-archive-provenance.txt`.
 
 Run the repository's verifier on a Mac before opening the application:
@@ -42,6 +45,7 @@ Minutes meeting store and has no cloud mode.
 | Evidence fidelity | Results are exact excerpts with source revision and page, paragraph, or section anchors | legal benchmark and document-vault smoke |
 | Live-source fence | Root membership, link status, file identity, bytes, and SHA-256 are rechecked before display; stale evidence is withdrawn | mutation/replacement tests and document-vault smoke |
 | Webview authority | No filesystem, shell, opener, updater, autostart, global shortcut, or network capability is exposed | Tauri capability and CSP inspection |
+| Update window | The parent makes one automatic check and at most one user-consented signed download, both before any folder is approved; both are refused thereafter | update-gate tests in `archive/src-tauri/src/main.rs` and network observation |
 | Distribution | Exact protected commit is built and exercised before credentials unlock; candidate code is not executed afterward | fixed workflow policy tests and run log |
 
 ## Adversarial review cases
@@ -62,15 +66,103 @@ The reviewer should independently attempt at least these cases:
 | Ask for criteria anywhere in one document | each criterion is tied to exact evidence in that same document |
 | Exceed the candidate budget | search fails closed rather than claiming completeness |
 | Disable networking for the entire installed-app session | census, indexing, exact search, and supported semantic suggestions still work |
+| Approve a folder, then remove it, then try to make the app check for updates | the check is refused; removing the location does not reopen the window |
+| Rebuild with the endpoint pointed at a host you control, and serve a manifest signed with your own minisign key | the download is refused and the installed application is unchanged |
+| Same, with a signature that is valid but was made over different bytes | the download is refused |
+| Drive `check_for_archive_update` in a loop from the webview console before approving anything | exactly one request leaves the process |
+| Serve a manifest that never finishes, or a 500, or malformed JSON | the app reports that it could not check and is otherwise unaffected |
 | Close the only window after indexing | process exits and cannot answer without rebuilding the vault |
+
+## The bounded update surface, and what it costs
+
+Minutes Archive is no longer network-free. The parent process makes one
+automatic outbound check and may make one user-consented update download. The
+reviewer should treat that as a real change to the product rather than a
+footnote, because every earlier round of this review was
+conducted against a binary that made none.
+
+**Why it exists.** The pilot is delivered as a signed application to an
+attorney who will not track releases and cannot be asked to re-download it. A
+security fix that reaches nobody is not a fix. The alternative considered and
+rejected was mailing him a new build each time, which moves the same problem to
+an unauthenticated channel and depends on him acting.
+
+**What it is.** A GET of a static JSON file at the endpoint configured in
+`archive/src-tauri/tauri.conf.json`. It carries no query string: the endpoint
+contains none of the `{{current_version}}`, `{{target}}` or `{{arch}}`
+placeholders `tauri-plugin-updater` would otherwise substitute, and
+`check_for_archive_update` calls `clear_headers()` before building the updater
+so nothing can be attached to it. It runs before a folder has been approved, so
+no value derived from the operator's archive exists in the process yet.
+
+**The residual, stated plainly.** The request is not zero-information. It
+discloses to whoever serves the endpoint, and to anything on the path, that a
+copy of Minutes Archive was opened from that IP at that time. TLS conceals the
+path, but SNI and DNS name the host. The request also carries a fixed
+`User-Agent` of the form `tauri-plugin-updater/<version>`, which is set by the
+library on its own client and cannot be removed through its builder API; it
+identifies the library, not the installation. There is no cookie, no
+identifier, and no state carried between launches, so two launches are not
+linkable except by IP. For an attorney whose network is observed, "this Mac
+opened Minutes Archive at 09:14" is the disclosure, and it is not nothing.
+Nothing about the archive, the folder, or any document is in it.
+
+**How each step is kept to one.** The gate is `claim_network_window` in
+`archive/src-tauri/src/main.rs`. It refuses when either the live session state
+shows the process has taken on the operator's archive -- an approved location,
+a census report, an open index, or a scan in flight -- or when a monotone latch
+was set as soon as the folder picker opened. The latch exists because the live
+read alone lets approve-then-remove reopen the window. Both are proven by
+mutation: removing the live read makes
+`an_update_check_is_refused_once_a_location_is_approved` and
+`an_update_check_is_refused_once_an_index_exists` fail; removing the latch makes
+`removing_an_approved_location_does_not_reopen_the_window` fail; replacing the
+compare-exchange with an unconditional store makes
+`a_launch_session_that_has_seen_nothing_may_check_once` fail. The window is also
+closed when the folder picker opens, before the operator has chosen anything,
+so cancelling the panel does not restore it.
+
+**Signature verification.** Installation goes through
+`Update::download_and_install`, which verifies the minisign signature against
+the public key in `tauri.conf.json` before writing. That is the same key the
+main Minutes application uses; no second key was introduced. There is no other
+install path in the file -- the plugin's bare `install` would accept whatever
+bytes it was given, and adding a second entry point is how an unverified one
+appears later. A download only happens if the operator presses the button
+against a visible offer.
+
+**What did not change.** `archive-main` still does not carry `updater:default`,
+so the plugin's own commands remain unreachable from the webview; the "Webview
+authority" row above is unchanged. Both workers still run under
+`(deny network*)`. The CSP still has no `connect-src` beyond IPC.
+
+**Release and recovery path.** Archive uses its own fixed `archive-stable`
+manifest, never the normal Minutes `latest.json`. An `archive-vX.Y.Z` tag runs
+the protected signing workflow, uploads a versioned signed updater archive and
+notarized DMG, and replaces the stable manifest only after those versioned
+assets exist. The reviewer must confirm the stable manifest returns 200 and
+names the exact reviewed version before delivery. If a release must be stopped,
+the stable manifest can be replaced or removed so older clients no longer see
+it; clients that already installed it require a higher patch release or a
+manual DMG. The UI states that the installed app stays unchanged after a failed
+update and names the signed DMG as the recovery path.
 
 ## Egress and observation checks
 
 Use synthetic documents only for security testing. With networking disabled,
 exercise census, content authorization, PDF and DOCX conversion, semantic
 suggestions, export, and close. Repeat with networking enabled while observing
-the app and both workers. Any network connection attributable to the Archive
-processes is a stop-ship finding.
+the app and both workers.
+
+The expected observation without accepting an update is exactly one updater
+check, from the parent process only, to the configured update endpoint, before
+any folder is approved. A test that presses Install additionally observes one
+signed download operation. GitHub may redirect either request to its
+release-asset host; those redirect hops
+belong to the same bounded operation and must stay on GitHub-owned HTTPS hosts.
+Any connection from either worker, any repeated check or download, any
+connection after a folder has been approved, and any check request carrying a
+query string, cookie, or body is a stop-ship finding.
 
 Inspect unified logs, crash reports, window titles, exported census JSON, and
 temporary directories for synthetic canary strings, filenames, source paths,
@@ -193,6 +285,11 @@ that can:
 - return evidence after its source is no longer current and authorized;
 - persist source text or vectors across application exit;
 - execute document text or candidate-controlled code as instructions;
+- use the network at any moment other than the single announced launch check,
+  send anything in that request, repeat it, or make it after a folder has been
+  approved;
+- install an update whose minisign signature does not verify against the key in
+  `tauri.conf.json`, or install one without the operator asking;
 - silently use a network or downloaded model;
 - present a generated legal conclusion as source evidence;
 - bypass the protected signing, notarization, or provenance boundary; or

--- a/scripts/archive-ui-smoke.mjs
+++ b/scripts/archive-ui-smoke.mjs
@@ -385,6 +385,13 @@ try {
           throw new Error("the update check ran without saying so on screen");
         }
         if (
+          updateStrip.getAttribute("role") !== "status" ||
+          updateStrip.getAttribute("aria-live") !== "polite" ||
+          updateStrip.getAttribute("aria-atomic") !== "true"
+        ) {
+          throw new Error("the complete update announcement is not one atomic live region");
+        }
+        if (
           !updateStrip.textContent.includes("0.2.0") ||
           !updateStrip.textContent.includes("0.1.0")
         ) {
@@ -398,6 +405,10 @@ try {
         if (installUpdate.hidden) {
           throw new Error("an available update offered no way to consent to it");
         }
+        installUpdate.focus();
+        if (document.activeElement !== installUpdate) {
+          throw new Error("the update consent control could not receive focus");
+        }
         installUpdate.click();
         await waitFor(
           () => updateStrip.dataset.state === "installed",
@@ -405,6 +416,12 @@ try {
         );
         if (!installUpdate.hidden) {
           throw new Error("the install button survived the install it performed");
+        }
+        if (document.activeElement !== updateStrip) {
+          throw new Error("focus was lost when the install button disappeared");
+        }
+        if (!updateStrip.textContent.includes("0.2.0")) {
+          throw new Error("the live update result omitted the installed version");
         }
         const setupButtonBounds = document
           .querySelector("#add-locations")

--- a/scripts/archive-ui-smoke.mjs
+++ b/scripts/archive-ui-smoke.mjs
@@ -11,6 +11,7 @@ const chrome =
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 const profile = await mkdtemp(join(tmpdir(), "minutes-archive-ui-"));
 const screenshot = join(profile, "search-proof.png");
+const updateScreenshot = join(profile, "update-proof.png");
 const frontend = pathToFileURL(resolve("archive/src/index.html")).href;
 
 const census = {
@@ -233,6 +234,7 @@ const mockScript = `
             scanRunning: false,
             report: null,
             textVaultReport: null,
+            update: { state: "notChecked" },
           },
           choose_archive_locations: {
             locations: [{ id: 1, label: "Approved location 1" }],
@@ -252,6 +254,15 @@ const mockScript = `
             total: 3,
           },
           clear_archive_exclusions: 0,
+          // The one network surface, exercised the way an operator meets it:
+          // an offer at launch that must be visible, must name both versions,
+          // and must not download anything until the button is pressed.
+          check_for_archive_update: {
+            state: "available",
+            installed: "0.1.0",
+            offered: "0.2.0",
+          },
+          install_archive_update: { state: "installed", offered: "0.2.0" },
           remove_archive_location: [],
           run_archive_census: census,
           cancel_archive_census: true,
@@ -360,6 +371,41 @@ try {
         if (!document.querySelector("#build-identity").textContent.includes("build 39773037b5d5")) {
           throw new Error("The running build does not identify itself");
         }
+
+        // The update check has to be something the operator SAW, not something
+        // they are asked to take on trust, and nothing may download until they
+        // choose to.
+        const updateStrip = document.querySelector("#update-strip");
+        const installUpdate = document.querySelector("#install-update");
+        await waitFor(
+          () => updateStrip.dataset.state === "available",
+          "update check result",
+        );
+        if (updateStrip.hidden) {
+          throw new Error("the update check ran without saying so on screen");
+        }
+        if (
+          !updateStrip.textContent.includes("0.2.0") ||
+          !updateStrip.textContent.includes("0.1.0")
+        ) {
+          throw new Error(
+            "the update offer did not name both versions: " + updateStrip.textContent,
+          );
+        }
+        if (!updateStrip.textContent.includes("Nothing has been downloaded")) {
+          throw new Error("the update offer did not say that nothing was downloaded yet");
+        }
+        if (installUpdate.hidden) {
+          throw new Error("an available update offered no way to consent to it");
+        }
+        installUpdate.click();
+        await waitFor(
+          () => updateStrip.dataset.state === "installed",
+          "update install result",
+        );
+        if (!installUpdate.hidden) {
+          throw new Error("the install button survived the install it performed");
+        }
         const setupButtonBounds = document
           .querySelector("#add-locations")
           .getBoundingClientRect()
@@ -424,7 +470,11 @@ try {
           !body.includes("Checked for this search") ||
           !body.includes("when this search ran") ||
           !body.toLowerCase().includes("not exact matches") ||
-          !body.includes("Closing this window forgets everything")
+          !body.includes("Closing this window forgets everything") ||
+          // The footer used to claim networking was disabled outright. It is
+          // not, and the corrected claim is load-bearing for the disclosure
+          // Peter is given.
+          !body.includes("Updates only before folders open")
         ) {
           throw new Error("Evidence provenance or session-disposal notice did not render");
         }
@@ -518,12 +568,22 @@ try {
     captureBeyondViewport: false,
   });
   await writeFile(screenshot, Buffer.from(image.data, "base64"));
+  await cdp.send("Runtime.evaluate", {
+    expression: "window.scrollTo({ top: 0, behavior: 'instant' })",
+  });
+  const updateImage = await cdp.send("Page.captureScreenshot", {
+    format: "png",
+    captureBeyondViewport: false,
+  });
+  await writeFile(updateScreenshot, Buffer.from(updateImage.data, "base64"));
   cdp.close();
   process.stdout.write(
     `${JSON.stringify(
       {
         ...smoke.result.value,
-        ...(process.env.ARCHIVE_KEEP_UI_SMOKE ? { screenshot } : {}),
+        ...(process.env.ARCHIVE_KEEP_UI_SMOKE
+          ? { screenshot, updateScreenshot }
+          : {}),
       },
       null,
       2,

--- a/scripts/create-branded-dmg.sh
+++ b/scripts/create-branded-dmg.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Create the branded Minutes macOS installer DMG.
+# Create a branded Minutes-family macOS installer DMG.
 #
 # Tauri's built-in create-dmg wrapper hides the useful stderr when the DMG
 # cosmetics step fails on CI. Keep this script small and explicit so release
@@ -8,10 +8,10 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/create-branded-dmg.sh --app <Minutes.app> --version <x.y.z> --output <path.dmg>
+Usage: scripts/create-branded-dmg.sh --app <application.app> --version <x.y.z> --output <path.dmg>
 
 Creates a signed-app installer DMG with:
-  - Minutes.app on the left
+  - the supplied application on the left
   - /Applications symlink on the right
   - the generated Minutes DMG background
 EOF
@@ -81,6 +81,8 @@ mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 OUTPUT_NAME="$(basename "$OUTPUT_PATH")"
 FINAL_DMG="$OUTPUT_DIR/$OUTPUT_NAME"
+APP_NAME="$(basename "$APP_PATH")"
+VOLUME_NAME="${APP_NAME%.app}"
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/minutes-dmg.XXXXXX")"
 STAGING_DIR="$WORK_DIR/staging"
@@ -97,7 +99,7 @@ trap cleanup EXIT
 
 echo "Preparing branded DMG staging folder..."
 mkdir -p "$STAGING_DIR/.background" "$MOUNT_DIR"
-cp -R "$APP_PATH" "$STAGING_DIR/Minutes.app"
+cp -R "$APP_PATH" "$STAGING_DIR/$APP_NAME"
 ln -s /Applications "$STAGING_DIR/Applications"
 cp "$BACKGROUND_PATH" "$STAGING_DIR/.background/dmg-background.png"
 cp "$ICON_PATH" "$STAGING_DIR/.VolumeIcon.icns"
@@ -110,7 +112,7 @@ DMG_SIZE_MB="$((APP_SIZE_MB + 80))"
 echo "Creating read/write DMG (${DMG_SIZE_MB} MB)..."
 rm -f "$RW_DMG" "$FINAL_DMG"
 hdiutil create \
-  -volname "Minutes" \
+  -volname "$VOLUME_NAME" \
   -srcfolder "$STAGING_DIR" \
   -fs HFS+ \
   -fsargs "-c c=64,a=16,e=16" \
@@ -133,9 +135,10 @@ if command -v SetFile >/dev/null 2>&1; then
 fi
 chflags hidden "$MOUNT_DIR/.background" "$MOUNT_DIR/.VolumeIcon.icns" || true
 
-osascript - "$MOUNT_DIR" <<'APPLESCRIPT'
+osascript - "$MOUNT_DIR" "$APP_NAME" <<'APPLESCRIPT'
 on run argv
   set mountPath to item 1 of argv
+  set appName to item 2 of argv
   set dmgFolder to POSIX file mountPath as alias
   set bgPic to POSIX file (mountPath & "/.background/dmg-background.png") as alias
 
@@ -153,7 +156,7 @@ on run argv
     set text size of opts to 16
     set background picture of opts to bgPic
 
-    set position of item "Minutes.app" of dmgFolder to {180, 200}
+    set position of item appName of dmgFolder to {180, 200}
     set position of item "Applications" of dmgFolder to {480, 200}
     update dmgFolder without registering applications
     delay 2


### PR DESCRIPTION
## What changed

- packages Minutes Archive 0.2.0 as a signed/notarized DMG
- adds a visible one-time launch update check and explicit signed install action
- keeps updater commands behind Rust IPC with no updater permission exposed to the webview
- holds an exclusive backend lease across each network operation so folder/archive access cannot overlap it
- downloads through Tauri's minisign verifier, then performs a link-free, Developer-ID-checked, same-volume atomic macOS app exchange instead of Tauri's incomplete rollback path
- uses a dedicated `archive-stable` channel, separate from normal Minutes releases
- stages release-tag artifacts in a private draft for exact-byte independent review
- promotes only the reviewed checksum set through a second protected environment, with resumable public-byte verification before the stable manifest advances
- binds credential-bearing release tooling to the exact current `main` SHA and tears down all credentials before executing the signed candidate
- gives the complete update announcement one accessible live region and preserves focus when the Install button disappears
- preserves a notarized DMG as the manual recovery path

## Why

Peter should receive a normal Mac installer and should not be stranded on an old pilot build. The update path must remain compatible with the Archive trust boundary: no archive state overlaps update traffic, downloads require explicit consent, and every replacement is verified against both the Minutes updater key and Developer ID identity.

The release path also preserves the independent-review boundary. A version tag creates a private draft and stops. Promotion requires the independently recorded checksum-record hash, refuses changed or unexpected assets, verifies the bytes after they become public, and advances `archive-stable` last. A partial promotion safely resumes from the same reviewed inputs.

## Validation

- full `./scripts/verify-archive-dev-app.sh` — passed, including 4,000-document soak (4,000 indexed; 42 MB peak RSS)
- focused Archive app tests — 21 passed, including concurrent network/archive arbitration, hostile updater archive rejection, and atomic bundle exchange
- strict Archive clippy — passed
- deterministic UI click-through — passed, including update consent, atomic live region, and focus transfer
- rebuilt and installed current `Minutes Archive Dev.app`; bundle seal, executable hash equality, document/worker smoke, and native close/purge passed
- artifact verifier and synthetic QA fixture harnesses — passed
- both release workflows pass `actionlint`
- signing-secret scope policy — passed
- local Tauri app/updater artifact build — passed

## Independent review

The review at `d2eca60d` returned CHANGES REQUIRED with six findings. Exact head `64686fc89d323bd9786b3e75e35f3909f82b3c98` addresses all prior findings, requires and tests the Apple Developer ID trust chain, fails closed if credential teardown cannot complete, and makes Peter's permitted network behavior unambiguous. It is undergoing a fresh detached, read-only review, and no earlier decision is being reused.

## Release gates remaining

This PR intentionally does not deliver anything to Peter. After merge, the exact version-tag build still requires protected signing/notarization into a private draft, independent review of that exact DMG, checksum-bound protected promotion, stable manifest verification, a disposable older-build end-to-end updater test, and final delivery authorization.




