### PR TITLE
fix(attribution): require consistent segment voice evidence

### DIFF
--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -173,6 +173,16 @@ pub struct SpeakerSegment {
     pub end: f64,
 }
 
+/// One reliable, normalized segment embedding retained for identity safety.
+///
+/// This stays in memory only. Meeting diagnostics summarize counts and
+/// decisions; they never serialize the embedding itself.
+#[derive(Debug, Clone)]
+pub struct SpeakerEmbeddingSegment {
+    pub embedding: Vec<f32>,
+    pub speech_seconds: f64,
+}
+
 #[derive(Debug, Clone)]
 pub struct DiarizationResult {
     pub segments: Vec<SpeakerSegment>,
@@ -191,6 +201,13 @@ pub struct DiarizationResult {
     /// Per-speaker averaged embeddings (for Level 3 confirmed learning).
     /// Empty when using the Python subprocess engine.
     pub speaker_embeddings: std::collections::HashMap<String, Vec<f32>>,
+    /// Reliable segment embeddings grouped by their final speaker label.
+    ///
+    /// A cluster centroid alone cannot establish that every segment in the
+    /// cluster belongs to the same enrolled person (issue #753). Retaining the
+    /// inputs that formed it lets attribution require consistent evidence and
+    /// abstain before a wrong High-confidence rewrite.
+    pub speaker_embedding_segments: std::collections::HashMap<String, Vec<SpeakerEmbeddingSegment>>,
 }
 
 impl Default for DiarizationResult {
@@ -204,6 +221,7 @@ impl Default for DiarizationResult {
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         }
     }
 }
@@ -1817,6 +1835,7 @@ fn diarization_from_energy_windows(
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         });
     }
 
@@ -1880,6 +1899,7 @@ fn diarization_from_energy_windows(
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         })
     }
 }
@@ -2080,6 +2100,17 @@ fn remap_diarization_labels(
         }
     }
 
+    let mut speaker_embedding_segments = std::collections::HashMap::new();
+    let mut evidence_keys: Vec<String> =
+        result.speaker_embedding_segments.keys().cloned().collect();
+    evidence_keys.sort();
+    for raw_label in evidence_keys {
+        let remapped_label = remap_label(&raw_label);
+        if let Some(evidence) = result.speaker_embedding_segments.get(&raw_label) {
+            speaker_embedding_segments.insert(remapped_label, evidence.clone());
+        }
+    }
+
     DiarizationResult {
         segments,
         num_speakers: label_map.len(),
@@ -2089,6 +2120,7 @@ fn remap_diarization_labels(
         from_stems: result.from_stems,
         source_aware: result.source_aware,
         speaker_embeddings,
+        speaker_embedding_segments,
     }
 }
 
@@ -2156,6 +2188,12 @@ fn merge_remote_diarization_into_stem_result(
         .filter(|(label, _)| present_labels.contains(*label))
         .map(|(label, embedding)| (label.clone(), embedding.clone()))
         .collect();
+    let speaker_embedding_segments = remote_result
+        .speaker_embedding_segments
+        .iter()
+        .filter(|(label, _)| present_labels.contains(*label))
+        .map(|(label, evidence)| (label.clone(), evidence.clone()))
+        .collect();
 
     DiarizationResult {
         num_speakers: present_labels.len(),
@@ -2166,6 +2204,7 @@ fn merge_remote_diarization_into_stem_result(
         from_stems: false,
         source_aware: true,
         speaker_embeddings,
+        speaker_embedding_segments,
     }
 }
 
@@ -3222,6 +3261,9 @@ fn diarize_with_pyannote_rs(
     let mut speaker_templates: Vec<(Vec<f32>, usize)> = Vec::new();
     // Per-segment: which speaker index was assigned
     let mut seg_speaker_ids: Vec<usize> = Vec::new();
+    // Reliable embeddings parallel to `speech_segments`. Short segments stay
+    // `None` and are never allowed to vote on an identity decision.
+    let mut seg_embeddings: Vec<Option<Vec<f32>>> = Vec::new();
 
     // Minimum samples for reliable embedding extraction (~1.5s at 16kHz).
     // Shorter segments produce unstable embeddings that corrupt clustering.
@@ -3244,6 +3286,7 @@ fn diarize_with_pyannote_rs(
         // transcript but inherit the nearest speaker label.
         if seg_i16.len() < min_embed_samples {
             seg_speaker_ids.push(usize::MAX); // sentinel: inherit later
+            seg_embeddings.push(None);
             continue;
         }
 
@@ -3252,6 +3295,7 @@ fn diarize_with_pyannote_rs(
         // L2-normalize so every segment contributes equally to the
         // average direction, regardless of the model's output magnitude.
         let embedding = l2_normalize(&raw_embedding);
+        seg_embeddings.push(Some(embedding.clone()));
 
         // Find best matching speaker by cosine similarity
         let mut best_id = None;
@@ -3394,6 +3438,23 @@ fn diarize_with_pyannote_rs(
         });
     }
 
+    let mut speaker_embedding_segments: std::collections::HashMap<
+        String,
+        Vec<SpeakerEmbeddingSegment>,
+    > = std::collections::HashMap::new();
+    for (idx, embedding) in seg_embeddings.into_iter().enumerate() {
+        let Some(embedding) = embedding else {
+            continue;
+        };
+        speaker_embedding_segments
+            .entry(final_labels[idx].clone())
+            .or_default()
+            .push(SpeakerEmbeddingSegment {
+                embedding,
+                speech_seconds: (speech_segments[idx].end - speech_segments[idx].start).max(0.0),
+            });
+    }
+
     // Rebuild final speaker embeddings by weighted-averaging merged templates.
     // Each template is weighted by its segment count so a template built from
     // 50 segments contributes proportionally more than one from 2 segments.
@@ -3438,6 +3499,7 @@ fn diarize_with_pyannote_rs(
         from_stems: false,
         source_aware: false,
         speaker_embeddings,
+        speaker_embedding_segments,
     })
 }
 
@@ -3855,6 +3917,7 @@ except Exception as e:
         from_stems: false,
         source_aware: false,
         speaker_embeddings: std::collections::HashMap::new(), // Python path can't extract embeddings
+        speaker_embedding_segments: std::collections::HashMap::new(),
     })
 }
 
@@ -4744,6 +4807,7 @@ mod tests {
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
 
         let labeled = apply_speakers(transcript, &result);
@@ -4776,6 +4840,7 @@ mod tests {
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
 
         let labeled = apply_speakers(transcript, &result);
@@ -4811,6 +4876,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
 
         let labeled = apply_speakers(transcript, &result);
@@ -4919,6 +4985,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let windows = vec![
             TranscriptWindow {
@@ -4972,6 +5039,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let one_overlapping_window = vec![TranscriptWindow {
             start_secs: 5.5,
@@ -4999,6 +5067,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let windows = vec![TranscriptWindow {
             start_secs: 12.0,
@@ -5064,6 +5133,22 @@ mod tests {
                 ("remote-alex".to_string(), vec![0.1, 0.2]),
                 ("remote-sam".to_string(), vec![0.3, 0.4]),
             ]),
+            speaker_embedding_segments: std::collections::HashMap::from([
+                (
+                    "remote-alex".to_string(),
+                    vec![SpeakerEmbeddingSegment {
+                        embedding: vec![0.1, 0.2],
+                        speech_seconds: 3.0,
+                    }],
+                ),
+                (
+                    "remote-sam".to_string(),
+                    vec![SpeakerEmbeddingSegment {
+                        embedding: vec![0.3, 0.4],
+                        speech_seconds: 3.0,
+                    }],
+                ),
+            ]),
         };
 
         let remapped = remap_diarization_labels(&result, 1);
@@ -5073,6 +5158,12 @@ mod tests {
         assert_eq!(remapped.segments[2].speaker, "SPEAKER_1");
         assert!(remapped.speaker_embeddings.contains_key("SPEAKER_1"));
         assert!(remapped.speaker_embeddings.contains_key("SPEAKER_2"));
+        assert!(remapped
+            .speaker_embedding_segments
+            .contains_key("SPEAKER_1"));
+        assert!(remapped
+            .speaker_embedding_segments
+            .contains_key("SPEAKER_2"));
     }
 
     #[test]
@@ -5107,6 +5198,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let remote_result = DiarizationResult {
             segments: vec![
@@ -5141,6 +5233,22 @@ mod tests {
                 ("SPEAKER_2".to_string(), vec![0.1]),
                 ("SPEAKER_3".to_string(), vec![0.2]),
             ]),
+            speaker_embedding_segments: std::collections::HashMap::from([
+                (
+                    "SPEAKER_2".to_string(),
+                    vec![SpeakerEmbeddingSegment {
+                        embedding: vec![0.1],
+                        speech_seconds: 3.0,
+                    }],
+                ),
+                (
+                    "SPEAKER_3".to_string(),
+                    vec![SpeakerEmbeddingSegment {
+                        embedding: vec![0.2],
+                        speech_seconds: 3.0,
+                    }],
+                ),
+            ]),
         };
 
         let merged = merge_remote_diarization_into_stem_result(&stem_result, &remote_result);
@@ -5168,6 +5276,8 @@ mod tests {
         );
         assert!(merged.speaker_embeddings.contains_key("SPEAKER_2"));
         assert!(merged.speaker_embeddings.contains_key("SPEAKER_3"));
+        assert!(merged.speaker_embedding_segments.contains_key("SPEAKER_2"));
+        assert!(merged.speaker_embedding_segments.contains_key("SPEAKER_3"));
     }
 
     #[test]
@@ -5197,6 +5307,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let single_remote = DiarizationResult {
             segments: vec![SpeakerSegment {
@@ -5211,6 +5322,7 @@ mod tests {
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let strong_remote = DiarizationResult {
             segments: vec![
@@ -5237,6 +5349,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
 
         assert!(!has_meaningful_remote_structure(&weak_remote));
@@ -5266,6 +5379,7 @@ mod tests {
             from_stems: true,
             source_aware: true,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let remote_result = DiarizationResult {
             segments: vec![SpeakerSegment {
@@ -5282,6 +5396,13 @@ mod tests {
             speaker_embeddings: std::collections::HashMap::from([(
                 "SPEAKER_2".to_string(),
                 vec![0.2],
+            )]),
+            speaker_embedding_segments: std::collections::HashMap::from([(
+                "SPEAKER_2".to_string(),
+                vec![SpeakerEmbeddingSegment {
+                    embedding: vec![0.2],
+                    speech_seconds: 3.0,
+                }],
             )]),
         };
 
@@ -5514,6 +5635,7 @@ mod tests {
             from_stems: false,
             source_aware: false,
             speaker_embeddings: std::collections::HashMap::new(),
+            speaker_embedding_segments: std::collections::HashMap::new(),
         };
         let mut attempted_paths = Vec::new();
 
@@ -5757,6 +5879,7 @@ mod tests {
                     from_stems: true,
                     source_aware: true,
                     speaker_embeddings: std::collections::HashMap::new(),
+                    speaker_embedding_segments: std::collections::HashMap::new(),
                 })
             },
         )
@@ -5809,6 +5932,7 @@ mod tests {
                     from_stems: true,
                     source_aware: true,
                     speaker_embeddings: std::collections::HashMap::new(),
+                    speaker_embedding_segments: std::collections::HashMap::new(),
                 })
             },
         );

--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -180,6 +180,9 @@ pub struct SpeakerSegment {
 #[derive(Debug, Clone)]
 pub struct SpeakerEmbeddingSegment {
     pub embedding: Vec<f32>,
+    /// Amount of audio the embedding model actually evaluated.
+    pub embedding_seconds: f64,
+    /// Amount of diarized speech this evidence is being asked to represent.
     pub speech_seconds: f64,
 }
 
@@ -3263,7 +3266,7 @@ fn diarize_with_pyannote_rs(
     let mut seg_speaker_ids: Vec<usize> = Vec::new();
     // Reliable embeddings parallel to `speech_segments`. Short segments stay
     // `None` and are never allowed to vote on an identity decision.
-    let mut seg_embeddings: Vec<Option<Vec<f32>>> = Vec::new();
+    let mut seg_embeddings: Vec<Option<(Vec<f32>, f64)>> = Vec::new();
 
     // Minimum samples for reliable embedding extraction (~1.5s at 16kHz).
     // Shorter segments produce unstable embeddings that corrupt clustering.
@@ -3295,7 +3298,8 @@ fn diarize_with_pyannote_rs(
         // L2-normalize so every segment contributes equally to the
         // average direction, regardless of the model's output magnitude.
         let embedding = l2_normalize(&raw_embedding);
-        seg_embeddings.push(Some(embedding.clone()));
+        let embedding_seconds = (embed_end - seg.start_sample) as f64 / sample_rate as f64;
+        seg_embeddings.push(Some((embedding.clone(), embedding_seconds)));
 
         // Find best matching speaker by cosine similarity
         let mut best_id = None;
@@ -3442,8 +3446,8 @@ fn diarize_with_pyannote_rs(
         String,
         Vec<SpeakerEmbeddingSegment>,
     > = std::collections::HashMap::new();
-    for (idx, embedding) in seg_embeddings.into_iter().enumerate() {
-        let Some(embedding) = embedding else {
+    for (idx, evidence) in seg_embeddings.into_iter().enumerate() {
+        let Some((embedding, embedding_seconds)) = evidence else {
             continue;
         };
         speaker_embedding_segments
@@ -3451,7 +3455,12 @@ fn diarize_with_pyannote_rs(
             .or_default()
             .push(SpeakerEmbeddingSegment {
                 embedding,
-                speech_seconds: (speech_segments[idx].end - speech_segments[idx].start).max(0.0),
+                embedding_seconds,
+                speech_seconds: speech_segments[idx]
+                    .end_sample
+                    .saturating_sub(speech_segments[idx].start_sample)
+                    as f64
+                    / sample_rate as f64,
             });
     }
 
@@ -5138,6 +5147,7 @@ mod tests {
                     "remote-alex".to_string(),
                     vec![SpeakerEmbeddingSegment {
                         embedding: vec![0.1, 0.2],
+                        embedding_seconds: 3.0,
                         speech_seconds: 3.0,
                     }],
                 ),
@@ -5145,6 +5155,7 @@ mod tests {
                     "remote-sam".to_string(),
                     vec![SpeakerEmbeddingSegment {
                         embedding: vec![0.3, 0.4],
+                        embedding_seconds: 3.0,
                         speech_seconds: 3.0,
                     }],
                 ),
@@ -5238,6 +5249,7 @@ mod tests {
                     "SPEAKER_2".to_string(),
                     vec![SpeakerEmbeddingSegment {
                         embedding: vec![0.1],
+                        embedding_seconds: 3.0,
                         speech_seconds: 3.0,
                     }],
                 ),
@@ -5245,6 +5257,7 @@ mod tests {
                     "SPEAKER_3".to_string(),
                     vec![SpeakerEmbeddingSegment {
                         embedding: vec![0.2],
+                        embedding_seconds: 3.0,
                         speech_seconds: 3.0,
                     }],
                 ),
@@ -5401,6 +5414,7 @@ mod tests {
                 "SPEAKER_2".to_string(),
                 vec![SpeakerEmbeddingSegment {
                     embedding: vec![0.2],
+                    embedding_seconds: 3.0,
                     speech_seconds: 3.0,
                 }],
             )]),

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -299,6 +299,35 @@ struct VoiceMatchResult {
     /// Whether the user's own enrolled profile exists in the database
     /// (by `config.identity.name`), regardless of whether it matched a speaker.
     self_profile_exists: bool,
+    /// Privacy-safe aggregate evidence for every centroid considered.
+    diagnostics: Vec<VoiceMatchDiagnostic>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct VoiceMatchDiagnostic {
+    speaker_label: String,
+    model_id: String,
+    accepted: bool,
+    reason: String,
+    winner_name: Option<String>,
+    centroid_similarity: Option<f32>,
+    centroid_runner_up_similarity: Option<f32>,
+    centroid_margin: Option<f32>,
+    threshold: f32,
+    segment_evidence_count: usize,
+    segment_matching_count: usize,
+    segment_rejected_count: usize,
+    segment_conflicting_identity_count: usize,
+    segment_speech_seconds: f64,
+}
+
+#[derive(Debug, Clone)]
+struct ProvisionalVoiceMatch {
+    diagnostic_index: usize,
+    speaker_label: String,
+    winner_slug: String,
+    winner_name: String,
+    similarity: f32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
@@ -370,6 +399,7 @@ struct AttributionDebugInfo {
     raw_diarization_num_speakers: usize,
     effective_transcript_speaker_labels: Vec<String>,
     self_attribution: SelfAttributionDebug,
+    voice_matches: Vec<VoiceMatchDiagnostic>,
     final_speaker_map: Vec<SpeakerAttributionDebug>,
 }
 
@@ -453,69 +483,266 @@ fn voice_stem_fallback_note(
     }
 }
 
-/// Match diarized speaker embeddings against enrolled voice profiles (Level 2).
+fn evidence_has_unique_winner(evidence: &crate::voice::VoiceMatchEvidence) -> bool {
+    evidence.accepted
+        && evidence
+            .runner_up_similarity
+            .is_none_or(|runner_up| runner_up < evidence.threshold)
+}
+
+/// Apply the meeting-level safety policy to structured, model-compatible voice
+/// matches.
 ///
-/// For each speaker label, `match_embedding` returns at most one name — the
-/// profile with the highest cosine similarity above threshold. This means each
-/// label gets at most one attribution, even if multiple profiles exceed the
-/// threshold.
+/// A centroid is only provisional. Every reliable segment that formed the
+/// cluster must independently clear the existing configured identity threshold
+/// for the same unique profile. This is deliberately unanimity, not a new
+/// percentage threshold: any contradictory segment means the cluster cannot
+/// support a High-confidence rewrite. A final pass also keeps the assignment
+/// one-to-one by abstaining on every duplicate claim to one profile.
+fn evaluate_speaker_voice_matches(
+    model_id: &str,
+    profiles: &[crate::voice::ActiveProfile],
+    self_profile_slug: Option<&str>,
+    threshold: f32,
+    diarization_embeddings: &std::collections::HashMap<String, Vec<f32>>,
+    speaker_embedding_segments: &std::collections::HashMap<
+        String,
+        Vec<diarize::SpeakerEmbeddingSegment>,
+    >,
+) -> VoiceMatchResult {
+    let self_profile_exists = self_profile_slug
+        .is_some_and(|slug| profiles.iter().any(|profile| profile.person_slug == slug));
+    let mut diagnostics = Vec::new();
+    let mut provisional = Vec::new();
+    let mut labels: Vec<&String> = diarization_embeddings.keys().collect();
+    labels.sort();
+
+    for label in labels {
+        let centroid = crate::voice::match_active_profiles(
+            &diarization_embeddings[label],
+            model_id,
+            profiles,
+            threshold,
+        );
+        let segment_evidence = speaker_embedding_segments
+            .get(label)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let segment_speech_seconds = segment_evidence
+            .iter()
+            .map(|segment| segment.speech_seconds)
+            .sum();
+        let mut diagnostic = VoiceMatchDiagnostic {
+            speaker_label: label.clone(),
+            model_id: model_id.to_string(),
+            accepted: false,
+            reason: centroid.reason.clone(),
+            winner_name: centroid.winner_name.clone(),
+            centroid_similarity: centroid.similarity,
+            centroid_runner_up_similarity: centroid.runner_up_similarity,
+            centroid_margin: centroid.margin,
+            threshold,
+            segment_evidence_count: segment_evidence.len(),
+            segment_matching_count: 0,
+            segment_rejected_count: 0,
+            segment_conflicting_identity_count: 0,
+            segment_speech_seconds,
+        };
+
+        if centroid
+            .similarity
+            .is_some_and(|similarity| !similarity.is_finite())
+            || centroid
+                .runner_up_similarity
+                .is_some_and(|score| !score.is_finite())
+            || centroid.margin.is_some_and(|margin| !margin.is_finite())
+        {
+            diagnostic.reason = "voice match produced non-finite evidence".to_string();
+            diagnostics.push(diagnostic);
+            continue;
+        }
+
+        if !evidence_has_unique_winner(&centroid) {
+            diagnostic.reason = if centroid.accepted {
+                "multiple compatible profiles cleared the configured threshold".to_string()
+            } else {
+                centroid.reason.clone()
+            };
+            diagnostics.push(diagnostic);
+            continue;
+        }
+        let Some(winner_slug) = centroid.winner_slug.as_deref() else {
+            diagnostic.reason = "accepted centroid had no winning profile".to_string();
+            diagnostics.push(diagnostic);
+            continue;
+        };
+        let Some(winner_name) = centroid.winner_name.as_deref() else {
+            diagnostic.reason = "accepted centroid had no winning profile name".to_string();
+            diagnostics.push(diagnostic);
+            continue;
+        };
+        if segment_evidence.is_empty() {
+            diagnostic.reason =
+                "centroid had no reliable intra-cluster segment evidence".to_string();
+            diagnostics.push(diagnostic);
+            continue;
+        }
+
+        for segment in segment_evidence {
+            if segment.embedding.iter().any(|value| !value.is_finite()) {
+                diagnostic.segment_rejected_count += 1;
+                continue;
+            }
+            let evidence = crate::voice::match_active_profiles(
+                &segment.embedding,
+                model_id,
+                profiles,
+                threshold,
+            );
+            if evidence_has_unique_winner(&evidence)
+                && evidence.winner_slug.as_deref() == Some(winner_slug)
+            {
+                diagnostic.segment_matching_count += 1;
+            } else if evidence_has_unique_winner(&evidence) {
+                diagnostic.segment_conflicting_identity_count += 1;
+            } else {
+                diagnostic.segment_rejected_count += 1;
+            }
+        }
+
+        if diagnostic.segment_matching_count != diagnostic.segment_evidence_count {
+            diagnostic.reason =
+                "intra-cluster segment evidence did not consistently support the centroid winner"
+                    .to_string();
+            diagnostics.push(diagnostic);
+            continue;
+        }
+
+        diagnostic.accepted = true;
+        diagnostic.reason =
+            "centroid and every reliable segment supported one enrolled profile".to_string();
+        let diagnostic_index = diagnostics.len();
+        provisional.push(ProvisionalVoiceMatch {
+            diagnostic_index,
+            speaker_label: label.clone(),
+            winner_slug: winner_slug.to_string(),
+            winner_name: winner_name.to_string(),
+            similarity: centroid.similarity.unwrap_or(f32::MIN),
+        });
+        diagnostics.push(diagnostic);
+    }
+
+    let mut claims_by_profile: std::collections::BTreeMap<String, Vec<usize>> =
+        std::collections::BTreeMap::new();
+    for (candidate_index, candidate) in provisional.iter().enumerate() {
+        claims_by_profile
+            .entry(candidate.winner_slug.clone())
+            .or_default()
+            .push(candidate_index);
+    }
+    for candidate_indices in claims_by_profile.values_mut() {
+        if candidate_indices.len() < 2 {
+            continue;
+        }
+        candidate_indices.sort_by(|left, right| {
+            provisional[*right]
+                .similarity
+                .total_cmp(&provisional[*left].similarity)
+                .then_with(|| {
+                    provisional[*left]
+                        .speaker_label
+                        .cmp(&provisional[*right].speaker_label)
+                })
+        });
+        let strongest = provisional[candidate_indices[0]].similarity;
+        let tied = provisional[candidate_indices[1]].similarity == strongest;
+        // One centroid being slightly stronger does not prove that it owns the
+        // profile and the others do not. Multiple clusters claiming one human
+        // means the meeting-level assignment itself is ambiguous, so decline
+        // every claim instead of introducing another uncalibrated margin.
+        let rejected = candidate_indices.as_slice();
+        for candidate_index in rejected {
+            let diagnostic = &mut diagnostics[provisional[*candidate_index].diagnostic_index];
+            diagnostic.accepted = false;
+            diagnostic.reason = if tied {
+                "two speaker clusters tied for the same enrolled profile".to_string()
+            } else {
+                "multiple speaker clusters claimed the same enrolled profile".to_string()
+            };
+        }
+    }
+
+    let attributions = provisional
+        .into_iter()
+        .filter(|candidate| diagnostics[candidate.diagnostic_index].accepted)
+        .map(|candidate| {
+            tracing::info!(
+                speaker = %candidate.speaker_label,
+                name = %candidate.winner_name,
+                threshold,
+                "Level 2: consistent voice enrollment match"
+            );
+            diarize::SpeakerAttribution {
+                speaker_label: candidate.speaker_label,
+                name: candidate.winner_name,
+                confidence: diarize::Confidence::High,
+                source: diarize::AttributionSource::Enrollment,
+            }
+        })
+        .collect();
+
+    VoiceMatchResult {
+        attributions,
+        self_profile_exists,
+        diagnostics,
+    }
+}
+
+/// Match diarized speaker evidence against enrolled voice profiles (Level 2).
 fn match_speakers_by_voice(
     config: &Config,
     diarization_embeddings: &std::collections::HashMap<String, Vec<f32>>,
+    speaker_embedding_segments: &std::collections::HashMap<
+        String,
+        Vec<diarize::SpeakerEmbeddingSegment>,
+    >,
 ) -> VoiceMatchResult {
     if !config.voice.enabled || diarization_embeddings.is_empty() {
         return VoiceMatchResult {
             attributions: Vec::new(),
             self_profile_exists: false,
+            diagnostics: Vec::new(),
         };
     }
 
+    let model_id = crate::voice::model_version(config);
     let profiles = crate::voice::open_db()
         .ok()
-        .and_then(|conn| crate::voice::load_all_with_embeddings(&conn).ok())
+        .and_then(|conn| {
+            if let Err(error) = crate::voice::migrate_legacy_profiles(&conn) {
+                tracing::warn!(%error, "failed to migrate legacy voice profiles before matching");
+            }
+            crate::voice::list_active_profiles(&conn, model_id).ok()
+        })
         .unwrap_or_default();
 
     if profiles.is_empty() {
         return VoiceMatchResult {
             attributions: Vec::new(),
             self_profile_exists: false,
+            diagnostics: Vec::new(),
         };
     }
 
-    let self_profile_exists = config
-        .identity
-        .name
-        .as_ref()
-        .map(|name| {
-            let slug = slugify(name);
-            profiles.iter().any(|p| p.person_slug == slug)
-        })
-        .unwrap_or(false);
-
-    let threshold = config.voice.match_threshold;
-    let mut attributions = Vec::new();
-
-    for (label, emb) in diarization_embeddings {
-        if let Some(name) = crate::voice::match_embedding(emb, &profiles, threshold) {
-            tracing::info!(
-                speaker = %label,
-                name = %name,
-                threshold = threshold,
-                "Level 2: voice enrollment match"
-            );
-            attributions.push(diarize::SpeakerAttribution {
-                speaker_label: label.clone(),
-                name,
-                confidence: diarize::Confidence::High,
-                source: diarize::AttributionSource::Enrollment,
-            });
-        }
-    }
-
-    VoiceMatchResult {
-        attributions,
-        self_profile_exists,
-    }
+    let self_profile_slug = config.identity.name.as_ref().map(|name| slugify(name));
+    evaluate_speaker_voice_matches(
+        model_id,
+        &profiles,
+        self_profile_slug.as_deref(),
+        config.voice.match_threshold,
+        diarization_embeddings,
+        speaker_embedding_segments,
+    )
 }
 
 fn confidence_label(confidence: diarize::Confidence) -> String {
@@ -2387,6 +2614,7 @@ fn log_attribution_decision(
         "raw_diarization_num_speakers": details.raw_diarization_num_speakers,
         "effective_transcript_speaker_labels": details.effective_transcript_speaker_labels,
         "self_attribution": details.self_attribution,
+        "voice_matches": details.voice_matches,
         "speaker_map": details.final_speaker_map,
     });
     logging::log_step(
@@ -2403,6 +2631,7 @@ fn log_attribution_decision(
         raw_diarization_num_speakers = details.raw_diarization_num_speakers,
         effective_transcript_speaker_labels = ?details.effective_transcript_speaker_labels,
         self_attribution = ?details.self_attribution,
+        voice_matches = ?details.voice_matches,
         speaker_map = ?details.final_speaker_map,
         "meeting attribution instrumentation"
     );
@@ -2535,8 +2764,11 @@ fn single_stem_speaker_self_attribution(
         if let Some(source_backed_label) = source_backed_speaker_label.clone() {
             if let Some(voice_stem_result) = diarize::diarize(&stems.voice, config) {
                 let voice_stem_speakers = diarize::attributed_speaker_count(&voice_stem_result);
-                let voice_match =
-                    match_speakers_by_voice(config, &voice_stem_result.speaker_embeddings);
+                let voice_match = match_speakers_by_voice(
+                    config,
+                    &voice_stem_result.speaker_embeddings,
+                    &voice_stem_result.speaker_embedding_segments,
+                );
                 let matched_self = voice_match
                     .attributions
                     .iter()
@@ -2634,6 +2866,10 @@ fn attribute_meeting_speakers(
     diarization_from_stems: bool,
     degraded_ml_fallback: bool,
     diarization_embeddings: &std::collections::HashMap<String, Vec<f32>>,
+    speaker_embedding_segments: &std::collections::HashMap<
+        String,
+        Vec<diarize::SpeakerEmbeddingSegment>,
+    >,
     transcript: String,
 ) -> AttributionProcessingResult {
     let mut transcript = transcript;
@@ -2646,7 +2882,8 @@ fn attribute_meeting_speakers(
     } else if content_type != ContentType::Meeting {
         SelfAttributionOutcome::skipped(SelfAttributionSkippedReason::NoStableLabel)
     } else {
-        let voice_result = match_speakers_by_voice(config, diarization_embeddings);
+        let voice_result =
+            match_speakers_by_voice(config, diarization_embeddings, speaker_embedding_segments);
         speaker_map.extend(voice_result.attributions.clone());
 
         let transcript_labels = crate::summarize::extract_speaker_labels_pub(&transcript);
@@ -2765,6 +3002,7 @@ fn attribute_meeting_speakers(
                 raw_diarization_num_speakers: diarization_num_speakers,
                 effective_transcript_speaker_labels,
                 self_attribution: self_attribution.debug,
+                voice_matches: voice_result.diagnostics,
                 final_speaker_map: debug_speaker_map(&speaker_map),
             },
             transcript,
@@ -2781,6 +3019,7 @@ fn attribute_meeting_speakers(
                 &transcript,
             ),
             self_attribution: self_attribution.debug,
+            voice_matches: Vec::new(),
             final_speaker_map: debug_speaker_map(&speaker_map),
         },
         transcript,
@@ -4752,6 +4991,10 @@ where
     let mut degraded_ml_fallback = false;
     let mut diarization_embeddings: std::collections::HashMap<String, Vec<f32>> =
         std::collections::HashMap::new();
+    let mut speaker_embedding_segments: std::collections::HashMap<
+        String,
+        Vec<diarize::SpeakerEmbeddingSegment>,
+    > = std::collections::HashMap::new();
     let mut recording_health: Option<markdown::RecordingHealth> = None;
     if config.diarization.engine != "none" && artifact.frontmatter.r#type == ContentType::Meeting {
         on_progress(PipelineStage::Diarizing);
@@ -4787,6 +5030,7 @@ where
                     }
                 }
                 diarization_embeddings = result.speaker_embeddings.clone();
+                speaker_embedding_segments = result.speaker_embedding_segments.clone();
                 logging::log_step(
                     "diarize",
                     &diagnostic_audio_target,
@@ -4974,6 +5218,7 @@ where
         diarization_from_stems,
         degraded_ml_fallback,
         &diarization_embeddings,
+        &speaker_embedding_segments,
         transcript,
     );
     let attribution_ms = attribution_start.elapsed().as_millis() as u64;
@@ -5422,6 +5667,10 @@ where
     let mut degraded_ml_fallback = false;
     let mut diarization_embeddings: std::collections::HashMap<String, Vec<f32>> =
         std::collections::HashMap::new();
+    let mut speaker_embedding_segments: std::collections::HashMap<
+        String,
+        Vec<diarize::SpeakerEmbeddingSegment>,
+    > = std::collections::HashMap::new();
     let mut recording_health = prepared_recording_health;
     let diarization_audio_path = diarization_audio_path.as_deref().unwrap_or(audio_path);
     let transcript = if config.diarization.engine != "none" && content_type == ContentType::Meeting
@@ -5461,6 +5710,7 @@ where
                     }
                 }
                 diarization_embeddings = result.speaker_embeddings.clone();
+                speaker_embedding_segments = result.speaker_embedding_segments.clone();
                 let transcript = diarize::apply_speakers(&transcript, &result);
                 log_rendered_label_collapse_diagnostic(diagnostic_audio_path, &result, &transcript);
                 transcript
@@ -5668,6 +5918,7 @@ where
         diarization_from_stems,
         degraded_ml_fallback,
         &diarization_embeddings,
+        &speaker_embedding_segments,
         transcript,
     );
     let attribution_ms = attribution_start.elapsed().as_millis() as u64;
@@ -9094,6 +9345,252 @@ mod tests {
         );
     }
 
+    fn active_voice_profile(
+        slug: &str,
+        name: &str,
+        model_id: &str,
+        embedding: &[f32],
+    ) -> crate::voice::ActiveProfile {
+        crate::voice::ActiveProfile {
+            person_slug: slug.into(),
+            model_id: model_id.into(),
+            name: name.into(),
+            embedding: embedding.to_vec(),
+            embedding_dim: embedding.len(),
+            sample_count: 1,
+        }
+    }
+
+    fn segment_evidence(embedding: &[f32]) -> diarize::SpeakerEmbeddingSegment {
+        diarize::SpeakerEmbeddingSegment {
+            embedding: embedding.to_vec(),
+            speech_seconds: 3.0,
+        }
+    }
+
+    #[test]
+    fn mixed_cluster_centroid_abstains_when_one_segment_rejects_identity() {
+        let profiles = vec![active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0])];
+        let centroids =
+            std::collections::HashMap::from([("SPEAKER_1".to_string(), vec![0.95, 0.20])]);
+        let segments = std::collections::HashMap::from([(
+            "SPEAKER_1".to_string(),
+            vec![segment_evidence(&[1.0, 0.0]), segment_evidence(&[0.0, 1.0])],
+        )]);
+
+        let result = evaluate_speaker_voice_matches(
+            "model-a",
+            &profiles,
+            Some("mat"),
+            0.65,
+            &centroids,
+            &segments,
+        );
+
+        assert!(result.attributions.is_empty());
+        assert!(result.self_profile_exists);
+        assert_eq!(result.diagnostics.len(), 1);
+        let diagnostic = &result.diagnostics[0];
+        assert!(!diagnostic.accepted);
+        assert_eq!(diagnostic.segment_evidence_count, 2);
+        assert_eq!(diagnostic.segment_matching_count, 1);
+        assert_eq!(diagnostic.segment_rejected_count, 1);
+        assert_eq!(diagnostic.segment_conflicting_identity_count, 0);
+    }
+
+    #[test]
+    fn consistently_matching_cluster_keeps_high_confidence_rewrite() {
+        let profiles = vec![active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0])];
+        let centroids =
+            std::collections::HashMap::from([("SPEAKER_1".to_string(), vec![0.99, 0.02])]);
+        let segments = std::collections::HashMap::from([(
+            "SPEAKER_1".to_string(),
+            vec![
+                segment_evidence(&[1.0, 0.0]),
+                segment_evidence(&[0.98, 0.05]),
+            ],
+        )]);
+
+        let result = evaluate_speaker_voice_matches(
+            "model-a",
+            &profiles,
+            Some("mat"),
+            0.65,
+            &centroids,
+            &segments,
+        );
+
+        assert_eq!(result.attributions.len(), 1);
+        assert_eq!(result.attributions[0].confidence, diarize::Confidence::High);
+        assert_eq!(
+            result.attributions[0].source,
+            diarize::AttributionSource::Enrollment
+        );
+        assert_eq!(
+            diarize::apply_confirmed_names(
+                "[SPEAKER_1 0:00] synthetic fixture\n",
+                &result.attributions,
+            ),
+            "[Mat 0:00] synthetic fixture\n"
+        );
+        assert!(result.diagnostics[0].accepted);
+    }
+
+    #[test]
+    fn open_speaker_bleed_on_other_labels_does_not_block_clean_local_match() {
+        let profiles = vec![active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0])];
+        let centroids = std::collections::HashMap::from([
+            ("SPEAKER_0".to_string(), vec![0.99, 0.01]),
+            ("SPEAKER_1".to_string(), vec![0.05, 0.99]),
+            ("SPEAKER_2".to_string(), vec![0.10, 0.95]),
+        ]);
+        let segments = std::collections::HashMap::from([
+            (
+                "SPEAKER_0".to_string(),
+                vec![
+                    segment_evidence(&[1.0, 0.0]),
+                    segment_evidence(&[0.98, 0.03]),
+                ],
+            ),
+            ("SPEAKER_1".to_string(), vec![segment_evidence(&[0.0, 1.0])]),
+            (
+                "SPEAKER_2".to_string(),
+                vec![segment_evidence(&[0.1, 0.99])],
+            ),
+        ]);
+
+        let result = evaluate_speaker_voice_matches(
+            "model-a",
+            &profiles,
+            Some("mat"),
+            0.65,
+            &centroids,
+            &segments,
+        );
+
+        assert_eq!(result.attributions.len(), 1);
+        assert_eq!(result.attributions[0].speaker_label, "SPEAKER_0");
+        assert_eq!(result.attributions[0].name, "Mat");
+    }
+
+    #[test]
+    fn voice_match_requires_segment_evidence_and_model_compatibility() {
+        let profiles = vec![active_voice_profile("mat", "Mat", "model-b", &[1.0, 0.0])];
+        let centroids =
+            std::collections::HashMap::from([("SPEAKER_1".to_string(), vec![1.0, 0.0])]);
+        let no_segments = std::collections::HashMap::new();
+
+        let model_mismatch = evaluate_speaker_voice_matches(
+            "model-a",
+            &profiles,
+            None,
+            0.65,
+            &centroids,
+            &no_segments,
+        );
+        assert!(model_mismatch.attributions.is_empty());
+        assert_eq!(
+            model_mismatch.diagnostics[0].reason,
+            "no compatible active voice profiles"
+        );
+
+        let compatible = vec![active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0])];
+        let missing_segments = evaluate_speaker_voice_matches(
+            "model-a",
+            &compatible,
+            Some("mat"),
+            0.65,
+            &centroids,
+            &no_segments,
+        );
+        assert!(missing_segments.attributions.is_empty());
+        assert_eq!(
+            missing_segments.diagnostics[0].reason,
+            "centroid had no reliable intra-cluster segment evidence"
+        );
+    }
+
+    #[test]
+    fn one_to_one_voice_matching_abstains_on_all_duplicate_profile_claims() {
+        let profiles = vec![active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0])];
+        let centroids = std::collections::HashMap::from([
+            ("SPEAKER_1".to_string(), vec![1.0, 0.0]),
+            ("SPEAKER_2".to_string(), vec![0.90, 0.10]),
+        ]);
+        let segments = std::collections::HashMap::from([
+            ("SPEAKER_1".to_string(), vec![segment_evidence(&[1.0, 0.0])]),
+            (
+                "SPEAKER_2".to_string(),
+                vec![segment_evidence(&[0.90, 0.10])],
+            ),
+        ]);
+
+        let result = evaluate_speaker_voice_matches(
+            "model-a",
+            &profiles,
+            Some("mat"),
+            0.65,
+            &centroids,
+            &segments,
+        );
+
+        assert!(result.attributions.is_empty());
+        assert!(result.diagnostics.iter().all(|diagnostic| {
+            !diagnostic.accepted
+                && diagnostic.reason
+                    == "multiple speaker clusters claimed the same enrolled profile"
+        }));
+    }
+
+    #[test]
+    fn two_profiles_above_threshold_are_ambiguous_without_a_new_margin_constant() {
+        let profiles = vec![
+            active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0]),
+            active_voice_profile("alex", "Alex", "model-a", &[0.8, 0.6]),
+        ];
+        let centroids =
+            std::collections::HashMap::from([("SPEAKER_1".to_string(), vec![0.9, 0.4])]);
+        let segments = std::collections::HashMap::from([(
+            "SPEAKER_1".to_string(),
+            vec![segment_evidence(&[0.9, 0.4])],
+        )]);
+
+        let result =
+            evaluate_speaker_voice_matches("model-a", &profiles, None, 0.65, &centroids, &segments);
+
+        assert!(result.attributions.is_empty());
+        assert_eq!(
+            result.diagnostics[0].reason,
+            "multiple compatible profiles cleared the configured threshold"
+        );
+    }
+
+    #[test]
+    fn non_finite_voice_evidence_fails_closed() {
+        let profiles = vec![active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0])];
+        let centroids =
+            std::collections::HashMap::from([("SPEAKER_1".to_string(), vec![f32::NAN, 0.0])]);
+        let segments = std::collections::HashMap::from([(
+            "SPEAKER_1".to_string(),
+            vec![segment_evidence(&[f32::INFINITY, 0.0])],
+        )]);
+
+        let result = evaluate_speaker_voice_matches(
+            "model-a",
+            &profiles,
+            Some("mat"),
+            0.65,
+            &centroids,
+            &segments,
+        );
+
+        assert!(result.attributions.is_empty());
+        assert_eq!(
+            result.diagnostics[0].reason,
+            "voice match produced non-finite evidence"
+        );
+    }
+
     #[test]
     fn single_stem_speaker_self_attribution_maps_to_identity() {
         let mut config = Config::default();
@@ -9102,6 +9599,7 @@ mod tests {
         let voice_result = VoiceMatchResult {
             attributions: vec![],
             self_profile_exists: true,
+            diagnostics: vec![],
         };
         let labels = vec!["SPEAKER_0".to_string()];
         let l2_labels = std::collections::HashSet::new();
@@ -9140,6 +9638,7 @@ mod tests {
         let voice_result = VoiceMatchResult {
             attributions: vec![],
             self_profile_exists: false,
+            diagnostics: vec![],
         };
         let labels = vec!["SPEAKER_2".to_string()];
         let l2_labels = std::collections::HashSet::new();
@@ -9198,6 +9697,7 @@ mod tests {
         let voice_result = VoiceMatchResult {
             attributions: vec![],
             self_profile_exists: true,
+            diagnostics: vec![],
         };
 
         let outcome = single_stem_speaker_self_attribution(
@@ -9229,6 +9729,7 @@ mod tests {
         let voice_result = VoiceMatchResult {
             attributions: vec![],
             self_profile_exists: true,
+            diagnostics: vec![],
         };
 
         let outcome = single_stem_speaker_self_attribution(
@@ -9289,6 +9790,7 @@ mod tests {
             true,
             false,
             &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
             "[SPEAKER_0 0:00] hello\n[SPEAKER_1 0:01] hi\n".into(),
         );
 
@@ -9316,6 +9818,7 @@ mod tests {
             2,
             false,
             true,
+            &std::collections::HashMap::new(),
             &std::collections::HashMap::new(),
             "[SPEAKER_0 0:00] hello\n[SPEAKER_1 0:01] hi\n".into(),
         );
@@ -9455,6 +9958,7 @@ mod tests {
             2,
             true,
             false,
+            &std::collections::HashMap::new(),
             &std::collections::HashMap::new(),
             "[SPEAKER_1 0:00] hi\n[SPEAKER_0 0:01] hello\n".into(),
         );

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -318,6 +318,8 @@ struct VoiceMatchDiagnostic {
     segment_matching_count: usize,
     segment_rejected_count: usize,
     segment_conflicting_identity_count: usize,
+    segment_uncovered_count: usize,
+    segment_embedding_seconds: f64,
     segment_speech_seconds: f64,
 }
 
@@ -532,6 +534,10 @@ fn evaluate_speaker_voice_matches(
             .iter()
             .map(|segment| segment.speech_seconds)
             .sum();
+        let segment_embedding_seconds = segment_evidence
+            .iter()
+            .map(|segment| segment.embedding_seconds)
+            .sum();
         let mut diagnostic = VoiceMatchDiagnostic {
             speaker_label: label.clone(),
             model_id: model_id.to_string(),
@@ -546,6 +552,8 @@ fn evaluate_speaker_voice_matches(
             segment_matching_count: 0,
             segment_rejected_count: 0,
             segment_conflicting_identity_count: 0,
+            segment_uncovered_count: 0,
+            segment_embedding_seconds,
             segment_speech_seconds,
         };
 
@@ -589,6 +597,16 @@ fn evaluate_speaker_voice_matches(
         }
 
         for segment in segment_evidence {
+            if !segment.embedding_seconds.is_finite()
+                || !segment.speech_seconds.is_finite()
+                || segment.embedding_seconds <= 0.0
+                || segment.speech_seconds <= 0.0
+                || segment.embedding_seconds < segment.speech_seconds
+            {
+                diagnostic.segment_rejected_count += 1;
+                diagnostic.segment_uncovered_count += 1;
+                continue;
+            }
             if segment.embedding.iter().any(|value| !value.is_finite()) {
                 diagnostic.segment_rejected_count += 1;
                 continue;
@@ -611,9 +629,12 @@ fn evaluate_speaker_voice_matches(
         }
 
         if diagnostic.segment_matching_count != diagnostic.segment_evidence_count {
-            diagnostic.reason =
+            diagnostic.reason = if diagnostic.segment_uncovered_count > 0 {
+                "intra-cluster embedding evidence did not cover all represented speech".to_string()
+            } else {
                 "intra-cluster segment evidence did not consistently support the centroid winner"
-                    .to_string();
+                    .to_string()
+            };
             diagnostics.push(diagnostic);
             continue;
         }
@@ -9364,8 +9385,46 @@ mod tests {
     fn segment_evidence(embedding: &[f32]) -> diarize::SpeakerEmbeddingSegment {
         diarize::SpeakerEmbeddingSegment {
             embedding: embedding.to_vec(),
+            embedding_seconds: 3.0,
             speech_seconds: 3.0,
         }
+    }
+
+    #[test]
+    fn long_segment_abstains_when_embedding_did_not_cover_all_speech() {
+        let profiles = vec![active_voice_profile("mat", "Mat", "model-a", &[1.0, 0.0])];
+        let centroids =
+            std::collections::HashMap::from([("SPEAKER_1".to_string(), vec![1.0, 0.0])]);
+        let segments = std::collections::HashMap::from([(
+            "SPEAKER_1".to_string(),
+            vec![diarize::SpeakerEmbeddingSegment {
+                embedding: vec![1.0, 0.0],
+                embedding_seconds: 60.0,
+                speech_seconds: 120.0,
+            }],
+        )]);
+
+        let result = evaluate_speaker_voice_matches(
+            "model-a",
+            &profiles,
+            Some("mat"),
+            0.65,
+            &centroids,
+            &segments,
+        );
+
+        assert!(result.attributions.is_empty());
+        let diagnostic = &result.diagnostics[0];
+        assert!(!diagnostic.accepted);
+        assert_eq!(diagnostic.segment_matching_count, 0);
+        assert_eq!(diagnostic.segment_rejected_count, 1);
+        assert_eq!(diagnostic.segment_uncovered_count, 1);
+        assert_eq!(diagnostic.segment_embedding_seconds, 60.0);
+        assert_eq!(diagnostic.segment_speech_seconds, 120.0);
+        assert_eq!(
+            diagnostic.reason,
+            "intra-cluster embedding evidence did not cover all represented speech"
+        );
     }
 
     #[test]

--- a/crates/core/src/voice.rs
+++ b/crates/core/src/voice.rs
@@ -1216,12 +1216,19 @@ pub fn delete_all_voice_data(config: &Config) -> Result<DeleteVoiceDataReport, V
     delete_all_voice_data_at(&db_path(), std::slice::from_ref(&config.output_dir))
 }
 
+const LEGACY_PROFILE_MIGRATION_QUALITY_JSON: &str = "{\"migration\":\"legacy-profile-sync-v1\"}";
+
 /// Import legacy mutable profiles as manual immutable samples without creating duplicates.
+///
+/// Legacy `minutes enroll` updates one mutable centroid while retaining its
+/// original enrollment timestamp. If that centroid changes, revoke the prior
+/// imported snapshot and insert an immutable replacement so matching observes
+/// the enrollment the CLI says it saved.
 pub fn migrate_legacy_profiles(conn: &Connection) -> Result<usize, VoiceError> {
     let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     let legacy_profiles = {
         let mut stmt = transaction.prepare(
-            "SELECT person_slug, name, embedding, enrolled_at, source, model_version
+            "SELECT person_slug, name, embedding, enrolled_at, updated_at, source, model_version
              FROM voice_profiles
              ORDER BY id ASC",
         )?;
@@ -1233,33 +1240,64 @@ pub fn migrate_legacy_profiles(conn: &Connection) -> Result<usize, VoiceError> {
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
                 row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
             ))
         })?;
         rows.collect::<Result<Vec<_>, _>>()?
     };
 
     let mut migrated = 0;
-    for (slug, name, embedding, enrolled_at, source, legacy_model_id) in legacy_profiles {
+    for (slug, name, embedding, enrolled_at, updated_at, source, legacy_model_id) in legacy_profiles
+    {
         let model_id = if embedding.len() % std::mem::size_of::<f32>() == 0 {
             legacy_model_id
         } else {
             "unknown".to_string()
         };
-        let exists: bool = transaction.query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM voice_samples
-                WHERE person_slug = ?1 AND model_id = ?2 AND created_at = ?3
-                    AND trust_class = 'manual'
-             )",
-            params![slug, model_id, enrolled_at],
-            |row| row.get(0),
-        )?;
-        if !exists {
+
+        let migrated_samples = {
+            let mut stmt = transaction.prepare(
+                "SELECT id, name, embedding, model_id, capture_source
+                 FROM voice_samples
+                 WHERE person_slug = ?1 AND trust_class = 'manual' AND revoked_at IS NULL
+                   AND (quality_json = ?2 OR (created_at = ?3 AND quality_json IS NULL))
+                 ORDER BY id ASC",
+            )?;
+            let rows = stmt.query_map(
+                params![slug, LEGACY_PROFILE_MIGRATION_QUALITY_JSON, enrolled_at],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                    ))
+                },
+            )?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+        let current_sample_matches = migrated_samples.len() == 1
+            && migrated_samples[0].1 == name
+            && migrated_samples[0].2 == embedding
+            && migrated_samples[0].3 == model_id
+            && migrated_samples[0].4.as_deref() == Some(source.as_str());
+
+        if !current_sample_matches {
+            let revoked_at = now_timestamp();
+            let mut affected_models = std::collections::BTreeSet::new();
+            for (id, _, _, migrated_model_id, _) in &migrated_samples {
+                transaction.execute(
+                    "UPDATE voice_samples SET revoked_at = ?1 WHERE id = ?2",
+                    params![revoked_at, id],
+                )?;
+                affected_models.insert(migrated_model_id.clone());
+            }
             transaction.execute(
                 "INSERT INTO voice_samples (
                     person_slug, name, embedding, embedding_dim, model_id, normalization,
-                    trust_class, capture_source, sensitivity, created_at
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, 'l2', 'manual', ?6, 'normal', ?7)",
+                    trust_class, capture_source, quality_json, sensitivity, created_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, 'l2', 'manual', ?6, ?7, 'normal', ?8)",
                 params![
                     slug,
                     name,
@@ -1267,9 +1305,13 @@ pub fn migrate_legacy_profiles(conn: &Connection) -> Result<usize, VoiceError> {
                     embedding.len() / std::mem::size_of::<f32>(),
                     model_id,
                     source,
-                    enrolled_at,
+                    LEGACY_PROFILE_MIGRATION_QUALITY_JSON,
+                    updated_at,
                 ],
             )?;
+            for affected_model in affected_models {
+                rebuild_active_profile_in_transaction(&transaction, &slug, &affected_model)?;
+            }
             migrated += 1;
         }
         rebuild_active_profile_in_transaction(&transaction, &slug, &model_id)?;
@@ -1380,10 +1422,7 @@ pub fn load_all_with_embeddings(
 }
 
 pub fn delete_profile(conn: &Connection, slug: &str) -> Result<bool, VoiceError> {
-    Ok(conn.execute(
-        "DELETE FROM voice_profiles WHERE person_slug = ?1",
-        params![slug],
-    )? > 0)
+    Ok(revoke_voice_person(conn, slug)? > 0)
 }
 
 pub fn match_embedding(
@@ -1693,6 +1732,53 @@ mod tests {
     }
 
     #[test]
+    fn voice_samples_migration_replaces_changed_legacy_centroid() {
+        let (conn, _tmp) = test_db();
+        conn.execute(
+            "INSERT INTO voice_profiles (
+                person_slug, name, embedding, enrolled_at, updated_at,
+                sample_count, source, model_version
+             ) VALUES ('mat', 'Mat', ?1, ?2, ?2, 1, 'legacy', 'model-a')",
+            params![embedding_to_bytes(&[1.0, 0.0]), "2026-01-01T00:00:00Z"],
+        )
+        .unwrap();
+
+        assert_eq!(migrate_legacy_profiles(&conn).unwrap(), 1);
+        assert_embedding_close(
+            &active_profile(&conn, "mat", "model-a")
+                .unwrap()
+                .unwrap()
+                .embedding,
+            &[1.0, 0.0],
+        );
+
+        conn.execute(
+            "UPDATE voice_profiles
+             SET embedding = ?1, updated_at = ?2, sample_count = 2
+             WHERE person_slug = 'mat'",
+            params![embedding_to_bytes(&[0.8, 0.2]), "2026-01-02T00:00:00Z"],
+        )
+        .unwrap();
+
+        assert_eq!(migrate_legacy_profiles(&conn).unwrap(), 1);
+        assert_eq!(migrate_legacy_profiles(&conn).unwrap(), 0);
+        let profile = active_profile(&conn, "mat", "model-a").unwrap().unwrap();
+        assert_eq!(profile.sample_count, 1);
+        assert_embedding_close(&profile.embedding, &[0.8, 0.2]);
+        let (active, revoked): (i64, i64) = conn
+            .query_row(
+                "SELECT
+                    SUM(CASE WHEN revoked_at IS NULL THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN revoked_at IS NOT NULL THEN 1 ELSE 0 END)
+                 FROM voice_samples WHERE person_slug = 'mat'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((active, revoked), (1, 1));
+    }
+
+    #[test]
     fn voice_samples_migrate_malformed_legacy_blob_as_unknown() {
         let (conn, _tmp) = test_db();
         conn.execute(
@@ -1835,6 +1921,41 @@ mod tests {
         .unwrap();
         assert!(delete_profile(&conn, "mat").unwrap());
         assert!(list_profiles(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_profile_revokes_migrated_samples_and_removes_active_profile() {
+        let (conn, _tmp) = test_db();
+        save_profile(
+            &conn,
+            "mat",
+            "Mat",
+            &[0.1f32; 4],
+            "self-enrollment",
+            TEST_MODEL_VERSION,
+        )
+        .unwrap();
+        assert_eq!(migrate_legacy_profiles(&conn).unwrap(), 1);
+        assert!(active_profile(&conn, "mat", TEST_MODEL_VERSION)
+            .unwrap()
+            .is_some());
+
+        assert!(delete_profile(&conn, "mat").unwrap());
+        assert!(list_profiles(&conn).unwrap().is_empty());
+        assert!(active_profile(&conn, "mat", TEST_MODEL_VERSION)
+            .unwrap()
+            .is_none());
+        let (active, revoked): (i64, i64) = conn
+            .query_row(
+                "SELECT
+                    SUM(CASE WHEN revoked_at IS NULL THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN revoked_at IS NOT NULL THEN 1 ELSE 0 END)
+                 FROM voice_samples WHERE person_slug = 'mat'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((active, revoked), (0, 1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retain reliable per-segment speaker embeddings through diarization label remapping and stem-result merging
- route meeting attribution through model-scoped active voice profiles and structured match evidence
- require the centroid and every fully covered reliable segment to uniquely support the same enrolled profile before assigning High / Enrollment
- fail closed when a merged speech region is longer than the audio its capped embedding actually evaluated
- make legacy voice deletion revoke migrated immutable samples and clear the active matching cache
- synchronize changed legacy enrollment centroids into the immutable sample architecture
- abstain on missing, conflicting, ambiguous, duplicate-profile, non-finite, or incompletely covered evidence
- add privacy-safe aggregate diagnostics and synthetic regressions for mixed clusters, long merged regions, clean enrollment, model compatibility, deletion, repeat enrollment, duplicate claims, and open-speaker bleed

## Root cause

Meeting attribution used a final cluster centroid as sufficient evidence for a High-confidence enrollment match. A diarization cluster containing two humans could average into an enrolled profile even though the cluster's individual segments did not consistently support that identity.

The first implementation also exposed two migration gaps during release-gate review: capped embeddings could represent longer merged speech regions than they actually heard, and legacy delete/re-enroll operations did not update the new immutable sample path.

This change preserves the individual segment evidence and its exact audio coverage, then composes it with the structured active-profile matcher. It does not add a speaker-count guard or a new percentage threshold.

## Validation

- `cargo test -p minutes-core --features diarize pipeline::tests:: -- --test-threads=1` — 114 passed, 1 ignored
- `cargo test -p minutes-core voice::tests:: -- --test-threads=1` — 29 passed
- `cargo test -p minutes-core --features diarize diarize::tests:: -- --test-threads=1` — 83 passed, 1 ignored
- broad no-default lib suite — 1724 passed, 1 ignored; four worker-harness tests required the documented worker binary prebuild and all four passed independently afterward
- `cargo clippy --all --no-default-features -- -D warnings`
- `cargo clippy -p minutes-core --features diarize -- -D warnings`
- `cargo fmt --all -- --check`
- private local reproduction, aggregate-only: old policy accepted one cluster; revised policy produced zero High-confidence attributions across two diarized speakers and 182 reliable segment embeddings; three incompletely covered long merged regions were detected and rejected

All repository fixtures are synthetic. No private audio, transcript, embeddings, names, or paths are included.

Closes #753
