### PR TITLE
fix(release): keep publishing behind the tag

### DIFF
--- a/docs/release/pre-release-checklist.md
+++ b/docs/release/pre-release-checklist.md
@@ -1,5 +1,12 @@
 # Pre-release checklist
 
+> **Full binary releases:** [`procedure.md`](./procedure.md) is the sole
+> executable release procedure. Do not publish npm packages, create a `v*`
+> GitHub release, or create/push a release tag from this checklist. Registry
+> publishing starts only after the reviewed tag is pushed and is owned by
+> `release-publish.yml`. This document retains background checks and the
+> separate plugin-only path.
+
 Use this before cutting any `vX.Y.Z` tag. Companion to [`channels.md`](./channels.md), [`platform-macos.md`](./platform-macos.md), and [`platform-windows.md`](./platform-windows.md).
 
 > **Plugin-only releases follow a different path.** If the only thing you're
@@ -48,42 +55,18 @@ The MCP server and SDK are real npm packages. They have their own build steps an
 (cd crates/mcp && npm install --dry-run)   # surfaces unresolved versions early
 ```
 
-`npm install --dry-run` is the step that would have caught the v0.10.3 npm publish ordering bug. If it complains about a version that does not exist on the registry, you have an ordering problem and you must publish the missing dep first.
+`npm install --dry-run` is historical evidence for the v0.10.3 ordering bug.
+The current procedure avoids that failure mode by testing MCP against the
+locally packed SDK, committing the exact SDK pin, and letting the trusted
+tag-triggered workflow publish SDK before MCP. Do not manually publish a
+missing dependency to make this check pass.
 
-## Phase 3: Version bump (in this exact order)
+## Phase 3 and later: follow the canonical procedure
 
-The trap here is that the MCP package depends on the SDK by published version, not by relative path. If you bump the MCP dep before publishing the SDK, CI breaks.
-
-1. Bump the SDK in `crates/sdk/package.json` only. Commit (do not push yet).
-2. Build and publish the SDK to npm:
-   ```bash
-   (cd crates/sdk && npm run build && npm publish --registry https://registry.npmjs.org/)
-   ```
-   The local `npm config get registry` may point at `registry.yarnpkg.com` (read-only). Always pass the explicit `--registry` flag.
-3. Verify the SDK is live:
-   ```bash
-   npm view minutes-sdk@<new-version> version --registry https://registry.npmjs.org/
-   ```
-4. Now bump everything else in a single commit:
-   - `Cargo.toml` (workspace `version`)
-   - `tauri/src-tauri/tauri.conf.json`
-   - `crates/cli/Cargo.toml` (the `minutes-core` path-dep `version` field)
-   - `crates/mcp/package.json` (own version + `minutes-sdk` dep)
-   - `crates/mcp/src/index.ts` (the `MCP_SERVER_VERSION` constant)
-   - `manifest.json`
-5. Run `cargo check -p minutes-core -p minutes-app -p minutes-cli` to refresh `Cargo.lock`.
-6. Stage the bumped files explicitly (do not `git add -A`, the worktree may have unrelated untracked files).
-7. Commit, push to main.
-
-## Phase 4: Publish MCP and verify
-
-After the version-bump commit lands on main:
-
-```bash
-(cd crates/mcp && npm install)   # picks up the just-published SDK
-(cd crates/mcp && npm publish --registry https://registry.npmjs.org/)
-npm view minutes-mcp@<new-version> version --registry https://registry.npmjs.org/
-```
+Continue with [`procedure.md`](./procedure.md), starting at its version-sync
+step. Its committed flow handles the exact SDK pin, draft release, local tag,
+trusted tag-triggered package publishing, artifacts, and post-release
+verification in the required order. There are no manual pre-tag npm publishes.
 
 ## Phase 5: Release notes (must match the policy)
 
@@ -116,23 +99,17 @@ the whole major-release narrative into the patch body.
 
 ## Phase 6: Cut the release
 
-Per [`platform-macos.md`](./platform-macos.md), the convention is "create the GitHub Release first, let that create the tag", which then triggers the build workflows:
-
-```bash
-gh release create vX.Y.Z \
-  --target main \
-  --title "vX.Y.Z: Short descriptive subtitle" \
-  --notes-file notes.md
-```
-
-For preview releases, add `--prerelease` and use a `-alpha.N` / `-beta.N` / `-rc.N` suffix.
+Use [`procedure.md`](./procedure.md). The safe sequence is a draft GitHub
+release, then a locally created annotated tag, then an explicit tag push after
+all immutable-tag gates pass. Do not let `gh release create` implicitly create
+the release tag.
 
 ## Phase 6.5: Build and upload the .mcpb bundle
 
 The `minutes.mcpb` Claude Desktop marketplace bundle is NOT built by any release workflow. It is built locally with `scripts/pack_mcpb.sh` and uploaded by hand. Forgetting this step means the Claude Desktop marketplace surface is missing from the release, which will block users who install Minutes through that channel.
 
 ```bash
-# From the repo root, after Phase 4 has completed (MCP and SDK already published).
+# From the repo root, at the post-tag MCPB step in procedure.md.
 (cd crates/mcp && npm run build)   # ensures dist/ and dist-ui/ are fresh
 ./scripts/pack_mcpb.sh minutes.mcpb  # writes minutes.mcpb at repo root
 ./scripts/check_mcpb_bundle.sh minutes.mcpb

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -12,12 +12,9 @@ import {
 import os from "node:os";
 import path from "node:path";
 
-const STATE_FILE = ".minutes-release-state.json";
 const SDK_DIRECTORY = "crates/sdk";
 const MCP_DIRECTORY = "crates/mcp";
 const PHASE2_FILES = ["crates/mcp/package.json", "crates/mcp/package-lock.json"];
-const DEFAULT_REGISTRY_URL = "https://registry.npmjs.org/";
-const DEFAULT_POLL_DELAYS_MS = [5_000, 10_000, 20_000, 40_000, 60_000, 60_000, 60_000, 45_000];
 const exactVersionPattern = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?$/;
 
 const toolPath = process.env.RELEASE_TOOL_PATH;
@@ -61,7 +58,7 @@ function exec(command, args, { cwd, input, env = childEnvironment } = {}) {
 function usage() {
   return [
     "Usage:",
-    "  node scripts/release.mjs phase1 <version>",
+    "  node scripts/release.mjs phase1 <version> --dry-run",
     "  node scripts/release.mjs phase2 <version>",
     "  node scripts/release.mjs tag <version> [--skip-ci-check]",
     "  node scripts/release.mjs status",
@@ -80,8 +77,13 @@ function parseArgs(argv) {
 
   let version;
   let skipCiCheck = false;
+  let dryRun = false;
   for (const argument of rest) {
-    if (argument === "--skip-ci-check") {
+    if (argument === "--dry-run") {
+      if (command !== "phase1") throw new Error("--dry-run is only valid with phase1");
+      if (dryRun) throw new Error("--dry-run may only be specified once");
+      dryRun = true;
+    } else if (argument === "--skip-ci-check") {
       if (command !== "tag") throw new Error("--skip-ci-check is only valid with tag");
       if (skipCiCheck) throw new Error("--skip-ci-check may only be specified once");
       skipCiCheck = true;
@@ -97,7 +99,7 @@ function parseArgs(argv) {
   if (!exactVersionPattern.test(version)) {
     throw new Error(`invalid version ${JSON.stringify(version)}; expected x.y.z or x.y.z-prerelease`);
   }
-  return { command, version, skipCiCheck };
+  return { command, version, skipCiCheck, dryRun };
 }
 
 async function repositoryRoot() {
@@ -107,41 +109,6 @@ async function repositoryRoot() {
 
 async function readJson(file) {
   return JSON.parse(await readFile(file, "utf8"));
-}
-
-async function readState(root) {
-  try {
-    return await readJson(path.join(root, STATE_FILE));
-  } catch (error) {
-    if (error && error.code === "ENOENT") return null;
-    throw new Error(`cannot read ${STATE_FILE}: ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-async function writeState(root, state) {
-  await writeFile(path.join(root, STATE_FILE), `${JSON.stringify(state, null, 2)}\n`, "utf8");
-}
-
-function now() {
-  return new Date().toISOString();
-}
-
-function requireStateVersion(state, version) {
-  if (state === null) {
-    throw new Error(`phase1 state is missing for ${version}; run node scripts/release.mjs phase1 ${version}`);
-  }
-  if (state.version !== version) {
-    throw new Error(
-      `${STATE_FILE} belongs to ${state.version ?? "an unknown version"}, not ${version}; finish or remove that state deliberately`,
-    );
-  }
-  if (typeof state.sdkIntegrity !== "string" || !state.sdkIntegrity.startsWith("sha512-")) {
-    throw new Error(`${STATE_FILE} has no valid sdkIntegrity`);
-  }
-}
-
-function phase1Complete(state) {
-  return ["phase1-complete", "phase2-complete", "tag-complete"].includes(state?.phase);
 }
 
 async function assertCleanAndPushed(root, { requireMain = false } = {}) {
@@ -230,132 +197,6 @@ async function packPackage(root, directory) {
   return withPackedPackage(root, directory, ({ integrity }) => integrity);
 }
 
-function registryUrl() {
-  const configured = process.env.RELEASE_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
-  return configured.endsWith("/") ? configured : `${configured}/`;
-}
-
-async function registryLookup(packageName, version) {
-  const url = new URL(`${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`, registryUrl());
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
-  let response;
-  try {
-    response = await fetch(url, {
-      headers: { accept: "application/json" },
-      signal: controller.signal,
-    });
-  } catch (error) {
-    return { kind: "server-error", detail: error instanceof Error ? error.message : String(error) };
-  } finally {
-    clearTimeout(timeout);
-  }
-
-  if (response.status === 404) return { kind: "missing" };
-  if (response.status >= 500 && response.status <= 599) {
-    return { kind: "server-error", detail: `HTTP ${response.status}` };
-  }
-  if (!response.ok) {
-    throw new Error(`registry lookup for ${packageName}@${version} failed with HTTP ${response.status}`);
-  }
-  let metadata;
-  try {
-    metadata = await response.json();
-  } catch (error) {
-    throw new Error(
-      `registry returned invalid JSON for ${packageName}@${version}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-  return { kind: "found", integrity: metadata?.dist?.integrity };
-}
-
-function assertRegistryIntegrity(packageName, version, actual, expected) {
-  if (typeof actual !== "string") {
-    throw new Error(`registry metadata for ${packageName}@${version} has no dist.integrity`);
-  }
-  if (actual !== expected) {
-    throw new Error(
-      `${packageName}@${version} already exists with different integrity\n` +
-        `  registry: ${actual}\n  local:    ${expected}\nRefusing to replace published provenance.`,
-    );
-  }
-}
-
-function pollDelays() {
-  const configured = process.env.RELEASE_POLL_DELAYS_MS;
-  if (configured === undefined) return DEFAULT_POLL_DELAYS_MS;
-  const delays = configured.split(",").map((value) => Number(value));
-  if (delays.length === 0 || delays.some((value) => !Number.isFinite(value) || value < 0)) {
-    throw new Error("RELEASE_POLL_DELAYS_MS must be a comma-separated list of non-negative numbers");
-  }
-  return delays;
-}
-
-function sleep(milliseconds) {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-async function pollForPackage(packageName, version, integrity) {
-  const delays = pollDelays();
-  let lastResult;
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
-    lastResult = await registryLookup(packageName, version);
-    if (lastResult.kind === "found") {
-      assertRegistryIntegrity(packageName, version, lastResult.integrity, integrity);
-      console.log(`Registry confirms ${packageName}@${version} (${integrity}).`);
-      return;
-    }
-    if (attempt < delays.length) {
-      const description = lastResult.kind === "missing" ? "404 (not visible yet)" : lastResult.detail;
-      console.log(`Registry poll ${attempt + 1}: ${description}; retrying in ${delays[attempt]}ms.`);
-      await sleep(delays[attempt]);
-    }
-  }
-  const lastDescription = lastResult?.kind === "missing" ? "404" : lastResult?.detail ?? "unknown error";
-  throw new Error(
-    `${packageName}@${version} did not become visible before the registry polling timeout (last result: ${lastDescription}). ` +
-      "This is the npm registry lag pattern that can leave minutes-mcp depending on an SDK version the registry cannot resolve; stop and retry phase1 later.",
-  );
-}
-
-async function publishPackage(root, directory, packageName, version, integrity, { poll = false } = {}) {
-  const firstLookup = await registryLookup(packageName, version);
-  if (firstLookup.kind === "found") {
-    assertRegistryIntegrity(packageName, version, firstLookup.integrity, integrity);
-    console.log(`${packageName}@${version} is already published with matching integrity; skipping npm publish.`);
-    if (poll) await pollForPackage(packageName, version, integrity);
-    return false;
-  }
-  if (firstLookup.kind === "server-error") {
-    throw new Error(
-      `cannot safely determine whether ${packageName}@${version} already exists (${firstLookup.detail}); refusing to publish`,
-    );
-  }
-
-  try {
-    await exec(
-      "npm",
-      ["publish", "--access", "public", "--registry", registryUrl()],
-      { cwd: path.join(root, directory) },
-    );
-  } catch (error) {
-    // A concurrent publisher can win after our 404. Verify provenance before
-    // deciding whether the failed publish is nevertheless an idempotent success.
-    const afterFailure = await registryLookup(packageName, version);
-    if (afterFailure.kind === "found") {
-      assertRegistryIntegrity(packageName, version, afterFailure.integrity, integrity);
-      console.log(`${packageName}@${version} appeared concurrently with matching integrity; continuing.`);
-      if (poll) await pollForPackage(packageName, version, integrity);
-      return false;
-    }
-    throw error;
-  }
-
-  console.log(`Published ${packageName}@${version}.`);
-  if (poll) await pollForPackage(packageName, version, integrity);
-  return true;
-}
-
 async function testMcpAgainstSdkTarball(root, tarball, sdkIntegrity) {
   let primaryError;
   try {
@@ -381,62 +222,23 @@ async function testMcpAgainstSdkTarball(root, tarball, sdkIntegrity) {
   if (primaryError !== undefined) throw primaryError;
 }
 
-async function phase1(root, version) {
+async function phase1(root, version, dryRun) {
+  if (!dryRun) {
+    throw new Error(
+      "phase1 is a preflight-only command; pass --dry-run (registry publishing begins only after the release tag is pushed)",
+    );
+  }
   await assertCleanAndPushed(root, { requireMain: true });
   await runVersionCheck(root);
   await assertTreeVersion(root, version);
 
-  let existingState = await readState(root);
-  if (existingState !== null && existingState.version !== version && existingState.phase === "tag-complete") {
-    console.log(`Previous release ${existingState.version} is complete; starting release ${version}.`);
-    existingState = null;
-  }
-  if (existingState !== null) requireStateVersion(existingState, version);
-
-  const sdkPackage = await readJson(path.join(root, SDK_DIRECTORY, "package.json"));
-  let state;
   const integrity = await withPackedPackage(root, SDK_DIRECTORY, async ({ tarball, integrity: packedIntegrity }) => {
-    if (existingState?.sdkIntegrity && existingState.sdkIntegrity !== packedIntegrity) {
-      throw new Error(
-        `SDK provenance changed since phase1 began\n  state: ${existingState.sdkIntegrity}\n  local: ${packedIntegrity}`,
-      );
-    }
-    state = {
-      version,
-      phase: phase1Complete(existingState) ? existingState.phase : "phase1-started",
-      sdkPublished: existingState?.sdkPublished === true,
-      sdkIntegrity: packedIntegrity,
-      timestamps: {
-        ...(existingState?.timestamps ?? {}),
-        phase1StartedAt: existingState?.timestamps?.phase1StartedAt ?? now(),
-      },
-    };
-    await writeState(root, state);
-    if (!phase1Complete(existingState)) {
-      await testMcpAgainstSdkTarball(root, tarball, packedIntegrity);
-    }
+    await testMcpAgainstSdkTarball(root, tarball, packedIntegrity);
     return packedIntegrity;
   });
 
-  const publishedNow = await publishPackage(
-    root,
-    SDK_DIRECTORY,
-    sdkPackage.name,
-    version,
-    integrity,
-    { poll: false },
-  );
-  state.sdkPublished = true;
-  state.timestamps.sdkPublishedAt = state.timestamps.sdkPublishedAt ?? now();
-  if (publishedNow) state.timestamps.sdkPublishCommandCompletedAt = now();
-  await writeState(root, state);
-
-  await pollForPackage(sdkPackage.name, version, integrity);
-  state.phase = phase1Complete(existingState) ? existingState.phase : "phase1-complete";
-  state.timestamps.phase1CompletedAt = state.timestamps.phase1CompletedAt ?? now();
-  await writeState(root, state);
-
-  console.log("\nPhase 1 complete. Run Phase 2 from this checkout:");
+  console.log(`Credential-free SDK preflight complete (${integrity}). No package was published.`);
+  console.log("\nRun Phase 2 from this checkout:");
   console.log(`  node scripts/release.mjs phase2 ${version}`);
 }
 
@@ -452,22 +254,9 @@ function assertOnlyPhase2Files(files, context) {
   }
 }
 
-async function verifySdkStateOnRegistry(state) {
-  const lookup = await registryLookup("minutes-sdk", state.version);
-  if (lookup.kind !== "found") {
-    const detail = lookup.kind === "missing" ? "404 (missing)" : lookup.detail;
-    throw new Error(`minutes-sdk@${state.version} is not currently visible on the registry (${detail})`);
-  }
-  assertRegistryIntegrity("minutes-sdk", state.version, lookup.integrity, state.sdkIntegrity);
-}
-
 async function phase2(root, version) {
-  const state = await readState(root);
-  requireStateVersion(state, version);
-  if (!phase1Complete(state)) {
-    throw new Error(`phase1 is not complete for ${version} (current state: ${state.phase ?? "unknown"})`);
-  }
-  await verifySdkStateOnRegistry(state);
+  await runVersionCheck(root);
+  await assertTreeVersion(root, version);
 
   const preexisting = await changedFilesFromHead(root);
   assertOnlyPhase2Files(preexisting, "before pinning");
@@ -486,9 +275,6 @@ async function phase2(root, version) {
     lockJson.packages?.[""]?.dependencies?.["minutes-sdk"] === version
   ) {
     await runVersionCheck(root, true);
-    if (state.phase !== "tag-complete") state.phase = "phase2-complete";
-    state.timestamps = { ...(state.timestamps ?? {}), phase2CompletedAt: state.timestamps?.phase2CompletedAt ?? now() };
-    await writeState(root, state);
     console.log(`Phase 2 is already committed for ${version}; nothing to change.`);
     printPhase3Instructions(version);
     return;
@@ -529,9 +315,6 @@ async function phase2(root, version) {
     throw error;
   }
 
-  state.phase = "phase2-complete";
-  state.timestamps = { ...(state.timestamps ?? {}), phase2CompletedAt: now() };
-  await writeState(root, state);
   console.log(`Committed exact minutes-sdk ${version} pin for MCP.`);
   printPhase3Instructions(version);
 }
@@ -597,52 +380,28 @@ async function ensureAnnotatedTag(root, version, head) {
 }
 
 async function tagRelease(root, version, skipCiCheck) {
-  const state = await readState(root);
-  requireStateVersion(state, version);
-  if (!["phase2-complete", "tag-complete"].includes(state.phase)) {
-    throw new Error(`phase2 is not complete for ${version} (current state: ${state.phase ?? "unknown"})`);
-  }
-  await verifySdkStateOnRegistry(state);
-
   const head = await assertCleanAndPushed(root);
   await assertCiGreen(root, head, skipCiCheck);
   await runVersionCheck(root, true);
+  await assertTreeVersion(root, version);
   const sdkIntegrity = await packPackage(root, SDK_DIRECTORY);
-  if (sdkIntegrity !== state.sdkIntegrity) {
-    throw new Error(
-      `SDK provenance mismatch: npm pack from HEAD no longer reproduces phase1\n` +
-        `  phase1: ${state.sdkIntegrity}\n  HEAD:   ${sdkIntegrity}`,
-    );
-  }
 
   // Build and pack MCP before creating the tag. npm publish has no MCP build
-  // lifecycle, so from the annotated tag onward every publish input is frozen.
-  const mcpPackage = await readJson(path.join(root, MCP_DIRECTORY, "package.json"));
+  // lifecycle, so prove both registry inputs pack before freezing the tag.
   const mcpIntegrity = await packPackage(root, MCP_DIRECTORY);
 
   const tag = await ensureAnnotatedTag(root, version, head);
   console.log(`Push it only after the draft GitHub release is ready:\n  git push origin ${tag}`);
-
-  await publishPackage(root, MCP_DIRECTORY, mcpPackage.name, version, mcpIntegrity);
-
-  state.phase = "tag-complete";
-  state.timestamps = { ...(state.timestamps ?? {}), tagCompletedAt: now() };
-  await writeState(root, state);
-  console.log(`\nRelease command flow complete for ${tag}. The local tag has not been pushed.`);
+  console.log(`Packed minutes-sdk (${sdkIntegrity}) and minutes-mcp (${mcpIntegrity}) without publishing.`);
+  console.log(`\nLocal tag ${tag} is ready. Registry publishing begins only in the tag-triggered workflow.`);
 }
 
 async function printStatus(root) {
-  const state = await readState(root);
-  if (state === null) {
-    console.log("no release in progress");
-    return;
-  }
-  console.log(`release ${state.version ?? "<unknown>"}: ${state.phase ?? "<unknown phase>"}`);
-  console.log(`sdk published: ${state.sdkPublished === true ? "yes" : "no"}`);
-  if (state.sdkIntegrity) console.log(`sdk integrity: ${state.sdkIntegrity}`);
-  if (state.timestamps && typeof state.timestamps === "object") {
-    for (const [name, value] of Object.entries(state.timestamps)) console.log(`${name}: ${value}`);
-  }
+  const sdkPackage = await readJson(path.join(root, SDK_DIRECTORY, "package.json"));
+  const mcpPackage = await readJson(path.join(root, MCP_DIRECTORY, "package.json"));
+  console.log(`release inputs: minutes-sdk ${sdkPackage.version}; minutes-mcp ${mcpPackage.version}`);
+  console.log(`MCP SDK pin: ${mcpPackage.dependencies?.["minutes-sdk"] ?? "missing"}`);
+  console.log("registry publishing: tag-triggered workflow only");
 }
 
 let options;
@@ -650,7 +409,7 @@ try {
   options = parseArgs(process.argv.slice(2));
   const root = await repositoryRoot();
   if (options.command === "status") await printStatus(root);
-  else if (options.command === "phase1") await phase1(root, options.version);
+  else if (options.command === "phase1") await phase1(root, options.version, options.dryRun);
   else if (options.command === "phase2") await phase2(root, options.version);
   else await tagRelease(root, options.version, options.skipCiCheck);
 } catch (error) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import { spawn, spawnSync } from "node:child_process";
 import {
   chmod,
@@ -9,8 +8,6 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -37,14 +34,6 @@ async function writeFixture(root, file, contents) {
 
 async function writeJson(root, file, value) {
   await writeFixture(root, file, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function packageBytes(name, packageVersion, variant = "original") {
-  return Buffer.from(`${name}:${packageVersion}:${variant}\n`);
-}
-
-function integrityFor(name, packageVersion, variant = "original") {
-  return `sha512-${createHash("sha512").update(packageBytes(name, packageVersion, variant)).digest("base64")}`;
 }
 
 async function installToolShims(root) {
@@ -117,54 +106,7 @@ console.log(JSON.stringify([{
   return tools;
 }
 
-async function startRegistry(t, root, config) {
-  const markers = path.join(root, ".release-markers");
-  await mkdir(markers, { recursive: true });
-  const server = http.createServer((request, response) => {
-    const segments = new URL(request.url, "http://fixture.invalid").pathname
-      .split("/")
-      .filter(Boolean)
-      .map(decodeURIComponent);
-    const packageName = segments[0];
-    const packageVersion = segments[1];
-    if (!packageName || packageVersion !== version) {
-      response.writeHead(404).end(JSON.stringify({ error: "not found" }));
-      return;
-    }
-
-    const sequence = config.sequences?.[packageName];
-    if (sequence?.length) {
-      const status = sequence.shift();
-      if (status !== 200) {
-        response.writeHead(status).end(JSON.stringify({ error: `fixture ${status}` }));
-        return;
-      }
-    }
-
-    let packageIntegrity = config.integrities?.[packageName];
-    if (packageIntegrity === undefined && existsSync(path.join(markers, `published-${packageName}`))) {
-      const remainingLag = config.visibilityLag?.[packageName] ?? 0;
-      if (remainingLag > 0) {
-        config.visibilityLag[packageName] = remainingLag - 1;
-        response.writeHead(404).end(JSON.stringify({ error: "not visible yet" }));
-        return;
-      }
-      packageIntegrity = config.expected[packageName];
-    }
-    if (packageIntegrity === undefined) {
-      response.writeHead(404).end(JSON.stringify({ error: "not found" }));
-      return;
-    }
-    response.writeHead(200, { "content-type": "application/json" });
-    response.end(JSON.stringify({ name: packageName, version, dist: { integrity: packageIntegrity } }));
-  });
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  t.after(() => new Promise((resolve) => server.close(resolve)));
-  const address = server.address();
-  return { markers, url: `http://127.0.0.1:${address.port}/` };
-}
-
-async function makeRepo(t, registryConfig = {}) {
+async function makeRepo(t) {
   const root = await mkdtemp(path.join(os.tmpdir(), "minutes-release-fixture-"));
   t.after(() => rm(root, { recursive: true, force: true }));
   const remote = `${root}-remote.git`;
@@ -231,22 +173,10 @@ console.log("site release constants already match.");
 
   const tools = await installToolShims(root);
   const log = path.join(root, ".release-shim.log");
+  const markers = path.join(root, ".release-markers");
   await writeFile(log, "");
-  const expected = {
-    "minutes-sdk": integrityFor("minutes-sdk", version),
-    "minutes-mcp": integrityFor("minutes-mcp", version),
-  };
-  const config = {
-    expected,
-    integrities: {},
-    visibilityLag: {},
-    ...registryConfig,
-  };
-  config.expected = { ...expected, ...(registryConfig.expected ?? {}) };
-  config.integrities = { ...(registryConfig.integrities ?? {}) };
-  config.visibilityLag = { ...(registryConfig.visibilityLag ?? {}) };
-  const registry = await startRegistry(t, root, config);
-  return { root, tools, log, config, registry };
+  await mkdir(markers, { recursive: true });
+  return { root, tools, log, markers };
 }
 
 function runRelease(fixture, args, extraEnvironment = {}) {
@@ -254,14 +184,12 @@ function runRelease(fixture, args, extraEnvironment = {}) {
     const child = spawn(process.execPath, [releaseScript, ...args], {
       cwd: fixture.root,
       env: {
-      ...process.env,
-      RELEASE_TOOL_PATH: fixture.tools,
-      RELEASE_REAL_GIT: run("which", ["git"]).stdout.trim(),
-      RELEASE_REGISTRY_URL: fixture.registry.url,
-      RELEASE_POLL_DELAYS_MS: "1,1,1",
-      RELEASE_SHIM_LOG: fixture.log,
-      RELEASE_SHIM_MARKERS: fixture.registry.markers,
-      ...extraEnvironment,
+        ...process.env,
+        RELEASE_TOOL_PATH: fixture.tools,
+        RELEASE_REAL_GIT: run("which", ["git"]).stdout.trim(),
+        RELEASE_SHIM_LOG: fixture.log,
+        RELEASE_SHIM_MARKERS: fixture.markers,
+        ...extraEnvironment,
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -281,7 +209,7 @@ function assertSucceeded(result) {
 }
 
 async function completePhase1(fixture, extraEnvironment = {}) {
-  const result = await runRelease(fixture, ["phase1", version], extraEnvironment);
+  const result = await runRelease(fixture, ["phase1", version, "--dry-run"], extraEnvironment);
   assertSucceeded(result);
   return result;
 }
@@ -292,10 +220,11 @@ async function completePhase2(fixture) {
   return result;
 }
 
-test("happy path completes phase1, phase2, and tag with resumable state", async (t) => {
+test("happy path preflights, pins, and tags without publishing before the tag push", async (t) => {
   const fixture = await makeRepo(t);
   const phase1 = await completePhase1(fixture);
-  assert.match(phase1.stdout, /Phase 1 complete/);
+  assert.match(phase1.stdout, /Credential-free SDK preflight complete/);
+  assert.match(phase1.stdout, /No package was published/);
   const phase2 = await completePhase2(fixture);
   assert.match(phase2.stdout, /Committed exact minutes-sdk 1\.2\.3 pin/);
   assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
@@ -308,55 +237,44 @@ test("happy path completes phase1, phase2, and tag with resumable state", async 
 
   const mcpPackage = JSON.parse(await readFile(path.join(fixture.root, "crates/mcp/package.json"), "utf8"));
   assert.equal(mcpPackage.dependencies["minutes-sdk"], version);
-  const state = JSON.parse(await readFile(path.join(fixture.root, ".minutes-release-state.json"), "utf8"));
-  assert.equal(state.phase, "tag-complete");
-  assert.equal(state.sdkPublished, true);
-  assert.equal(state.sdkIntegrity, integrityFor("minutes-sdk", version));
   const log = await readFile(fixture.log, "utf8");
-  assert.match(log, /npm publish .*crates\/sdk/);
-  assert.match(log, /npm publish .*crates\/mcp/);
-});
-
-test("phase1 polls through registry 404 responses until the SDK is visible", async (t) => {
-  const fixture = await makeRepo(t, { visibilityLag: { "minutes-sdk": 2 } });
-  const result = await completePhase1(fixture);
-  assert.match(result.stdout, /404 \(not visible yet\)/);
-  assert.match(result.stdout, /Registry confirms minutes-sdk@1\.2\.3/);
-});
-
-test("phase1 polling timeout fails with the npm lag-pattern explanation", async (t) => {
-  const fixture = await makeRepo(t, { visibilityLag: { "minutes-sdk": 99 } });
-  const result = await runRelease(fixture, ["phase1", version], { RELEASE_POLL_DELAYS_MS: "1,1" });
-  assert.equal(result.status, 1);
-  assert.match(result.stderr, /registry lag pattern/);
-  const state = JSON.parse(await readFile(path.join(fixture.root, ".minutes-release-state.json"), "utf8"));
-  assert.equal(state.sdkPublished, true);
-  assert.equal(state.phase, "phase1-started");
-});
-
-test("phase1 skips an existing SDK version with matching integrity", async (t) => {
-  const fixture = await makeRepo(t, {
-    integrities: { "minutes-sdk": integrityFor("minutes-sdk", version) },
-  });
-  const result = await completePhase1(fixture);
-  assert.match(result.stdout, /already published with matching integrity; skipping npm publish/);
-  const log = await readFile(fixture.log, "utf8");
+  assert.match(log, /npm pack .*crates\/sdk/);
+  assert.match(log, /npm pack .*crates\/mcp/);
   assert.doesNotMatch(log, /npm publish/);
 });
 
-test("phase1 aborts when an existing SDK version has different integrity", async (t) => {
-  const fixture = await makeRepo(t, {
-    integrities: { "minutes-sdk": "sha512-not-the-local-package" },
-  });
+test("phase1 refuses to run without the explicit dry-run flag", async (t) => {
+  const fixture = await makeRepo(t);
   const result = await runRelease(fixture, ["phase1", version]);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /already exists with different integrity/);
-  assert.match(result.stderr, /Refusing to replace published provenance/);
+  assert.match(result.stderr, /preflight-only command; pass --dry-run/);
+  const log = await readFile(fixture.log, "utf8");
+  assert.doesNotMatch(log, /npm (?:pack|publish)/);
+});
+
+test("status reports committed release inputs without legacy publish state", async (t) => {
+  const fixture = await makeRepo(t);
+  const result = await runRelease(fixture, ["status"]);
+  assertSucceeded(result);
+  assert.match(result.stdout, /release inputs: minutes-sdk 1\.2\.3; minutes-mcp 1\.2\.3/);
+  assert.match(result.stdout, /MCP SDK pin: \^1\.0\.0/);
+  assert.match(result.stdout, /registry publishing: tag-triggered workflow only/);
+});
+
+test("phase1 dry-run tests MCP against the packed SDK and restores dependencies", async (t) => {
+  const fixture = await makeRepo(t);
+  await completePhase1(fixture);
+  const log = await readFile(fixture.log, "utf8");
+  assert.match(log, /npm pack .*crates\/sdk/);
+  assert.match(log, /npm install .*\.tgz --no-save --package-lock=false .*crates\/mcp/);
+  assert.match(log, /npm run build .*crates\/mcp/);
+  assert.match(log, /npx tsc --noEmit .*crates\/mcp/);
+  assert.match(log, /npm ci .*crates\/mcp/);
+  assert.doesNotMatch(log, /npm publish/);
 });
 
 test("phase2 diff restriction aborts when another tracked file is dirty", async (t) => {
   const fixture = await makeRepo(t);
-  await completePhase1(fixture);
   await writeFile(path.join(fixture.root, "extra.txt"), "modified\n");
   const result = await runRelease(fixture, ["phase2", version]);
   assert.equal(result.status, 1);
@@ -364,20 +282,20 @@ test("phase2 diff restriction aborts when another tracked file is dirty", async 
   assert.match(result.stderr, /extra\.txt/);
 });
 
-test("tag aborts when SDK tarball provenance no longer matches phase1", async (t) => {
+test("phase1 is optional and tag packs current inputs without publishing", async (t) => {
   const fixture = await makeRepo(t);
-  await completePhase1(fixture);
   await completePhase2(fixture);
   assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
-  const result = await runRelease(fixture, ["tag", version], { RELEASE_SHIM_SDK_VARIANT: "changed" });
-  assert.equal(result.status, 1);
-  assert.match(result.stderr, /SDK provenance mismatch/);
-  assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), "");
+  const result = await runRelease(fixture, ["tag", version]);
+  assertSucceeded(result);
+  assert.match(result.stdout, /Packed minutes-sdk .* and minutes-mcp .* without publishing/);
+  assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), `v${version}`);
+  const log = await readFile(fixture.log, "utf8");
+  assert.doesNotMatch(log, /npm publish/);
 });
 
 test("tag aborts when the --release version policy check fails", async (t) => {
   const fixture = await makeRepo(t);
-  await completePhase1(fixture);
   await completePhase2(fixture);
   assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
   const result = await runRelease(fixture, ["tag", version], { RELEASE_CHECK_FAIL: "release" });
@@ -393,7 +311,6 @@ test("tag aborts when the site release constants are stale", async (t) => {
   // exists: release-cli.yml runs the same check, but only on the tag push, and
   // by then the immutable-tag policy rules out simply retagging.
   const fixture = await makeRepo(t);
-  await completePhase1(fixture);
   await completePhase2(fixture);
   assert.equal(git(fixture.root, "push", "-q", "origin", "main").status, 0);
   const result = await runRelease(fixture, ["tag", version], { RELEASE_SITE_CHECK_FAIL: "1" });


### PR DESCRIPTION
## What changed

- make Phase 1 an explicit credential-free `--dry-run` preflight
- remove every pre-tag `npm publish` path and legacy registry state/polling
- let Phase 2 pin the exact SDK version without requiring a package already on npm
- make `tag` pack both registry inputs and create only the local annotated tag
- leave registry mutation exclusively to the trusted tag-triggered workflow

## Why

The documented 0.25 release procedure says no registry mutation occurs before the trusted tag workflow, but the committed helper still implemented the older publish-before-tag sequence. Running it would have made the release partially public before the immutable release gate.

## Verification

- `node --check scripts/release.mjs`
- 54/54 release/version/hook tests passed
- `node scripts/sync_site_release_version.mjs --check-release`
- `node scripts/check_version_sync.mjs`
- tests assert no `npm publish` occurs in Phase 1 or `tag`