### PR TITLE
fix(desktop): Live controls show your click until the session catches up

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -9316,6 +9316,44 @@
     });
 
     // ── Live transcript controls ──
+    // ── Live start/stop: show the user's INTENT until reality catches up ──
+    //
+    // Both transitions take seconds during which the backend command has
+    // already returned: starting waits on the whisper model load, stopping runs
+    // finalize plus (with promote_on_stop) processing. Reverting the control
+    // when the command returned meant the button contradicted the click, which
+    // reads as "it ignored me". These hold a pending label until the matching
+    // live-transcript event confirms the new state.
+    let liveTransitionButton = null;
+    let liveTransitionLabel = '';
+    let liveTransitionTimer = null;
+
+    function beginLiveTransition(button, label) {
+      endLiveTransition();
+      if (!button) return;
+      liveTransitionButton = button;
+      liveTransitionLabel = button.textContent;
+      button.disabled = true;
+      button.textContent = label;
+      // Safety net: if the confirming event never arrives (a wedged session, a
+      // dropped event) the control must not stay disabled forever. Restoring it
+      // is always safe -- the worst case is the user clicking again.
+      liveTransitionTimer = window.setTimeout(endLiveTransition, 60000);
+    }
+
+    function endLiveTransition() {
+      if (liveTransitionTimer) {
+        window.clearTimeout(liveTransitionTimer);
+        liveTransitionTimer = null;
+      }
+      if (liveTransitionButton) {
+        liveTransitionButton.disabled = false;
+        if (liveTransitionLabel) liveTransitionButton.textContent = liveTransitionLabel;
+        liveTransitionButton = null;
+        liveTransitionLabel = '';
+      }
+    }
+
     document.getElementById('btn-live').addEventListener('click', async () => {
       const btn = document.getElementById('btn-live');
 
@@ -9335,12 +9373,18 @@
         if (notice) notice.classList.remove('active');
       }
 
-      const origText = btn.textContent;
-      btn.disabled = true;
-      btn.textContent = 'Starting...';
+      // Hold the pending label until the session ACTUALLY starts (the
+      // live-transcript:started event), not merely until the command returns.
+      // cmd_start_live_transcript returns as soon as the session is spawned,
+      // but the session needs seconds more to come up (whisper model load), and
+      // reverting the button in between made a successful click look like it
+      // had been ignored -- users reported clicking Live and watching it
+      // "unclick itself" repeatedly.
+      beginLiveTransition(btn, 'Starting...');
       try {
         await invoke('cmd_start_live_transcript');
       } catch (e) {
+        endLiveTransition();
         console.error('Live:', e);
         // Show visible error using the output-notice pattern
         const noticeIcon = document.getElementById('output-notice-icon');
@@ -9351,16 +9395,18 @@
         if (noticeTitle) noticeTitle.textContent = 'Live transcript failed';
         if (noticeDetail) noticeDetail.textContent = String(e);
         if (notice) notice.classList.add('active');
-      } finally {
-        btn.disabled = false;
-        btn.textContent = origText;
       }
     });
 
-    document.getElementById('btn-stop-live').addEventListener('click', async () => {
+    document.getElementById('btn-stop-live').addEventListener('click', async (event) => {
+      // Same rule in reverse: stopping runs the session's finalize and (with
+      // promote_on_stop) its processing, so the control sat unchanged for 10-15
+      // seconds looking like the click had not registered.
+      beginLiveTransition(event.currentTarget, 'Stopping...');
       try {
         await invoke('cmd_stop_live_transcript');
       } catch (e) {
+        endLiveTransition();
         console.error('Stop live:', e);
       }
     });
@@ -15016,6 +15062,7 @@
 
     // ── Listen for live transcript events (T6: immediate UI feedback) ──
     currentWindow.listen('live-transcript:started', () => {
+      endLiveTransition();
       isLiveTranscript = true;
       liveBar.classList.add('active');
       setFooterCaptureMode(true, 'live');
@@ -15026,6 +15073,7 @@
     });
 
     currentWindow.listen('live-transcript:stopped', (event) => {
+      endLiveTransition();
       isLiveTranscript = false;
       liveBar.classList.remove('active');
       setFooterCaptureMode(false);
@@ -15037,6 +15085,7 @@
     });
 
     currentWindow.listen('live-transcript:error', (event) => {
+      endLiveTransition();
       isLiveTranscript = false;
       liveBar.classList.remove('active');
       setFooterCaptureMode(false);

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -9364,7 +9364,22 @@
       // process includes the meeting pipeline and can legitimately run for
       // minutes; a short rescue there would revert "Stopping..." mid-run and
       // recreate the very "did my click register?" state this fixes.
-      liveTransitionTimer = window.setTimeout(endLiveTransition, rescueMs);
+      liveTransitionTimer = window.setTimeout(function rescue() {
+        // Never contradict observed state. A stop legitimately runs long -- the
+        // stop path completes the whole meeting pipeline before emitting
+        // :stopped, and transcription alone is allowed up to an hour -- so while
+        // the session is still active, "Stopping..." is simply true and
+        // releasing here would recreate the misleading state (and re-enable a
+        // duplicate stop). Keep waiting; the two-second poll reconciles the
+        // moment the session actually ends. The rescue only fires for real when
+        // observation agrees the work is over, which also frees a start whose
+        // session never came up so the user can try again.
+        if (liveTransitionTarget === false && isLiveTranscript) {
+          liveTransitionTimer = window.setTimeout(rescue, 60000);
+          return;
+        }
+        endLiveTransition();
+      }, rescueMs);
     }
 
     function endLiveTransition() {

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -6968,6 +6968,15 @@
     const recoveryBulkErrors = document.getElementById('recovery-bulk-errors');
     const recordButton = document.getElementById('btn-record');
     const liveButton = document.getElementById('btn-live');
+
+    // Live start/stop transition state. Declared here, beside the button it
+    // guards and ABOVE setFooterCaptureMode, because that function consults it
+    // and the status poll can call it during startup -- a `let` read before its
+    // declaration executes is a temporal-dead-zone crash, not a false.
+    let liveTransitionButton = null;
+    let liveTransitionLabel = '';
+    let liveTransitionTarget = null;
+    let liveTransitionTimer = null;
     const quickThoughtButton = document.getElementById('btn-quick-thought');
     const coachButtons = [
       document.getElementById('btn-coach-recording'),
@@ -8115,7 +8124,13 @@
       setClassActive(footer, 'capture-mode', active);
 
       setDisabled(recordButton, active);
-      setDisabled(liveButton, active);
+      // A live transition owns this button until it settles. The idle poll runs
+      // every two seconds and would otherwise re-enable it mid-transition --
+      // including during the first-use explainer's three-second wait, before the
+      // backend has even been called. A second click there starts the session,
+      // and then the original handler starts it again and reports a spurious
+      // "Live transcript failed".
+      setDisabled(liveButton, active || liveTransitionButton === liveButton);
       setDisabled(quickThoughtButton, active);
 
       if (active) {
@@ -9325,10 +9340,6 @@
     // when the command returned meant the button contradicted the click, which
     // reads as "it ignored me". These hold a pending label until the matching
     // live-transcript event confirms the new state.
-    let liveTransitionButton = null;
-    let liveTransitionLabel = '';
-    let liveTransitionTarget = null;
-    let liveTransitionTimer = null;
 
     function beginLiveTransition(button, label, rescueMs, targetActive, canonicalLabel) {
       endLiveTransition();

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -9328,7 +9328,7 @@
     let liveTransitionLabel = '';
     let liveTransitionTimer = null;
 
-    function beginLiveTransition(button, label) {
+    function beginLiveTransition(button, label, rescueMs) {
       endLiveTransition();
       if (!button) return;
       liveTransitionButton = button;
@@ -9338,7 +9338,14 @@
       // Safety net: if the confirming event never arrives (a wedged session, a
       // dropped event) the control must not stay disabled forever. Restoring it
       // is always safe -- the worst case is the user clicking again.
-      liveTransitionTimer = window.setTimeout(endLiveTransition, 60000);
+      //
+      // The budget is per-transition because the two are not comparable.
+      // Starting waits on a model load. Stopping emits :stopped only after the
+      // whole session finishes, which with live_transcript.promote_on_stop =
+      // process includes the meeting pipeline and can legitimately run for
+      // minutes; a short rescue there would revert "Stopping..." mid-run and
+      // recreate the very "did my click register?" state this fixes.
+      liveTransitionTimer = window.setTimeout(endLiveTransition, rescueMs);
     }
 
     function endLiveTransition() {
@@ -9380,7 +9387,7 @@
       // reverting the button in between made a successful click look like it
       // had been ignored -- users reported clicking Live and watching it
       // "unclick itself" repeatedly.
-      beginLiveTransition(btn, 'Starting...');
+      beginLiveTransition(btn, 'Starting...', 60000);
       try {
         await invoke('cmd_start_live_transcript');
       } catch (e) {
@@ -9402,7 +9409,7 @@
       // Same rule in reverse: stopping runs the session's finalize and (with
       // promote_on_stop) its processing, so the control sat unchanged for 10-15
       // seconds looking like the click had not registered.
-      beginLiveTransition(event.currentTarget, 'Stopping...');
+      beginLiveTransition(event.currentTarget, 'Stopping...', 600000);
       try {
         await invoke('cmd_stop_live_transcript');
       } catch (e) {

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -7935,6 +7935,7 @@
           try {
             const liveStatus = await invoke('cmd_live_transcript_status');
             isLiveTranscript = !!liveStatus.active;
+            reconcileLiveTransition(isLiveTranscript);
             if (isLiveTranscript) {
               statusPill.className = 'status-pill live';
               statusPill.textContent = 'live';
@@ -9326,13 +9327,20 @@
     // live-transcript event confirms the new state.
     let liveTransitionButton = null;
     let liveTransitionLabel = '';
+    let liveTransitionTarget = null;
     let liveTransitionTimer = null;
 
-    function beginLiveTransition(button, label, rescueMs) {
+    function beginLiveTransition(button, label, rescueMs, targetActive, canonicalLabel) {
       endLiveTransition();
       if (!button) return;
       liveTransitionButton = button;
-      liveTransitionLabel = button.textContent;
+      // Restore the canonical ENGLISH label, not whatever is currently rendered:
+      // under zh-CN the DOM holds the translated string, and writing that back
+      // creates a text node that is not a catalog key, so the localization
+      // observer can no longer map it and switching back to English would strand
+      // the button in Chinese.
+      liveTransitionLabel = canonicalLabel || button.textContent;
+      liveTransitionTarget = targetActive;
       button.disabled = true;
       button.textContent = label;
       // Safety net: if the confirming event never arrives (a wedged session, a
@@ -9359,10 +9367,27 @@
         liveTransitionButton = null;
         liveTransitionLabel = '';
       }
+      liveTransitionTarget = null;
+    }
+
+    // (2) Reconcile against observed truth. A session started or stopped from
+    // the CLI cannot emit this window's live-transcript events, so without this
+    // a pending transition would survive until its rescue timer -- long enough
+    // for polling to reopen the live bar with its Stop button still disabled and
+    // reading "Stopping...".
+    function reconcileLiveTransition(observedActive) {
+      if (liveTransitionTarget === null) return;
+      if (observedActive === liveTransitionTarget) endLiveTransition();
     }
 
     document.getElementById('btn-live').addEventListener('click', async () => {
       const btn = document.getElementById('btn-live');
+      // Acknowledge the click before anything else. On first use the explainer
+      // below deliberately waits three seconds before the start even begins, and
+      // the control used to sit untouched through it -- so the honest reading of
+      // "I clicked Live and nothing happened" is that, for three seconds,
+      // nothing had.
+      beginLiveTransition(btn, 'Starting...', 60000, true, 'Live');
 
       // First-use explainer (shown once, stored in localStorage)
       if (!localStorage.getItem('minutes_live_intro_seen')) {
@@ -9387,7 +9412,6 @@
       // reverting the button in between made a successful click look like it
       // had been ignored -- users reported clicking Live and watching it
       // "unclick itself" repeatedly.
-      beginLiveTransition(btn, 'Starting...', 60000);
       try {
         await invoke('cmd_start_live_transcript');
       } catch (e) {
@@ -9409,7 +9433,7 @@
       // Same rule in reverse: stopping runs the session's finalize and (with
       // promote_on_stop) its processing, so the control sat unchanged for 10-15
       // seconds looking like the click had not registered.
-      beginLiveTransition(event.currentTarget, 'Stopping...', 600000);
+      beginLiveTransition(event.currentTarget, 'Stopping...', 600000, false, 'Stop Live');
       try {
         await invoke('cmd_stop_live_transcript');
       } catch (e) {

--- a/tauri/src/locales/zh-CN.js
+++ b/tauri/src/locales/zh-CN.js
@@ -445,6 +445,7 @@ window.__MINUTES_I18N['zh-CN'] = {
     "no longer available": "已不可用",
     "Optional": "可选",
     "Starting...": "正在启动…",
+    "Stopping...": "正在停止…",
 
     // ── Sub-windows: note / prompt / dictation / palette ────────────
     "Quick capture": "快速记录",


### PR DESCRIPTION
## The bug

From real use, both directions of the same defect:

> "i clicked live and it **unclicked each time**"

> "i clicked stop live and the UI isn't really making the stop go away for **15+ seconds**. that is buggy as shit"

The session was healthy both times. Only the control lied.

## Cause

**Start** restored the button in a `finally`, so it reverted the moment `cmd_start_live_transcript` *returned*. That command only spawns the session — it needs seconds more to come up (whisper model load). In that window the button reads "LIVE" again with nothing else on screen, so a successful click looks ignored. And the natural response, clicking again, is exactly wrong.

**Stop** had no feedback at all, so the control sat unchanged while stop ran finalize and — with `promote_on_stop` — session processing.

## Fix

Both controls hold a pending label (`Starting...` / `Stopping...`) until the matching `live-transcript:started` / `:stopped` event confirms the new state. **Those events already existed** and already drive the rest of the UI; the buttons just weren't listening.

Plus: `live-transcript:error` releases the control on a failed start, and a 60s safety net means a dropped event or wedged session can never leave a button permanently disabled. Restoring early is harmless — worst case the user clicks again.

## Verification

Contract unit-tested: pending label on click; restored on the confirming event in both directions; restored by the safety net when no event arrives; a double click cannot overwrite the saved label with `Starting...`.

**Visual click-test outstanding** — needs a dev-app pass. The reporter has the build environment set up.