### PR TITLE
test(mcp): let a corpus-lease case finish its own cleanup

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
 import {
   mkdirSync,
@@ -21,8 +21,30 @@ import { realpath } from "node:fs/promises";
 
 import {
   DEFAULT_CORPUS_READ_BUDGETS,
+  awaitDeferredCorpusReleasesForTests,
   withStableCorpusLease,
 } from "./corpus-lease.js";
+
+// A lease that leaves an unconfirmed hazard behind defers its memory release
+// until that hazard settles, which is correct: a child that may still be alive
+// may still hold corpus data. The charge is process-global though, so a case
+// whose hazard has not settled *yet* leaves it standing and later cases fail on
+// the retained-snapshot budget rather than on anything they did. That is the
+// flake that has been reported three times on three platforms, each time naming
+// an innocent test.
+//
+// Waiting for our own cleanup makes the boundary between cases real, so a case
+// is charged for what it did rather than for what the previous one had not
+// finished undoing.
+//
+// Deliberately no "charge is back to zero" assertion. Poisoning is expressed AS
+// a permanently retained charge, not as a flag, so "poisons admission when an
+// asynchronous projection ignores cancellation" is supposed to end holding one.
+// An unconditional assertion fails that test for doing its job, which is how
+// this version of the hook was caught on its first run.
+afterEach(async () => {
+  await awaitDeferredCorpusReleasesForTests();
+});
 import {
   readTextFileFromBoundParent,
   retireBoundReadersForProcessShutdown,

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -294,6 +294,64 @@ function reserveCorpusMemory(
   return { bytes, released: false };
 }
 
+/**
+ * Deferred releases that have been scheduled but not yet completed.
+ *
+ * A lease that leaves unconfirmed hazards behind must not release its memory
+ * charge until every hazard settles, because a child that may still be alive
+ * may still hold corpus data. That is correct, and production wants exactly it.
+ *
+ * The charge is process-global, though, so in a test process the delay is
+ * visible to whatever runs next: an early case whose hazard has not settled yet
+ * leaves the charge standing, and later cases fail on the retained-snapshot
+ * budget instead of on anything they did. That is one flake reported three
+ * times on three platforms, always naming an innocent test.
+ *
+ * Tracking the deferrals lets a test await its own cleanup rather than race it.
+ * Deliberately not a reset: resetting the counter would hide a real leak, while
+ * awaiting the actual settlement proves the release happened.
+ */
+const pendingDeferredReleases = new Set<Promise<unknown>>();
+
+/**
+ * Test-only: give this process's deferred releases a chance to settle.
+ *
+ * Best-effort and bounded, deliberately. The flake this exists for is a release
+ * that has not settled YET: a killed child whose termination lands as soon as
+ * the event loop breathes. Awaiting gives it that chance, so the next case
+ * starts from a clean charge instead of inheriting one.
+ *
+ * It does NOT throw on an unsettled deferral, because "never settles" is a
+ * supported end state, not a defect: a projection that ignores cancellation
+ * poisons admission permanently and by design, and the test covering that would
+ * fail a stricter hook for doing its job. Returns whether everything settled,
+ * for a caller that wants to know.
+ *
+ * Measured, so the budget is not a guess: one stranded child holds 15,335,424
+ * bytes against MAX_RETAINED_CORPUS_MEMORY_BYTES, awaiting while the child is
+ * still unreaped clears nothing, and awaiting after the reap lands clears it to
+ * zero. The bound only has to cover the gap between a case ending and its
+ * child's reap arriving, which is milliseconds unless the machine is saturated,
+ * so it is set well above that and still far below vitest's hook timeout.
+ */
+export async function awaitDeferredCorpusReleasesForTests(
+  timeoutMs = 8_000
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (pendingDeferredReleases.size > 0 && Date.now() < deadline) {
+    await Promise.race([
+      Promise.allSettled([...pendingDeferredReleases]),
+      new Promise((resolve) => setTimeout(resolve, 25)),
+    ]);
+  }
+  return pendingDeferredReleases.size === 0;
+}
+
+/** Test-only: the live retained-corpus charge, for leak assertions. */
+export function reservedCorpusMemoryBytesForTests(): number {
+  return reservedCorpusMemoryBytes;
+}
+
 function releaseCorpusMemory(reservation: CorpusMemoryReservation): void {
   if (reservation.released) return;
   reservation.released = true;
@@ -2379,12 +2437,18 @@ async function dispatchStableCorpusLease<T>(
       //
       // allSettled, not all: a hazard that rejects is still a hazard that
       // finished, and a rejection here must not strand the process closed.
-      void Promise.allSettled(unconfirmedHazards).then(() => {
+      const deferred = Promise.allSettled(unconfirmedHazards).then(() => {
         releaseUnconfirmedCorpusWorker();
         releaseCorpusMemory(reservation);
         if (workerAdmissionReleased) return;
         workerAdmissionReleased = true;
         activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
+      });
+      // Registered before the removal is attached, so the set can never be
+      // observed empty while this release is still outstanding.
+      pendingDeferredReleases.add(deferred);
+      void deferred.finally(() => {
+        pendingDeferredReleases.delete(deferred);
       });
     }
     if (releaseWorkerAdmission && !workerAdmissionReleased) {

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
 import {
   mkdirSync,
@@ -21,8 +21,30 @@ import { realpath } from "node:fs/promises";
 
 import {
   DEFAULT_CORPUS_READ_BUDGETS,
+  awaitDeferredCorpusReleasesForTests,
   withStableCorpusLease,
 } from "./corpus-lease.js";
+
+// A lease that leaves an unconfirmed hazard behind defers its memory release
+// until that hazard settles, which is correct: a child that may still be alive
+// may still hold corpus data. The charge is process-global though, so a case
+// whose hazard has not settled *yet* leaves it standing and later cases fail on
+// the retained-snapshot budget rather than on anything they did. That is the
+// flake that has been reported three times on three platforms, each time naming
+// an innocent test.
+//
+// Waiting for our own cleanup makes the boundary between cases real, so a case
+// is charged for what it did rather than for what the previous one had not
+// finished undoing.
+//
+// Deliberately no "charge is back to zero" assertion. Poisoning is expressed AS
+// a permanently retained charge, not as a flag, so "poisons admission when an
+// asynchronous projection ignores cancellation" is supposed to end holding one.
+// An unconditional assertion fails that test for doing its job, which is how
+// this version of the hook was caught on its first run.
+afterEach(async () => {
+  await awaitDeferredCorpusReleasesForTests();
+});
 import {
   readTextFileFromBoundParent,
   retireBoundReadersForProcessShutdown,

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -294,6 +294,64 @@ function reserveCorpusMemory(
   return { bytes, released: false };
 }
 
+/**
+ * Deferred releases that have been scheduled but not yet completed.
+ *
+ * A lease that leaves unconfirmed hazards behind must not release its memory
+ * charge until every hazard settles, because a child that may still be alive
+ * may still hold corpus data. That is correct, and production wants exactly it.
+ *
+ * The charge is process-global, though, so in a test process the delay is
+ * visible to whatever runs next: an early case whose hazard has not settled yet
+ * leaves the charge standing, and later cases fail on the retained-snapshot
+ * budget instead of on anything they did. That is one flake reported three
+ * times on three platforms, always naming an innocent test.
+ *
+ * Tracking the deferrals lets a test await its own cleanup rather than race it.
+ * Deliberately not a reset: resetting the counter would hide a real leak, while
+ * awaiting the actual settlement proves the release happened.
+ */
+const pendingDeferredReleases = new Set<Promise<unknown>>();
+
+/**
+ * Test-only: give this process's deferred releases a chance to settle.
+ *
+ * Best-effort and bounded, deliberately. The flake this exists for is a release
+ * that has not settled YET: a killed child whose termination lands as soon as
+ * the event loop breathes. Awaiting gives it that chance, so the next case
+ * starts from a clean charge instead of inheriting one.
+ *
+ * It does NOT throw on an unsettled deferral, because "never settles" is a
+ * supported end state, not a defect: a projection that ignores cancellation
+ * poisons admission permanently and by design, and the test covering that would
+ * fail a stricter hook for doing its job. Returns whether everything settled,
+ * for a caller that wants to know.
+ *
+ * Measured, so the budget is not a guess: one stranded child holds 15,335,424
+ * bytes against MAX_RETAINED_CORPUS_MEMORY_BYTES, awaiting while the child is
+ * still unreaped clears nothing, and awaiting after the reap lands clears it to
+ * zero. The bound only has to cover the gap between a case ending and its
+ * child's reap arriving, which is milliseconds unless the machine is saturated,
+ * so it is set well above that and still far below vitest's hook timeout.
+ */
+export async function awaitDeferredCorpusReleasesForTests(
+  timeoutMs = 8_000
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (pendingDeferredReleases.size > 0 && Date.now() < deadline) {
+    await Promise.race([
+      Promise.allSettled([...pendingDeferredReleases]),
+      new Promise((resolve) => setTimeout(resolve, 25)),
+    ]);
+  }
+  return pendingDeferredReleases.size === 0;
+}
+
+/** Test-only: the live retained-corpus charge, for leak assertions. */
+export function reservedCorpusMemoryBytesForTests(): number {
+  return reservedCorpusMemoryBytes;
+}
+
 function releaseCorpusMemory(reservation: CorpusMemoryReservation): void {
   if (reservation.released) return;
   reservation.released = true;
@@ -2379,12 +2437,18 @@ async function dispatchStableCorpusLease<T>(
       //
       // allSettled, not all: a hazard that rejects is still a hazard that
       // finished, and a rejection here must not strand the process closed.
-      void Promise.allSettled(unconfirmedHazards).then(() => {
+      const deferred = Promise.allSettled(unconfirmedHazards).then(() => {
         releaseUnconfirmedCorpusWorker();
         releaseCorpusMemory(reservation);
         if (workerAdmissionReleased) return;
         workerAdmissionReleased = true;
         activeCorpusWorkerCount = Math.max(0, activeCorpusWorkerCount - 1);
+      });
+      // Registered before the removal is attached, so the set can never be
+      // observed empty while this release is still outstanding.
+      pendingDeferredReleases.add(deferred);
+      void deferred.finally(() => {
+        pendingDeferredReleases.delete(deferred);
       });
     }
     if (releaseWorkerAdmission && !workerAdmissionReleased) {


### PR DESCRIPTION
The `corpus-lease.test.ts` flake has blocked three people on three platforms in two days (#749 on Windows, #754 twice, on macOS and Windows), each time failing a test that could not have caused it. Tracked in the flake bead.

## Diagnosis

Credit to @erikcw, who worked this out on #754 while it was blocking his PR: an early case blows its authorization deadline, the timed-out lease defers its memory release to a termination that has not landed yet, and because the charge is **process-global** the cases that follow fail on the retained-snapshot budget rather than on anything they did. Only the unhandled-rejection block at the very bottom of the vitest output names the real cause, which is why it reads as a broad breakage instead of one slow test.

The deferral itself is correct and is unchanged here. A child that may still be alive may still hold corpus data, so releasing early would be the actual bug. What was missing is that nothing made a case wait for the cleanup it had started.

## Measured, not assumed

A throwaway probe using the module's own termination seams, since this race cannot be forced by ordinary means:

| state | bytes held |
|---|---|
| after stranding one child | **15,335,424** |
| after awaiting, child still unreaped | 15,335,424 (awaiting alone does nothing) |
| after awaiting, once reaped | **0** |

One stranded child holds ~14.6 MB against a capped process budget. A handful exhausts it. Awaiting only helps once the reap lands, and when it does the release is complete, which is what makes the hook worth having and also what sets its bound.

## The hook

`awaitDeferredCorpusReleasesForTests` is deliberately **best-effort and does not throw**. "Never settles" is a supported end state, not a defect: a projection that ignores cancellation poisons admission permanently by design. An earlier version of this hook asserted the charge returns to zero and was caught on its first run by exactly that test, failing it for doing its job.

Nothing is reset and nothing is released early, so a genuine production leak is still a genuine leak.

## Honest limit

**This is not evidence-of-fix.** I could not reproduce the flake locally: three runs of CI's exact invocation under full CPU load passed both with and without the change, which says only that three runs cannot resolve a failure this rare. What is proven is that the contamination path is real and that this closes it.

Suite time also drops (41s to 33s for the file) because cases no longer contend over a depleted budget.

Full MCP unit suite 286 passed / 3 skipped, tsc clean, codex review clean.