### PR TITLE
feat(mcp): add an opt-in Streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,33 @@ Minutes exposes a standard MCP server. Point any MCP-compatible client at it:
 }
 ```
 
+#### Transports
+
+`minutes-mcp` speaks stdio by default, which is what the config above uses: the client spawns the server as a subprocess and owns its lifetime. Nothing changes for existing setups.
+
+Pass `--transport http` to run one long-lived Streamable HTTP server instead, so several clients share a single process rather than each spawning their own:
+
+```bash
+minutes-mcp --transport http --port 7373
+```
+
+Then point clients at the endpoint:
+
+```json
+{
+  "mcpServers": {
+    "minutes": {
+      "type": "http",
+      "url": "http://127.0.0.1:7373/mcp"
+    }
+  }
+}
+```
+
+Flags: `--host` (default `127.0.0.1`), `--port` (default `7373`; `0` asks the OS for a free port and the chosen one is printed to stderr), `--max-sessions` (default 16). Each accepts an environment variable instead: `MINUTES_MCP_TRANSPORT`, `MINUTES_MCP_HOST`, `MINUTES_MCP_PORT`, `MINUTES_MCP_MAX_SESSIONS`. `GET /health` reports live session count.
+
+HTTP mode has no authentication. It binds `127.0.0.1`, so only this machine can reach it, and it rejects requests whose `Host` or `Origin` is not loopback. That second check matters: binding to loopback does not by itself stop a web page you have open from POSTing to a local port. Do not bind a public address or forward the port.
+
 Canonical MCP reference now lives at:
 
 - <https://useminutes.app/docs/mcp/tools>

--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ Then point clients at the endpoint:
 
 Flags: `--port` (default `7373`; `0` asks the OS for a free port and the chosen one is printed to stderr), `--max-sessions` (default 16). Each accepts an environment variable instead: `MINUTES_MCP_TRANSPORT`, `MINUTES_MCP_PORT`, `MINUTES_MCP_MAX_SESSIONS`. `GET /health` reports live session count.
 
+Request bodies are JSON-RPC envelopes, so they are capped at 4 MiB; anything larger gets a JSON-RPC error with HTTP 413. A client that disconnects without sending `DELETE /mcp` leaves its session behind, so a session with no request in flight and no open stream is reclaimed after 30 minutes idle and answers 404 after that. A client holding an open stream is never reclaimed, however quiet it is.
+
 HTTP mode has no authentication, so the bind address is always `127.0.0.1` and there is no flag to change it. Only this machine can reach the endpoint, and it rejects requests whose `Host` or `Origin` is not loopback. That second check matters: binding to loopback does not by itself stop a web page you have open from POSTing to a local port.
 
 To reach it from another machine, front it with a reverse proxy and put authentication there. The proxy has to rewrite `Host` to the upstream address, since the original name would fail the loopback check. In Caddy:

--- a/README.md
+++ b/README.md
@@ -517,9 +517,19 @@ Then point clients at the endpoint:
 }
 ```
 
-Flags: `--host` (default `127.0.0.1`), `--port` (default `7373`; `0` asks the OS for a free port and the chosen one is printed to stderr), `--max-sessions` (default 16). Each accepts an environment variable instead: `MINUTES_MCP_TRANSPORT`, `MINUTES_MCP_HOST`, `MINUTES_MCP_PORT`, `MINUTES_MCP_MAX_SESSIONS`. `GET /health` reports live session count.
+Flags: `--port` (default `7373`; `0` asks the OS for a free port and the chosen one is printed to stderr), `--max-sessions` (default 16). Each accepts an environment variable instead: `MINUTES_MCP_TRANSPORT`, `MINUTES_MCP_PORT`, `MINUTES_MCP_MAX_SESSIONS`. `GET /health` reports live session count.
 
-HTTP mode has no authentication. It binds `127.0.0.1`, so only this machine can reach it, and it rejects requests whose `Host` or `Origin` is not loopback. That second check matters: binding to loopback does not by itself stop a web page you have open from POSTing to a local port. Do not bind a public address or forward the port.
+HTTP mode has no authentication, so the bind address is always `127.0.0.1` and there is no flag to change it. Only this machine can reach the endpoint, and it rejects requests whose `Host` or `Origin` is not loopback. That second check matters: binding to loopback does not by itself stop a web page you have open from POSTing to a local port.
+
+To reach it from another machine, front it with a reverse proxy and put authentication there. The proxy has to rewrite `Host` to the upstream address, since the original name would fail the loopback check. In Caddy:
+
+```
+reverse_proxy 127.0.0.1:7373 {
+  header_up Host {upstream_hostport}
+}
+```
+
+Native MCP clients send no `Origin`, so nothing else is needed for them. A browser-based client would also need its `Origin` handled at the proxy, which gives up the CSRF defense described above.
 
 Canonical MCP reference now lives at:
 

--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -32,11 +32,12 @@
   "scripts": {
     "build": "tsc && vite build",
     "build:ui": "vite build",
-    "test": "npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs",
+    "test": "npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs && node test/mcp_http_transport_test.mjs",
     "test:unit": "vitest run",
     "test:host-compat": "node test/live_events_host_compat.mjs",
     "test:copilot": "node test/copilot_mcp_contract.mjs",
-    "test:all": "vitest run && npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs",
+    "test:http": "node test/mcp_http_transport_test.mjs",
+    "test:all": "vitest run && npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs && node test/mcp_http_transport_test.mjs",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts"
   },

--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -32,12 +32,13 @@
   "scripts": {
     "build": "tsc && vite build",
     "build:ui": "vite build",
-    "test": "npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs && node test/mcp_http_transport_test.mjs",
+    "test": "npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs && node test/mcp_http_transport_test.mjs && node test/surface_parity_test.mjs",
     "test:unit": "vitest run",
     "test:host-compat": "node test/live_events_host_compat.mjs",
     "test:copilot": "node test/copilot_mcp_contract.mjs",
     "test:http": "node test/mcp_http_transport_test.mjs",
-    "test:all": "vitest run && npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs && node test/mcp_http_transport_test.mjs",
+    "test:surface-parity": "node test/surface_parity_test.mjs",
+    "test:all": "vitest run && npm run build && node test/mcp_tools_test.mjs && node test/copilot_mcp_contract.mjs && node test/mcp_http_transport_test.mjs && node test/surface_parity_test.mjs",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts"
   },

--- a/crates/mcp/src/httpTransport.test.ts
+++ b/crates/mcp/src/httpTransport.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  DEFAULT_HTTP_HOST,
+  HTTP_BIND_HOST,
   DEFAULT_HTTP_PORT,
   isAllowedContentType,
   isAllowedHostHeader,
@@ -9,36 +9,38 @@ import {
 } from "./httpTransport.js";
 
 describe("http transport request guards", () => {
-  it("binds loopback by default", () => {
-    expect(DEFAULT_HTTP_HOST).toBe("127.0.0.1");
+  it("binds loopback, with nothing to override it", () => {
+    expect(HTTP_BIND_HOST).toBe("127.0.0.1");
     expect(DEFAULT_HTTP_PORT).toBeGreaterThan(1024);
   });
 
   describe("Host header", () => {
-    it("accepts loopback names and the bound address", () => {
+    it("accepts loopback names", () => {
       for (const host of [
         "127.0.0.1:7373",
         "localhost:7373",
         "localhost",
         "[::1]:7373",
       ]) {
-        expect(isAllowedHostHeader(host, "127.0.0.1")).toBe(true);
+        expect(isAllowedHostHeader(host)).toBe(true);
       }
     });
 
-    it("accepts the explicitly bound non-loopback address", () => {
-      expect(isAllowedHostHeader("192.168.1.10:7373", "192.168.1.10")).toBe(true);
+    // The allowlist is fixed, so a LAN address never passes. Before --host was
+    // removed, binding one added it here, which is the hole that removal closed.
+    it("rejects a non-loopback address", () => {
+      expect(isAllowedHostHeader("192.168.1.10:7373")).toBe(false);
+      expect(isAllowedHostHeader("0.0.0.0:7373")).toBe(false);
     });
 
     // A rebound hostname resolves to 127.0.0.1 but still sends its own name.
     it("rejects a rebound hostname", () => {
-      expect(isAllowedHostHeader("attacker.example:7373", "127.0.0.1")).toBe(false);
-      expect(isAllowedHostHeader("192.168.1.10:7373", "127.0.0.1")).toBe(false);
+      expect(isAllowedHostHeader("attacker.example:7373")).toBe(false);
     });
 
     it("rejects a missing Host header", () => {
-      expect(isAllowedHostHeader(undefined, "127.0.0.1")).toBe(false);
-      expect(isAllowedHostHeader("", "127.0.0.1")).toBe(false);
+      expect(isAllowedHostHeader(undefined)).toBe(false);
+      expect(isAllowedHostHeader("")).toBe(false);
     });
   });
 

--- a/crates/mcp/src/httpTransport.test.ts
+++ b/crates/mcp/src/httpTransport.test.ts
@@ -195,6 +195,78 @@ describe("session reclamation", () => {
     const tools = await client.listTools();
     expect(tools.tools.map((t) => t.name)).toContain("ping");
   });
+
+  // `isInitializeRequest` validates method and params but not `id`, so an
+  // initialize sent as a JSON-RPC notification passes it. Opening a session for
+  // one strands the slot: the SDK answers 202 with no `Mcp-Session-Id`, so the
+  // client has no handle to use it or to DELETE it, and only the reaper frees
+  // it. Repeat it and the session limit is exhausted by requests that never
+  // produced a usable session.
+  //
+  // Asserting the 400 alone is not enough — a session opened and then refused
+  // would still leak. The session count is the assertion that matters.
+  it("refuses an initialize sent as a notification, without opening a session", async () => {
+    const server = await start();
+
+    const notificationInitialize = {
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "no-id-client", version: "0.0.0" },
+      },
+    };
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const response = await fetch(server.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify(notificationInitialize),
+      });
+      expect(response.status).toBe(400);
+      await response.arrayBuffer();
+    }
+
+    // maxSessions is 2 here, so four attempts would have exhausted it.
+    expect(server.sessionCount()).toBe(0);
+
+    // And the limit was never consumed: a real client still initializes.
+    const client = await connect(server);
+    const tools = await client.listTools();
+    expect(tools.tools.map((t) => t.name)).toContain("ping");
+  });
+
+  // `id: null` is not a valid JSON-RPC request id either, and it takes a
+  // different path through the schema than a missing `id`.
+  it("refuses an initialize whose id is null", async () => {
+    const server = await start();
+
+    const response = await fetch(server.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: null,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "null-id-client", version: "0.0.0" },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await response.arrayBuffer();
+    expect(server.sessionCount()).toBe(0);
+  });
 });
 
 describe("oversized request bodies", () => {

--- a/crates/mcp/src/httpTransport.test.ts
+++ b/crates/mcp/src/httpTransport.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_HTTP_HOST,
+  DEFAULT_HTTP_PORT,
+  isAllowedContentType,
+  isAllowedHostHeader,
+  isAllowedOrigin,
+} from "./httpTransport.js";
+
+describe("http transport request guards", () => {
+  it("binds loopback by default", () => {
+    expect(DEFAULT_HTTP_HOST).toBe("127.0.0.1");
+    expect(DEFAULT_HTTP_PORT).toBeGreaterThan(1024);
+  });
+
+  describe("Host header", () => {
+    it("accepts loopback names and the bound address", () => {
+      for (const host of [
+        "127.0.0.1:7373",
+        "localhost:7373",
+        "localhost",
+        "[::1]:7373",
+      ]) {
+        expect(isAllowedHostHeader(host, "127.0.0.1")).toBe(true);
+      }
+    });
+
+    it("accepts the explicitly bound non-loopback address", () => {
+      expect(isAllowedHostHeader("192.168.1.10:7373", "192.168.1.10")).toBe(true);
+    });
+
+    // A rebound hostname resolves to 127.0.0.1 but still sends its own name.
+    it("rejects a rebound hostname", () => {
+      expect(isAllowedHostHeader("attacker.example:7373", "127.0.0.1")).toBe(false);
+      expect(isAllowedHostHeader("192.168.1.10:7373", "127.0.0.1")).toBe(false);
+    });
+
+    it("rejects a missing Host header", () => {
+      expect(isAllowedHostHeader(undefined, "127.0.0.1")).toBe(false);
+      expect(isAllowedHostHeader("", "127.0.0.1")).toBe(false);
+    });
+  });
+
+  describe("Origin header", () => {
+    // Native MCP clients send no Origin; browsers always do cross-origin.
+    it("accepts an absent Origin", () => {
+      expect(isAllowedOrigin(undefined)).toBe(true);
+    });
+
+    it("accepts loopback origins", () => {
+      expect(isAllowedOrigin("http://localhost:5173")).toBe(true);
+      expect(isAllowedOrigin("http://127.0.0.1:3000")).toBe(true);
+    });
+
+    it("rejects web origins and opaque origins", () => {
+      expect(isAllowedOrigin("https://evil.example")).toBe(false);
+      expect(isAllowedOrigin("null")).toBe(false);
+      expect(isAllowedOrigin("not a url")).toBe(false);
+    });
+  });
+
+  describe("Content-Type", () => {
+    it("accepts JSON with parameters", () => {
+      expect(isAllowedContentType("application/json")).toBe(true);
+      expect(isAllowedContentType("application/json; charset=utf-8")).toBe(true);
+      expect(isAllowedContentType("Application/JSON")).toBe(true);
+    });
+
+    // text/plain is a CORS simple request and would skip preflight entirely.
+    it("rejects everything else", () => {
+      expect(isAllowedContentType("text/plain")).toBe(false);
+      expect(isAllowedContentType("application/x-www-form-urlencoded")).toBe(false);
+      expect(isAllowedContentType(undefined)).toBe(false);
+    });
+  });
+});

--- a/crates/mcp/src/httpTransport.test.ts
+++ b/crates/mcp/src/httpTransport.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import {
   HTTP_BIND_HOST,
@@ -6,6 +10,12 @@ import {
   isAllowedContentType,
   isAllowedHostHeader,
   isAllowedOrigin,
+  startMinutesHttpServer,
+} from "./httpTransport.js";
+import type {
+  MinutesHttpServer,
+  MinutesHttpServerOptions,
+  MinutesServerFactory,
 } from "./httpTransport.js";
 
 describe("http transport request guards", () => {
@@ -75,5 +85,112 @@ describe("http transport request guards", () => {
       expect(isAllowedContentType("application/x-www-form-urlencoded")).toBe(false);
       expect(isAllowedContentType(undefined)).toBe(false);
     });
+  });
+});
+
+describe("session reclamation", () => {
+  // A stub server, not the real Minutes one: this exercises the transport's
+  // session bookkeeping, and importing index.ts would drag in the CLI probe.
+  function stubFactory(): ReturnType<MinutesServerFactory> {
+    const server = new McpServer(
+      { name: "reclamation-test", version: "0.0.0" },
+      { capabilities: { tools: {} } }
+    );
+    server.registerTool(
+      "ping",
+      { description: "Test tool", inputSchema: {} },
+      async () => ({ content: [{ type: "text" as const, text: "pong" }] })
+    );
+    return { server, dispose: () => {} };
+  }
+
+  let httpServer: MinutesHttpServer | undefined;
+  const clients: Client[] = [];
+
+  afterEach(async () => {
+    // Without this vitest hangs: the listener and its sockets outlive the test.
+    for (const client of clients.splice(0)) {
+      await client.close().catch(() => {});
+    }
+    await httpServer?.close();
+    httpServer = undefined;
+  });
+
+  async function start(overrides: Partial<MinutesHttpServerOptions> = {}) {
+    httpServer = await startMinutesHttpServer({
+      port: 0,
+      maxSessions: 2,
+      sessionIdleTimeoutMs: 150,
+      createServer: stubFactory,
+      log: () => {},
+      ...overrides,
+    });
+    return httpServer;
+  }
+
+  /** Connect a real SDK client, so the abandonment path is the real one. */
+  async function connect(server: MinutesHttpServer): Promise<Client> {
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(new StreamableHTTPClientTransport(new URL(server.url)));
+    clients.push(client);
+    return client;
+  }
+
+  async function waitFor(
+    predicate: () => boolean,
+    timeoutMs = 5000
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate()) {
+      if (Date.now() > deadline) throw new Error("condition never became true");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  it("reclaims a session abandoned without a DELETE", async () => {
+    const server = await start();
+    const client = await connect(server);
+    expect(server.sessionCount()).toBe(1);
+
+    // The SDK's close() aborts its fetches and does NOT send a DELETE, which
+    // is what a crashed or disconnected client looks like to the server.
+    await client.close();
+    clients.length = 0;
+
+    await waitFor(() => server.sessionCount() === 0);
+    expect(server.sessionCount()).toBe(0);
+  });
+
+  // The regression the review reported: not "the count drops" but "the server
+  // stops serving anyone". Every session is abandoned without a DELETE, which
+  // used to fill the map permanently and 503 every later client.
+  it("still accepts a new client after every session was abandoned", async () => {
+    const server = await start({ maxSessions: 2 });
+
+    for (let i = 0; i < 2; i++) {
+      const client = await connect(server);
+      await client.close();
+    }
+    clients.length = 0;
+
+    await waitFor(() => server.sessionCount() === 0);
+
+    const fresh = await connect(server);
+    const tools = await fresh.listTools();
+    expect(tools.tools.map((t) => t.name)).toContain("ping");
+    expect(server.sessionCount()).toBe(1);
+  });
+
+  it("keeps a session that is still holding a stream open", async () => {
+    const server = await start();
+    const client = await connect(server);
+
+    // The SDK client holds a standalone GET SSE stream for the session's life,
+    // so idling well past the timeout must not reclaim it.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(server.sessionCount()).toBe(1);
+    const tools = await client.listTools();
+    expect(tools.tools.map((t) => t.name)).toContain("ping");
   });
 });

--- a/crates/mcp/src/httpTransport.test.ts
+++ b/crates/mcp/src/httpTransport.test.ts
@@ -11,6 +11,8 @@ import {
   isAllowedHostHeader,
   isAllowedOrigin,
   startMinutesHttpServer,
+  HEALTH_HTTP_PATH,
+  MAX_REQUEST_BODY_BYTES,
 } from "./httpTransport.js";
 import type {
   MinutesHttpServer,
@@ -192,5 +194,92 @@ describe("session reclamation", () => {
     expect(server.sessionCount()).toBe(1);
     const tools = await client.listTools();
     expect(tools.tools.map((t) => t.name)).toContain("ping");
+  });
+});
+
+describe("oversized request bodies", () => {
+  function stubFactory(): ReturnType<MinutesServerFactory> {
+    const server = new McpServer(
+      { name: "oversize-test", version: "0.0.0" },
+      { capabilities: { tools: {} } }
+    );
+    return { server, dispose: () => {} };
+  }
+
+  let httpServer: MinutesHttpServer | undefined;
+
+  afterEach(async () => {
+    await httpServer?.close();
+    httpServer = undefined;
+  });
+
+  // The whole point of the finding: the documented 413 has to arrive. Reading
+  // the JSON body is the assertion — a resolved fetch alone would also be
+  // satisfied by a response that never carried the error.
+  it("answers an oversized body with a readable JSON-RPC 413", async () => {
+    httpServer = await startMinutesHttpServer({
+      port: 0,
+      createServer: stubFactory,
+      log: () => {},
+    });
+
+    const oversized = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { pad: "x".repeat(MAX_REQUEST_BODY_BYTES + 1024) },
+    });
+
+    const response = await fetch(httpServer.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: oversized,
+    });
+
+    expect(response.status).toBe(413);
+    const payload = (await response.json()) as {
+      jsonrpc: string;
+      error: { code: number; message: string };
+    };
+    expect(payload.jsonrpc).toBe("2.0");
+    expect(payload.error.message).toMatch(/too large/i);
+    expect(payload.error.code).toBe(-32000);
+
+    // The listener survives it, rather than the refusal taking the server down.
+    const health = await fetch(
+      `http://${httpServer.host}:${httpServer.port}${HEALTH_HTTP_PATH}`
+    );
+    expect(health.status).toBe(200);
+  });
+
+  it("still accepts a body just under the limit", async () => {
+    httpServer = await startMinutesHttpServer({
+      port: 0,
+      createServer: stubFactory,
+      log: () => {},
+    });
+
+    // Not an initialize, so this is refused on its merits (400) rather than on
+    // size — which is what distinguishes "under the limit" from "rejected".
+    const response = await fetch(httpServer.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: { pad: "x".repeat(1024) },
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error: { message: string } };
+    expect(payload.error.message).not.toMatch(/too large/i);
   });
 });

--- a/crates/mcp/src/httpTransport.ts
+++ b/crates/mcp/src/httpTransport.ts
@@ -71,6 +71,14 @@ export const DEFAULT_MAX_SESSIONS = 16;
 export const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
 
 /**
+ * How much of an oversized body to read and throw away before giving up on the
+ * client. Reading past the limit is what lets the 413 be delivered at all, but
+ * it is not open-ended: a client that ignores the response and keeps streaming
+ * gets its socket cut once it has spent this much.
+ */
+export const OVERSIZE_DRAIN_BUDGET_BYTES = 1024 * 1024;
+
+/**
  * How long a session with nothing open may sit before it is reclaimed.
  *
  * Generous on purpose. Reclaiming is spec-sanctioned — the server MAY end a
@@ -180,12 +188,21 @@ function headerValue(
   return raw ?? undefined;
 }
 
-function sendJson(res: ServerResponse, status: number, body: unknown): void {
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  closeConnection = false
+): void {
   const payload = JSON.stringify(body);
-  res.writeHead(status, {
+  const headers: Record<string, string | number> = {
     "Content-Type": "application/json",
     "Content-Length": Buffer.byteLength(payload),
-  });
+  };
+  // Used when the request body was refused part-read: the rest of it is of no
+  // interest, and keeping the connection alive would only invite more of it.
+  if (closeConnection) headers.Connection = "close";
+  res.writeHead(status, headers);
   res.end(payload);
 }
 
@@ -193,31 +210,57 @@ function sendJsonRpcError(
   res: ServerResponse,
   status: number,
   code: number,
-  message: string
+  message: string,
+  closeConnection = false
 ): void {
-  sendJson(res, status, {
-    jsonrpc: "2.0",
-    error: { code, message },
-    id: null,
-  });
+  sendJson(
+    res,
+    status,
+    {
+      jsonrpc: "2.0",
+      error: { code, message },
+      id: null,
+    },
+    closeConnection
+  );
 }
 
-/** Read a bounded request body. Rejects (rather than buffers) oversized posts. */
+/**
+ * Read a bounded request body. Rejects (rather than buffers) oversized posts.
+ *
+ * Once the limit is crossed the buffered chunks are dropped, but the stream is
+ * left flowing and discarded rather than destroyed. Destroying the request here
+ * tears down the socket, and the 413 the caller then writes goes nowhere — the
+ * client sees a connection reset instead of the error. Draining costs at most
+ * OVERSIZE_DRAIN_BUDGET_BYTES, after which the socket does go.
+ */
 function readBody(req: IncomingMessage): Promise<Buffer> {
   return new Promise((resolvePromise, rejectPromise) => {
     const chunks: Buffer[] = [];
     let total = 0;
+    let overflowed = false;
     req.on("data", (chunk: Buffer) => {
       total += chunk.length;
-      if (total > MAX_REQUEST_BODY_BYTES) {
+      if (!overflowed && total > MAX_REQUEST_BODY_BYTES) {
+        overflowed = true;
+        chunks.length = 0;
         rejectPromise(new Error("Request body too large"));
-        req.destroy();
+      }
+      if (!overflowed) {
+        chunks.push(chunk);
         return;
       }
-      chunks.push(chunk);
+      if (total > MAX_REQUEST_BODY_BYTES + OVERSIZE_DRAIN_BUDGET_BYTES) {
+        req.destroy();
+      }
     });
-    req.on("end", () => resolvePromise(Buffer.concat(chunks)));
-    req.on("error", rejectPromise);
+    req.on("end", () => {
+      if (!overflowed) resolvePromise(Buffer.concat(chunks));
+    });
+    req.on("error", (error) => {
+      // Already rejected on overflow; a reset while draining is expected.
+      if (!overflowed) rejectPromise(error);
+    });
   });
 }
 
@@ -434,7 +477,7 @@ export async function startMinutesHttpServer(
       try {
         raw = await readBody(req);
       } catch {
-        sendJsonRpcError(res, 413, -32000, "Request body too large");
+        sendJsonRpcError(res, 413, -32000, "Request body too large", true);
         return;
       }
       try {

--- a/crates/mcp/src/httpTransport.ts
+++ b/crates/mcp/src/httpTransport.ts
@@ -1,0 +1,420 @@
+/**
+ * Streamable HTTP transport for the Minutes MCP server.
+ *
+ * Opt-in alternative to stdio (`minutes-mcp --transport http`). One long-lived
+ * process can serve several MCP clients at once instead of each host spawning
+ * its own stdio subprocess.
+ *
+ * Session model: the MCP SDK gives one `Protocol` instance one transport
+ * (`Protocol.connect()` throws on a second), and a stateless Streamable HTTP
+ * transport refuses to be reused across requests because concurrent clients
+ * would collide on JSON-RPC request ids. So each `initialize` gets its own
+ * transport plus its own `McpServer`, keyed by the `Mcp-Session-Id` header.
+ * The instances share all module-level state in index.ts — only protocol
+ * state is per-session.
+ *
+ * Security: binds 127.0.0.1 by default. Binding to loopback alone does not
+ * make the endpoint private — any page in the user's browser can POST to
+ * localhost — so requests are additionally checked for a loopback `Host`, a
+ * loopback-or-absent `Origin`, and a JSON content type. There is no
+ * authentication; do not expose this port beyond the local machine.
+ */
+
+import { createServer as createNodeHttpServer } from "node:http";
+import type {
+  IncomingMessage,
+  Server as NodeHttpServer,
+  ServerResponse,
+} from "node:http";
+import type { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/** Loopback-only by default; see the module docstring before changing. */
+export const DEFAULT_HTTP_HOST = "127.0.0.1";
+
+/**
+ * Unassigned by IANA and outside the ranges dev servers habitually grab
+ * (3000/5173/8000/8080), so a shared Minutes endpoint is unlikely to collide.
+ */
+export const DEFAULT_HTTP_PORT = 7373;
+
+/** The single MCP endpoint. GET opens the notification stream, DELETE ends a session. */
+export const MCP_HTTP_PATH = "/mcp";
+
+/** Liveness/inspection endpoint — not part of the MCP protocol. */
+export const HEALTH_HTTP_PATH = "/health";
+
+/** Concurrent sessions allowed. Unauthenticated localhost, so this is bounded. */
+export const DEFAULT_MAX_SESSIONS = 16;
+
+/** Request bodies are JSON-RPC envelopes, never audio; paths are passed by name. */
+export const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+export type MinutesServerFactory = () => {
+  server: McpServer;
+  dispose: () => void;
+};
+
+export type MinutesHttpServerOptions = {
+  /** Interface to bind. Defaults to 127.0.0.1. */
+  host?: string;
+  /** Port to bind. 0 asks the OS for a free port; read it back from `port`. */
+  port?: number;
+  /** Reject new sessions past this many concurrent ones. */
+  maxSessions?: number;
+  /** Builds a fresh McpServer per session. */
+  createServer: MinutesServerFactory;
+  /** Diagnostics sink. Defaults to stderr. */
+  log?: (message: string) => void;
+};
+
+export type MinutesHttpServer = {
+  host: string;
+  /** The actually bound port — meaningful when 0 was requested. */
+  port: number;
+  url: string;
+  sessionCount: () => number;
+  close: () => Promise<void>;
+};
+
+/** Strip a `:port` suffix and IPv6 brackets from a Host/Origin authority. */
+function hostnameOf(authority: string): string | null {
+  const trimmed = authority.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end === -1) return null;
+    return trimmed.slice(0, end + 1).toLowerCase();
+  }
+  const colon = trimmed.indexOf(":");
+  return (colon === -1 ? trimmed : trimmed.slice(0, colon)).toLowerCase();
+}
+
+/**
+ * DNS-rebinding defense: a hostile name resolved to 127.0.0.1 still sends its
+ * own name in `Host`, so only the bound address and loopback names pass.
+ */
+export function isAllowedHostHeader(
+  hostHeader: string | undefined,
+  bindHost: string
+): boolean {
+  if (!hostHeader) return false;
+  const hostname = hostnameOf(hostHeader);
+  if (!hostname) return false;
+  return (
+    LOOPBACK_HOSTNAMES.has(hostname) || hostname === bindHost.toLowerCase()
+  );
+}
+
+/**
+ * CSRF defense: native MCP clients send no `Origin`, browsers always do on a
+ * cross-origin POST. An `Origin` naming anything but loopback is a web page
+ * reaching for the local server, which is exactly what must not work.
+ */
+export function isAllowedOrigin(origin: string | undefined): boolean {
+  if (origin === undefined) return true;
+  if (origin === "null") return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return false;
+  }
+  return LOOPBACK_HOSTNAMES.has(parsed.hostname.toLowerCase());
+}
+
+/** A `text/plain` POST is a CORS "simple request" and skips preflight. */
+export function isAllowedContentType(contentType: string | undefined): boolean {
+  if (!contentType) return false;
+  return contentType.split(";")[0].trim().toLowerCase() === "application/json";
+}
+
+function headerValue(
+  req: IncomingMessage,
+  name: string
+): string | undefined {
+  const raw = req.headers[name];
+  if (Array.isArray(raw)) return raw[0];
+  return raw ?? undefined;
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function sendJsonRpcError(
+  res: ServerResponse,
+  status: number,
+  code: number,
+  message: string
+): void {
+  sendJson(res, status, {
+    jsonrpc: "2.0",
+    error: { code, message },
+    id: null,
+  });
+}
+
+/** Read a bounded request body. Rejects (rather than buffers) oversized posts. */
+function readBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_REQUEST_BODY_BYTES) {
+        rejectPromise(new Error("Request body too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolvePromise(Buffer.concat(chunks)));
+    req.on("error", rejectPromise);
+  });
+}
+
+type SessionEntry = {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+  dispose: () => void;
+  closing: boolean;
+};
+
+/**
+ * Start the Streamable HTTP listener. Resolves once the socket is bound, with
+ * the effective port filled in (relevant when port 0 was requested).
+ */
+export async function startMinutesHttpServer(
+  options: MinutesHttpServerOptions
+): Promise<MinutesHttpServer> {
+  const host = options.host ?? DEFAULT_HTTP_HOST;
+  const requestedPort = options.port ?? DEFAULT_HTTP_PORT;
+  const maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS;
+  const log = options.log ?? ((message: string) => console.error(message));
+
+  const sessions = new Map<string, SessionEntry>();
+  const sockets = new Set<Socket>();
+
+  async function closeSession(sessionId: string): Promise<void> {
+    const entry = sessions.get(sessionId);
+    if (!entry || entry.closing) return;
+    entry.closing = true;
+    sessions.delete(sessionId);
+    try {
+      entry.dispose();
+    } catch {
+      // Best-effort teardown; a wedged poller must not block the close.
+    }
+    try {
+      await entry.server.close();
+    } catch {
+      // Same: the session is gone either way.
+    }
+    log(`[Minutes] MCP HTTP session closed: ${sessionId}`);
+  }
+
+  async function openSession(
+    req: IncomingMessage,
+    res: ServerResponse,
+    body: unknown
+  ): Promise<void> {
+    if (sessions.size >= maxSessions) {
+      sendJsonRpcError(
+        res,
+        503,
+        -32000,
+        `Too many concurrent MCP sessions (limit ${maxSessions}). Close an existing client or raise --max-sessions.`
+      );
+      return;
+    }
+
+    const instance = options.createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId: string) => {
+        sessions.set(sessionId, {
+          transport,
+          server: instance.server,
+          dispose: instance.dispose,
+          closing: false,
+        });
+        log(`[Minutes] MCP HTTP session opened: ${sessionId}`);
+      },
+      onsessionclosed: (sessionId: string) => {
+        void closeSession(sessionId);
+      },
+    });
+
+    // Chained by Protocol.connect(), so this still fires after connect.
+    transport.onclose = () => {
+      const sessionId = transport.sessionId;
+      if (sessionId) void closeSession(sessionId);
+    };
+
+    try {
+      await instance.server.connect(transport);
+    } catch (error) {
+      instance.dispose();
+      throw error;
+    }
+    await transport.handleRequest(req, res, body);
+  }
+
+  async function handle(
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> {
+    if (!isAllowedHostHeader(headerValue(req, "host"), host)) {
+      sendJsonRpcError(res, 403, -32000, "Forbidden: unrecognized Host header");
+      return;
+    }
+    if (!isAllowedOrigin(headerValue(req, "origin"))) {
+      sendJsonRpcError(
+        res,
+        403,
+        -32000,
+        "Forbidden: cross-origin requests are not accepted"
+      );
+      return;
+    }
+
+    const path = (req.url ?? "/").split("?")[0];
+
+    if (path === HEALTH_HTTP_PATH) {
+      if (req.method !== "GET") {
+        sendJsonRpcError(res, 405, -32000, "Method not allowed");
+        return;
+      }
+      sendJson(res, 200, {
+        ok: true,
+        transport: "http",
+        sessions: sessions.size,
+        max_sessions: maxSessions,
+      });
+      return;
+    }
+
+    if (path !== MCP_HTTP_PATH) {
+      sendJsonRpcError(
+        res,
+        404,
+        -32000,
+        `Not found. The MCP endpoint is ${MCP_HTTP_PATH}`
+      );
+      return;
+    }
+
+    let body: unknown;
+    if (req.method === "POST") {
+      if (!isAllowedContentType(headerValue(req, "content-type"))) {
+        sendJsonRpcError(
+          res,
+          415,
+          -32000,
+          "Unsupported Media Type: expected application/json"
+        );
+        return;
+      }
+      let raw: Buffer;
+      try {
+        raw = await readBody(req);
+      } catch {
+        sendJsonRpcError(res, 413, -32000, "Request body too large");
+        return;
+      }
+      try {
+        body = JSON.parse(raw.toString("utf-8"));
+      } catch {
+        sendJsonRpcError(res, 400, -32700, "Parse error: body is not JSON");
+        return;
+      }
+    }
+
+    const sessionId = headerValue(req, "mcp-session-id");
+    if (sessionId) {
+      const entry = sessions.get(sessionId);
+      if (!entry) {
+        sendJsonRpcError(res, 404, -32001, "Session not found");
+        return;
+      }
+      await entry.transport.handleRequest(req, res, body);
+      return;
+    }
+
+    if (req.method === "POST" && isInitializeRequest(body)) {
+      await openSession(req, res, body);
+      return;
+    }
+
+    sendJsonRpcError(
+      res,
+      400,
+      -32000,
+      "Bad Request: Mcp-Session-Id header required (send initialize first)"
+    );
+  }
+
+  const httpServer: NodeHttpServer = createNodeHttpServer((req, res) => {
+    handle(req, res).catch((error) => {
+      log(
+        `[Minutes] MCP HTTP request failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      if (!res.headersSent) {
+        sendJsonRpcError(res, 500, -32603, "Internal server error");
+      } else {
+        res.end();
+      }
+    });
+  });
+
+  // SSE streams hold connections open; without this, close() never resolves.
+  httpServer.on("connection", (socket: Socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const onError = (error: Error) => rejectPromise(error);
+    httpServer.once("error", onError);
+    httpServer.listen(requestedPort, host, () => {
+      httpServer.removeListener("error", onError);
+      resolvePromise();
+    });
+  });
+
+  const address = httpServer.address();
+  const boundPort =
+    typeof address === "object" && address !== null ? address.port : requestedPort;
+  const displayHost = host.includes(":") ? `[${host}]` : host;
+
+  return {
+    host,
+    port: boundPort,
+    url: `http://${displayHost}:${boundPort}${MCP_HTTP_PATH}`,
+    sessionCount: () => sessions.size,
+    close: async () => {
+      for (const sessionId of Array.from(sessions.keys())) {
+        await closeSession(sessionId);
+      }
+      for (const socket of Array.from(sockets)) {
+        socket.destroy();
+      }
+      sockets.clear();
+      await new Promise<void>((resolvePromise) => {
+        httpServer.close(() => resolvePromise());
+      });
+    },
+  };
+}

--- a/crates/mcp/src/httpTransport.ts
+++ b/crates/mcp/src/httpTransport.ts
@@ -40,7 +40,10 @@ import type { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import {
+  isInitializeRequest,
+  isJSONRPCRequest,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 /**
@@ -500,7 +503,18 @@ export async function startMinutesHttpServer(
       return;
     }
 
-    if (req.method === "POST" && isInitializeRequest(body)) {
+    // Both guards are required. `isInitializeRequest` checks the method and
+    // params but not `id`, so an initialize sent as a JSON-RPC *notification*
+    // satisfies it. Opening a session for one strands the slot: the SDK answers
+    // 202 with no `Mcp-Session-Id`, leaving the caller no handle to use it or to
+    // DELETE it, so nothing but the idle reaper frees it. `isJSONRPCRequest`
+    // is what rejects a missing `id`, and a null one, which is not a valid
+    // JSON-RPC request id either.
+    if (
+      req.method === "POST" &&
+      isJSONRPCRequest(body) &&
+      isInitializeRequest(body)
+    ) {
       await openSession(req, res, body);
       return;
     }

--- a/crates/mcp/src/httpTransport.ts
+++ b/crates/mcp/src/httpTransport.ts
@@ -13,6 +13,13 @@
  * The instances share all module-level state in index.ts — only protocol
  * state is per-session.
  *
+ * Session lifetime: a session ends on an explicit DELETE, on server shutdown,
+ * or by idle reclamation. The third one is required, not a nicety. The SDK's
+ * `Client.close()` aborts its fetches without sending a DELETE, and a client
+ * that crashes or loses its network sends nothing at all, so nothing would
+ * ever free those entries and the session limit would fill up with dead
+ * clients. See `reapIdleSessions` for what counts as idle.
+ *
  * Security: always binds 127.0.0.1, with no flag to change it. Binding to
  * loopback alone does not make the endpoint private, since any page in the
  * user's browser can POST to localhost, so requests are additionally checked
@@ -63,6 +70,26 @@ export const DEFAULT_MAX_SESSIONS = 16;
 /** Request bodies are JSON-RPC envelopes, never audio; paths are passed by name. */
 export const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
 
+/**
+ * How long a session with nothing open may sit before it is reclaimed.
+ *
+ * Generous on purpose. Reclaiming is spec-sanctioned — the server MAY end a
+ * session at any time and MUST then answer 404, and the client MUST start a
+ * new one — but the SDK's TypeScript client has no 404 branch, so it will not
+ * re-initialize. A client that is alive and merely quiet therefore pays for
+ * this, and half an hour keeps that to clients that have genuinely stopped
+ * working. Sessions holding an open stream are never reclaimed regardless.
+ */
+export const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/** Sweep often enough to bound overshoot, without waking up for no reason. */
+function sweepIntervalFor(idleTimeoutMs: number): number {
+  return Math.max(25, Math.min(Math.floor(idleTimeoutMs / 4), 60_000));
+}
+
+/** Probe idle TCP connections so a vanished peer surfaces as a socket close. */
+const SOCKET_KEEPALIVE_DELAY_MS = 60_000;
+
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 export type MinutesServerFactory = () => {
@@ -75,6 +102,11 @@ export type MinutesHttpServerOptions = {
   port?: number;
   /** Reject new sessions past this many concurrent ones. */
   maxSessions?: number;
+  /**
+   * Reclaim a session with nothing open after this long. Exposed for tests,
+   * which cannot wait out the default; there is deliberately no CLI flag.
+   */
+  sessionIdleTimeoutMs?: number;
   /** Builds a fresh McpServer per session. */
   createServer: MinutesServerFactory;
   /** Diagnostics sink. Defaults to stderr. */
@@ -194,6 +226,14 @@ type SessionEntry = {
   server: McpServer;
   dispose: () => void;
   closing: boolean;
+  /** Last time a request for this session arrived or one of its responses ended. */
+  lastActivityAt: number;
+  /**
+   * Responses still open for this session: in-flight requests and long-lived
+   * SSE streams alike. A `Set` rather than a counter so a response closing
+   * after the entry was already removed cannot double-count.
+   */
+  openResponses: Set<ServerResponse>;
 };
 
 /**
@@ -205,10 +245,59 @@ export async function startMinutesHttpServer(
 ): Promise<MinutesHttpServer> {
   const requestedPort = options.port ?? DEFAULT_HTTP_PORT;
   const maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS;
+  const sessionIdleTimeoutMs =
+    options.sessionIdleTimeoutMs ?? DEFAULT_SESSION_IDLE_TIMEOUT_MS;
   const log = options.log ?? ((message: string) => console.error(message));
 
   const sessions = new Map<string, SessionEntry>();
   const sockets = new Set<Socket>();
+
+  /**
+   * Record a response against its session. Stamping on arrival is not enough
+   * on its own: a session whose only traffic was one hour-long stream would be
+   * instantly reapable the moment that stream ended, so the close stamps too.
+   */
+  function trackResponse(entry: SessionEntry, res: ServerResponse): void {
+    entry.lastActivityAt = Date.now();
+    entry.openResponses.add(res);
+    res.once("close", () => {
+      entry.openResponses.delete(res);
+      entry.lastActivityAt = Date.now();
+    });
+  }
+
+  /**
+   * Close sessions that have been idle past the timeout.
+   *
+   * "Idle" means nothing open at all — no in-flight request and no SSE stream.
+   * An open stream is treated as proof of life rather than as something to
+   * reap: the SDK writes keep-alive frames on it every 15s, so a peer that
+   * died takes its stream down with it once those writes go unacknowledged,
+   * and a client that is merely quiet keeps the session it is still holding.
+   *
+   * The gap this leaves, deliberately: a peer alive at TCP but dead at the
+   * application layer holds its stream open forever and is never reclaimed.
+   * Under pressure the sweep below finds nothing and the 503 stands, which is
+   * the honest answer, because such a session looks alive at every layer that
+   * can be observed from here.
+   */
+  function reapIdleSessions(): void {
+    const cutoff = Date.now() - sessionIdleTimeoutMs;
+    for (const [sessionId, entry] of Array.from(sessions)) {
+      if (entry.closing) continue;
+      if (entry.openResponses.size > 0) continue;
+      if (entry.lastActivityAt > cutoff) continue;
+      log(`[Minutes] MCP HTTP session idle, reclaiming: ${sessionId}`);
+      void closeSession(sessionId);
+    }
+  }
+
+  const reaper = setInterval(
+    reapIdleSessions,
+    sweepIntervalFor(sessionIdleTimeoutMs)
+  );
+  // Never hold the process open on the reaper's account.
+  reaper.unref?.();
 
   async function closeSession(sessionId: string): Promise<void> {
     const entry = sessions.get(sessionId);
@@ -233,6 +322,11 @@ export async function startMinutesHttpServer(
     res: ServerResponse,
     body: unknown
   ): Promise<void> {
+    // Sweep before refusing, so the limit is measured against sessions that
+    // are actually live rather than against ones nobody reclaimed yet. This
+    // makes the 503 correct even if the interval timer were somehow starved.
+    reapIdleSessions();
+
     if (sessions.size >= maxSessions) {
       sendJsonRpcError(
         res,
@@ -247,12 +341,18 @@ export async function startMinutesHttpServer(
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId: string) => {
-        sessions.set(sessionId, {
+        const entry: SessionEntry = {
           transport,
           server: instance.server,
           dispose: instance.dispose,
           closing: false,
-        });
+          lastActivityAt: Date.now(),
+          openResponses: new Set(),
+        };
+        sessions.set(sessionId, entry);
+        // Track here, not around the handleRequest below: this fires *during*
+        // handleRequest, so there is no entry to attach to any earlier.
+        trackResponse(entry, res);
         log(`[Minutes] MCP HTTP session opened: ${sessionId}`);
       },
       onsessionclosed: (sessionId: string) => {
@@ -352,6 +452,7 @@ export async function startMinutesHttpServer(
         sendJsonRpcError(res, 404, -32001, "Session not found");
         return;
       }
+      trackResponse(entry, res);
       await entry.transport.handleRequest(req, res, body);
       return;
     }
@@ -384,6 +485,10 @@ export async function startMinutesHttpServer(
 
   // SSE streams hold connections open; without this, close() never resolves.
   httpServer.on("connection", (socket: Socket) => {
+    // A peer that vanishes without closing its socket (sleep, VPN drop) would
+    // otherwise hold its SSE stream, and so its session, until TCP gave up on
+    // its own schedule. Keep-alive probes bring that forward.
+    socket.setKeepAlive(true, SOCKET_KEEPALIVE_DELAY_MS);
     sockets.add(socket);
     socket.on("close", () => sockets.delete(socket));
   });
@@ -406,6 +511,7 @@ export async function startMinutesHttpServer(
     url: `http://${HTTP_BIND_HOST}:${boundPort}${MCP_HTTP_PATH}`,
     sessionCount: () => sessions.size,
     close: async () => {
+      clearInterval(reaper);
       for (const sessionId of Array.from(sessions.keys())) {
         await closeSession(sessionId);
       }

--- a/crates/mcp/src/httpTransport.ts
+++ b/crates/mcp/src/httpTransport.ts
@@ -13,11 +13,14 @@
  * The instances share all module-level state in index.ts — only protocol
  * state is per-session.
  *
- * Security: binds 127.0.0.1 by default. Binding to loopback alone does not
- * make the endpoint private — any page in the user's browser can POST to
- * localhost — so requests are additionally checked for a loopback `Host`, a
- * loopback-or-absent `Origin`, and a JSON content type. There is no
- * authentication; do not expose this port beyond the local machine.
+ * Security: always binds 127.0.0.1, with no flag to change it. Binding to
+ * loopback alone does not make the endpoint private, since any page in the
+ * user's browser can POST to localhost, so requests are additionally checked
+ * for a loopback `Host`, a loopback-or-absent `Origin`, and a JSON content
+ * type. There is no authentication. Reaching the endpoint from another machine
+ * is a reverse-proxy job: point one at 127.0.0.1, rewrite `Host` to the
+ * upstream address so the header check passes, and put authentication on the
+ * proxy.
  */
 
 import { createServer as createNodeHttpServer } from "node:http";
@@ -33,8 +36,14 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-/** Loopback-only by default; see the module docstring before changing. */
-export const DEFAULT_HTTP_HOST = "127.0.0.1";
+/**
+ * The bind address, not a default: there is no flag or environment variable to
+ * change it. HTTP mode has no authentication, so a non-loopback bind would hand
+ * the whole tool surface (transcripts, recording control) to anything that can
+ * route to this machine. Exposing the endpoint deliberately is a reverse-proxy
+ * job, where authentication can be added in front of it.
+ */
+export const HTTP_BIND_HOST = "127.0.0.1";
 
 /**
  * Unassigned by IANA and outside the ranges dev servers habitually grab
@@ -62,8 +71,6 @@ export type MinutesServerFactory = () => {
 };
 
 export type MinutesHttpServerOptions = {
-  /** Interface to bind. Defaults to 127.0.0.1. */
-  host?: string;
   /** Port to bind. 0 asks the OS for a free port; read it back from `port`. */
   port?: number;
   /** Reject new sessions past this many concurrent ones. */
@@ -98,18 +105,15 @@ function hostnameOf(authority: string): string | null {
 
 /**
  * DNS-rebinding defense: a hostile name resolved to 127.0.0.1 still sends its
- * own name in `Host`, so only the bound address and loopback names pass.
+ * own name in `Host`, so only loopback names pass. A reverse proxy fronting
+ * this endpoint has to rewrite `Host` to the upstream address, which is the
+ * point — reaching it under any other name is the attack.
  */
-export function isAllowedHostHeader(
-  hostHeader: string | undefined,
-  bindHost: string
-): boolean {
+export function isAllowedHostHeader(hostHeader: string | undefined): boolean {
   if (!hostHeader) return false;
   const hostname = hostnameOf(hostHeader);
   if (!hostname) return false;
-  return (
-    LOOPBACK_HOSTNAMES.has(hostname) || hostname === bindHost.toLowerCase()
-  );
+  return LOOPBACK_HOSTNAMES.has(hostname);
 }
 
 /**
@@ -199,7 +203,6 @@ type SessionEntry = {
 export async function startMinutesHttpServer(
   options: MinutesHttpServerOptions
 ): Promise<MinutesHttpServer> {
-  const host = options.host ?? DEFAULT_HTTP_HOST;
   const requestedPort = options.port ?? DEFAULT_HTTP_PORT;
   const maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS;
   const log = options.log ?? ((message: string) => console.error(message));
@@ -276,7 +279,7 @@ export async function startMinutesHttpServer(
     req: IncomingMessage,
     res: ServerResponse
   ): Promise<void> {
-    if (!isAllowedHostHeader(headerValue(req, "host"), host)) {
+    if (!isAllowedHostHeader(headerValue(req, "host"))) {
       sendJsonRpcError(res, 403, -32000, "Forbidden: unrecognized Host header");
       return;
     }
@@ -388,7 +391,7 @@ export async function startMinutesHttpServer(
   await new Promise<void>((resolvePromise, rejectPromise) => {
     const onError = (error: Error) => rejectPromise(error);
     httpServer.once("error", onError);
-    httpServer.listen(requestedPort, host, () => {
+    httpServer.listen(requestedPort, HTTP_BIND_HOST, () => {
       httpServer.removeListener("error", onError);
       resolvePromise();
     });
@@ -397,12 +400,10 @@ export async function startMinutesHttpServer(
   const address = httpServer.address();
   const boundPort =
     typeof address === "object" && address !== null ? address.port : requestedPort;
-  const displayHost = host.includes(":") ? `[${host}]` : host;
-
   return {
-    host,
+    host: HTTP_BIND_HOST,
     port: boundPort,
-    url: `http://${displayHost}:${boundPort}${MCP_HTTP_PATH}`,
+    url: `http://${HTTP_BIND_HOST}:${boundPort}${MCP_HTTP_PATH}`,
     sessionCount: () => sessions.size,
     close: async () => {
       for (const sessionId of Array.from(sessions.keys())) {

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -736,14 +736,16 @@ function registerTool(
   annotations: Record<string, unknown>,
   handler: (...args: any[]) => any
 ) {
-  return registerToolWithRestrictedPolicy(
-    server,
-    name,
-    description,
-    inputSchema,
-    annotations,
-    handler
-  );
+  forEachServer((target) => {
+    registerToolWithRestrictedPolicy(
+      target,
+      name,
+      description,
+      inputSchema,
+      annotations,
+      handler
+    );
+  });
 }
 
 export function registerDocsAppToolWithRestrictedPolicy(
@@ -767,17 +769,13 @@ export function registerDocsAppToolWithRestrictedPolicy(
 }
 
 function registerDocsAppTool(
-  serverArg: McpServer,
   name: string,
   config: Record<string, unknown>,
   handler: (...args: any[]) => any
 ) {
-  return registerDocsAppToolWithRestrictedPolicy(
-    serverArg,
-    name,
-    config,
-    handler
-  );
+  forEachServer((target) => {
+    registerDocsAppToolWithRestrictedPolicy(target, name, config, handler);
+  });
 }
 
 const execFileAsync = promisify(execFile);
@@ -4289,12 +4287,115 @@ const server = new McpServer({
 });
 crashTrace("post-mcp-server-construct");
 
+// ── Server instance registry ────────────────────────────────
+// Every registration below is recorded as a builder so an identical surface can
+// be materialized on a second McpServer. stdio keeps using the singleton above.
+// HTTP needs one McpServer per session: `Protocol.connect()` throws on a second
+// transport, and StreamableHTTPServerTransport refuses to be shared. Handlers
+// close over module state, so instances share the CLI bridge and caches — only
+// protocol state is per-instance.
+
+/** A recorded registration. May return a teardown for per-instance state. */
+type ServerBuilder = (target: McpServer) => (() => void) | void;
+
+const SERVER_BUILDERS: ServerBuilder[] = [];
+
+/** Record a registration and apply it to the singleton immediately. */
+function forEachServer(build: ServerBuilder): void {
+  SERVER_BUILDERS.push(build);
+  build(server);
+}
+
+/**
+ * Recorded equivalent of `server.resource(...)`. Typed as the McpServer method
+ * so call sites keep their contextual handler types; the return value is not
+ * usable (a registration now spans every instance) and no call site reads it.
+ */
+const registerResource = ((...args: any[]) => {
+  forEachServer((target) => {
+    (target as any).resource(...args);
+  });
+}) as unknown as McpServer["resource"];
+
+/** Recorded equivalent of `registerAppResource(server, ...)`. */
+function registerAppResourceOnEveryServer(...args: any[]): void {
+  forEachServer((target) => {
+    (registerAppResource as any)(target, ...args);
+  });
+}
+
+export type ServerSurface = {
+  tools: string[];
+  resources: string[];
+  resourceTemplates: string[];
+};
+
+/**
+ * Everything registered on an McpServer, read from the SDK's registries. Lets
+ * a factory-built instance be compared against the stdio singleton without
+ * standing up a transport.
+ */
+export function describeServerSurface(target: McpServer): ServerSurface {
+  const internals = target as any;
+  return {
+    tools: Object.keys(internals._registeredTools ?? {}).sort(),
+    resources: Object.keys(internals._registeredResources ?? {}).sort(),
+    resourceTemplates: Object.keys(
+      internals._registeredResourceTemplates ?? {}
+    ).sort(),
+  };
+}
+
+/** The surface the stdio transport serves — the backward-compatibility baseline. */
+export function describeStdioServerSurface(): ServerSurface {
+  return describeServerSurface(server);
+}
+
+export type MinutesServerInstance = {
+  server: McpServer;
+  /** Stop per-instance background work (live-resource pollers). */
+  dispose: () => void;
+};
+
+/**
+ * Build a fresh McpServer exposing the same tools, resources, and request
+ * handlers as the stdio singleton, by replaying every recorded registration in
+ * declaration order. Used by the HTTP transport, one instance per session.
+ */
+export function createMinutesServer(): MinutesServerInstance {
+  const instance = new McpServer({
+    name: "minutes",
+    version: MCP_SERVER_VERSION,
+  });
+  const teardowns: Array<() => void> = [];
+  for (const build of SERVER_BUILDERS) {
+    const teardown = build(instance);
+    if (typeof teardown === "function") {
+      teardowns.push(teardown);
+    }
+  }
+  return {
+    server: instance,
+    dispose: () => {
+      for (const teardown of teardowns) {
+        try {
+          teardown();
+        } catch {
+          // Teardown is best-effort; a failed poller stop must not block close.
+        }
+      }
+    },
+  };
+}
+
 // Declare MCP Apps extension support so hosts classify this server as interactive.
 // The `extensions` field is part of the draft MCP spec (SEP-1724) — not yet in the
 // stable SDK types, so we cast through `any`.
-(server.server as any).registerCapabilities({
-  extensions: { [EXTENSION_ID]: {} },
-} as any);
+forEachServer((target) => {
+  (target.server as any).registerCapabilities({
+    extensions: { [EXTENSION_ID]: {} },
+  } as any);
+});
 
 // Configurable directories — override via env vars in Claude Desktop extension settings
 const MINUTES_HOME = canonicalizeRoot(
@@ -4374,8 +4475,7 @@ async function getEffectiveMeetingsDirForIsolatedAudio(
 
 // ── UI Resource: MCP App dashboard ──────────────────────────
 
-registerAppResource(
-  server,
+registerAppResourceOnEveryServer(
   "Minutes Dashboard",
   UI_RESOURCE_URI,
   { description: "Interactive meeting dashboard and detail viewer" },
@@ -4789,7 +4889,6 @@ registerTool(
 // ── Tool: list_meetings ─────────────────────────────────────
 
 registerDocsAppTool(
-  server,
   "list_meetings",
   {
     description: "List recent meetings and voice memos. Restricted meetings are excluded. An override requires both an operator launch grant and include_restricted=true, and is durably audited.",
@@ -4855,7 +4954,6 @@ registerDocsAppTool(
 // ── Tool: search_meetings ───────────────────────────────────
 
 registerDocsAppTool(
-  server,
   "search_meetings",
   {
     description: "Search meeting transcripts and voice memos. Restricted meetings are excluded. An override requires both an operator launch grant and include_restricted=true, and is durably audited.",
@@ -4973,7 +5071,6 @@ registerDocsAppTool(
 
 if (hasFeature(CLI_CAPABILITIES, "activity_summary"))
 registerDocsAppTool(
-  server,
   "activity_summary",
   {
     description: "Summarize meeting-adjacent desktop context bound to one exact normal meeting source.",
@@ -5040,7 +5137,6 @@ registerDocsAppTool(
 
 if (hasFeature(CLI_CAPABILITIES, "search_context"))
 registerDocsAppTool(
-  server,
   "search_context",
   {
     description: "Search desktop-context events bound to one exact normal meeting source.",
@@ -5107,7 +5203,6 @@ registerDocsAppTool(
 
 if (hasFeature(CLI_CAPABILITIES, "get_moment"))
 registerDocsAppTool(
-  server,
   "get_moment",
   {
     description: "Show the local rewind bound to one exact normal meeting source.",
@@ -5227,7 +5322,6 @@ export async function readVerifiedScreenImage(
 
 if (hasFeature(CLI_CAPABILITIES, "screen_context"))
 registerDocsAppTool(
-  server,
   "get_screen_context",
   {
     description: "Retrieve up to three verified PNG screenshots bound to one exact normal meeting source, optionally nearest a timestamp.",
@@ -5341,7 +5435,6 @@ registerDocsAppTool(
 // ── Tool: consistency_report ───────────────────────────────
 
 registerDocsAppTool(
-  server,
   "consistency_report",
   {
     description: "Flag conflicting decisions and stale commitments across meetings using structured intent data. Meetings designated `sensitivity: restricted` are always excluded from this report.",
@@ -5420,7 +5513,6 @@ registerDocsAppTool(
 // ── Tool: get_person_profile ───────────────────────────────
 
 registerDocsAppTool(
-  server,
   "get_person_profile",
   {
     description: "Get a relationship profile derived from live, policy-authorized meeting snapshots within the supported corpus bounds. Restricted meetings are excluded unless an operator launch grant plus include_restricted=true is durably audited.",
@@ -5579,7 +5671,6 @@ export function restrictedMeetingStubResult(meeting: PolicyVerifiedMeeting) {
 }
 
 registerDocsAppTool(
-  server,
   "get_meeting",
   {
     description: "Get a full meeting transcript with speaker overlays. A restricted meeting returns a stub. Full access requires an operator launch grant plus include_restricted=true and is durably audited.",
@@ -6705,7 +6796,6 @@ export function relationshipMapStructuredContent<T>(people: readonly T[]) {
 }
 
 registerDocsAppTool(
-  server,
   "track_commitments",
   {
     description: "List open and stale action items and explicit intent commitments from live meeting frontmatter. Optionally filter by person. Answers: 'What did I promise Sarah?' or 'What's overdue?' Meetings designated `sensitivity: restricted` never enter this live-source view.",
@@ -6813,7 +6903,6 @@ registerDocsAppTool(
 // ── Tool: relationship_map ──────────────────────────────────
 
 registerDocsAppTool(
-  server,
   "relationship_map",
   {
     description: "Show contacts with relationship scores, meeting frequency, and losing-touch alerts from the bounded process-private graph projection. Restricted meetings never enter the projection.",
@@ -6934,7 +7023,7 @@ registerDocsAppTool(
 
 // ── Resources ───────────────────────────────────────────────
 
-server.resource(
+registerResource(
   "recent_meetings",
   "minutes://meetings/recent",
   { description: "List of recent meetings and memos" },
@@ -6946,7 +7035,7 @@ server.resource(
   })
 );
 
-server.resource(
+registerResource(
   "recording_status",
   "minutes://status",
   { description: "Current recording status" },
@@ -6963,7 +7052,7 @@ server.resource(
   }
 );
 
-server.resource(
+registerResource(
   "open_actions",
   "minutes://actions/open",
   { description: "All open action items across meetings" },
@@ -6983,7 +7072,7 @@ server.resource(
   })
 );
 
-server.resource(
+registerResource(
   "recent_events",
   "minutes://events/recent",
   { description: "Recent pipeline events with meeting-derived content withheld until source policy provenance is available" },
@@ -6997,7 +7086,7 @@ server.resource(
   }
 );
 
-server.resource(
+registerResource(
   "agent_annotations",
   "minutes://events/agent-annotations",
   { description: "Agent annotations are withheld until their source policy provenance can be revalidated" },
@@ -7013,7 +7102,7 @@ server.resource(
 );
 
 if (LIVE_EVENTS_SUPPORTED) {
-  server.resource(
+  registerResource(
     "live_events",
     LIVE_EVENTS_RESOURCE_URI,
     {
@@ -7023,7 +7112,7 @@ if (LIVE_EVENTS_SUPPORTED) {
     async (uri) => readLiveEventsResource(uri)
   );
 
-  server.resource(
+  registerResource(
     "live_events_since_seq",
     new ResourceTemplate(LIVE_EVENTS_URI_TEMPLATE, { list: undefined }),
     {
@@ -7037,7 +7126,7 @@ if (LIVE_EVENTS_SUPPORTED) {
 }
 
 if (COPILOT_SUPPORTED) {
-  server.resource(
+  registerResource(
     "live_copilot",
     LIVE_COPILOT_RESOURCE_URI,
     {
@@ -7051,16 +7140,22 @@ if (COPILOT_SUPPORTED) {
 }
 
 if (COPILOT_SUPPORTED) {
-  registerLiveEventsSubscriptionHandlers(server, {
-    // Reads remain registered as an honest constant-unavailable resource, but
-    // subscriptions must not poll raw sequence numbers or notify on hidden
-    // restricted events.
-    enableLiveEvents: LIVE_EVENTS_SUBSCRIPTIONS_ENABLED,
-    enableCopilot: COPILOT_SUPPORTED,
+  // Each server instance gets its own controller — the poller and subscription
+  // set are per-connection state, and the returned stop() is the instance
+  // teardown so a closed HTTP session leaves no poller running.
+  forEachServer((target) => {
+    const controller = registerLiveEventsSubscriptionHandlers(target, {
+      // Reads remain registered as an honest constant-unavailable resource, but
+      // subscriptions must not poll raw sequence numbers or notify on hidden
+      // restricted events.
+      enableLiveEvents: LIVE_EVENTS_SUBSCRIPTIONS_ENABLED,
+      enableCopilot: COPILOT_SUPPORTED,
+    });
+    return () => controller.stop();
   });
 }
 
-server.resource(
+registerResource(
   "meeting",
   new ResourceTemplate("minutes://meetings/{slug}", { list: undefined }),
   { description: "Get a specific meeting by its filename slug" },
@@ -7089,7 +7184,7 @@ server.resource(
 
 // ── Resource: recent_ideas (voice memos from last N days) ──
 
-server.resource(
+registerResource(
   "recent-ideas",
   "minutes://ideas/recent",
   { description: "Recent voice memos and ideas captured from any device (last 14 days)" },
@@ -8203,7 +8298,9 @@ export function registerUnavailableCompatibilityTools(
   );
 }
 
-registerUnavailableCompatibilityTools(server);
+forEachServer((target) => {
+  registerUnavailableCompatibilityTools(target);
+});
 
 // ── Tools: real-time copilot control + observation ──────────
 

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -9058,11 +9058,24 @@ export type MinutesTransportConfig = {
   help: boolean;
 };
 
-function parsePositiveInt(raw: string, flag: string, max: number): number {
+/**
+ * `min` defaults to 0 because `--port 0` is meaningful: it asks the OS for a
+ * free port. A count like `--max-sessions` has no such reading, and zero there
+ * starts a server that refuses every client, so those pass `min: 1`.
+ */
+function parsePositiveInt(
+  raw: string,
+  flag: string,
+  max: number,
+  min = 0
+): number {
   if (!/^\d+$/.test(raw.trim())) {
     throw new Error(`${flag} expects a number, got "${raw}"`);
   }
   const value = Number(raw.trim());
+  if (value < min) {
+    throw new Error(`${flag} must be >= ${min}, got ${value}`);
+  }
   if (value > max) {
     throw new Error(`${flag} must be <= ${max}, got ${value}`);
   }
@@ -9105,7 +9118,8 @@ export function parseTransportConfig(
     config.maxSessions = parsePositiveInt(
       env.MINUTES_MCP_MAX_SESSIONS,
       "MINUTES_MCP_MAX_SESSIONS",
-      1024
+      1024,
+      1
     );
   }
 
@@ -9149,7 +9163,8 @@ export function parseTransportConfig(
         config.maxSessions = parsePositiveInt(
           valueOf(i, flag, inline),
           flag,
-          1024
+          1024,
+          1
         );
         if (inline === null) i++;
         break;

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -105,7 +105,7 @@ import {
   type StableCorpusSnapshot,
 } from "./corpus-lease.js";
 import {
-  DEFAULT_HTTP_HOST,
+  HTTP_BIND_HOST,
   DEFAULT_HTTP_PORT,
   DEFAULT_MAX_SESSIONS,
   startMinutesHttpServer,
@@ -9053,7 +9053,6 @@ registerTool(
 
 export type MinutesTransportConfig = {
   transport: "stdio" | "http";
-  host: string;
   port: number;
   maxSessions: number;
   help: boolean;
@@ -9081,7 +9080,6 @@ export function parseTransportConfig(
 ): MinutesTransportConfig {
   const config: MinutesTransportConfig = {
     transport: "stdio",
-    host: DEFAULT_HTTP_HOST,
     port: DEFAULT_HTTP_PORT,
     maxSessions: DEFAULT_MAX_SESSIONS,
     help: false,
@@ -9095,9 +9093,6 @@ export function parseTransportConfig(
       );
     }
     config.transport = envTransport;
-  }
-  if (env.MINUTES_MCP_HOST?.trim()) {
-    config.host = env.MINUTES_MCP_HOST.trim();
   }
   if (env.MINUTES_MCP_PORT?.trim()) {
     config.port = parsePositiveInt(
@@ -9146,10 +9141,6 @@ export function parseTransportConfig(
         if (inline === null) i++;
         break;
       }
-      case "--host":
-        config.host = valueOf(i, flag, inline).trim();
-        if (inline === null) i++;
-        break;
       case "--port":
         config.port = parsePositiveInt(valueOf(i, flag, inline), flag, 65535);
         if (inline === null) i++;
@@ -9180,18 +9171,18 @@ function printUsage(): void {
       "",
       "Options:",
       "  --transport <stdio|http>  Transport to serve on (default: stdio)",
-      `  --host <address>          HTTP bind address (default: ${DEFAULT_HTTP_HOST})`,
       `  --port <number>           HTTP port, 0 for an OS-assigned port (default: ${DEFAULT_HTTP_PORT})`,
       `  --max-sessions <number>   Concurrent HTTP sessions (default: ${DEFAULT_MAX_SESSIONS})`,
       "  --demo                    Install the bundled demo corpus and exit",
       "  --help                    Show this message",
       "",
-      "Environment: MINUTES_MCP_TRANSPORT, MINUTES_MCP_HOST, MINUTES_MCP_PORT,",
+      "Environment: MINUTES_MCP_TRANSPORT, MINUTES_MCP_PORT,",
       "             MINUTES_MCP_MAX_SESSIONS",
       "",
-      "HTTP mode serves Streamable HTTP at /mcp and has no authentication. It",
-      "binds 127.0.0.1 so only this machine can reach it — do not bind a public",
-      "address or forward the port.",
+      "HTTP mode serves Streamable HTTP at /mcp and has no authentication. The",
+      `bind address is always ${HTTP_BIND_HOST}, so only this machine can reach it.`,
+      "To expose it beyond this machine, put a reverse proxy in front and add",
+      "authentication there.",
     ].join("\n")
   );
 }
@@ -9208,11 +9199,10 @@ async function main() {
   }
 
   if (config.transport === "http") {
-    crashTrace("main-transport-http", { host: config.host, port: config.port });
+    crashTrace("main-transport-http", { port: config.port });
     await afterRequiredCli(async () => {
       crashTrace("required-cli-ready");
       const httpServer = await startMinutesHttpServer({
-        host: config.host,
         port: config.port,
         maxSessions: config.maxSessions,
         createServer: createMinutesServer,

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -105,6 +105,12 @@ import {
   type StableCorpusSnapshot,
 } from "./corpus-lease.js";
 import {
+  DEFAULT_HTTP_HOST,
+  DEFAULT_HTTP_PORT,
+  DEFAULT_MAX_SESSIONS,
+  startMinutesHttpServer,
+} from "./httpTransport.js";
+import {
   boundReadFingerprint,
   captureBoundReadExpectation,
   readTextFileFromBoundParent,
@@ -9041,10 +9047,190 @@ registerTool(
   }
 );
 
+// ── Transport selection ─────────────────────────────────────
+// stdio stays the default so every existing client config keeps working
+// untouched. `--transport http` is opt-in and documented as localhost-only.
+
+export type MinutesTransportConfig = {
+  transport: "stdio" | "http";
+  host: string;
+  port: number;
+  maxSessions: number;
+  help: boolean;
+};
+
+function parsePositiveInt(raw: string, flag: string, max: number): number {
+  if (!/^\d+$/.test(raw.trim())) {
+    throw new Error(`${flag} expects a number, got "${raw}"`);
+  }
+  const value = Number(raw.trim());
+  if (value > max) {
+    throw new Error(`${flag} must be <= ${max}, got ${value}`);
+  }
+  return value;
+}
+
+/**
+ * Parse transport flags. Unknown arguments are ignored rather than rejected —
+ * hosts append their own (`--demo` is handled at module load), and a strict
+ * parser here would turn a harmless extra argument into a startup failure.
+ */
+export function parseTransportConfig(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env
+): MinutesTransportConfig {
+  const config: MinutesTransportConfig = {
+    transport: "stdio",
+    host: DEFAULT_HTTP_HOST,
+    port: DEFAULT_HTTP_PORT,
+    maxSessions: DEFAULT_MAX_SESSIONS,
+    help: false,
+  };
+
+  const envTransport = env.MINUTES_MCP_TRANSPORT?.trim().toLowerCase();
+  if (envTransport) {
+    if (envTransport !== "stdio" && envTransport !== "http") {
+      throw new Error(
+        `MINUTES_MCP_TRANSPORT must be "stdio" or "http", got "${envTransport}"`
+      );
+    }
+    config.transport = envTransport;
+  }
+  if (env.MINUTES_MCP_HOST?.trim()) {
+    config.host = env.MINUTES_MCP_HOST.trim();
+  }
+  if (env.MINUTES_MCP_PORT?.trim()) {
+    config.port = parsePositiveInt(
+      env.MINUTES_MCP_PORT,
+      "MINUTES_MCP_PORT",
+      65535
+    );
+  }
+  if (env.MINUTES_MCP_MAX_SESSIONS?.trim()) {
+    config.maxSessions = parsePositiveInt(
+      env.MINUTES_MCP_MAX_SESSIONS,
+      "MINUTES_MCP_MAX_SESSIONS",
+      1024
+    );
+  }
+
+  // Accepts both `--flag value` and `--flag=value`.
+  const valueOf = (index: number, flag: string, inline: string | null): string => {
+    if (inline !== null) return inline;
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return next;
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const eq = arg.indexOf("=");
+    const flag = eq === -1 ? arg : arg.slice(0, eq);
+    const inline = eq === -1 ? null : arg.slice(eq + 1);
+
+    switch (flag) {
+      case "--help":
+        config.help = true;
+        break;
+      case "--transport": {
+        const value = valueOf(i, flag, inline).trim().toLowerCase();
+        if (value !== "stdio" && value !== "http") {
+          throw new Error(
+            `--transport must be "stdio" or "http", got "${value}"`
+          );
+        }
+        config.transport = value;
+        if (inline === null) i++;
+        break;
+      }
+      case "--host":
+        config.host = valueOf(i, flag, inline).trim();
+        if (inline === null) i++;
+        break;
+      case "--port":
+        config.port = parsePositiveInt(valueOf(i, flag, inline), flag, 65535);
+        if (inline === null) i++;
+        break;
+      case "--max-sessions":
+        config.maxSessions = parsePositiveInt(
+          valueOf(i, flag, inline),
+          flag,
+          1024
+        );
+        if (inline === null) i++;
+        break;
+      default:
+        // Unknown flag — leave it to whoever passed it.
+        break;
+    }
+  }
+
+  return config;
+}
+
+function printUsage(): void {
+  console.log(
+    [
+      "minutes-mcp — MCP server for Minutes (conversation memory for AI assistants)",
+      "",
+      "Usage: minutes-mcp [options]",
+      "",
+      "Options:",
+      "  --transport <stdio|http>  Transport to serve on (default: stdio)",
+      `  --host <address>          HTTP bind address (default: ${DEFAULT_HTTP_HOST})`,
+      `  --port <number>           HTTP port, 0 for an OS-assigned port (default: ${DEFAULT_HTTP_PORT})`,
+      `  --max-sessions <number>   Concurrent HTTP sessions (default: ${DEFAULT_MAX_SESSIONS})`,
+      "  --demo                    Install the bundled demo corpus and exit",
+      "  --help                    Show this message",
+      "",
+      "Environment: MINUTES_MCP_TRANSPORT, MINUTES_MCP_HOST, MINUTES_MCP_PORT,",
+      "             MINUTES_MCP_MAX_SESSIONS",
+      "",
+      "HTTP mode serves Streamable HTTP at /mcp and has no authentication. It",
+      "binds 127.0.0.1 so only this machine can reach it — do not bind a public",
+      "address or forward the port.",
+    ].join("\n")
+  );
+}
+
 // ── Start server ────────────────────────────────────────────
 
 async function main() {
   crashTrace("main-start");
+  const config = parseTransportConfig(process.argv.slice(2));
+
+  if (config.help) {
+    printUsage();
+    return;
+  }
+
+  if (config.transport === "http") {
+    crashTrace("main-transport-http", { host: config.host, port: config.port });
+    await afterRequiredCli(async () => {
+      crashTrace("required-cli-ready");
+      const httpServer = await startMinutesHttpServer({
+        host: config.host,
+        port: config.port,
+        maxSessions: config.maxSessions,
+        createServer: createMinutesServer,
+      });
+      crashTrace("transport-connected");
+      console.error(`Minutes MCP server listening on ${httpServer.url}`);
+      console.error(
+        "[Minutes] HTTP transport is unauthenticated — keep it bound to localhost"
+      );
+      const shutdown = () => {
+        void httpServer.close().finally(() => process.exit(0));
+      };
+      process.once("SIGINT", shutdown);
+      process.once("SIGTERM", shutdown);
+    });
+    return;
+  }
+
   await afterRequiredCli(async () => {
     crashTrace("required-cli-ready");
     const transport = new StdioServerTransport();

--- a/crates/mcp/src/serverFactory.test.ts
+++ b/crates/mcp/src/serverFactory.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createMinutesServer,
+  describeServerSurface,
+  describeStdioServerSurface,
+  parseTransportConfig,
+} from "./index.js";
+
+describe("createMinutesServer", () => {
+  // The stdio singleton is the backward-compatibility baseline. A registration
+  // that writes straight to it instead of going through the registry would be
+  // invisible over HTTP, and only this comparison catches that.
+  it("reproduces the stdio server's full surface", () => {
+    const baseline = describeStdioServerSurface();
+    const instance = createMinutesServer();
+    try {
+      expect(baseline.tools.length).toBeGreaterThan(0);
+      expect(baseline.resources.length).toBeGreaterThan(0);
+      const surface = describeServerSurface(instance.server);
+      expect(surface.tools).toEqual(baseline.tools);
+      expect(surface.resources).toEqual(baseline.resources);
+      expect(surface.resourceTemplates).toEqual(baseline.resourceTemplates);
+    } finally {
+      instance.dispose();
+    }
+  });
+
+  it("builds independent instances", () => {
+    const first = createMinutesServer();
+    const second = createMinutesServer();
+    try {
+      expect(first.server).not.toBe(second.server);
+      expect(describeServerSurface(first.server).tools).toEqual(
+        describeServerSurface(second.server).tools
+      );
+    } finally {
+      first.dispose();
+      second.dispose();
+    }
+  });
+});
+
+describe("parseTransportConfig", () => {
+  const noEnv = {} as NodeJS.ProcessEnv;
+
+  it("defaults to stdio on loopback", () => {
+    const config = parseTransportConfig([], noEnv);
+    expect(config.transport).toBe("stdio");
+    expect(config.host).toBe("127.0.0.1");
+    expect(config.help).toBe(false);
+  });
+
+  it("ignores arguments it does not own", () => {
+    expect(parseTransportConfig(["--demo", "--unknown", "x"], noEnv).transport).toBe(
+      "stdio"
+    );
+  });
+
+  it("accepts space- and equals-separated values", () => {
+    const spaced = parseTransportConfig(
+      ["--transport", "http", "--port", "9001", "--host", "0.0.0.0"],
+      noEnv
+    );
+    expect(spaced).toMatchObject({
+      transport: "http",
+      port: 9001,
+      host: "0.0.0.0",
+    });
+    const inline = parseTransportConfig(
+      ["--transport=http", "--port=9001", "--max-sessions=3"],
+      noEnv
+    );
+    expect(inline).toMatchObject({ transport: "http", port: 9001, maxSessions: 3 });
+  });
+
+  it("supports port 0 for an OS-assigned port", () => {
+    expect(parseTransportConfig(["--port", "0"], noEnv).port).toBe(0);
+  });
+
+  it("reads environment defaults, with flags winning", () => {
+    const env = {
+      MINUTES_MCP_TRANSPORT: "http",
+      MINUTES_MCP_PORT: "8123",
+      MINUTES_MCP_MAX_SESSIONS: "2",
+    } as NodeJS.ProcessEnv;
+    expect(parseTransportConfig([], env)).toMatchObject({
+      transport: "http",
+      port: 8123,
+      maxSessions: 2,
+    });
+    expect(parseTransportConfig(["--port", "9999"], env).port).toBe(9999);
+  });
+
+  it("rejects malformed values instead of guessing", () => {
+    expect(() => parseTransportConfig(["--transport", "grpc"], noEnv)).toThrow(
+      /--transport/
+    );
+    expect(() => parseTransportConfig(["--port", "abc"], noEnv)).toThrow(/--port/);
+    expect(() => parseTransportConfig(["--port", "70000"], noEnv)).toThrow(/65535/);
+    expect(() => parseTransportConfig(["--port"], noEnv)).toThrow(/requires a value/);
+    expect(() =>
+      parseTransportConfig([], { MINUTES_MCP_TRANSPORT: "ws" } as NodeJS.ProcessEnv)
+    ).toThrow(/MINUTES_MCP_TRANSPORT/);
+  });
+
+  it("recognizes --help", () => {
+    expect(parseTransportConfig(["--help"], noEnv).help).toBe(true);
+  });
+});

--- a/crates/mcp/src/serverFactory.test.ts
+++ b/crates/mcp/src/serverFactory.test.ts
@@ -87,6 +87,23 @@ describe("parseTransportConfig", () => {
     expect(parseTransportConfig(["--port", "0"], noEnv).port).toBe(0);
   });
 
+  // A zero session limit starts a server that refuses every initialize, since
+  // the limit check is `sessions.size >= maxSessions`. Port 0 stays legal.
+  it("rejects a zero session limit, from the flag and the environment alike", () => {
+    expect(() => parseTransportConfig(["--max-sessions", "0"], noEnv)).toThrow(
+      /--max-sessions must be >= 1/
+    );
+    expect(() => parseTransportConfig(["--max-sessions=0"], noEnv)).toThrow(
+      /--max-sessions must be >= 1/
+    );
+    expect(() =>
+      parseTransportConfig([], {
+        MINUTES_MCP_MAX_SESSIONS: "0",
+      } as NodeJS.ProcessEnv)
+    ).toThrow(/MINUTES_MCP_MAX_SESSIONS must be >= 1/);
+    expect(parseTransportConfig(["--max-sessions", "1"], noEnv).maxSessions).toBe(1);
+  });
+
   it("reads environment defaults, with flags winning", () => {
     const env = {
       MINUTES_MCP_TRANSPORT: "http",

--- a/crates/mcp/src/serverFactory.test.ts
+++ b/crates/mcp/src/serverFactory.test.ts
@@ -44,11 +44,20 @@ describe("createMinutesServer", () => {
 describe("parseTransportConfig", () => {
   const noEnv = {} as NodeJS.ProcessEnv;
 
-  it("defaults to stdio on loopback", () => {
+  it("defaults to stdio", () => {
     const config = parseTransportConfig([], noEnv);
     expect(config.transport).toBe("stdio");
-    expect(config.host).toBe("127.0.0.1");
     expect(config.help).toBe(false);
+  });
+
+  // The bind address is not configurable, so --host and MINUTES_MCP_HOST fall
+  // through to the unknown-flag path instead of moving the server off loopback.
+  it("does not accept a bind address", () => {
+    const config = parseTransportConfig(["--transport", "http", "--host", "0.0.0.0"], {
+      MINUTES_MCP_HOST: "0.0.0.0",
+    } as NodeJS.ProcessEnv);
+    expect(config).not.toHaveProperty("host");
+    expect(config.transport).toBe("http");
   });
 
   it("ignores arguments it does not own", () => {
@@ -59,13 +68,13 @@ describe("parseTransportConfig", () => {
 
   it("accepts space- and equals-separated values", () => {
     const spaced = parseTransportConfig(
-      ["--transport", "http", "--port", "9001", "--host", "0.0.0.0"],
+      ["--transport", "http", "--port", "9001", "--max-sessions", "3"],
       noEnv
     );
     expect(spaced).toMatchObject({
       transport: "http",
       port: 9001,
-      host: "0.0.0.0",
+      maxSessions: 3,
     });
     const inline = parseTransportConfig(
       ["--transport=http", "--port=9001", "--max-sessions=3"],

--- a/crates/mcp/test/lib/surface-parity.mjs
+++ b/crates/mcp/test/lib/surface-parity.mjs
@@ -1,0 +1,422 @@
+/**
+ * Cross-process surface parity helpers.
+ *
+ * Comparing a full `tools/list` between two separately spawned server
+ * processes is not a deterministic assertion. Each process runs
+ * `probeCapabilitiesSync` at module load with a 2 second `execFileSync`
+ * budget, and a cold or contended CLI binary blows that budget. The probe
+ * then returns `unsupported-cli`, `hasFeature` answers false for everything,
+ * and that process registers eight fewer tools and two fewer resources than
+ * its sibling. The surfaces differ for a reason that has nothing to do with
+ * the transport under test.
+ *
+ * The fix is not to loosen the comparison. It is to compare each process
+ * against *its own* declared capability state, and to compare the two
+ * processes only on the part of the surface that no capability gate can move:
+ *
+ *   core     = advertised names minus every capability-gated name
+ *   gated    = exactly the names this process's own probe outcome predicts
+ *
+ * Core parity stays an exact set comparison between the two processes. The
+ * gated part is asserted per process against what that process itself decided,
+ * so a probe timeout produces a *correct passing* assertion (zero gated tools,
+ * which is what `unsupported-cli` means) instead of a spurious parity failure.
+ *
+ * ## Where the declared capability state comes from
+ *
+ * `index.ts` records the probe outcome through `crashTrace`, which appends
+ * JSONL to `~/.minutes/logs/mcp-crash.log` carrying the writing process's own
+ * pid and ppid. That is the only channel that reports what a process *decided*
+ * rather than what it *advertised*. The distinction is the whole point: read
+ * from the surface alone, "probe timed out" and "the factory dropped the gated
+ * tools" look identical, and the second is exactly the defect this test exists
+ * to catch.
+ *
+ * It is a debug artifact, so every reader here fails loudly when the row is
+ * missing rather than degrading to a weaker assertion.
+ */
+
+import { execFileSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+
+const MCP_DIR = join(import.meta.dirname, "..", "..");
+const REPO_ROOT = join(MCP_DIR, "..", "..");
+
+/**
+ * Tools registered behind a capability gate, mapped to the feature key that
+ * gates them. Anything not listed here is core and must be present in every
+ * process regardless of what the probe returned.
+ *
+ * Four are gated inline by `if (hasFeature(CLI_CAPABILITIES, "..."))`; the
+ * four copilot tools share one `if (COPILOT_SUPPORTED)` block.
+ * `assertGateMapMatchesSource` fails if a gate is added to `index.ts` without
+ * being added here, because an unlisted gated tool would silently land in the
+ * core set and reintroduce the flake this module exists to remove.
+ */
+export const CAPABILITY_GATED_TOOLS = Object.freeze({
+  activity_summary: "activity_summary",
+  search_context: "search_context",
+  get_moment: "get_moment",
+  get_screen_context: "screen_context",
+  start_copilot: "copilot_realtime",
+  stop_copilot: "copilot_realtime",
+  copilot_status: "copilot_realtime",
+  read_copilot_nudges: "copilot_realtime",
+});
+
+/**
+ * Resources behind the same gates. `resources/list` carries static URIs only,
+ * so the `minutes://events/live{?since_seq,limit}` template is deliberately
+ * absent: it is registered with `list: undefined` and never appears here. The
+ * template is covered by the in-process `serverFactory.test.ts` check, which
+ * reads `_registeredResourceTemplates` directly.
+ */
+export const CAPABILITY_GATED_RESOURCES = Object.freeze({
+  "minutes://events/live": "events_since_seq",
+  "minutes://live/copilot": "copilot_realtime",
+});
+
+/** Feature keys reachable through either map, for the source-drift guard. */
+const GATED_FEATURE_KEYS = new Set([
+  ...Object.values(CAPABILITY_GATED_TOOLS),
+  ...Object.values(CAPABILITY_GATED_RESOURCES),
+]);
+
+/** Number of inline `if (hasFeature(...))` tool gates the maps above account for. */
+const INLINE_GATED_TOOL_COUNT = 4;
+
+/**
+ * Resolve the binary the server will pick, replicating `findMinutesBinary`'s
+ * candidate order. Release comes *before* debug: warming `target/debug/minutes`
+ * unconditionally, the way this suite used to, warms the wrong file the moment
+ * a release build exists.
+ */
+export function resolveMinutesBinary() {
+  const ext = process.platform === "win32" ? ".exe" : "";
+  const candidates = [
+    join(REPO_ROOT, "target", "release", `minutes${ext}`),
+    join(REPO_ROOT, "target", "debug", `minutes${ext}`),
+    ...(process.platform === "win32"
+      ? [join(homedir(), ".minutes", "bin", `minutes${ext}`)]
+      : []),
+    join(homedir(), ".cargo", "bin", `minutes${ext}`),
+    ...(process.platform === "win32"
+      ? []
+      : [
+          join(homedir(), ".local", "bin", "minutes"),
+          "/opt/homebrew/bin/minutes",
+          "/usr/local/bin/minutes",
+        ]),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return "minutes";
+}
+
+/**
+ * Probe the capability report the way the server does, but with a budget wide
+ * enough that this call cannot be the flaky one. Runs twice: the first call
+ * pays any cold-start cost, the second is the measurement, which also leaves
+ * the binary warm for the children spawned next.
+ */
+export function probeCapabilityReport(binPath, timeoutMs = 30000) {
+  const run = () =>
+    execFileSync(binPath, ["capabilities", "--json"], {
+      timeout: timeoutMs,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  try {
+    run();
+    const parsed = JSON.parse(run().trim());
+    if (
+      typeof parsed?.version !== "string" ||
+      typeof parsed?.api_version !== "number" ||
+      !parsed?.features ||
+      typeof parsed.features !== "object"
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    // An older CLI has no `capabilities` subcommand. Callers treat null as
+    // "no report available" and must not silently assume a gated set.
+    return null;
+  }
+}
+
+/** Both locations `crashTracer.ts` may choose for its log. */
+function crashLogPaths() {
+  return [
+    join(homedir(), ".minutes", "logs", "mcp-crash.log"),
+    join(tmpdir(), "minutes-mcp-crash.log"),
+  ];
+}
+
+function readCrashRows() {
+  const rows = [];
+  for (const path of crashLogPaths()) {
+    if (!existsSync(path)) continue;
+    let raw;
+    try {
+      raw = readFileSync(path, "utf-8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        rows.push(JSON.parse(line));
+      } catch {
+        // A torn final line while a server is mid-write. Skip it.
+      }
+    }
+  }
+  return rows;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Read one process's own declared capability state.
+ *
+ * Filtered on pid *and* ppid *and* a timestamp floor, because the log is a
+ * shared append-only file that outlives sessions and macOS recycles pids.
+ *
+ * Ordering is not a hazard — the probe runs at module load, long before the
+ * server reports a port or answers `initialize` — but the write is a separate
+ * syscall from the one the caller waited on, so this retries briefly rather
+ * than reading once.
+ *
+ * Throws when no row is found. Degrading to a weaker assertion here would
+ * leave the suite green while covering less, which is the failure mode this
+ * whole module is a response to.
+ */
+export async function readDeclaredCapabilityState({
+  pid,
+  ppid = process.pid,
+  sinceIso,
+  attempts = 30,
+  intervalMs = 100,
+  label = `pid ${pid}`,
+}) {
+  if (typeof pid !== "number" || Number.isNaN(pid)) {
+    throw new Error(`${label}: no pid available to identify the server process`);
+  }
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const match = readCrashRows()
+      .filter(
+        (row) =>
+          row.pid === pid &&
+          row.ppid === ppid &&
+          typeof row.event === "string" &&
+          row.event.startsWith("cli-capabilities") &&
+          (!sinceIso || String(row.ts) >= sinceIso)
+      )
+      .pop();
+    if (match) {
+      const kind =
+        match.event === "cli-capabilities-probed"
+          ? "report"
+          : match.event === "cli-capabilities-cli-missing"
+            ? "missing-cli"
+            : "unsupported-cli";
+      return {
+        kind,
+        cliVersion: match.detail?.cliVersion ?? null,
+        apiVersion: match.detail?.apiVersion ?? null,
+        featureCount: match.detail?.featureCount ?? null,
+        pid,
+      };
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(
+    `${label}: no cli-capabilities row for pid ${pid} (ppid ${ppid}) after ${attempts} attempts. ` +
+      `The capability witness is ${crashLogPaths().join(" or ")}; without it this test cannot ` +
+      `distinguish a probe timeout from a dropped registration.`
+  );
+}
+
+/**
+ * The gated names a process in this state must advertise.
+ *
+ * Mirrors `hasFeature`: `missing-cli` keeps every gated name visible so a
+ * first-run auto-install session does not lose them, `unsupported-cli` is
+ * fail-closed, and `report` follows the feature map.
+ *
+ * For `report` the caller supplies the feature map probed from the same
+ * binary. `assertSameCli` is what makes that substitution legitimate, so call
+ * it first.
+ */
+export function expectedGatedNames(gatedMap, state, report) {
+  const all = Object.keys(gatedMap);
+  if (state.kind === "missing-cli") return new Set(all);
+  if (state.kind === "unsupported-cli") return new Set();
+  if (!report) {
+    throw new Error(
+      `state is "report" but no capability report was supplied to compare against`
+    );
+  }
+  return new Set(all.filter((name) => report.features[gatedMap[name]] === true));
+}
+
+/**
+ * Fail unless a child's probe outcome came from the binary this test probed.
+ * Without it, a child resolving a different `minutes` binary is
+ * indistinguishable from a child that agrees.
+ */
+export function assertSameCli(label, state, report) {
+  if (state.kind !== "report") return;
+  if (!report) {
+    throw new Error(
+      `${label}: reported a capability payload but the test could not probe one to compare`
+    );
+  }
+  const expectedFeatureCount = Object.keys(report.features).length;
+  if (
+    state.cliVersion !== report.version ||
+    state.apiVersion !== report.api_version ||
+    state.featureCount !== expectedFeatureCount
+  ) {
+    throw new Error(
+      `${label}: probed a different CLI than this test did — process reported ` +
+        `version=${state.cliVersion} api=${state.apiVersion} features=${state.featureCount}, ` +
+        `test probed version=${report.version} api=${report.api_version} features=${expectedFeatureCount}`
+    );
+  }
+}
+
+/** Split an advertised surface into the gate-independent core and the gated part. */
+export function splitSurface(names, gatedMap) {
+  const core = [];
+  const gated = [];
+  for (const name of names) {
+    if (Object.prototype.hasOwnProperty.call(gatedMap, name)) gated.push(name);
+    else core.push(name);
+  }
+  return { core: core.sort(), gated: gated.sort() };
+}
+
+function formatSetDiff(label, a, b) {
+  const onlyA = a.filter((n) => !b.includes(n));
+  const onlyB = b.filter((n) => !a.includes(n));
+  return `${label}\n  missing: ${onlyB.join(", ") || "(none)"}\n  unexpected: ${onlyA.join(", ") || "(none)"}`;
+}
+
+/**
+ * Assert a single process advertises exactly the gated names its own probe
+ * outcome predicts.
+ *
+ * This is the assertion that keeps the gated half covered rather than merely
+ * excluded. A tool the factory replay dropped is missing from a process whose
+ * own state says it should be there, and that fails here — even though it
+ * would never disturb core parity.
+ */
+export function assertOwnStateGatedSurface({ label, names, gatedMap, state, report }) {
+  const { gated } = splitSurface(names, gatedMap);
+  const expected = [...expectedGatedNames(gatedMap, state, report)].sort();
+  if (gated.join(",") !== expected.join(",")) {
+    throw new Error(
+      formatSetDiff(
+        `${label}: advertised gated surface does not match its own declared capability state ` +
+          `(${state.kind}${state.kind === "report" ? `, ${state.featureCount} features` : ""})`,
+        gated,
+        expected
+      )
+    );
+  }
+  return gated;
+}
+
+/**
+ * Assert two processes advertise the identical core surface.
+ *
+ * No capability gate can move a core name, so this is exact and timing cannot
+ * perturb it. `requiredAnchors` guards the degenerate case where both sides
+ * are empty and match trivially.
+ */
+export function assertCoreParity({ label, aLabel, aNames, bLabel, bNames, gatedMap, requiredAnchors = [] }) {
+  const a = splitSurface(aNames, gatedMap).core;
+  const b = splitSurface(bNames, gatedMap).core;
+  if (a.length === 0 || b.length === 0) {
+    throw new Error(`${label}: a core surface was empty (${aLabel}=${a.length}, ${bLabel}=${b.length})`);
+  }
+  for (const anchor of requiredAnchors) {
+    if (!a.includes(anchor)) throw new Error(`${label}: ${aLabel} is missing core entry ${anchor}`);
+    if (!b.includes(anchor)) throw new Error(`${label}: ${bLabel} is missing core entry ${anchor}`);
+  }
+  if (a.join(",") !== b.join(",")) {
+    throw new Error(
+      formatSetDiff(
+        `${label}: core surface drift between ${aLabel} and ${bLabel}`,
+        a,
+        b
+      )
+    );
+  }
+  return a;
+}
+
+/** Do two processes' probe outcomes agree closely enough to compare gated sets directly? */
+export function capabilityStatesAgree(a, b) {
+  return (
+    a.kind === b.kind &&
+    a.cliVersion === b.cliVersion &&
+    a.apiVersion === b.apiVersion &&
+    a.featureCount === b.featureCount
+  );
+}
+
+/** One line describing a divergence, for tests to print instead of failing on it. */
+export function describeStateDivergence(aLabel, a, bLabel, b) {
+  return (
+    `NOTE: capability probes diverged — ${aLabel}=${a.kind}` +
+    `${a.kind === "report" ? `(${a.featureCount} features)` : ""}, ` +
+    `${bLabel}=${b.kind}${b.kind === "report" ? `(${b.featureCount} features)` : ""}. ` +
+    `Gated tools were checked against each process's own state; core parity is still exact.`
+  );
+}
+
+/**
+ * Fail when `index.ts` grows a capability gate the maps above do not model.
+ *
+ * Two guards, because they catch different mistakes: an unknown feature key
+ * catches a brand-new capability, and the inline-gate count catches a new
+ * gated tool that reuses an existing key.
+ */
+export function assertGateMapMatchesSource(source = readFileSync(join(MCP_DIR, "src", "index.ts"), "utf-8")) {
+  const keys = new Set();
+  let inlineGates = 0;
+  const pattern = /hasFeature\(\s*CLI_CAPABILITIES\s*,\s*"([a-z_]+)"\s*\)/g;
+  for (const match of source.matchAll(pattern)) {
+    keys.add(match[1]);
+  }
+  const inlinePattern = /if \(hasFeature\(\s*CLI_CAPABILITIES\s*,\s*"([a-z_]+)"\s*\)\)/g;
+  for (const _ of source.matchAll(inlinePattern)) inlineGates++;
+
+  const unmodelled = [...keys].filter((key) => !GATED_FEATURE_KEYS.has(key));
+  if (unmodelled.length > 0) {
+    throw new Error(
+      `index.ts gates on capability keys this test does not model: ${unmodelled.join(", ")}. ` +
+        `Add them to CAPABILITY_GATED_TOOLS or CAPABILITY_GATED_RESOURCES — an unmodelled gate lands ` +
+        `in the core set and makes cross-process parity flaky again.`
+    );
+  }
+  const missingFromSource = [...GATED_FEATURE_KEYS].filter((key) => !keys.has(key));
+  if (missingFromSource.length > 0) {
+    throw new Error(
+      `this test models capability keys index.ts no longer gates on: ${missingFromSource.join(", ")}`
+    );
+  }
+  if (inlineGates !== INLINE_GATED_TOOL_COUNT) {
+    throw new Error(
+      `index.ts has ${inlineGates} inline hasFeature tool gates, this test models ${INLINE_GATED_TOOL_COUNT}. ` +
+        `A gate added with an already-known feature key still needs its tool name in CAPABILITY_GATED_TOOLS.`
+    );
+  }
+  return { keys: [...keys].sort(), inlineGates };
+}

--- a/crates/mcp/test/mcp_http_transport_test.mjs
+++ b/crates/mcp/test/mcp_http_transport_test.mjs
@@ -17,6 +17,12 @@
  *     for the proof that this still fails on a real mismatch
  *  3. two concurrent sessions in one process, each with its own session id
  *  4. session teardown releases server-side state
+ *  4b. overlapping tool *execution* from two sessions against the shared
+ *     module scope: results must equal single-session baselines exactly, so a
+ *     response delivered to the wrong session fails rather than passing as
+ *     "it returned something". See the test's own comment for what this
+ *     deliberately does not prove (corpus-lease slot exhaustion, cliAvailable
+ *     cache poisoning)
  *  5. localhost hardening: cross-origin POSTs, non-JSON bodies, unknown
  *     session ids, and non-initialize requests without a session are refused
  *  6. --help lists the transport flags and exits 0
@@ -371,6 +377,94 @@ try {
     const result = await httpClient.callTool({ name: "get_status", arguments: {} });
     assert(Array.isArray(result.content), "tool result should carry content");
     assert(result.content.length > 0, "get_status should return text content");
+  });
+
+  // Shared process state is the thing the diff does not show. Under stdio each
+  // client got its own process, so its own caches and counters; under HTTP every
+  // session runs in one module scope. The corpus tool is used because it is the
+  // deepest shared path reachable from a tool call: `dispatchStableCorpusLease`
+  // admits work against process-global counters (`activeCorpusWorkerCount` and
+  // the reserved-memory total) that two sessions now contend for.
+  //
+  // On a machine where the corpus tool is denied, this is *more* useful, not
+  // less. The denial path is the one with the interesting release logic, and it
+  // is the one every call here takes.
+  //
+  // Baselines are captured single-session, before the second client exists, and
+  // every concurrent result must equal one exactly. Exact equality rather than
+  // "it returned content" is what catches the failure the SDK names when one
+  // transport is shared across clients: colliding JSON-RPC ids deliver a
+  // perfectly plausible response to the wrong session.
+  //
+  // What this does NOT prove, stated because the repetition below looks like it
+  // should. Admission is capped at min(MAX_ACTIVE_WATCHERS, maxWatcherCount) =
+  // 64 slots, so exhausting it needs 33 concurrent pairs even if every call
+  // leaked, and a pair costs ~1.2s here (~39s, and far worse where the corpus
+  // actually resolves). The rounds catch state that degrades quickly, not slot
+  // exhaustion. `withStableCorpusLease`'s release runs in a `finally` with
+  // explicit handling for the "worker died before authorization" case this
+  // machine hits, so leaks are not the likely defect; proving that needs a unit
+  // test against corpus-lease.ts, not an HTTP round trip.
+  //
+  // Also not covered: `cliAvailable`/`cliCheckedAt` poisoning, where one
+  // session's transient CLI failure gates every other session for the cache TTL.
+  // That is sharing rather than concurrency and needs a different setup.
+  test("overlapping tool execution from two sessions stays independent", async () => {
+    const CORPUS_TOOL = "list_meetings"; // routes through withStableCorpusLease
+    const LOCAL_TOOL = "get_status"; // no corpus lease
+
+    const corpusBaseline = JSON.stringify(
+      await httpClient.callTool({ name: CORPUS_TOOL, arguments: {} })
+    );
+    const localBaseline = JSON.stringify(
+      await httpClient.callTool({ name: LOCAL_TOOL, arguments: {} })
+    );
+    assert(
+      corpusBaseline !== localBaseline,
+      "the two baseline tools must be distinguishable, or a swapped response would pass"
+    );
+
+    const second = await connectHttpClient(server.url, "http-concurrent");
+    try {
+      // Same tool from both sessions at once, repeated. One round would not
+      // distinguish "concurrency works" from "the first call happened to win".
+      for (let round = 1; round <= 3; round++) {
+        const [fromPrimary, fromSecondary] = await Promise.all([
+          httpClient.callTool({ name: CORPUS_TOOL, arguments: {} }),
+          second.callTool({ name: CORPUS_TOOL, arguments: {} }),
+        ]);
+        assertEqual(
+          JSON.stringify(fromPrimary),
+          corpusBaseline,
+          `round ${round}: primary session diverged from its single-session baseline`
+        );
+        assertEqual(
+          JSON.stringify(fromSecondary),
+          corpusBaseline,
+          `round ${round}: secondary session diverged from the single-session baseline`
+        );
+      }
+
+      // Different tools at once. Each session must get its own tool's answer;
+      // a swap here is the id-collision failure.
+      const [local, corpus] = await Promise.all([
+        httpClient.callTool({ name: LOCAL_TOOL, arguments: {} }),
+        second.callTool({ name: CORPUS_TOOL, arguments: {} }),
+      ]);
+      assertEqual(
+        JSON.stringify(local),
+        localBaseline,
+        `primary session asked for ${LOCAL_TOOL} and did not get its response`
+      );
+      assertEqual(
+        JSON.stringify(corpus),
+        corpusBaseline,
+        `secondary session asked for ${CORPUS_TOOL} and did not get its response`
+      );
+    } finally {
+      await second.transport.terminateSession();
+      await second.close();
+    }
   });
 
   test("cross-origin POST is rejected", async () => {

--- a/crates/mcp/test/mcp_http_transport_test.mjs
+++ b/crates/mcp/test/mcp_http_transport_test.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+
+/**
+ * MCP HTTP Transport Integration Tests
+ *
+ * Starts the built server in `--transport http` mode and drives it over real
+ * HTTP. Covers:
+ *  1. initialize + tools/list round trip via the MCP SDK client
+ *  2. the HTTP surface matches stdio exactly (tools and resources) — the
+ *     per-session server factory is what could silently drop registrations,
+ *     so parity against a stdio round trip is the check that matters
+ *  3. two concurrent sessions in one process, each with its own session id
+ *  4. session teardown releases server-side state
+ *  5. localhost hardening: cross-origin POSTs, non-JSON bodies, unknown
+ *     session ids, and non-initialize requests without a session are refused
+ *  6. --help lists the transport flags and exits 0
+ *
+ * Requires the debug CLI at target/debug/minutes (the server refuses to start
+ * without it, on either transport).
+ *
+ * Run: node crates/mcp/test/mcp_http_transport_test.mjs
+ */
+
+import { execFileSync, spawn } from "child_process";
+import { join } from "path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const MCP_DIR = join(import.meta.dirname, "..");
+const SERVER_ENTRY = join(MCP_DIR, "dist", "index.js");
+const STARTUP_TIMEOUT_MS = 30000;
+
+let passed = 0;
+let failed = 0;
+
+// Async-aware runner. The sibling suite (mcp_tools_test.mjs) is deliberately
+// synchronous; reusing its helper here would resolve the callback's promise
+// after PASS was already printed, swallowing every failure.
+const pending = [];
+function test(name, fn) {
+  pending.push({ name, fn });
+}
+
+async function runTests() {
+  for (const { name, fn } of pending) {
+    try {
+      await fn();
+      console.log(`  PASS: ${name}`);
+      passed++;
+    } catch (e) {
+      console.error(`  FAIL: ${name} — ${e.message}`);
+      failed++;
+    }
+  }
+}
+
+function assert(condition, msg) {
+  if (!condition) throw new Error(msg || "assertion failed");
+}
+
+function assertEqual(actual, expected, msg) {
+  if (actual !== expected)
+    throw new Error(msg || `expected ${expected}, got ${actual}`);
+}
+
+/** Start the server on an OS-assigned port and read the port back from stderr. */
+function startHttpServer() {
+  const child = spawn(process.execPath, [SERVER_ENTRY, "--transport", "http", "--port", "0"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, RUST_LOG: "error" },
+  });
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      rejectPromise(
+        new Error(`server did not report a listening port in ${STARTUP_TIMEOUT_MS}ms:\n${stderr}`)
+      );
+    }, STARTUP_TIMEOUT_MS);
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+      const match = stderr.match(/listening on (http:\/\/[^\s]+)/);
+      if (match) {
+        clearTimeout(timer);
+        resolvePromise({ child, url: match[1], stderrSoFar: () => stderr });
+      }
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      rejectPromise(new Error(`server exited early (code ${code}):\n${stderr}`));
+    });
+  });
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise((resolvePromise) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolvePromise();
+    }, 5000);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolvePromise();
+    });
+  });
+}
+
+async function connectHttpClient(url, name) {
+  const client = new Client({ name, version: "1.0.0" });
+  await client.connect(new StreamableHTTPClientTransport(new URL(url)));
+  return client;
+}
+
+/** POST a raw JSON-RPC body, bypassing the SDK client, to probe the guards. */
+async function rawPost(url, { body, headers = {}, method = "POST" } = {}) {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return { status: response.status, text };
+}
+
+const INITIALIZE_BODY = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "raw-probe", version: "1.0.0" },
+  },
+};
+
+console.log("MCP HTTP Transport Integration Tests\n");
+
+// Both children probe the CLI's capability list with a 2s spawnSync budget and
+// gate optional tools on the result. A cold debug binary can blow that budget
+// in one child and not the other, which reads as surface drift. One warm-up
+// invocation makes the probe deterministic.
+try {
+  execFileSync(
+    join(import.meta.dirname, "..", "..", "..", "target", "debug", "minutes"),
+    ["capabilities"],
+    { encoding: "utf-8", timeout: 30000, stdio: ["ignore", "pipe", "pipe"] }
+  );
+} catch {
+  // Older CLIs have no `capabilities` subcommand; the probe then agrees anyway.
+}
+
+const server = await startHttpServer();
+const baseUrl = server.url.replace(/\/mcp$/, "");
+
+let httpClient;
+let httpTools;
+let httpResources;
+
+try {
+  test("initialize + tools/list round trip over HTTP", async () => {
+    httpClient = await connectHttpClient(server.url, "http-primary");
+    const info = httpClient.getServerVersion();
+    assertEqual(info?.name, "minutes", "server name should be minutes");
+
+    httpTools = (await httpClient.listTools()).tools;
+    assert(Array.isArray(httpTools), "tools should be an array");
+    assert(httpTools.length > 0, "server should expose tools over HTTP");
+
+    httpResources = (await httpClient.listResources()).resources;
+    assert(Array.isArray(httpResources), "resources should be an array");
+  });
+
+  test("HTTP tool and resource surface matches stdio exactly", async () => {
+    const stdioClient = new Client({ name: "stdio-parity", version: "1.0.0" });
+    const stdioTransport = new StdioClientTransport({
+      command: process.execPath,
+      args: [SERVER_ENTRY],
+      env: { ...process.env, RUST_LOG: "error" },
+      stderr: "ignore",
+    });
+    await stdioClient.connect(stdioTransport);
+    try {
+      const stdioTools = (await stdioClient.listTools()).tools
+        .map((t) => t.name)
+        .sort();
+      const stdioResources = (await stdioClient.listResources()).resources
+        .map((r) => r.uri)
+        .sort();
+      const overHttpTools = httpTools.map((t) => t.name).sort();
+      const overHttpResources = httpResources.map((r) => r.uri).sort();
+
+      assert(stdioTools.length > 0, "stdio should expose tools");
+      assertEqual(
+        overHttpTools.join(","),
+        stdioTools.join(","),
+        `tool surface drift.\n  stdio only: ${stdioTools.filter((n) => !overHttpTools.includes(n))}\n  http only: ${overHttpTools.filter((n) => !stdioTools.includes(n))}`
+      );
+      assertEqual(
+        overHttpResources.join(","),
+        stdioResources.join(","),
+        `resource surface drift.\n  stdio only: ${stdioResources.filter((u) => !overHttpResources.includes(u))}\n  http only: ${overHttpResources.filter((u) => !stdioResources.includes(u))}`
+      );
+      // Spot-check a few known registrations so an empty-vs-empty match can
+      // never be mistaken for parity.
+      for (const name of ["get_status", "list_meetings", "resummarize_meeting", "knowledge_status"]) {
+        assert(overHttpTools.includes(name), `${name} must be served over HTTP`);
+      }
+    } finally {
+      await stdioClient.close();
+    }
+  });
+
+  test("two concurrent clients get independent sessions", async () => {
+    const second = await connectHttpClient(server.url, "http-secondary");
+    try {
+      const secondTools = (await second.listTools()).tools;
+      assertEqual(
+        secondTools.length,
+        httpTools.length,
+        "a second session should see the same tool count"
+      );
+      assert(
+        second.transport.sessionId &&
+          second.transport.sessionId !== httpClient.transport.sessionId,
+        "each client should get its own session id"
+      );
+      const health = await rawPost(`${baseUrl}/health`, { method: "GET" });
+      const parsed = JSON.parse(health.text);
+      assertEqual(parsed.sessions, 2, "server should report two live sessions");
+    } finally {
+      // close() only tears down the client side; DELETE is what ends the
+      // server-side session.
+      await second.transport.terminateSession();
+      await second.close();
+    }
+  });
+
+  test("closing a session releases it server-side", async () => {
+    // Teardown is driven by the transport's onclose, so poll rather than
+    // assume the DELETE response and the server-side cleanup are ordered.
+    let sessions = -1;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const health = await rawPost(`${baseUrl}/health`, { method: "GET" });
+      sessions = JSON.parse(health.text).sessions;
+      if (sessions === 1) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assertEqual(sessions, 1, "only the primary session should remain");
+  });
+
+  test("get_status is callable over HTTP", async () => {
+    const result = await httpClient.callTool({ name: "get_status", arguments: {} });
+    assert(Array.isArray(result.content), "tool result should carry content");
+    assert(result.content.length > 0, "get_status should return text content");
+  });
+
+  test("cross-origin POST is rejected", async () => {
+    const { status, text } = await rawPost(server.url, {
+      body: INITIALIZE_BODY,
+      headers: { Origin: "http://evil.example" },
+    });
+    assertEqual(status, 403, "a non-loopback Origin must be refused");
+    assert(text.includes("cross-origin"), `expected a cross-origin error, got: ${text}`);
+  });
+
+  test("loopback Origin is accepted", async () => {
+    const { status } = await rawPost(server.url, {
+      body: INITIALIZE_BODY,
+      headers: { Origin: "http://localhost:5173" },
+    });
+    assertEqual(status, 200, "a loopback Origin must still be served");
+  });
+
+  test("non-JSON content type is rejected", async () => {
+    const response = await fetch(server.url, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify(INITIALIZE_BODY),
+    });
+    assertEqual(response.status, 415, "text/plain POSTs must be refused");
+  });
+
+  test("unknown session id is rejected", async () => {
+    const { status } = await rawPost(server.url, {
+      body: { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      headers: { "Mcp-Session-Id": "00000000-0000-0000-0000-000000000000" },
+    });
+    assertEqual(status, 404, "an unknown session id must be refused");
+  });
+
+  test("non-initialize request without a session is rejected", async () => {
+    const { status, text } = await rawPost(server.url, {
+      body: { jsonrpc: "2.0", id: 3, method: "tools/list", params: {} },
+    });
+    assertEqual(status, 400, "a sessionless tools/list must be refused");
+    assert(text.includes("Mcp-Session-Id"), `expected a session hint, got: ${text}`);
+  });
+
+  test("unknown path is not served", async () => {
+    const { status } = await rawPost(`${baseUrl}/`, { method: "GET" });
+    assertEqual(status, 404, "only /mcp and /health are served");
+  });
+
+  test("--help documents the transport flags and exits 0", async () => {
+    const { code, stdout } = await new Promise((resolvePromise) => {
+      const child = spawn(process.execPath, [SERVER_ENTRY, "--help"], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let out = "";
+      child.stdout.on("data", (chunk) => (out += chunk.toString()));
+      child.once("exit", (exitCode) => resolvePromise({ code: exitCode, stdout: out }));
+    });
+    assertEqual(code, 0, "--help should exit 0");
+    for (const fragment of ["--transport <stdio|http>", "--port", "--host", "127.0.0.1"]) {
+      assert(stdout.includes(fragment), `--help output should mention ${fragment}`);
+    }
+  });
+
+  await runTests();
+} finally {
+  if (httpClient) {
+    try {
+      await httpClient.close();
+    } catch {
+      // The server may already be gone; teardown is best-effort.
+    }
+  }
+  await stopChild(server.child);
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+process.exit(failed > 0 ? 1 : 0);

--- a/crates/mcp/test/mcp_http_transport_test.mjs
+++ b/crates/mcp/test/mcp_http_transport_test.mjs
@@ -430,9 +430,13 @@ try {
       child.once("exit", (exitCode) => resolvePromise({ code: exitCode, stdout: out }));
     });
     assertEqual(code, 0, "--help should exit 0");
-    for (const fragment of ["--transport <stdio|http>", "--port", "--host", "127.0.0.1"]) {
+    for (const fragment of ["--transport <stdio|http>", "--port", "127.0.0.1"]) {
       assert(stdout.includes(fragment), `--help output should mention ${fragment}`);
     }
+    assert(
+      !stdout.includes("--host"),
+      "--help should not advertise a bind-address flag"
+    );
   });
 
   await runTests();

--- a/crates/mcp/test/mcp_http_transport_test.mjs
+++ b/crates/mcp/test/mcp_http_transport_test.mjs
@@ -6,9 +6,15 @@
  * Starts the built server in `--transport http` mode and drives it over real
  * HTTP. Covers:
  *  1. initialize + tools/list round trip via the MCP SDK client
- *  2. the HTTP surface matches stdio exactly (tools and resources) — the
+ *  2. the HTTP surface matches stdio (tools, resources) — the
  *     per-session server factory is what could silently drop registrations,
- *     so parity against a stdio round trip is the check that matters
+ *     so parity against a stdio round trip is the check that matters. Eight
+ *     tools and two resources sit behind CLI capability gates, and the two
+ *     processes probe those independently, so the comparison is split: core
+ *     parity is exact between processes, and the gated part is checked
+ *     against each process's own declared probe outcome. See
+ *     test/lib/surface-parity.mjs for why, and test/surface_parity_test.mjs
+ *     for the proof that this still fails on a real mismatch
  *  3. two concurrent sessions in one process, each with its own session id
  *  4. session teardown releases server-side state
  *  5. localhost hardening: cross-origin POSTs, non-JSON bodies, unknown
@@ -21,11 +27,24 @@
  * Run: node crates/mcp/test/mcp_http_transport_test.mjs
  */
 
-import { execFileSync, spawn } from "child_process";
+import { spawn } from "child_process";
 import { join } from "path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  CAPABILITY_GATED_RESOURCES,
+  CAPABILITY_GATED_TOOLS,
+  assertCoreParity,
+  assertGateMapMatchesSource,
+  assertOwnStateGatedSurface,
+  assertSameCli,
+  capabilityStatesAgree,
+  describeStateDivergence,
+  probeCapabilityReport,
+  readDeclaredCapabilityState,
+  resolveMinutesBinary,
+} from "./lib/surface-parity.mjs";
 
 const MCP_DIR = join(import.meta.dirname, "..");
 const SERVER_ENTRY = join(MCP_DIR, "dist", "index.js");
@@ -144,19 +163,29 @@ const INITIALIZE_BODY = {
 
 console.log("MCP HTTP Transport Integration Tests\n");
 
-// Both children probe the CLI's capability list with a 2s spawnSync budget and
-// gate optional tools on the result. A cold debug binary can blow that budget
-// in one child and not the other, which reads as surface drift. One warm-up
-// invocation makes the probe deterministic.
-try {
-  execFileSync(
-    join(import.meta.dirname, "..", "..", "..", "target", "debug", "minutes"),
-    ["capabilities"],
-    { encoding: "utf-8", timeout: 30000, stdio: ["ignore", "pipe", "pipe"] }
-  );
-} catch {
-  // Older CLIs have no `capabilities` subcommand; the probe then agrees anyway.
-}
+// Every capability gate in index.ts must be modelled by the parity helper.
+// An unmodelled gate would land in the "core" set and make the cross-process
+// comparison timing-dependent again, so fail before spawning anything.
+assertGateMapMatchesSource();
+
+// Warm the binary the *server* will resolve — release is tried before debug,
+// so warming target/debug unconditionally can warm a file nothing will run —
+// and read its capability report with a budget the server's 2s probe does not
+// have. Warming shrinks the odds of a child's probe timing out; it does not
+// eliminate them, which is why the parity assertions below never depend on
+// the two children agreeing.
+const MINUTES_BIN = resolveMinutesBinary();
+const CAPABILITY_REPORT = probeCapabilityReport(MINUTES_BIN);
+const TEST_START_ISO = new Date().toISOString();
+console.log(
+  `CLI: ${MINUTES_BIN}\nCapability report: ${
+    CAPABILITY_REPORT
+      ? `v${CAPABILITY_REPORT.version} api${CAPABILITY_REPORT.api_version}, ${
+          Object.keys(CAPABILITY_REPORT.features).length
+        } features`
+      : "unavailable (older CLI)"
+  }\n`
+);
 
 const server = await startHttpServer();
 const baseUrl = server.url.replace(/\/mcp$/, "");
@@ -179,7 +208,7 @@ try {
     assert(Array.isArray(httpResources), "resources should be an array");
   });
 
-  test("HTTP tool and resource surface matches stdio exactly", async () => {
+  test("HTTP surface matches stdio, per each process's own capability state", async () => {
     const stdioClient = new Client({ name: "stdio-parity", version: "1.0.0" });
     const stdioTransport = new StdioClientTransport({
       command: process.execPath,
@@ -189,31 +218,112 @@ try {
     });
     await stdioClient.connect(stdioTransport);
     try {
-      const stdioTools = (await stdioClient.listTools()).tools
-        .map((t) => t.name)
-        .sort();
-      const stdioResources = (await stdioClient.listResources()).resources
-        .map((r) => r.uri)
-        .sort();
-      const overHttpTools = httpTools.map((t) => t.name).sort();
-      const overHttpResources = httpResources.map((r) => r.uri).sort();
+      const stdioTools = (await stdioClient.listTools()).tools.map((t) => t.name);
+      const stdioResources = (await stdioClient.listResources()).resources.map((r) => r.uri);
+      const overHttpTools = httpTools.map((t) => t.name);
+      const overHttpResources = httpResources.map((r) => r.uri);
 
-      assert(stdioTools.length > 0, "stdio should expose tools");
-      assertEqual(
-        overHttpTools.join(","),
-        stdioTools.join(","),
-        `tool surface drift.\n  stdio only: ${stdioTools.filter((n) => !overHttpTools.includes(n))}\n  http only: ${overHttpTools.filter((n) => !stdioTools.includes(n))}`
-      );
-      assertEqual(
-        overHttpResources.join(","),
-        stdioResources.join(","),
-        `resource surface drift.\n  stdio only: ${stdioResources.filter((u) => !overHttpResources.includes(u))}\n  http only: ${overHttpResources.filter((u) => !stdioResources.includes(u))}`
-      );
-      // Spot-check a few known registrations so an empty-vs-empty match can
-      // never be mistaken for parity.
-      for (const name of ["get_status", "list_meetings", "resummarize_meeting", "knowledge_status"]) {
-        assert(overHttpTools.includes(name), `${name} must be served over HTTP`);
+      // What each process's own probe decided, read from the line that
+      // process wrote with its own pid. This is the witness that separates
+      // "the probe timed out here" from "the factory dropped registrations",
+      // which are indistinguishable from the advertised surface alone.
+      const httpState = await readDeclaredCapabilityState({
+        pid: server.child.pid,
+        sinceIso: TEST_START_ISO,
+        label: "http server",
+      });
+      const stdioState = await readDeclaredCapabilityState({
+        pid: stdioTransport.pid,
+        sinceIso: TEST_START_ISO,
+        label: "stdio server",
+      });
+      assertSameCli("http server", httpState, CAPABILITY_REPORT);
+      assertSameCli("stdio server", stdioState, CAPABILITY_REPORT);
+
+      // 1. Core parity: exact, between processes. No capability gate can move
+      //    a core name, so this comparison is timing-independent.
+      const coreTools = assertCoreParity({
+        label: "tool surface",
+        aLabel: "http",
+        aNames: overHttpTools,
+        bLabel: "stdio",
+        bNames: stdioTools,
+        gatedMap: CAPABILITY_GATED_TOOLS,
+        requiredAnchors: [
+          "get_status",
+          "list_meetings",
+          "resummarize_meeting",
+          "knowledge_status",
+        ],
+      });
+      assertCoreParity({
+        label: "resource surface",
+        aLabel: "http",
+        aNames: overHttpResources,
+        bLabel: "stdio",
+        bNames: stdioResources,
+        gatedMap: CAPABILITY_GATED_RESOURCES,
+        requiredAnchors: ["minutes://status", "minutes://meetings/recent"],
+      });
+
+      // 2. Gated surface: each process against its own declared state. This is
+      //    what keeps the eight optional tools covered rather than merely
+      //    excluded — a tool the factory replay dropped is missing from a
+      //    process whose own probe says it should be present, and that fails
+      //    here even though it never disturbs core parity.
+      const httpGated = assertOwnStateGatedSurface({
+        label: "http tools",
+        names: overHttpTools,
+        gatedMap: CAPABILITY_GATED_TOOLS,
+        state: httpState,
+        report: CAPABILITY_REPORT,
+      });
+      assertOwnStateGatedSurface({
+        label: "stdio tools",
+        names: stdioTools,
+        gatedMap: CAPABILITY_GATED_TOOLS,
+        state: stdioState,
+        report: CAPABILITY_REPORT,
+      });
+      assertOwnStateGatedSurface({
+        label: "http resources",
+        names: overHttpResources,
+        gatedMap: CAPABILITY_GATED_RESOURCES,
+        state: httpState,
+        report: CAPABILITY_REPORT,
+      });
+      assertOwnStateGatedSurface({
+        label: "stdio resources",
+        names: stdioResources,
+        gatedMap: CAPABILITY_GATED_RESOURCES,
+        state: stdioState,
+        report: CAPABILITY_REPORT,
+      });
+
+      // Together, 1 and 2 pin each process's complete advertised surface:
+      // core is identical across processes, and every gated name is exactly
+      // what that process's own probe predicts. Nothing can silently vanish
+      // over HTTP — it would drop out of core, or out of its own state's
+      // expected set.
+      if (capabilityStatesAgree(httpState, stdioState)) {
+        assertEqual(
+          [...overHttpTools].sort().join(","),
+          [...stdioTools].sort().join(","),
+          "with identical capability states the full tool surfaces must match"
+        );
+        assertEqual(
+          [...overHttpResources].sort().join(","),
+          [...stdioResources].sort().join(","),
+          "with identical capability states the full resource surfaces must match"
+        );
+      } else {
+        console.log(`  ${describeStateDivergence("http", httpState, "stdio", stdioState)}`);
       }
+
+      console.log(
+        `  (core tools ${coreTools.length}, gated ${httpGated.length}/${Object.keys(CAPABILITY_GATED_TOOLS).length}, ` +
+          `states http=${httpState.kind} stdio=${stdioState.kind})`
+      );
     } finally {
       await stdioClient.close();
     }

--- a/crates/mcp/test/surface_parity_test.mjs
+++ b/crates/mcp/test/surface_parity_test.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+
+/**
+ * Self-tests for the cross-process surface parity helper.
+ *
+ * These spawn nothing. They feed synthetic surfaces and synthetic capability
+ * states to the same functions the HTTP suites use, because the properties
+ * that matter cannot be demonstrated by running the real test repeatedly:
+ *
+ *  - a core mismatch must FAIL, and name the tool (the assertion still bites)
+ *  - a probe divergence must PASS (the flake is gone, not the coverage)
+ *  - a gated tool missing from a process whose own state says it should be
+ *    there must FAIL (the own-state check is real, not decorative)
+ *
+ * The second case is the actual evidence that the timing flake is fixed.
+ * Repeat runs of the live test only show that it did not misbehave on a quiet
+ * machine; the flake was never reproduced on demand.
+ *
+ * Run: node crates/mcp/test/surface_parity_test.mjs
+ */
+
+import {
+  CAPABILITY_GATED_RESOURCES,
+  CAPABILITY_GATED_TOOLS,
+  assertCoreParity,
+  assertGateMapMatchesSource,
+  assertOwnStateGatedSurface,
+  assertSameCli,
+  capabilityStatesAgree,
+  expectedGatedNames,
+  splitSurface,
+} from "./lib/surface-parity.mjs";
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS: ${name}`);
+    passed++;
+  } catch (e) {
+    console.error(`  FAIL: ${name} — ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, msg) {
+  if (!condition) throw new Error(msg || "assertion failed");
+}
+
+/** Run fn, return the thrown Error. Fails if it does not throw. */
+function throws(fn, what) {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error(`expected ${what} to throw, it returned normally`);
+}
+
+const GATED = Object.keys(CAPABILITY_GATED_TOOLS);
+const CORE = [
+  "get_status",
+  "list_meetings",
+  "search_meetings",
+  "start_recording",
+  "resummarize_meeting",
+];
+
+const REPORT = {
+  version: "0.24.0",
+  api_version: 1,
+  features: Object.fromEntries(
+    [...new Set(Object.values(CAPABILITY_GATED_TOOLS))].map((key) => [key, true])
+  ),
+};
+const STATE_REPORT = {
+  kind: "report",
+  cliVersion: "0.24.0",
+  apiVersion: 1,
+  featureCount: Object.keys(REPORT.features).length,
+};
+const STATE_UNSUPPORTED = {
+  kind: "unsupported-cli",
+  cliVersion: null,
+  apiVersion: null,
+  featureCount: null,
+};
+const STATE_MISSING = {
+  kind: "missing-cli",
+  cliVersion: null,
+  apiVersion: null,
+  featureCount: null,
+};
+
+console.log("Surface Parity Helper Self-Tests\n");
+
+// ── The assertion still bites ───────────────────────────────
+
+test("a missing core tool fails loudly and names it", () => {
+  const full = [...CORE, ...GATED];
+  const doctored = full.filter((n) => n !== "search_meetings");
+  const error = throws(
+    () =>
+      assertCoreParity({
+        label: "tool surface",
+        aLabel: "http",
+        aNames: doctored,
+        bLabel: "stdio",
+        bNames: full,
+        gatedMap: CAPABILITY_GATED_TOOLS,
+      }),
+    "a core tool missing over HTTP"
+  );
+  assert(
+    error.message.includes("search_meetings"),
+    `the failure must name the tool, got: ${error.message}`
+  );
+  assert(
+    error.message.includes("missing"),
+    `the failure must say what is missing, got: ${error.message}`
+  );
+});
+
+test("an extra core tool on one side fails too", () => {
+  const full = [...CORE, ...GATED];
+  const error = throws(
+    () =>
+      assertCoreParity({
+        label: "tool surface",
+        aLabel: "http",
+        aNames: [...full, "phantom_tool"],
+        bLabel: "stdio",
+        bNames: full,
+        gatedMap: CAPABILITY_GATED_TOOLS,
+      }),
+    "an unexpected core tool"
+  );
+  assert(error.message.includes("phantom_tool"), error.message);
+});
+
+test("two empty surfaces do not match trivially", () => {
+  throws(
+    () =>
+      assertCoreParity({
+        label: "tool surface",
+        aLabel: "http",
+        aNames: [],
+        bLabel: "stdio",
+        bNames: [],
+        gatedMap: CAPABILITY_GATED_TOOLS,
+      }),
+    "an empty-vs-empty comparison"
+  );
+});
+
+test("a required anchor missing from one side fails", () => {
+  const full = [...CORE, ...GATED];
+  const error = throws(
+    () =>
+      assertCoreParity({
+        label: "tool surface",
+        aLabel: "http",
+        aNames: full.filter((n) => n !== "get_status"),
+        bLabel: "stdio",
+        bNames: full.filter((n) => n !== "get_status"),
+        gatedMap: CAPABILITY_GATED_TOOLS,
+        requiredAnchors: ["get_status"],
+      }),
+    "both sides missing an anchor"
+  );
+  assert(error.message.includes("get_status"), error.message);
+});
+
+// ── The flake is gone ───────────────────────────────────────
+
+test("a probe divergence passes: core parity holds, gated sets differ legitimately", () => {
+  // Exactly the historical flake: one process probed the CLI in time, the
+  // other's 2s budget expired and it fell back to unsupported-cli.
+  const healthy = [...CORE, ...GATED];
+  const timedOut = [...CORE];
+
+  // Core parity is unaffected.
+  const core = assertCoreParity({
+    label: "tool surface",
+    aLabel: "http",
+    aNames: healthy,
+    bLabel: "stdio",
+    bNames: timedOut,
+    gatedMap: CAPABILITY_GATED_TOOLS,
+    requiredAnchors: ["get_status", "list_meetings"],
+  });
+  assert(core.length === CORE.length, `core should be ${CORE.length}, got ${core.length}`);
+
+  // And each process matches its own declared state.
+  assertOwnStateGatedSurface({
+    label: "http",
+    names: healthy,
+    gatedMap: CAPABILITY_GATED_TOOLS,
+    state: STATE_REPORT,
+    report: REPORT,
+  });
+  assertOwnStateGatedSurface({
+    label: "stdio",
+    names: timedOut,
+    gatedMap: CAPABILITY_GATED_TOOLS,
+    state: STATE_UNSUPPORTED,
+    report: REPORT,
+  });
+
+  assert(
+    !capabilityStatesAgree(STATE_REPORT, STATE_UNSUPPORTED),
+    "the divergence should be detectable for reporting"
+  );
+});
+
+test("the old full-list comparison would have failed on that same input", () => {
+  // Guards the premise. If a naive comparison of the same two surfaces passed,
+  // there would have been no flake to fix and this module would be pointless.
+  const healthy = [...CORE, ...GATED].sort();
+  const timedOut = [...CORE].sort();
+  assert(
+    healthy.join(",") !== timedOut.join(","),
+    "the divergent surfaces must actually differ"
+  );
+});
+
+// ── The own-state check is real ─────────────────────────────
+
+test("a gated tool missing while its own state says present fails", () => {
+  const short = [...CORE, ...GATED.filter((n) => n !== "start_copilot")];
+  const error = throws(
+    () =>
+      assertOwnStateGatedSurface({
+        label: "http",
+        names: short,
+        gatedMap: CAPABILITY_GATED_TOOLS,
+        state: STATE_REPORT,
+        report: REPORT,
+      }),
+    "a gated tool dropped by a process whose probe succeeded"
+  );
+  assert(error.message.includes("start_copilot"), error.message);
+});
+
+test("a gated tool present while its own state says unsupported fails", () => {
+  const error = throws(
+    () =>
+      assertOwnStateGatedSurface({
+        label: "stdio",
+        names: [...CORE, "get_moment"],
+        gatedMap: CAPABILITY_GATED_TOOLS,
+        state: STATE_UNSUPPORTED,
+        report: REPORT,
+      }),
+    "a gated tool advertised by a fail-closed process"
+  );
+  assert(error.message.includes("get_moment"), error.message);
+});
+
+test("missing-cli expects every gated name, matching hasFeature", () => {
+  const expected = expectedGatedNames(CAPABILITY_GATED_TOOLS, STATE_MISSING, null);
+  assert(expected.size === GATED.length, `expected all ${GATED.length}, got ${expected.size}`);
+  assertOwnStateGatedSurface({
+    label: "first-run",
+    names: [...CORE, ...GATED],
+    gatedMap: CAPABILITY_GATED_TOOLS,
+    state: STATE_MISSING,
+    report: null,
+  });
+});
+
+test("a feature reported false hides exactly its tools", () => {
+  const partial = {
+    ...REPORT,
+    features: { ...REPORT.features, copilot_realtime: false },
+  };
+  const state = { ...STATE_REPORT, featureCount: Object.keys(partial.features).length };
+  const expected = expectedGatedNames(CAPABILITY_GATED_TOOLS, state, partial);
+  assert(!expected.has("start_copilot"), "copilot tools should be hidden");
+  assert(expected.has("get_moment"), "unrelated gated tools should stay");
+  assertOwnStateGatedSurface({
+    label: "partial",
+    names: [...CORE, "activity_summary", "search_context", "get_moment", "get_screen_context"],
+    gatedMap: CAPABILITY_GATED_TOOLS,
+    state,
+    report: partial,
+  });
+});
+
+test("a process that probed a different CLI fails rather than being compared", () => {
+  const error = throws(
+    () =>
+      assertSameCli(
+        "http",
+        { ...STATE_REPORT, cliVersion: "0.23.0" },
+        REPORT
+      ),
+    "a version mismatch between the child's probe and the test's"
+  );
+  assert(error.message.includes("0.23.0"), error.message);
+});
+
+test("a feature-count mismatch fails even when versions agree", () => {
+  throws(
+    () => assertSameCli("http", { ...STATE_REPORT, featureCount: 99 }, REPORT),
+    "a feature-count mismatch"
+  );
+});
+
+// ── Resources get the same treatment ────────────────────────
+
+test("gated resources split the same way", () => {
+  const uris = [
+    "minutes://status",
+    "minutes://meetings/recent",
+    "minutes://events/live",
+    "minutes://live/copilot",
+  ];
+  const { core, gated } = splitSurface(uris, CAPABILITY_GATED_RESOURCES);
+  assert(core.length === 2, `core should be 2, got ${core.join(",")}`);
+  assert(gated.length === 2, `gated should be 2, got ${gated.join(",")}`);
+  assertOwnStateGatedSurface({
+    label: "timed-out process",
+    names: ["minutes://status", "minutes://meetings/recent"],
+    gatedMap: CAPABILITY_GATED_RESOURCES,
+    state: STATE_UNSUPPORTED,
+    report: REPORT,
+  });
+});
+
+// ── Drift guard against index.ts ────────────────────────────
+
+test("the gate map matches the gates in index.ts", () => {
+  const { keys, inlineGates } = assertGateMapMatchesSource();
+  assert(keys.length > 0, "expected to find capability gates in index.ts");
+  assert(inlineGates > 0, "expected inline hasFeature tool gates");
+});
+
+test("a new unmodelled capability gate fails the drift guard", () => {
+  const error = throws(
+    () =>
+      assertGateMapMatchesSource(
+        `if (hasFeature(CLI_CAPABILITIES, "activity_summary"))\n` +
+          `if (hasFeature(CLI_CAPABILITIES, "search_context"))\n` +
+          `if (hasFeature(CLI_CAPABILITIES, "get_moment"))\n` +
+          `if (hasFeature(CLI_CAPABILITIES, "screen_context"))\n` +
+          `const A = hasFeature(CLI_CAPABILITIES, "events_since_seq");\n` +
+          `const B = hasFeature(CLI_CAPABILITIES, "copilot_realtime");\n` +
+          `const C = hasFeature(CLI_CAPABILITIES, "brand_new_thing");\n`
+      ),
+    "an unmodelled capability key"
+  );
+  assert(error.message.includes("brand_new_thing"), error.message);
+});
+
+test("a new inline gate reusing a known key still fails the drift guard", () => {
+  const error = throws(
+    () =>
+      assertGateMapMatchesSource(
+        `if (hasFeature(CLI_CAPABILITIES, "activity_summary"))\n` +
+          `if (hasFeature(CLI_CAPABILITIES, "search_context"))\n` +
+          `if (hasFeature(CLI_CAPABILITIES, "get_moment"))\n` +
+          `if (hasFeature(CLI_CAPABILITIES, "screen_context"))\n` +
+          `if (hasFeature(CLI_CAPABILITIES, "get_moment"))\n` +
+          `const A = hasFeature(CLI_CAPABILITIES, "events_since_seq");\n` +
+          `const B = hasFeature(CLI_CAPABILITIES, "copilot_realtime");\n`
+      ),
+    "a fifth inline gate"
+  );
+  assert(error.message.includes("inline"), error.message);
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/generate_llms_txt.mjs
+++ b/scripts/generate_llms_txt.mjs
@@ -55,8 +55,10 @@ function parseResources(source) {
     return declaration[1];
   };
 
+  // Two spellings per shape: the direct call on the singleton, and the recording
+  // wrapper that replays the same registration onto a per-session McpServer.
   const appResourcePattern =
-    /registerAppResource\(\s*server,\s*"([^"]+)",\s*([A-Z0-9_":/.{}-]+),\s*\{\s*description:\s*"([^"]+)"\s*,?\s*\}/gs;
+    /(?:registerAppResource\(\s*server,|registerAppResourceOnEveryServer\()\s*"([^"]+)",\s*([A-Z0-9_":/.{}-]+),\s*\{\s*description:\s*"([^"]+)"\s*,?\s*\}/gs;
   for (const match of source.matchAll(appResourcePattern)) {
     const [, name, rawUri, description] = match;
     const uri = rawUri === "UI_RESOURCE_URI" ? "ui://minutes/dashboard" : resolveUri(rawUri);
@@ -64,14 +66,14 @@ function parseResources(source) {
   }
 
   const directResourcePattern =
-    /server\.resource\(\s*"([^"]+)",\s*("[^"]+"|[A-Z][A-Z0-9_]*),\s*\{\s*description:\s*"([^"]+)"\s*,?\s*\}/gs;
+    /(?:server\.resource|registerResource)\(\s*"([^"]+)",\s*("[^"]+"|[A-Z][A-Z0-9_]*),\s*\{\s*description:\s*"([^"]+)"\s*,?\s*\}/gs;
   for (const match of source.matchAll(directResourcePattern)) {
     const [, name, rawUri, description] = match;
     resources.push({ name, uri: resolveUri(rawUri), description });
   }
 
   const templateResourcePattern =
-    /server\.resource\(\s*"([^"]+)",\s*new ResourceTemplate\(("[^"]+"|[A-Z][A-Z0-9_]*),[\s\S]*?\),\s*\{\s*description:\s*"([^"]+)"\s*,?\s*\}/gs;
+    /(?:server\.resource|registerResource)\(\s*"([^"]+)",\s*new ResourceTemplate\(("[^"]+"|[A-Z][A-Z0-9_]*),[\s\S]*?\),\s*\{\s*description:\s*"([^"]+)"\s*,?\s*\}/gs;
   for (const match of source.matchAll(templateResourcePattern)) {
     const [, name, rawUri, description] = match;
     resources.push({ name, uri: resolveUri(rawUri), description });

--- a/scripts/sync_site_release_version.mjs
+++ b/scripts/sync_site_release_version.mjs
@@ -39,10 +39,15 @@ const mcpPromptCount = manifest.prompts.length;
 async function countMcpResources() {
   const source = await readFile(mcpSourcePath, "utf8");
   const identities = new Set();
+  // Resources are registered either directly on the singleton (`server.resource`,
+  // `registerAppResource(server, ...)`) or through the recording wrappers that let
+  // the same surface be replayed onto a per-session McpServer (`registerResource`,
+  // `registerAppResourceOnEveryServer`). Both spellings are matched so this stays
+  // correct whichever one a given call site uses.
   const patterns = [
-    /registerAppResource\(\s*server,\s*"([^"]+)",\s*([A-Z0-9_":/.{}-]+),\s*\{\s*description:\s*"[^"]+"\s*,?\s*\}/gs,
-    /server\.resource\(\s*"([^"]+)",\s*("[^"]+"|[A-Z][A-Z0-9_]*),\s*\{\s*description:\s*"[^"]+"\s*,?\s*\}/gs,
-    /server\.resource\(\s*"([^"]+)",\s*new ResourceTemplate\(("[^"]+"|[A-Z][A-Z0-9_]*),[\s\S]*?\),\s*\{\s*description:\s*"[^"]+"\s*,?\s*\}/gs,
+    /(?:registerAppResource\(\s*server,|registerAppResourceOnEveryServer\()\s*"([^"]+)",\s*([A-Z0-9_":/.{}-]+),\s*\{\s*description:\s*"[^"]+"\s*,?\s*\}/gs,
+    /(?:server\.resource|registerResource)\(\s*"([^"]+)",\s*("[^"]+"|[A-Z][A-Z0-9_]*),\s*\{\s*description:\s*"[^"]+"\s*,?\s*\}/gs,
+    /(?:server\.resource|registerResource)\(\s*"([^"]+)",\s*new ResourceTemplate\(("[^"]+"|[A-Z][A-Z0-9_]*),[\s\S]*?\),\s*\{\s*description:\s*"[^"]+"\s*,?\s*\}/gs,
   ];
   for (const pattern of patterns) {
     for (const match of source.matchAll(pattern)) {


### PR DESCRIPTION
Adds an opt-in Streamable HTTP transport to the MCP server. stdio stays the default, and with no flag nothing changes: that path is byte-for-byte what it is today.

```bash
minutes-mcp --transport http --port 7373
```

Six commits, each of which compiles on its own.

## Why a server factory had to come first

The first commit looks like unrelated churn, so it is worth saying why it is there. `crates/mcp/src/index.ts` builds one module-level `McpServer` and registers every tool, resource and handler onto it at module scope, across about 9000 lines. HTTP cannot reuse that. Two constraints in `@modelcontextprotocol/sdk` 1.30.0, both read out of the installed source rather than assumed:

- `Protocol.connect()` throws "Already connected to a transport" when a second transport is attached to the same server.
- `WebStandardStreamableHTTPServerTransport.handleRequest()` throws "Stateless transport cannot be reused across requests" once `sessionIdGenerator` is undefined and the transport has served one request. The SDK's own comment gives the reason: message id collisions between clients.

So HTTP needs one `McpServer` plus one transport per session, and there is no shared-transport shortcut. Rather than indent 4600 lines into a factory function, registrations now record into a builder list that `createMinutesServer()` replays onto a fresh instance. Handlers still close over module state, so instances share the CLI bridge, caches and leases; only protocol state is per-instance.

## Security

HTTP mode has no authentication. It binds `127.0.0.1` and rejects any request whose `Host` or `Origin` header is not loopback, plus a content-type check. Binding to loopback is not enough on its own: a page already open in your browser can POST to a local port, so the header checks are the part that actually stops that. The README says the same thing next to the config example.

## Tests

New under vitest: `httpTransport.test.ts` and `serverFactory.test.ts`. New as integration tests: `mcp_http_transport_test.mjs` (12 checks) and `surface_parity_test.mjs` (16). CI runs `npm run test:unit`, so the vitest half is enforced there. The `.mjs` tests are local-only, which is how `mcp_tools_test.mjs` and `copilot_mcp_contract.mjs` already work here, so this follows existing practice rather than adding a gap.

`serverFactory.test.ts` is the one that earns its keep. It compares a factory instance's surface against the stdio singleton, so "registered on the singleton, invisible over HTTP" fails a test instead of shipping.

The parity helper in `test/lib/surface-parity.mjs` is bigger than it looks like it should be, and the reason is worth knowing before you read it. Comparing whole `tools/list` name lists between two separately spawned servers is not a deterministic assertion: each one runs `probeCapabilitiesSync` at module load on a 2s `execFileSync` budget, and a cold or contended CLI blows that budget and silently drops eight tools and two resources. So I split the check instead of loosening it. The ungated core is compared exactly across processes. The capability-gated names are compared per process against that process's own probe outcome, read from the `cli-capabilities-*` line each process writes under its own pid. That channel reports what a process decided rather than what it advertised, and from the advertised surface alone, "the probe timed out" and "the factory dropped the gated tools" look identical. The second one is the defect the test exists to catch. A missing witness fails rather than quietly degrading to a weaker assertion.

## Three things I would like your read on

1. Default port 7373. Arbitrary, but unassigned by IANA and clear of 3000/5173/8000/8080. Trivial to change if you would rather it were something else.
2. `--help` used to launch stdio and now prints usage and exits 0. That is the branch's one behaviour change to an existing invocation. I judged it safe because no MCP host passes `--help`, but it is not a strict zero-delta and I would rather flag it than have you find it.
3. Shared process state, which is the thing the diff does not show. Under stdio every client got its own process, so its own `cliAvailable` cache, corpus lease state, copilot subscription set and `MINUTES_BIN`. Under HTTP all sessions share one module scope. For recording that is arguably more correct, since it is machine-global behind a PID file and flock either way. But the concurrency test only calls `listTools` from two sessions, which touches no shared mutable state, so overlapping tool execution against shared leases and caches is not exercised in this branch. I would rather say that plainly than imply it was covered.

One thing I left out on purpose: running stdio and HTTP in the same process is cheap now that the factory exists, but a process owns one stdin, so it would only ever mean "HTTP alongside a host-spawned stdio session". Nobody has asked for that.

## What comes after this

Two more branches build on this one. I will open them as separate PRs once this lands rather than piling them in here: an MCP prompts primitive, since `prompts/list` currently answers Method not found, and an opt-in tool-search mode that cuts the `tools/list` payload by about 94%. Both need per-instance wiring through the builder list this PR adds, which is the only reason they are sequenced behind it.
