### PR TITLE
fix(release): pin unpublished SDK from its local artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,8 +537,7 @@ jobs:
           node-version: '22'
 
       - name: Install MCP dependencies
-        working-directory: crates/mcp
-        run: npm ci
+        run: node scripts/install_mcp_dependencies.mjs
 
       - name: TypeScript check
         working-directory: crates/mcp
@@ -609,8 +608,7 @@ jobs:
         run: node scripts/check_corpus_watch_fence.mjs crates/sdk/dist/corpus-lease.js
 
       - name: Install MCP dependencies
-        working-directory: crates/mcp
-        run: npm ci
+        run: node scripts/install_mcp_dependencies.mjs --sdk-ready
 
       - name: TypeScript check
         working-directory: crates/mcp

--- a/scripts/install_mcp_dependencies.mjs
+++ b/scripts/install_mcp_dependencies.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sdkDirectory = path.join(root, "crates", "sdk");
+const mcpDirectory = path.join(root, "crates", "mcp");
+const npmCommand = "npm";
+
+function runNpm(args, cwd, { capture = false } = {}) {
+  const result = spawnSync(npmCommand, args, {
+    cwd,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+    stdio: capture ? ["ignore", "pipe", "inherit"] : "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`npm ${args.join(" ")} failed with exit code ${result.status ?? "unknown"}`);
+  }
+  return result.stdout ?? "";
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+const args = process.argv.slice(2);
+const sdkReady = args.includes("--sdk-ready");
+if (args.some((argument) => argument !== "--sdk-ready")) {
+  throw new Error("usage: node scripts/install_mcp_dependencies.mjs [--sdk-ready]");
+}
+
+const sdkPackage = await readJson(path.join(sdkDirectory, "package.json"));
+const mcpPackage = await readJson(path.join(mcpDirectory, "package.json"));
+const mcpLock = await readJson(path.join(mcpDirectory, "package-lock.json"));
+const pinnedVersion = mcpPackage.dependencies?.["minutes-sdk"];
+
+if (pinnedVersion !== sdkPackage.version) {
+  console.log(`Installing MCP dependencies from the published minutes-sdk ${pinnedVersion}.`);
+  runNpm(["ci"], mcpDirectory);
+  process.exit(0);
+}
+
+const lockedSdk = mcpLock.packages?.["node_modules/minutes-sdk"];
+const expectedResolved = `https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-${sdkPackage.version}.tgz`;
+if (
+  mcpLock.packages?.[""]?.dependencies?.["minutes-sdk"] !== sdkPackage.version ||
+  lockedSdk?.version !== sdkPackage.version ||
+  lockedSdk.resolved !== expectedResolved ||
+  typeof lockedSdk.integrity !== "string" ||
+  !lockedSdk.integrity.startsWith("sha512-")
+) {
+  throw new Error(`MCP lockfile does not contain a complete exact minutes-sdk ${sdkPackage.version} pin`);
+}
+
+const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "minutes-mcp-local-sdk-"));
+try {
+  if (!sdkReady) {
+    runNpm(["ci"], sdkDirectory);
+    runNpm(["run", "build"], sdkDirectory);
+  }
+
+  const packOutput = runNpm(
+    ["pack", "--json", "--pack-destination", temporaryDirectory],
+    sdkDirectory,
+    { capture: true },
+  );
+  const [packed] = JSON.parse(packOutput);
+  if (!packed?.filename || !packed?.integrity) throw new Error("npm pack returned no filename or integrity");
+  if (packed.integrity !== lockedSdk.integrity) {
+    throw new Error(
+      `local minutes-sdk ${sdkPackage.version} integrity does not match the MCP lockfile\n` +
+        `  lockfile: ${lockedSdk.integrity}\n  local:    ${packed.integrity}`,
+    );
+  }
+
+  const tarball = path.join(temporaryDirectory, packed.filename);
+  const cacheDirectory = path.join(temporaryDirectory, "npm-cache");
+  runNpm(["cache", "add", tarball, "--cache", cacheDirectory], root);
+  runNpm(["ci", "--cache", cacheDirectory], mcpDirectory);
+  console.log(`Installed MCP dependencies from the exact local minutes-sdk ${sdkPackage.version} tarball.`);
+} finally {
+  await rm(temporaryDirectory, { recursive: true, force: true });
+}

--- a/scripts/install_mcp_dependencies.test.mjs
+++ b/scripts/install_mcp_dependencies.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const sourceScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "install_mcp_dependencies.mjs");
+
+async function writeJson(root, file, value) {
+  const target = path.join(root, file);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function makeFixture(t, dependency, integrity = "sha512-fixture") {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minutes-mcp-install-test-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(path.join(root, "scripts"), { recursive: true });
+  await cp(sourceScript, path.join(root, "scripts", "install_mcp_dependencies.mjs"));
+  await writeJson(root, "crates/sdk/package.json", { name: "minutes-sdk", version: "1.2.3" });
+  await writeJson(root, "crates/mcp/package.json", {
+    name: "minutes-mcp",
+    dependencies: { "minutes-sdk": dependency },
+  });
+  await writeJson(root, "crates/mcp/package-lock.json", {
+    lockfileVersion: 3,
+    packages: {
+      "": { dependencies: { "minutes-sdk": dependency } },
+      "node_modules/minutes-sdk": {
+        version: "1.2.3",
+        resolved: "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-1.2.3.tgz",
+        integrity,
+      },
+    },
+  });
+
+  const tools = path.join(root, "tools");
+  const log = path.join(root, "npm.log");
+  await mkdir(tools, { recursive: true });
+  const npmShim = path.join(tools, "npm");
+  await writeFile(
+    npmShim,
+    `#!/usr/bin/env node
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+const args = process.argv.slice(2);
+await appendFile(process.env.NPM_TEST_LOG, args.join(" ") + " @ " + process.cwd() + "\\n");
+if (args[0] === "pack") {
+  const destination = args[args.indexOf("--pack-destination") + 1];
+  await mkdir(destination, { recursive: true });
+  await writeFile(path.join(destination, "minutes-sdk-1.2.3.tgz"), "fixture");
+  console.log(JSON.stringify([{ filename: "minutes-sdk-1.2.3.tgz", integrity: "sha512-fixture" }]));
+}
+`,
+  );
+  await chmod(npmShim, 0o755);
+  await writeFile(log, "");
+  return { root, tools, log };
+}
+
+function runFixture(fixture, args = []) {
+  return spawnSync(process.execPath, [path.join(fixture.root, "scripts", "install_mcp_dependencies.mjs"), ...args], {
+    cwd: fixture.root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fixture.tools}${path.delimiter}${process.env.PATH}`,
+      NPM_TEST_LOG: fixture.log,
+    },
+  });
+}
+
+test("uses ordinary npm ci while MCP still targets the published SDK", async (t) => {
+  const fixture = await makeFixture(t, "0.24.0");
+  const result = runFixture(fixture);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /published minutes-sdk 0\.24\.0/);
+  const log = await readFile(fixture.log, "utf8");
+  assert.match(log, /ci @ .*crates\/mcp/);
+  assert.doesNotMatch(log, /pack --json/);
+});
+
+test("seeds npm from the exact local SDK when the release pin is unpublished", async (t) => {
+  const fixture = await makeFixture(t, "1.2.3");
+  const result = runFixture(fixture);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /exact local minutes-sdk 1\.2\.3 tarball/);
+  const log = await readFile(fixture.log, "utf8");
+  assert.match(log, /ci @ .*crates\/sdk/);
+  assert.match(log, /run build @ .*crates\/sdk/);
+  assert.match(log, /pack --json --pack-destination/);
+  assert.match(log, /cache add .*minutes-sdk-1\.2\.3\.tgz --cache/);
+  assert.match(log, /ci --cache .* @ .*crates\/mcp/);
+});
+
+test("refuses a local SDK whose tarball differs from the committed lock", async (t) => {
+  const fixture = await makeFixture(t, "1.2.3", "sha512-different");
+  const result = runFixture(fixture, ["--sdk-ready"]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /integrity does not match the MCP lockfile/);
+  const log = await readFile(fixture.log, "utf8");
+  assert.doesNotMatch(log, /ci --cache .*crates\/mcp/);
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -172,6 +172,7 @@ async function assertTreeVersion(root, version) {
 async function withPackedPackage(root, directory, callback) {
   const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "minutes-release-pack-"));
   try {
+    await exec("npm", ["ci"], { cwd: path.join(root, directory) });
     // minutes-sdk builds in prepublishOnly, a lifecycle that npm pack does not
     // run. Build explicitly so the provenance tarball contains the same dist/
     // payload that npm publish will pack. This is also harmlessly idempotent for
@@ -282,15 +283,52 @@ async function phase2(root, version) {
   if (!packageJson.dependencies || typeof packageJson.dependencies["minutes-sdk"] !== "string") {
     throw new Error('crates/mcp/package.json is missing dependencies["minutes-sdk"]');
   }
+  const dependencyText = `"minutes-sdk": ${JSON.stringify(packageJson.dependencies["minutes-sdk"])}`;
+  const pinnedPackageText = originalPackageText.replace(
+    dependencyText,
+    `"minutes-sdk": ${JSON.stringify(version)}`,
+  );
+  if (pinnedPackageText === originalPackageText) {
+    throw new Error("could not locate the minutes-sdk dependency text in crates/mcp/package.json");
+  }
   let committed = false;
   try {
-    packageJson.dependencies["minutes-sdk"] = version;
-    await writeFile(packageFile, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
-    await exec("npm", ["install", "--package-lock-only"], { cwd: path.join(root, MCP_DIRECTORY) });
+    await withPackedPackage(root, SDK_DIRECTORY, async ({ tarball, integrity }) => {
+      packageJson.dependencies["minutes-sdk"] = version;
+      await writeFile(packageFile, pinnedPackageText, "utf8");
+
+      // Let npm derive the lock entry from the exact local SDK artifact. Then
+      // replace only the temporary file reference with the registry URL that
+      // will become valid after the trusted tag workflow publishes the same
+      // tarball. This keeps Phase 2 credential-free and registry-independent.
+      await exec(
+        "npm",
+        [
+          "install",
+          "--package-lock-only",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          "--save-exact",
+          tarball,
+        ],
+        { cwd: path.join(root, MCP_DIRECTORY) },
+      );
+
+      const resultingLock = await readJson(lockFile);
+      const lockedSdk = resultingLock.packages?.["node_modules/minutes-sdk"];
+      if (lockedSdk?.version !== version || lockedSdk.integrity !== integrity) {
+        throw new Error(`npm did not lock the exact local minutes-sdk ${version} artifact`);
+      }
+      resultingLock.packages[""].dependencies["minutes-sdk"] = version;
+      lockedSdk.resolved = `https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-${version}.tgz`;
+      await writeFile(packageFile, pinnedPackageText, "utf8");
+      await writeFile(lockFile, `${JSON.stringify(resultingLock, null, 2)}\n`, "utf8");
+    });
 
     const resultingLock = await readJson(lockFile);
     if (resultingLock.packages?.[""]?.dependencies?.["minutes-sdk"] !== version) {
-      throw new Error(`npm did not regenerate package-lock.json with exact minutes-sdk ${version}`);
+      throw new Error(`package-lock.json does not contain exact minutes-sdk ${version}`);
     }
     const changed = await changedFilesFromHead(root);
     assertOnlyPhase2Files(changed, "after pinning");

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -55,6 +55,7 @@ process.exit(result.status ?? 1);
     "npm",
     `#!/usr/bin/env node
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import path from "node:path";
 const args = process.argv.slice(2);
 await appendFile(process.env.RELEASE_SHIM_LOG, "npm " + args.join(" ") + " @ " + process.cwd() + "\\n");
@@ -73,7 +74,18 @@ if (args[0] === "pack") {
 } else if (args[0] === "install" && args.includes("--package-lock-only")) {
   const lockFile = path.join(process.cwd(), "package-lock.json");
   const lock = JSON.parse(await readFile(lockFile, "utf8"));
-  lock.packages[""].dependencies["minutes-sdk"] = packageJson.dependencies["minutes-sdk"];
+  const tarball = args.find((argument) => argument.endsWith(".tgz"));
+  if (tarball) {
+    const version = path.basename(tarball).match(/^minutes-sdk-(.+)\\.tgz$/)?.[1];
+    const integrity = "sha512-" + createHash("sha512").update(await readFile(tarball)).digest("base64");
+    const fileDependency = "file:" + tarball;
+    packageJson.dependencies["minutes-sdk"] = fileDependency;
+    await writeFile(path.join(process.cwd(), "package.json"), JSON.stringify(packageJson, null, 2) + "\\n");
+    lock.packages[""].dependencies["minutes-sdk"] = fileDependency;
+    lock.packages["node_modules/minutes-sdk"] = { version, resolved: fileDependency, integrity, license: "MIT" };
+  } else {
+    lock.packages[""].dependencies["minutes-sdk"] = packageJson.dependencies["minutes-sdk"];
+  }
   await writeFile(lockFile, JSON.stringify(lock, null, 2) + "\\n");
 }
 `,


### PR DESCRIPTION
## What changed

- make Phase 2 pack the exact local SDK and derive the MCP lock entry without querying npm
- preserve the committed registry URL and tarball integrity for the later trusted publish
- teach pre-tag CI to seed npm from that exact local tarball when MCP is pinned to the repo SDK
- keep ordinary `npm ci` behavior outside the release pin window

## Why

The trusted publishing flow correctly keeps `minutes-sdk@0.25.0` private until the reviewed tag is pushed. Phase 2 still asked npm to resolve that unpublished version, so the safe release path could not create its exact pin without prematurely publishing.

## Verification

- 57/57 focused release, version, helper, and hook tests passed
- actionlint passed
- real end-to-end Phase 2 produced only the expected MCP manifest and lockfile changes
- real MCP install succeeded from the exact local SDK tarball while npm still reports 0.24.0
- release version and site release checks passed
- no package or tag was published