### PR TITLE
Sign Archive DMG container before notarization

### DIFF
--- a/.github/workflows/signed-archive-acceptance.yml
+++ b/.github/workflows/signed-archive-acceptance.yml
@@ -441,6 +441,9 @@ jobs:
             --app "$app" \
             --version "$version" \
             --output "$dmg"
+          codesign --force --timestamp \
+            --sign "$ARCHIVE_SIGNING_IDENTITY" "$dmg"
+          codesign --verify --strict --verbose=4 "$dmg"
           submit_json="$RUNNER_TEMP/archive-dmg-notary-submit.json"
           xcrun notarytool submit "$dmg" \
             --key "$ARCHIVE_API_KEY_PATH" \


### PR DESCRIPTION
The first protected archive-v0.2.0 run proved the app and DMG contents notarize, but Gatekeeper rejected the DMG container with `source=no usable signature`. This signs the final compressed DMG container with the already approved Developer ID Application identity, verifies that signature, and only then submits/staples/assesses it. No draft release or stable channel was created by the failed run.\n\nValidation: actionlint; signing secret scope guard; git diff check.\n\nDelivery remains held.