### PR TITLE
fix(sdk,mcp): make a refused bound read diagnosable instead of a hang

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -132,7 +132,12 @@ describe("stable corpus lease", () => {
             },
           })
         );
-        await didStart;
+        // Racing the read surfaces its rejection. Awaiting `didStart` alone
+        // hangs to the suite timeout whenever the first read is refused,
+        // because `markStarted` runs inside the read that just failed. That
+        // turned a named capacity refusal into an anonymous 15s timeout on
+        // Windows, which is what made #617 undiagnosable from CI logs.
+        await Promise.race([didStart, activeReads[activeReads.length - 1]]);
       }
 
       const thirdParent = join(root, "active-1");

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -23,6 +23,7 @@ import {
   fingerprintTextFileFromBoundParent,
   readTextFileWithRevisionFromBoundParent,
   type BoundFileRevision,
+  writeOperatorDiagnostic,
 } from "./secure-read.js";
 
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
@@ -2018,7 +2019,11 @@ async function dispatchStableCorpusLease<T>(
             const budget = overran
               ? `authorization budget overrun by ${magnitudeMs}ms`
               : `${magnitudeMs}ms of authorization budget remained`;
-            process.stderr.write(`[corpus-lease] denied: ${message} (${budget})\n`);
+            // Shared with the bound-reader refusal path, because a plain
+            // try/catch here never covered an asynchronous EPIPE: that
+            // arrives as an 'error' event on a later tick and is fatal
+            // without a listener.
+            writeOperatorDiagnostic(`[corpus-lease] denied: ${message} (${budget})\n`);
           } catch {
             // A broken stderr must never turn a clean denial into a crash.
           }

--- a/crates/mcp/src/secure-read.ts
+++ b/crates/mcp/src/secure-read.ts
@@ -78,6 +78,39 @@ export type BoundTextFileRead = {
   revision: BoundFileRevision;
 };
 
+/**
+ * Absorbed once, then never again: an 'error' event on stderr with no listener
+ * is fatal to the host process.
+ */
+let stderrErrorsAbsorbed = false;
+
+/**
+ * Write one operator-visible diagnostic line, without letting a broken stderr
+ * become fatal.
+ *
+ * A try/catch around the write is not sufficient. When the consumer of the
+ * pipe has gone, the write fails with an asynchronous EPIPE delivered as an
+ * 'error' event on a later tick, which no surrounding catch can see, and an
+ * 'error' event with no listener kills the process. Absorbing it is the same
+ * call corpus-lease.ts already makes for a killed worker's stdin, for the same
+ * reason: a diagnostic that cannot be delivered must never escalate into a
+ * failure of the thing it was describing.
+ *
+ * Callers defer this themselves so a blocked TTY or file cannot delay a
+ * refusal that has already been decided.
+ */
+export function writeOperatorDiagnostic(line: string): void {
+  try {
+    if (!stderrErrorsAbsorbed) {
+      stderrErrorsAbsorbed = true;
+      process.stderr.on("error", () => {});
+    }
+    process.stderr.write(line);
+  } catch {
+    // A synchronous failure is equally non-fatal here.
+  }
+}
+
 export function boundReadIdentity(info: BigIntStats): string {
   return `${info.dev}:${info.ino}`;
 }
@@ -483,11 +516,7 @@ class BoundParentReader {
       // Never inside the throw path's critical section, and never allowed to
       // turn a clean refusal into a crash.
       setImmediate(() => {
-        try {
-          process.stderr.write(`[bound-reader] refused: ${refusal}\n`);
-        } catch {
-          // A broken stderr must not escalate a refusal into a failure.
-        }
+        writeOperatorDiagnostic(`[bound-reader] refused: ${refusal}\n`);
       });
       throw new Error("Access denied: bound reader capacity exceeded");
     }

--- a/crates/mcp/src/secure-read.ts
+++ b/crates/mcp/src/secure-read.ts
@@ -458,14 +458,37 @@ class BoundParentReader {
     const reservedBytes = returnContent
       ? maxBytes * BOUND_READER_CONTENT_AMPLIFICATION
       : Math.max(1024 * 1024, Math.min(maxBytes, 64 * 1024));
-    if (
-      !Number.isSafeInteger(reservedBytes) ||
-      reservedBytes < 0 ||
-      this.pending.size >= maxInFlightPerReader ||
-      globalInFlightReads >= maxInFlightGlobal ||
-      globalReaderProcessBytes + globalReservedReadBytes >
-        maxReservedBytes - reservedBytes
-    ) {
+    // Which of these tripped is the whole diagnosis, and the thrown message
+    // deliberately does not say: callers must not learn why a read was
+    // refused. The reason goes to stderr, which is operator-visible only, the
+    // same split corpus-lease.ts uses for authorization denials.
+    //
+    // Worth the detail because this refusal is reachable from process-global
+    // counters, so the read that gets refused is often not the one at fault.
+    // A CI failure here previously gave no way to tell an exhausted byte
+    // reservation from an in-flight cap (#617).
+    const refusal =
+      !Number.isSafeInteger(reservedBytes) || reservedBytes < 0
+        ? `implausible reservation ${reservedBytes}`
+        : this.pending.size >= maxInFlightPerReader
+          ? `reader in-flight ${this.pending.size}/${maxInFlightPerReader}`
+          : globalInFlightReads >= maxInFlightGlobal
+            ? `global in-flight ${globalInFlightReads}/${maxInFlightGlobal}`
+            : globalReaderProcessBytes + globalReservedReadBytes >
+                maxReservedBytes - reservedBytes
+              ? `global bytes ${globalReaderProcessBytes + globalReservedReadBytes} + ` +
+                `${reservedBytes} requested > ${maxReservedBytes}`
+              : null;
+    if (refusal !== null) {
+      // Never inside the throw path's critical section, and never allowed to
+      // turn a clean refusal into a crash.
+      setImmediate(() => {
+        try {
+          process.stderr.write(`[bound-reader] refused: ${refusal}\n`);
+        } catch {
+          // A broken stderr must not escalate a refusal into a failure.
+        }
+      });
       throw new Error("Access denied: bound reader capacity exceeded");
     }
 

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -132,7 +132,12 @@ describe("stable corpus lease", () => {
             },
           })
         );
-        await didStart;
+        // Racing the read surfaces its rejection. Awaiting `didStart` alone
+        // hangs to the suite timeout whenever the first read is refused,
+        // because `markStarted` runs inside the read that just failed. That
+        // turned a named capacity refusal into an anonymous 15s timeout on
+        // Windows, which is what made #617 undiagnosable from CI logs.
+        await Promise.race([didStart, activeReads[activeReads.length - 1]]);
       }
 
       const thirdParent = join(root, "active-1");

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -23,6 +23,7 @@ import {
   fingerprintTextFileFromBoundParent,
   readTextFileWithRevisionFromBoundParent,
   type BoundFileRevision,
+  writeOperatorDiagnostic,
 } from "./secure-read.js";
 
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
@@ -2018,7 +2019,11 @@ async function dispatchStableCorpusLease<T>(
             const budget = overran
               ? `authorization budget overrun by ${magnitudeMs}ms`
               : `${magnitudeMs}ms of authorization budget remained`;
-            process.stderr.write(`[corpus-lease] denied: ${message} (${budget})\n`);
+            // Shared with the bound-reader refusal path, because a plain
+            // try/catch here never covered an asynchronous EPIPE: that
+            // arrives as an 'error' event on a later tick and is fatal
+            // without a listener.
+            writeOperatorDiagnostic(`[corpus-lease] denied: ${message} (${budget})\n`);
           } catch {
             // A broken stderr must never turn a clean denial into a crash.
           }

--- a/crates/sdk/src/secure-read.ts
+++ b/crates/sdk/src/secure-read.ts
@@ -78,6 +78,39 @@ export type BoundTextFileRead = {
   revision: BoundFileRevision;
 };
 
+/**
+ * Absorbed once, then never again: an 'error' event on stderr with no listener
+ * is fatal to the host process.
+ */
+let stderrErrorsAbsorbed = false;
+
+/**
+ * Write one operator-visible diagnostic line, without letting a broken stderr
+ * become fatal.
+ *
+ * A try/catch around the write is not sufficient. When the consumer of the
+ * pipe has gone, the write fails with an asynchronous EPIPE delivered as an
+ * 'error' event on a later tick, which no surrounding catch can see, and an
+ * 'error' event with no listener kills the process. Absorbing it is the same
+ * call corpus-lease.ts already makes for a killed worker's stdin, for the same
+ * reason: a diagnostic that cannot be delivered must never escalate into a
+ * failure of the thing it was describing.
+ *
+ * Callers defer this themselves so a blocked TTY or file cannot delay a
+ * refusal that has already been decided.
+ */
+export function writeOperatorDiagnostic(line: string): void {
+  try {
+    if (!stderrErrorsAbsorbed) {
+      stderrErrorsAbsorbed = true;
+      process.stderr.on("error", () => {});
+    }
+    process.stderr.write(line);
+  } catch {
+    // A synchronous failure is equally non-fatal here.
+  }
+}
+
 export function boundReadIdentity(info: BigIntStats): string {
   return `${info.dev}:${info.ino}`;
 }
@@ -483,11 +516,7 @@ class BoundParentReader {
       // Never inside the throw path's critical section, and never allowed to
       // turn a clean refusal into a crash.
       setImmediate(() => {
-        try {
-          process.stderr.write(`[bound-reader] refused: ${refusal}\n`);
-        } catch {
-          // A broken stderr must not escalate a refusal into a failure.
-        }
+        writeOperatorDiagnostic(`[bound-reader] refused: ${refusal}\n`);
       });
       throw new Error("Access denied: bound reader capacity exceeded");
     }

--- a/crates/sdk/src/secure-read.ts
+++ b/crates/sdk/src/secure-read.ts
@@ -458,14 +458,37 @@ class BoundParentReader {
     const reservedBytes = returnContent
       ? maxBytes * BOUND_READER_CONTENT_AMPLIFICATION
       : Math.max(1024 * 1024, Math.min(maxBytes, 64 * 1024));
-    if (
-      !Number.isSafeInteger(reservedBytes) ||
-      reservedBytes < 0 ||
-      this.pending.size >= maxInFlightPerReader ||
-      globalInFlightReads >= maxInFlightGlobal ||
-      globalReaderProcessBytes + globalReservedReadBytes >
-        maxReservedBytes - reservedBytes
-    ) {
+    // Which of these tripped is the whole diagnosis, and the thrown message
+    // deliberately does not say: callers must not learn why a read was
+    // refused. The reason goes to stderr, which is operator-visible only, the
+    // same split corpus-lease.ts uses for authorization denials.
+    //
+    // Worth the detail because this refusal is reachable from process-global
+    // counters, so the read that gets refused is often not the one at fault.
+    // A CI failure here previously gave no way to tell an exhausted byte
+    // reservation from an in-flight cap (#617).
+    const refusal =
+      !Number.isSafeInteger(reservedBytes) || reservedBytes < 0
+        ? `implausible reservation ${reservedBytes}`
+        : this.pending.size >= maxInFlightPerReader
+          ? `reader in-flight ${this.pending.size}/${maxInFlightPerReader}`
+          : globalInFlightReads >= maxInFlightGlobal
+            ? `global in-flight ${globalInFlightReads}/${maxInFlightGlobal}`
+            : globalReaderProcessBytes + globalReservedReadBytes >
+                maxReservedBytes - reservedBytes
+              ? `global bytes ${globalReaderProcessBytes + globalReservedReadBytes} + ` +
+                `${reservedBytes} requested > ${maxReservedBytes}`
+              : null;
+    if (refusal !== null) {
+      // Never inside the throw path's critical section, and never allowed to
+      // turn a clean refusal into a crash.
+      setImmediate(() => {
+        try {
+          process.stderr.write(`[bound-reader] refused: ${refusal}\n`);
+        } catch {
+          // A broken stderr must not escalate a refusal into a failure.
+        }
+      });
       throw new Error("Access denied: bound reader capacity exceeded");
     }
 


### PR DESCRIPTION
Refs #617. Takes the thread that #758 left open.

## Why this and not a fix

#758 closed a real corpus-lease contamination path. The file still failed on Windows afterwards: run `31753865023`, head `a29f4472`, which `git merge-base --is-ancestor` confirms contains the #758 merge commit. It timed out at 15s in `fails closed when every bounded reader at the cap is active`.

Note the symptom changed. #617 opened on a **budget** error; this is a **timeout**. And the CI log said nothing else, so there is no way to tell from it which resource was exhausted or even which read failed. That is the actual blocker on #617 right now, more than the flake itself.

## Two reasons it was undiagnosable

**The test turns any first-read failure into an infinite hang.** `markStarted` runs inside `afterFirstRead`, so a read refused before that point leaves the gate unresolved and the suite waits out its timeout rather than reporting the rejection. Racing the read against the gate surfaces the real error.

Verified with a throwaway probe rather than asserted: with a first read forced to fail, the old shape hung (confirmed by a 1.5s race against a sentinel) and the new shape rejected with the underlying error. Both cases passed, then the probe was deleted.

**The refusal itself said nothing.** Bound-read admission can be refused by a per-reader in-flight cap, a global in-flight cap, or a global byte reservation, and all three threw the identical sentence. Because those counters are **process-global**, the read that gets refused is usually not the one at fault, which is exactly the situation where the reason matters.

The reason now goes to stderr naming which limit tripped and its current values:

```
[bound-reader] refused: global bytes 402653184 + 33554432 requested > 402653184
```

The thrown message is deliberately unchanged. Callers still must not learn why a read was refused; the detail is operator-visible only. That split follows the denial diagnostics already in `corpus-lease.ts`, including deferring the write with `setImmediate` and never letting a broken stderr escalate a clean refusal into a crash.

## Honest scope

**This does not fix the flake and does not claim to.** It makes the next occurrence say which resource was exhausted instead of leaving another anonymous 15s timeout. Given the flake's rate, that is the difference between diagnosing it on the next hit and waiting for a dozen more.

I would not close #617 on this.

## Verification

SDK 153 passed, MCP 314 passed, both `tsc --noEmit` clean, and the sdk/mcp copies of both changed files are byte-identical.