### PR TITLE
fix(desktop): live panel says what it is doing, not "0 utterances"

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -5377,7 +5377,7 @@
       <div class="live-level">
         <div class="live-level-fill" id="live-level-fill"></div>
       </div>
-      <div class="live-utterances" id="live-utterances">0 utterances</div>
+      <div class="live-utterances" id="live-utterances">Listening…</div>
       <div class="live-actions">
         <button class="btn btn-secondary btn-sm coach-toggle" id="btn-coach-live" type="button" aria-pressed="false">Coach</button>
         <button class="btn btn-secondary btn-sm" id="btn-stop-live">Stop Live</button>
@@ -7947,7 +7947,16 @@
               const min = Math.floor(d / 60);
               const sec = d % 60;
               document.getElementById('live-time').textContent = `${min}:${String(sec).padStart(2, '0')}`;
-              document.getElementById('live-utterances').textContent = `${n} utterance${n !== 1 ? 's' : ''}`;
+              // Say what is happening, not what the pipeline calls it. An
+              // "utterance" is a VAD-bounded chunk finalized on a pause, so this
+              // is legitimately 0 while someone is still talking -- but "0
+              // utterances" beside a moving level meter reads as "this is
+              // broken", and the term means nothing to the person using it. A
+              // user reported exactly that: "it says zero utterances even though
+              // the green bar is moving" / "that goes over my head".
+              document.getElementById('live-utterances').textContent = n === 0
+                ? 'Listening…'
+                : `${n} line${n !== 1 ? 's' : ''} captured`;
               const lvl = Math.min(100, liveStatus.audioLevel || 0);
               document.getElementById('live-level-fill').style.width = lvl + '%';
               if (!wasLive) startFastPoll();


### PR DESCRIPTION
## The report

From real use, with the level meter clearly moving:

> "it says zero utterances even though the green bar is moving, is that to be expected?"
> …
> "i dont get that vs utterances, that goes over my head"

## Why it's a bug even though the behaviour was correct

An "utterance" is a VAD-bounded chunk finalized on a pause, so the count is *legitimately* 0 while someone is still talking — that session's transcript came out fine.

The problem is what it communicates. "Utterance" is pipeline vocabulary, and **0 of anything next to a live audio meter reads as "this is not working."** The user telling me the concept went over their head is the finding, not a misunderstanding to correct: nobody should need to know what an utterance is to trust their meeting is being captured.

## The change

| count | before | after |
|---|---|---|
| 0 | `0 utterances` | `Listening…` |
| 1+ | `3 utterances` | `3 lines captured` |

The idle placeholder in the markup was `0 utterances` too, so the panel **greeted every session with its most alarming state** before any audio had arrived. That's fixed as well.

Two-line change; no behaviour touched.