### PR TITLE
fix(live): explain which setting chose the live transcript model (#756)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1148,7 +1148,13 @@ pub struct LiveTranscriptConfig {
     ///   Whisper while signed runtime acceptance remains incomplete
     pub backend: String,
     /// Whisper model to use for live transcription.
-    /// Empty string means "use the dictation model".
+    ///
+    /// Empty (the default) means `dictation.model`, NOT `transcription.model`,
+    /// even though `backend` above defaults to `"inherit"`. Live transcription
+    /// is real-time and wants a small fast model; batch transcription can
+    /// afford a slower, more accurate one, so inheriting it would give anyone
+    /// who chose a large batch model a live sidecar too slow to keep up.
+    /// Set this explicitly to decouple the two (#756).
     pub model: String,
     /// Maximum utterance length in seconds before force-finalizing.
     pub max_utterance_secs: u64,

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -2021,12 +2021,44 @@ fn transcribe_utterance_for_sidecar(
 }
 
 #[cfg(feature = "whisper")]
+/// Resolve the Whisper model for live transcription.
+///
+/// An empty `live_transcript.model` falls back to `dictation.model`, NOT to
+/// `transcription.model`. That is deliberate: live transcription runs in real
+/// time against a streaming utterance and wants a small fast model, while batch
+/// transcription can afford a slower, more accurate one. Inheriting the batch
+/// model would hand anyone who chose a large model for quality a live sidecar
+/// too slow to keep up, trading a clear error for a vague performance problem.
+///
+/// The raw resolver error names a missing file but not the setting that chose
+/// it, which left a reporter reading our source to solve their own config
+/// problem (#756). The message is rewritten here to name the whole chain and
+/// both ways out, since `backend = "inherit"` sitting directly above `model`
+/// makes inheriting the natural assumption.
+fn resolve_live_model_path(config: &Config) -> Result<std::path::PathBuf, MinutesError> {
+    if !config.live_transcript.model.is_empty() {
+        return Ok(crate::transcribe::resolve_model_path_by_name(
+            &config.live_transcript.model,
+            config,
+        )?);
+    }
+    crate::transcribe::resolve_model_path_for_dictation(config).map_err(|error| match error {
+        TranscribeError::ModelNotFound(detail) => TranscribeError::ModelNotFound(format!(
+            "live transcript resolved to the dictation model \"{}\" because \
+             live_transcript.model is empty. Note that it does NOT inherit \
+             transcription.model (currently \"{}\"): live transcription is \
+             real-time and wants a small fast model.\n\n{}\nAlternatively set \
+             live_transcript.model to a model you already have.",
+            config.dictation.model, config.transcription.model, detail
+        ))
+        .into(),
+        other => other.into(),
+    })
+}
+
+#[cfg(feature = "whisper")]
 fn load_sidecar_whisper_ctx(config: &Config) -> Result<whisper_rs::WhisperContext, MinutesError> {
-    let model_path = if config.live_transcript.model.is_empty() {
-        crate::transcribe::resolve_model_path_for_dictation(config)?
-    } else {
-        crate::transcribe::resolve_model_path_by_name(&config.live_transcript.model, config)?
-    };
+    let model_path = resolve_live_model_path(config)?;
     tracing::info!(model = %model_path.display(), "loading whisper model for recording sidecar");
     Ok(whisper_rs::WhisperContext::new_with_params(
         model_path
@@ -2131,11 +2163,7 @@ fn ensure_live_whisper_ctx<'a>(
     config: &Config,
 ) -> Result<&'a whisper_rs::WhisperContext, MinutesError> {
     if whisper_ctx.is_none() {
-        let model_path = if config.live_transcript.model.is_empty() {
-            crate::transcribe::resolve_model_path_for_dictation(config)?
-        } else {
-            crate::transcribe::resolve_model_path_by_name(&config.live_transcript.model, config)?
-        };
+        let model_path = resolve_live_model_path(config)?;
         tracing::info!(
             model = %model_path.display(),
             "loading whisper model for live transcript fallback"
@@ -4281,6 +4309,51 @@ mod tests {
         let diagnostic = diagnostic.expect("fallback reason must remain visible");
         assert!(diagnostic.contains("retained parakeet"));
         assert!(diagnostic.contains("secure private audio"));
+    }
+
+    #[test]
+    fn empty_live_model_error_names_the_setting_that_chose_it() {
+        // #756: the reporter had to read our source to learn that a blank
+        // live_transcript.model routes to dictation.model rather than
+        // transcription.model. The message must close that gap by itself.
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = Config {
+            transcription: crate::config::TranscriptionConfig {
+                model: "small".into(),
+                model_path: dir.path().to_path_buf(),
+                ..Default::default()
+            },
+            dictation: crate::config::DictationConfig {
+                model: "base".into(),
+                ..Default::default()
+            },
+            live_transcript: crate::config::LiveTranscriptConfig {
+                model: String::new(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error = resolve_live_model_path(&config)
+            .expect_err("no model file exists in the temp dir")
+            .to_string();
+
+        assert!(
+            error.contains("live_transcript.model is empty"),
+            "must name the setting that is empty: {error}"
+        );
+        assert!(
+            error.contains("dictation model \"base\""),
+            "must name where it actually resolved: {error}"
+        );
+        assert!(
+            error.contains("transcription.model"),
+            "must correct the natural assumption: {error}"
+        );
+        assert!(
+            error.contains("small"),
+            "must show the batch model it did NOT use: {error}"
+        );
     }
 
     #[test]

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -324,7 +324,7 @@ Dictation clipboard behavior is platform-specific:
 
 | key | default | meaning |
 |---|---|---|
-| `model` | inherits dictation model | Whisper model for live mode |
+| `model` | empty, meaning `dictation.model` | Whisper model for live mode. An empty value uses `dictation.model`, **not** `transcription.model`: live transcription is real-time and wants a small fast model, while batch transcription can afford a slower, more accurate one. Set this explicitly to decouple them. |
 | `max_utterance_secs` | `30` | Force-finalize an utterance at this length |
 | `save_wav` | `true` | Save raw WAV so the stopped session can be preserved or processed |
 | `promote_on_stop` | `"process"` | `"process"` creates a normal meeting; `"preserve"` keeps a timestamped WAV/JSONL pair only; `"off"` leaves the overwrite-prone fixed slot unchanged |


### PR DESCRIPTION
Fixes #756.

## The report

With `live_transcript.model = ""` and `transcription.model = "small"`, the sidecar failed asking for `ggml-base.bin`, a model the user never chose. They traced it to the line: an empty `live_transcript.model` resolves via `resolve_model_path_for_dictation`, which reads `dictation.model` (default `"base"`), not `transcription.model` (default `"small"`).

## What is not changing, and why

The fallback is correct. Live transcription runs in real time against a streaming utterance and wants a small fast model; batch transcription can afford a slower, more accurate one. If the empty case inherited `transcription.model`, anyone who deliberately chose a large model for batch quality would get a live sidecar too slow to keep up. That trades a clear error for a vague performance problem, which is the worse failure.

## What was actually broken

We set the user up to expect otherwise, then gave them no way back:

1. **`backend = "inherit"` sits directly above `model`.** Reading that and then a blank `model`, inheriting is the obvious conclusion. The naming invites the assumption.
2. **The error was a dead end.** It named a missing file but not the setting that chose it, so there was no path from the message back to the knob. The reporter had to read our source to solve their own config problem.
3. **The docs stated the behavior with no rationale**, so even a reader who found it had no reason to think it deliberate rather than arbitrary.

## The change

Both resolution sites (`load_sidecar_whisper_ctx` and `ensure_live_whisper_ctx`, a hundred lines apart) now share `resolve_live_model_path`, which rewrites `ModelNotFound` to name the whole chain and both exits. **The reporter found one site**; a fix touching only that one would have left the other producing the identical confusing error.

What a user sees now:

```
Transcription model not found. live transcript resolved to the dictation model
"base" because live_transcript.model is empty. Note that it does NOT inherit
transcription.model (currently "small"): live transcription is real-time and
wants a small fast model.

Expected model file "ggml-base.bin" in ~/.minutes/models.

To fix this, run:

    minutes setup --model base

Alternatively set live_transcript.model to a model you already have.
```

Plus the rationale in the config doc comment and the user-facing config table, which previously said only "inherits dictation model".

## Verification

New test pins the message *contents* rather than its wording: the empty setting, where it resolved, the assumption it corrects, and the batch model it did not use. 38/38 `live_transcript` tests, `clippy --no-default-features -D warnings` clean, codex review clean.

No behavior change to model resolution itself, so an existing working config resolves exactly as before.