### PR TITLE
Verify exact Archive draft release payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,8 +3893,10 @@ dependencies = [
 name = "minutes-archive-app"
 version = "0.2.0"
 dependencies = [
+ "base64 0.22.1",
  "flate2",
  "libc",
+ "minisign-verify",
  "minutes-archive-convert",
  "minutes-archive-core",
  "minutes-archive-ocr",

--- a/archive/src-tauri/Cargo.toml
+++ b/archive/src-tauri/Cargo.toml
@@ -14,6 +14,8 @@ minutes-archive-ocr = { path = "../../crates/archive-ocr" }
 minutes-archive-semantic = { path = "../../crates/archive-semantic" }
 minutes-archive-worker-control = { path = "../../crates/archive-worker-control" }
 flate2 = "1"
+base64 = "0.22"
+minisign-verify = "0.2"
 serde = { workspace = true }
 sha2 = "0.10"
 serde_json = { workspace = true }

--- a/archive/src-tauri/examples/verify_updater_signature.rs
+++ b/archive/src-tauri/examples/verify_updater_signature.rs
@@ -1,0 +1,39 @@
+use base64::Engine as _;
+use minisign_verify::{PublicKey, Signature};
+use std::path::PathBuf;
+
+fn required_arg(name: &str) -> PathBuf {
+    std::env::args_os()
+        .nth(match name {
+            "archive" => 1,
+            "signature" => 2,
+            _ => unreachable!(),
+        })
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            eprintln!("usage: verify_updater_signature <archive> <signature>");
+            std::process::exit(2);
+        })
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let archive_path = required_arg("archive");
+    let signature_path = required_arg("signature");
+    let config: serde_json::Value = serde_json::from_slice(include_bytes!("../tauri.conf.json"))?;
+    let encoded_key = config["plugins"]["updater"]["pubkey"]
+        .as_str()
+        .ok_or("Archive updater public key is missing from tauri.conf.json")?;
+    let key_text =
+        String::from_utf8(base64::engine::general_purpose::STANDARD.decode(encoded_key)?)?;
+    let signature_text = String::from_utf8(
+        base64::engine::general_purpose::STANDARD
+            .decode(std::fs::read_to_string(signature_path)?.trim())?,
+    )?;
+
+    let public_key = PublicKey::decode(&key_text)?;
+    let signature = Signature::decode(&signature_text)?;
+    let archive = std::fs::read(archive_path)?;
+    public_key.verify(&archive, &signature, true)?;
+    println!("updater_signature=valid");
+    Ok(())
+}

--- a/docs/release/archive-peter-acceptance.md
+++ b/docs/release/archive-peter-acceptance.md
@@ -9,9 +9,11 @@ review before this run.
 
 The release operator records the exact candidate commit and verifies the
 downloaded notarized artifact with
-`scripts/verify-archive-pilot-artifact.sh`. An independent reviewer approves the
-security packet in `docs/security/archive-pilot-independent-review.md`. The
-operator then performs the complete installed-app interaction once with
+`scripts/verify-archive-pilot-artifact.sh`. The verifier accepts either the
+complete protected-run artifact or the exact six-file private draft release;
+the latter is the promotion decision object. An independent reviewer approves
+the security packet in `docs/security/archive-pilot-independent-review.md`.
+The operator then performs the complete installed-app interaction once with
 normal connectivity under network observation. Do not disable the Mac's Wi-Fi
 or alter system-wide connectivity for this test. The expected result is one
 update check at launch, to the configured GitHub endpoint and any GitHub

--- a/docs/release/archive-pilot-signing-and-handoff.md
+++ b/docs/release/archive-pilot-signing-and-handoff.md
@@ -124,11 +124,13 @@ public and does not touch `archive-stable`. The tag must point to the exact
 current `main` commit; the workflow resolves that SHA itself and checks out
 release tooling by SHA rather than implicitly trusting the tag checkout.
 
-Download that draft with `gh release download`, run the artifact verifier, and
-complete the independent Finder/security review against its exact DMG. Record
-the SHA-256 of `archive-release-SHA256SUMS.txt` from the reviewed draft. Any
-rerun or asset replacement invalidates that recorded value and requires a new
-artifact review.
+Download that draft with `gh release download` into an otherwise empty
+directory, run the artifact verifier on those exact six release assets, and
+complete the independent Finder/security review against its exact DMG. The
+verifier accepts this draft-release shape without the two legacy ZIP files that
+exist only in the complete Actions artifact. Record the SHA-256 of
+`archive-release-SHA256SUMS.txt` from the reviewed draft. Any rerun or asset
+replacement invalidates that recorded value and requires a new artifact review.
 
 Only after the independent decision is `ACCEPT` may the owner dispatch:
 

--- a/docs/security/archive-pilot-independent-review.md
+++ b/docs/security/archive-pilot-independent-review.md
@@ -9,7 +9,8 @@ substitute for the attorney's professional-responsibility analysis.
 
 The review object is one notarized `Minutes Archive.app` produced from an exact
 40-character candidate commit by the protected
-`Signed Archive Pilot Acceptance` workflow. The download must contain:
+`Signed Archive Pilot Acceptance` workflow. The complete protected-run artifact
+contains:
 
 - `minutes-archive-pilot-notarized.zip`;
 - `minutes-archive-pilot-notarized.zip.sha256`;
@@ -28,6 +29,13 @@ The verifier fails unless the zip digest, provenance, Developer ID signature,
 Minutes Team ID `63TMLKT8HN`, production identifier
 `com.useminutes.archive`, notarization ticket, staple, Gatekeeper assessment,
 executable digest, and forbidden-entitlement checks all agree.
+
+For release promotion, run the same verifier on the six files downloaded from
+the private draft. In that shape it additionally requires the exact release
+inventory, checksum coverage, updater manifest binding, updater minisign
+signature, safe tar structure, signed DMG container, expected mount layout, and
+byte-identical applications in the DMG and updater archive. The two legacy ZIP
+files are protected-run evidence, not versioned release assets.
 
 ## Product boundary to verify
 

--- a/scripts/verify-archive-pilot-artifact.sh
+++ b/scripts/verify-archive-pilot-artifact.sh
@@ -6,6 +6,8 @@ EXPECTED_IDENTIFIER="com.useminutes.archive"
 ZIP_NAME="minutes-archive-pilot-notarized.zip"
 SHA_NAME="${ZIP_NAME}.sha256"
 PROVENANCE_NAME="signed-archive-provenance.txt"
+SUMS_NAME="archive-release-SHA256SUMS.txt"
+MANIFEST_NAME="latest-archive.json"
 
 fail() {
   printf 'Archive pilot artifact verification failed: %s\n' "$*" >&2
@@ -14,8 +16,7 @@ fail() {
 
 usage() {
   printf 'Usage: %s <artifact-directory>\n' "$(basename "$0")" >&2
-  printf 'The directory must contain %s, %s, and %s.\n' \
-    "$ZIP_NAME" "$SHA_NAME" "$PROVENANCE_NAME" >&2
+  printf 'Accepts the complete protected-run artifact or the exact six-file draft release.\n' >&2
   exit 2
 }
 
@@ -23,134 +24,221 @@ usage() {
 [[ "$(uname -s)" == "Darwin" ]] ||
   fail "verification requires macOS Gatekeeper, codesign, and stapler"
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 ARTIFACT_DIR="$1"
 [[ -d "$ARTIFACT_DIR" ]] || fail "artifact directory does not exist"
 ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd -P)"
-
-ZIP_PATH="$ARTIFACT_DIR/$ZIP_NAME"
-SHA_PATH="$ARTIFACT_DIR/$SHA_NAME"
 PROVENANCE_PATH="$ARTIFACT_DIR/$PROVENANCE_NAME"
-
-[[ -f "$ZIP_PATH" ]] || fail "missing $ZIP_NAME"
-[[ -f "$SHA_PATH" ]] || fail "missing $SHA_NAME"
-[[ -f "$PROVENANCE_PATH" ]] || fail "missing $PROVENANCE_NAME"
-[[ ! -L "$ZIP_PATH" && ! -L "$SHA_PATH" && ! -L "$PROVENANCE_PATH" ]] ||
-  fail "artifact inputs must be regular files, not symbolic links"
-
-sha_lines="$(wc -l <"$SHA_PATH" | tr -d '[:space:]')"
-[[ "$sha_lines" == "1" ]] || fail "$SHA_NAME must contain exactly one line"
-sha_fields="$(awk 'NR == 1 { print NF }' "$SHA_PATH")"
-expected_zip_sha="$(awk 'NR == 1 { print $1 }' "$SHA_PATH")"
-declared_zip_name="$(awk 'NR == 1 { print $2 }' "$SHA_PATH")"
-[[ "$sha_fields" == "2" && "$declared_zip_name" == "$ZIP_NAME" ]] ||
-  fail "$SHA_NAME must bind only $ZIP_NAME"
-[[ ${#expected_zip_sha} -eq 64 && ! "$expected_zip_sha" =~ [^0-9a-f] ]] ||
-  fail "$SHA_NAME does not contain a lowercase SHA-256"
-
-actual_zip_sha="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
-[[ "$actual_zip_sha" == "$expected_zip_sha" ]] ||
-  fail "notarized zip SHA-256 does not match"
+[[ -f "$PROVENANCE_PATH" && ! -L "$PROVENANCE_PATH" ]] ||
+  fail "missing or linked $PROVENANCE_NAME"
 
 provenance_lines="$(wc -l <"$PROVENANCE_PATH" | tr -d '[:space:]')"
 [[ "$provenance_lines" == "6" ]] ||
   fail "$PROVENANCE_NAME must contain the six reviewed fields"
-
 candidate_sha="$(sed -n 's/^candidate=//p' "$PROVENANCE_PATH")"
 team_id="$(sed -n 's/^team_id=//p' "$PROVENANCE_PATH")"
 identifier="$(sed -n 's/^identifier=//p' "$PROVENANCE_PATH")"
 expected_executable_sha="$(sed -n 's/^executable_sha256=//p' "$PROVENANCE_PATH")"
 notarized="$(sed -n 's/^notarized=//p' "$PROVENANCE_PATH")"
 stapled="$(sed -n 's/^stapled=//p' "$PROVENANCE_PATH")"
-
 [[ ${#candidate_sha} -eq 40 && ! "$candidate_sha" =~ [^0-9a-f] ]] ||
   fail "candidate provenance is not one exact lowercase commit SHA"
 [[ "$team_id" == "$EXPECTED_TEAM_ID" ]] ||
   fail "provenance Team ID is not the reviewed Minutes team"
 [[ "$identifier" == "$EXPECTED_IDENTIFIER" ]] ||
   fail "provenance bundle identifier is not the Archive production identifier"
-[[ ${#expected_executable_sha} -eq 64 &&
-  ! "$expected_executable_sha" =~ [^0-9a-f] ]] ||
+[[ ${#expected_executable_sha} -eq 64 && ! "$expected_executable_sha" =~ [^0-9a-f] ]] ||
   fail "executable provenance is not a lowercase SHA-256"
 [[ "$notarized" == "true" && "$stapled" == "true" ]] ||
   fail "provenance does not claim both notarization and stapling"
-
-expected_fields="$(
-  grep -Ec \
-    '^(candidate|team_id|identifier|executable_sha256|notarized|stapled)=' \
-    "$PROVENANCE_PATH"
-)"
+expected_fields="$(grep -Ec '^(candidate|team_id|identifier|executable_sha256|notarized|stapled)=' "$PROVENANCE_PATH")"
 [[ "$expected_fields" == "6" ]] ||
   fail "$PROVENANCE_NAME contains an unknown or duplicate field"
 
-EXTRACT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/minutes-archive-verify.XXXXXX")"
+VERIFY_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/minutes-archive-verify.XXXXXX")"
+MOUNT_POINT=""
 cleanup() {
-  rm -rf "$EXTRACT_ROOT"
+  if [[ -n "$MOUNT_POINT" ]]; then
+    hdiutil detach "$MOUNT_POINT" -quiet || true
+  fi
+  rm -rf "$VERIFY_ROOT"
 }
 trap cleanup EXIT HUP INT TERM
 
-ditto -x -k "$ZIP_PATH" "$EXTRACT_ROOT"
-APP_PATH="$EXTRACT_ROOT/Minutes Archive.app"
-EXECUTABLE="$APP_PATH/Contents/MacOS/minutes-archive-app"
-INFO_PLIST="$APP_PATH/Contents/Info.plist"
+verify_app() {
+  local app="$1"
+  local expected_version="${2:-}"
+  local executable="$app/Contents/MacOS/minutes-archive-app"
+  local info_plist="$app/Contents/Info.plist"
+  [[ -d "$app" && -x "$executable" && -f "$info_plist" ]] ||
+    fail "package does not contain the expected Minutes Archive application"
+  if find "$app" -type l -print -quit | grep -q .; then
+    fail "application contains a symbolic link"
+  fi
+  local bundle_identifier
+  bundle_identifier="$(plutil -extract CFBundleIdentifier raw -o - "$info_plist")"
+  [[ "$bundle_identifier" == "$EXPECTED_IDENTIFIER" ]] ||
+    fail "Info.plist bundle identifier does not match"
+  if [[ -n "$expected_version" ]]; then
+    local bundle_version
+    bundle_version="$(plutil -extract CFBundleShortVersionString raw -o - "$info_plist")"
+    [[ "$bundle_version" == "$expected_version" ]] ||
+      fail "application version does not match the updater manifest"
+  fi
 
-[[ -d "$APP_PATH" && -x "$EXECUTABLE" && -f "$INFO_PLIST" ]] ||
-  fail "zip does not contain the expected Minutes Archive application"
-if find "$APP_PATH" -type l -print -quit | grep -q .; then
-  fail "application contains a symbolic link"
-fi
+  codesign --verify --deep --strict --verbose=4 "$app"
+  local identity signed_team_id signed_identifier
+  identity="$(codesign -dv --verbose=4 "$app" 2>&1)"
+  signed_team_id="$(awk -F= '/^TeamIdentifier=/{print $2}' <<<"$identity")"
+  signed_identifier="$(awk -F= '/^Identifier=/{print $2}' <<<"$identity")"
+  [[ "$signed_team_id" == "$EXPECTED_TEAM_ID" ]] || fail "code signature Team ID does not match"
+  [[ "$signed_identifier" == "$EXPECTED_IDENTIFIER" ]] || fail "code signature identifier does not match"
+  grep -Fq "Authority=Developer ID Application:" <<<"$identity" ||
+    fail "application is not signed with a Developer ID Application identity"
+  grep -Fq "flags=0x10000(runtime)" <<<"$identity" ||
+    grep -Eq "flags=0x[0-9a-f]*10000" <<<"$identity" ||
+    fail "application is not signed with the hardened runtime enabled"
 
-bundle_identifier="$(plutil -extract CFBundleIdentifier raw -o - "$INFO_PLIST")"
-[[ "$bundle_identifier" == "$EXPECTED_IDENTIFIER" ]] ||
-  fail "Info.plist bundle identifier does not match"
+  local entitlements_path="$VERIFY_ROOT/entitlements.$$.plist"
+  if ! codesign -d --entitlements - "$app" >"$entitlements_path" 2>/dev/null; then
+    fail "could not read entitlements; refusing to certify the artifact"
+  fi
+  if [[ -s "$entitlements_path" ]]; then
+    for forbidden_entitlement in \
+      "com.apple.security.get-task-allow" \
+      "com.apple.security.cs.disable-library-validation" \
+      "com.apple.security.cs.allow-dyld-environment-variables" \
+      "com.apple.security.cs.allow-unsigned-executable-memory"; do
+      if plutil -p "$entitlements_path" | grep -Fq "\"$forbidden_entitlement\" => true"; then
+        fail "forbidden entitlement enabled: $forbidden_entitlement"
+      fi
+    done
+  fi
+  xcrun stapler validate "$app"
+  spctl --assess --type execute --verbose=4 "$app"
+  actual_executable_sha="$(shasum -a 256 "$executable" | awk '{print $1}')"
+  [[ "$actual_executable_sha" == "$expected_executable_sha" ]] ||
+    fail "signed executable SHA-256 does not match provenance"
+}
 
-codesign --verify --deep --strict --verbose=4 "$APP_PATH"
-identity="$(codesign -dv --verbose=4 "$APP_PATH" 2>&1)"
-signed_team_id="$(awk -F= '/^TeamIdentifier=/{print $2}' <<<"$identity")"
-signed_identifier="$(awk -F= '/^Identifier=/{print $2}' <<<"$identity")"
-[[ "$signed_team_id" == "$EXPECTED_TEAM_ID" ]] ||
-  fail "code signature Team ID does not match"
-[[ "$signed_identifier" == "$EXPECTED_IDENTIFIER" ]] ||
-  fail "code signature identifier does not match"
-grep -Fq "Authority=Developer ID Application:" <<<"$identity" ||
-  fail "application is not signed with a Developer ID Application identity"
-
-# The hardened runtime must be on, or the forbidden-entitlement list below is
-# moot: without it, DYLD_INSERT_LIBRARIES can inject into the process holding
-# the in-memory index of privileged documents.
-grep -Fq "flags=0x10000(runtime)" <<<"$identity" ||
-  grep -Eq "flags=0x[0-9a-f]*10000" <<<"$identity" ||
-  fail "application is not signed with the hardened runtime enabled"
-
-entitlements_path="$EXTRACT_ROOT/entitlements.plist"
-# Fail closed. This previously used `|| true` and then skipped the whole loop
-# when the file was empty, so any codesign failure silently reported success
-# on every forbidden entitlement.
-if ! codesign -d --entitlements - "$APP_PATH" >"$entitlements_path" 2>/dev/null; then
-  fail "could not read entitlements; refusing to certify the artifact"
-fi
-if [[ -s "$entitlements_path" ]]; then
-  for forbidden_entitlement in \
-    "com.apple.security.get-task-allow" \
-    "com.apple.security.cs.disable-library-validation" \
-    "com.apple.security.cs.allow-dyld-environment-variables" \
-    "com.apple.security.cs.allow-unsigned-executable-memory"; do
-    if plutil -p "$entitlements_path" |
-      grep -Fq "\"$forbidden_entitlement\" => true"; then
-      fail "forbidden entitlement enabled: $forbidden_entitlement"
-    fi
+if [[ -e "$ARTIFACT_DIR/$ZIP_NAME" || -e "$ARTIFACT_DIR/$SHA_NAME" ]]; then
+  ZIP_PATH="$ARTIFACT_DIR/$ZIP_NAME"
+  SHA_PATH="$ARTIFACT_DIR/$SHA_NAME"
+  [[ -f "$ZIP_PATH" && -f "$SHA_PATH" && ! -L "$ZIP_PATH" && ! -L "$SHA_PATH" ]] ||
+    fail "complete-run artifact must contain regular $ZIP_NAME and $SHA_NAME"
+  sha_lines="$(wc -l <"$SHA_PATH" | tr -d '[:space:]')"
+  sha_fields="$(awk 'NR == 1 { print NF }' "$SHA_PATH")"
+  expected_zip_sha="$(awk 'NR == 1 { print $1 }' "$SHA_PATH")"
+  declared_zip_name="$(awk 'NR == 1 { print $2 }' "$SHA_PATH")"
+  [[ "$sha_lines" == "1" && "$sha_fields" == "2" && "$declared_zip_name" == "$ZIP_NAME" ]] ||
+    fail "$SHA_NAME must bind only $ZIP_NAME"
+  [[ ${#expected_zip_sha} -eq 64 && ! "$expected_zip_sha" =~ [^0-9a-f] ]] ||
+    fail "$SHA_NAME does not contain a lowercase SHA-256"
+  actual_zip_sha="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
+  [[ "$actual_zip_sha" == "$expected_zip_sha" ]] || fail "notarized zip SHA-256 does not match"
+  ditto -x -k "$ZIP_PATH" "$VERIFY_ROOT/legacy"
+  verify_app "$VERIFY_ROOT/legacy/Minutes Archive.app"
+  printf 'artifact_shape=complete-run\n'
+  printf 'zip_sha256=%s\n' "$actual_zip_sha"
+else
+  MANIFEST_PATH="$ARTIFACT_DIR/$MANIFEST_NAME"
+  SUMS_PATH="$ARTIFACT_DIR/$SUMS_NAME"
+  for path in "$MANIFEST_PATH" "$SUMS_PATH"; do
+    [[ -f "$path" && ! -L "$path" ]] || fail "missing or linked $(basename "$path")"
   done
+  version="$(python3 - "$MANIFEST_PATH" <<'PY'
+import json, sys
+value = json.load(open(sys.argv[1])).get("version", "")
+if not isinstance(value, str):
+    raise SystemExit(1)
+print(value)
+PY
+)" || fail "manifest is not valid JSON"
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "manifest version is not X.Y.Z"
+  DMG_NAME="Minutes_Archive_${version}_aarch64.dmg"
+  UPDATER_NAME="Minutes.Archive_${version}_aarch64.app.tar.gz"
+  SIGNATURE_NAME="${UPDATER_NAME}.sig"
+  expected_inventory="$VERIFY_ROOT/expected-inventory.txt"
+  actual_inventory="$VERIFY_ROOT/actual-inventory.txt"
+  printf '%s\n' "$DMG_NAME" "$UPDATER_NAME" "$SIGNATURE_NAME" "$SUMS_NAME" "$MANIFEST_NAME" "$PROVENANCE_NAME" | sort >"$expected_inventory"
+  find "$ARTIFACT_DIR" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort >"$actual_inventory"
+  diff -u "$expected_inventory" "$actual_inventory" >/dev/null ||
+    fail "draft-release directory is not the exact six-file promotion payload"
+  while IFS= read -r name; do
+    [[ ! -L "$ARTIFACT_DIR/$name" ]] || fail "release asset is a symbolic link: $name"
+  done <"$expected_inventory"
+
+  expected_checksum_names="$VERIFY_ROOT/expected-checksum-names.txt"
+  actual_checksum_names="$VERIFY_ROOT/actual-checksum-names.txt"
+  printf '%s\n' "$DMG_NAME" "$UPDATER_NAME" "$SIGNATURE_NAME" "$MANIFEST_NAME" "$PROVENANCE_NAME" | sort >"$expected_checksum_names"
+  awk '{name=$2; sub(/^\*/, "", name); print name}' "$SUMS_PATH" | sort >"$actual_checksum_names"
+  diff -u "$expected_checksum_names" "$actual_checksum_names" >/dev/null ||
+    fail "$SUMS_NAME does not bind the exact five release files"
+  (cd "$ARTIFACT_DIR" && shasum -a 256 -c "$SUMS_NAME")
+
+  expected_url="https://github.com/silverstein/minutes/releases/download/archive-v${version}/${UPDATER_NAME}"
+  python3 - "$MANIFEST_PATH" "$ARTIFACT_DIR/$SIGNATURE_NAME" "$version" "$expected_url" <<'PY' ||
+import json, pathlib, sys
+manifest = json.load(open(sys.argv[1]))
+signature = pathlib.Path(sys.argv[2]).read_text().strip()
+platforms = manifest.get("platforms")
+if not isinstance(platforms, dict) or set(platforms) != {"darwin-aarch64"}:
+    raise SystemExit("manifest must contain only darwin-aarch64")
+platform = platforms["darwin-aarch64"]
+if manifest.get("version") != sys.argv[3]:
+    raise SystemExit("manifest version mismatch")
+if platform.get("url") != sys.argv[4]:
+    raise SystemExit("manifest updater URL mismatch")
+if not signature or platform.get("signature") != signature:
+    raise SystemExit("manifest signature mismatch")
+PY
+    fail "manifest does not bind the exact updater release asset"
+
+  cargo run --quiet --manifest-path "$REPO_ROOT/archive/src-tauri/Cargo.toml" \
+    --example verify_updater_signature -- \
+    "$ARTIFACT_DIR/$UPDATER_NAME" "$ARTIFACT_DIR/$SIGNATURE_NAME" ||
+    fail "updater signature does not validate against the embedded Archive public key"
+
+  python3 - "$ARTIFACT_DIR/$UPDATER_NAME" "$VERIFY_ROOT/updater" <<'PY' ||
+import pathlib, sys, tarfile
+archive_path, destination = sys.argv[1:]
+root = pathlib.PurePosixPath("Minutes Archive.app")
+with tarfile.open(archive_path, "r:gz") as archive:
+    members = archive.getmembers()
+    if not members:
+        raise SystemExit("empty updater archive")
+    for member in members:
+        path = pathlib.PurePosixPath(member.name)
+        if not path.parts or path.parts[0] != str(root) or ".." in path.parts:
+            raise SystemExit(f"unsafe updater path: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise SystemExit("updater contains a link or special file")
+    archive.extractall(destination, filter="data")
+PY
+    fail "updater archive structure is unsafe"
+  verify_app "$VERIFY_ROOT/updater/Minutes Archive.app" "$version"
+
+  DMG_PATH="$ARTIFACT_DIR/$DMG_NAME"
+  codesign --verify --strict --verbose=4 "$DMG_PATH"
+  xcrun stapler validate "$DMG_PATH"
+  spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG_PATH"
+  attach_output="$(hdiutil attach -readonly -nobrowse "$DMG_PATH")" || fail "could not mount DMG read-only"
+  MOUNT_POINT="$(awk -F '\t' '$3 ~ /^\// { print $3; exit }' <<<"$attach_output")"
+  [[ -n "$MOUNT_POINT" && -d "$MOUNT_POINT/Minutes Archive.app" ]] || fail "DMG does not contain Minutes Archive.app"
+  [[ -L "$MOUNT_POINT/Applications" && "$(readlink "$MOUNT_POINT/Applications")" == "/Applications" ]] ||
+    fail "DMG does not contain the expected Applications link"
+  ditto "$MOUNT_POINT/Minutes Archive.app" "$VERIFY_ROOT/dmg/Minutes Archive.app"
+  hdiutil detach "$MOUNT_POINT" -quiet
+  MOUNT_POINT=""
+  verify_app "$VERIFY_ROOT/dmg/Minutes Archive.app" "$version"
+  diff -qr "$VERIFY_ROOT/updater/Minutes Archive.app" "$VERIFY_ROOT/dmg/Minutes Archive.app" >/dev/null ||
+    fail "DMG and updater archive do not contain identical application trees"
+  printf 'artifact_shape=draft-release\n'
+  printf 'release_sums_sha256=%s\n' "$(shasum -a 256 "$SUMS_PATH" | awk '{print $1}')"
 fi
-
-xcrun stapler validate "$APP_PATH"
-spctl --assess --type execute --verbose=4 "$APP_PATH"
-
-actual_executable_sha="$(shasum -a 256 "$EXECUTABLE" | awk '{print $1}')"
-[[ "$actual_executable_sha" == "$expected_executable_sha" ]] ||
-  fail "signed executable SHA-256 does not match provenance"
 
 printf 'artifact_verification=passed\n'
 printf 'candidate_sha=%s\n' "$candidate_sha"
-printf 'zip_sha256=%s\n' "$actual_zip_sha"
-printf 'team_id=%s\n' "$signed_team_id"
-printf 'identifier=%s\n' "$signed_identifier"
-printf 'executable_sha256=%s\n' "$actual_executable_sha"
+printf 'team_id=%s\n' "$team_id"
+printf 'identifier=%s\n' "$identifier"
+printf 'executable_sha256=%s\n' "$expected_executable_sha"

--- a/scripts/verify-archive-pilot-artifact.sh
+++ b/scripts/verify-archive-pilot-artifact.sh
@@ -220,6 +220,12 @@ PY
 
   DMG_PATH="$ARTIFACT_DIR/$DMG_NAME"
   codesign --verify --strict --verbose=4 "$DMG_PATH"
+  dmg_identity="$(codesign -dv --verbose=4 "$DMG_PATH" 2>&1)"
+  dmg_team_id="$(awk -F= '/^TeamIdentifier=/{print $2}' <<<"$dmg_identity")"
+  [[ "$dmg_team_id" == "$EXPECTED_TEAM_ID" ]] ||
+    fail "DMG code signature Team ID does not match"
+  grep -Fq "Authority=Developer ID Application:" <<<"$dmg_identity" ||
+    fail "DMG is not signed with a Developer ID Application identity"
   xcrun stapler validate "$DMG_PATH"
   spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG_PATH"
   attach_output="$(hdiutil attach -readonly -nobrowse "$DMG_PATH")" || fail "could not mount DMG read-only"
@@ -227,6 +233,10 @@ PY
   [[ -n "$MOUNT_POINT" && -d "$MOUNT_POINT/Minutes Archive.app" ]] || fail "DMG does not contain Minutes Archive.app"
   [[ -L "$MOUNT_POINT/Applications" && "$(readlink "$MOUNT_POINT/Applications")" == "/Applications" ]] ||
     fail "DMG does not contain the expected Applications link"
+  visible_mount_entries="$VERIFY_ROOT/visible-mount-entries.txt"
+  find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 ! -name '.*' -exec basename {} \; | sort >"$visible_mount_entries"
+  diff -u <(printf '%s\n' Applications 'Minutes Archive.app') "$visible_mount_entries" >/dev/null ||
+    fail "DMG contains an unexpected visible root payload"
   ditto "$MOUNT_POINT/Minutes Archive.app" "$VERIFY_ROOT/dmg/Minutes Archive.app"
   hdiutil detach "$MOUNT_POINT" -quiet
   MOUNT_POINT=""

--- a/scripts/verify-archive-pilot-artifact.test.sh
+++ b/scripts/verify-archive-pilot-artifact.test.sh
@@ -34,6 +34,12 @@ printf '%s\n' \
 
 printf '%s\n' \
   '#!/bin/bash' \
+  'target="${!#}"' \
+  'if [[ "$1" == "-dv" && "$target" == *.dmg ]]; then' \
+  '  printf "Authority=Developer ID Application: Test (63TMLKT8HN)\n" >&2' \
+  '  printf "TeamIdentifier=%s\n" "${ARCHIVE_TEST_DMG_TEAM_ID:-63TMLKT8HN}" >&2' \
+  '  exit 0' \
+  'fi' \
   "if [[ \"\$1\" == \"-dv\" ]]; then" \
   '  printf "Identifier=com.useminutes.archive\n" >&2' \
   '  printf "Authority=Developer ID Application: Test (63TMLKT8HN)\n" >&2' \
@@ -176,6 +182,17 @@ expect_failure "unexpected draft release asset" \
 make_draft_release
 printf 'changed\n' >>"$ARTIFACT_DIR/Minutes.Archive_0.2.0_aarch64.app.tar.gz"
 expect_failure "changed updater bytes" \
+  env PATH="$MOCK_BIN:$PATH" ARCHIVE_TEST_MOUNT_ROOT="$MOUNT_ROOT" \
+  "$VERIFIER" "$ARTIFACT_DIR"
+
+make_draft_release
+expect_failure "wrong DMG code-signing team" \
+  env PATH="$MOCK_BIN:$PATH" ARCHIVE_TEST_MOUNT_ROOT="$MOUNT_ROOT" \
+  ARCHIVE_TEST_DMG_TEAM_ID=WRONGTEAM "$VERIFIER" "$ARTIFACT_DIR"
+
+make_draft_release
+mkdir -p "$MOUNT_ROOT/Unexpected Installer.app"
+expect_failure "unexpected visible DMG payload" \
   env PATH="$MOCK_BIN:$PATH" ARCHIVE_TEST_MOUNT_ROOT="$MOUNT_ROOT" \
   "$VERIFIER" "$ARTIFACT_DIR"
 

--- a/scripts/verify-archive-pilot-artifact.test.sh
+++ b/scripts/verify-archive-pilot-artifact.test.sh
@@ -15,6 +15,7 @@ ARTIFACT_DIR="$TEST_ROOT/artifacts"
 SOURCE_ROOT="$TEST_ROOT/source"
 APP_PATH="$SOURCE_ROOT/Minutes Archive.app"
 EXECUTABLE="$APP_PATH/Contents/MacOS/minutes-archive-app"
+MOUNT_ROOT="$TEST_ROOT/mount"
 ZIP_NAME="minutes-archive-pilot-notarized.zip"
 SHA_NAME="${ZIP_NAME}.sha256"
 PROVENANCE_NAME="signed-archive-provenance.txt"
@@ -27,6 +28,7 @@ printf '%s\n' \
   '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
   '<plist version="1.0"><dict>' \
   '<key>CFBundleIdentifier</key><string>com.useminutes.archive</string>' \
+  '<key>CFBundleShortVersionString</key><string>0.2.0</string>' \
   '</dict></plist>' \
   >"$APP_PATH/Contents/Info.plist"
 
@@ -42,7 +44,16 @@ printf '%s\n' \
   >"$MOCK_BIN/codesign"
 printf '%s\n' '#!/bin/bash' 'exit 0' >"$MOCK_BIN/xcrun"
 printf '%s\n' '#!/bin/bash' 'exit 0' >"$MOCK_BIN/spctl"
-chmod 755 "$MOCK_BIN/codesign" "$MOCK_BIN/xcrun" "$MOCK_BIN/spctl"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'if [[ "$1" == "attach" ]]; then' \
+  '  printf "/dev/disk99\tApple_HFS\t%s\n" "$ARCHIVE_TEST_MOUNT_ROOT"' \
+  'fi' \
+  'exit 0' \
+  >"$MOCK_BIN/hdiutil"
+printf '%s\n' '#!/bin/bash' 'printf "updater_signature=valid\n"' >"$MOCK_BIN/cargo"
+chmod 755 "$MOCK_BIN/codesign" "$MOCK_BIN/xcrun" "$MOCK_BIN/spctl" \
+  "$MOCK_BIN/hdiutil" "$MOCK_BIN/cargo"
 
 make_artifact() {
   rm -rf "$ARTIFACT_DIR"
@@ -106,5 +117,66 @@ sed -i '' 's/^stapled=true$/unexpected=true/' \
   "$ARTIFACT_DIR/$PROVENANCE_NAME"
 expect_failure "unexpected provenance field" \
   env PATH="$MOCK_BIN:$PATH" "$VERIFIER" "$ARTIFACT_DIR"
+
+make_draft_release() {
+  rm -rf "$ARTIFACT_DIR" "$MOUNT_ROOT"
+  mkdir -p "$ARTIFACT_DIR" "$MOUNT_ROOT"
+  ditto "$APP_PATH" "$MOUNT_ROOT/Minutes Archive.app"
+  ln -s /Applications "$MOUNT_ROOT/Applications"
+  COPYFILE_DISABLE=1 tar -C "$SOURCE_ROOT" -czf \
+    "$ARTIFACT_DIR/Minutes.Archive_0.2.0_aarch64.app.tar.gz" \
+    "Minutes Archive.app"
+  printf 'synthetic dmg fixture\n' >"$ARTIFACT_DIR/Minutes_Archive_0.2.0_aarch64.dmg"
+  printf 'synthetic signature fixture\n' \
+    >"$ARTIFACT_DIR/Minutes.Archive_0.2.0_aarch64.app.tar.gz.sig"
+  printf '%s\n' \
+    '{' \
+    '  "version": "0.2.0",' \
+    '  "platforms": {' \
+    '    "darwin-aarch64": {' \
+    '      "signature": "synthetic signature fixture",' \
+    '      "url": "https://github.com/silverstein/minutes/releases/download/archive-v0.2.0/Minutes.Archive_0.2.0_aarch64.app.tar.gz"' \
+    '    }' \
+    '  }' \
+    '}' \
+    >"$ARTIFACT_DIR/latest-archive.json"
+  executable_sha="$(shasum -a 256 "$EXECUTABLE" | awk '{print $1}')"
+  printf '%s\n' \
+    "candidate=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    "team_id=63TMLKT8HN" \
+    "identifier=com.useminutes.archive" \
+    "executable_sha256=$executable_sha" \
+    "notarized=true" \
+    "stapled=true" \
+    >"$ARTIFACT_DIR/$PROVENANCE_NAME"
+  (
+    cd "$ARTIFACT_DIR"
+    shasum -a 256 \
+      Minutes_Archive_0.2.0_aarch64.dmg \
+      Minutes.Archive_0.2.0_aarch64.app.tar.gz \
+      Minutes.Archive_0.2.0_aarch64.app.tar.gz.sig \
+      latest-archive.json \
+      signed-archive-provenance.txt \
+      >archive-release-SHA256SUMS.txt
+  )
+}
+
+make_draft_release
+PATH="$MOCK_BIN:$PATH" ARCHIVE_TEST_MOUNT_ROOT="$MOUNT_ROOT" \
+  "$VERIFIER" "$ARTIFACT_DIR" >"$TEST_ROOT/draft-success.out"
+grep -Fq "artifact_shape=draft-release" "$TEST_ROOT/draft-success.out"
+grep -Fq "artifact_verification=passed" "$TEST_ROOT/draft-success.out"
+
+make_draft_release
+printf 'unexpected\n' >"$ARTIFACT_DIR/extra-file"
+expect_failure "unexpected draft release asset" \
+  env PATH="$MOCK_BIN:$PATH" ARCHIVE_TEST_MOUNT_ROOT="$MOUNT_ROOT" \
+  "$VERIFIER" "$ARTIFACT_DIR"
+
+make_draft_release
+printf 'changed\n' >>"$ARTIFACT_DIR/Minutes.Archive_0.2.0_aarch64.app.tar.gz"
+expect_failure "changed updater bytes" \
+  env PATH="$MOCK_BIN:$PATH" ARCHIVE_TEST_MOUNT_ROOT="$MOUNT_ROOT" \
+  "$VERIFIER" "$ARTIFACT_DIR"
 
 printf 'archive_pilot_artifact_verifier_tests=passed\n'


### PR DESCRIPTION
## Summary
- make the Archive artifact verifier accept the exact six-file private draft that promotion consumes
- verify checksum coverage, manifest binding, updater minisign signature, safe archive layout, DMG signature/staple/Gatekeeper, mount layout, and identical app trees
- retain verification of the complete protected-run ZIP artifact and document the two supported evidence shapes

## Validation
- `./scripts/verify-archive-pilot-artifact.test.sh`
- verifier passed against the exact current six-file private draft release
- verifier passed against the complete protected-run artifact
- `cargo fmt --all -- --check`
- `cargo clippy -p minutes-archive-app --example verify_updater_signature -- -D warnings`
- `cargo test -p minutes-archive-app` (22 passed)

This resolves the independent reviewer P1 without promoting or changing any signed release bytes.