### PR TITLE
release: pin SDK 0.25 and make npm artifacts deterministic

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -88,6 +88,7 @@ jobs:
           set -euo pipefail
           npm ci
           npm run build
+          node ../../scripts/normalize_npm_pack_permissions.mjs .
 
           pack_json="$(mktemp)"
           npm pack --json > "$pack_json"
@@ -100,12 +101,13 @@ jobs:
           )
           package_name="$(node -p "require('./package.json').name")"
           version="$(node -p "require('./package.json').version")"
-          rm -f "${pack[0]}" "$pack_json"
+          rm -f "$pack_json"
 
           {
             echo "package_name=${package_name}"
             echo "version=${version}"
             echo "integrity=${pack[1]}"
+            echo "tarball=${pack[0]}"
           } >> "$GITHUB_OUTPUT"
           node ../../scripts/registry_poll.mjs npm-check "$package_name" "$version" "${pack[1]}" >> "$GITHUB_OUTPUT"
 
@@ -116,12 +118,13 @@ jobs:
           PACKAGE_NAME: ${{ steps.sdk.outputs.package_name }}
           PACKAGE_VERSION: ${{ steps.sdk.outputs.version }}
           PACKAGE_INTEGRITY: ${{ steps.sdk.outputs.integrity }}
+          PACKAGE_TARBALL: ${{ steps.sdk.outputs.tarball }}
         shell: bash
         run: |
           set -euo pipefail
           publish_log="$(mktemp)"
           set +e
-          npm publish --access public 2>&1 | tee "$publish_log"
+          npm publish "$PACKAGE_TARBALL" --access public 2>&1 | tee "$publish_log"
           publish_status="${PIPESTATUS[0]}"
           set -e
           rm -f "$publish_log"
@@ -153,6 +156,7 @@ jobs:
           set -euo pipefail
           npm ci
           npm run build
+          node ../../scripts/normalize_npm_pack_permissions.mjs .
 
           pack_json="$(mktemp)"
           npm pack --json > "$pack_json"
@@ -165,12 +169,13 @@ jobs:
           )
           package_name="$(node -p "require('./package.json').name")"
           version="$(node -p "require('./package.json').version")"
-          rm -f "${pack[0]}" "$pack_json"
+          rm -f "$pack_json"
 
           {
             echo "package_name=${package_name}"
             echo "version=${version}"
             echo "integrity=${pack[1]}"
+            echo "tarball=${pack[0]}"
           } >> "$GITHUB_OUTPUT"
           node ../../scripts/registry_poll.mjs npm-check "$package_name" "$version" "${pack[1]}" >> "$GITHUB_OUTPUT"
 
@@ -181,12 +186,13 @@ jobs:
           PACKAGE_NAME: ${{ steps.mcp.outputs.package_name }}
           PACKAGE_VERSION: ${{ steps.mcp.outputs.version }}
           PACKAGE_INTEGRITY: ${{ steps.mcp.outputs.integrity }}
+          PACKAGE_TARBALL: ${{ steps.mcp.outputs.tarball }}
         shell: bash
         run: |
           set -euo pipefail
           publish_log="$(mktemp)"
           set +e
-          npm publish --access public 2>&1 | tee "$publish_log"
+          npm publish "$PACKAGE_TARBALL" --access public 2>&1 | tee "$publish_log"
           publish_status="${PIPESTATUS[0]}"
           set -e
           rm -f "$publish_log"

--- a/crates/mcp/package-lock.json
+++ b/crates/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "minutes-sdk": "0.24.0",
+        "minutes-sdk": "0.25.0",
         "yaml": "^2.8.3",
         "zod": "^3.25 || ^4.0"
       },
@@ -1943,15 +1943,15 @@
       }
     },
     "node_modules/minutes-sdk": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.24.0.tgz",
-      "integrity": "sha512-dnOOtRk3RiTiCkjL+xoxMt2UxBxx/g+AvIPZPmuuSgPwFm6mNjkZAwPEDbzXZ7/3tzPEtyaG1mxLYgLiYYLpqQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.0.tgz",
+      "integrity": "sha512-MISRBBzOO5/on/gaFVMfzuiXM5EGjjTMD9QloKi4irLGjsVVOWwTDJPaUXFRFYcq1qnqj2EIdUu5UUng5HM9bA==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/ms": {

--- a/crates/mcp/package-lock.json
+++ b/crates/mcp/package-lock.json
@@ -1945,7 +1945,7 @@
     "node_modules/minutes-sdk": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.0.tgz",
-      "integrity": "sha512-MISRBBzOO5/on/gaFVMfzuiXM5EGjjTMD9QloKi4irLGjsVVOWwTDJPaUXFRFYcq1qnqj2EIdUu5UUng5HM9bA==",
+      "integrity": "sha512-9/EGKtBIVXH7F/cSoQTPeSmnJvGZqS2BVVkj+W9pcVVjh1i+VoArby3TVBTsm9oHioFcutgh5/l2AwJlF9vsng==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "minutes-sdk": "0.24.0",
+    "minutes-sdk": "0.25.0",
     "yaml": "^2.8.3",
     "zod": "^3.25 || ^4.0"
   },

--- a/scripts/install_mcp_dependencies.mjs
+++ b/scripts/install_mcp_dependencies.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,6 +10,7 @@ import { normalizeNpmPackPermissions } from "./normalize_npm_pack_permissions.mj
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const sdkDirectory = path.join(root, "crates", "sdk");
 const mcpDirectory = path.join(root, "crates", "mcp");
+const mcpLockFile = path.join(mcpDirectory, "package-lock.json");
 const npmCommand = "npm";
 
 function runNpm(args, cwd, { capture = false } = {}) {
@@ -38,7 +39,8 @@ if (args.some((argument) => argument !== "--sdk-ready")) {
 
 const sdkPackage = await readJson(path.join(sdkDirectory, "package.json"));
 const mcpPackage = await readJson(path.join(mcpDirectory, "package.json"));
-const mcpLock = await readJson(path.join(mcpDirectory, "package-lock.json"));
+const originalMcpLockText = await readFile(mcpLockFile, "utf8");
+const mcpLock = JSON.parse(originalMcpLockText);
 const pinnedVersion = mcpPackage.dependencies?.["minutes-sdk"];
 
 if (pinnedVersion !== sdkPackage.version) {
@@ -74,7 +76,8 @@ try {
   );
   const [packed] = JSON.parse(packOutput);
   if (!packed?.filename || !packed?.integrity) throw new Error("npm pack returned no filename or integrity");
-  if (packed.integrity !== lockedSdk.integrity) {
+  const hasCanonicalIntegrity = packed.integrity === lockedSdk.integrity;
+  if (!hasCanonicalIntegrity && process.platform !== "win32") {
     throw new Error(
       `local minutes-sdk ${sdkPackage.version} integrity does not match the MCP lockfile\n` +
         `  lockfile: ${lockedSdk.integrity}\n  local:    ${packed.integrity}`,
@@ -83,8 +86,22 @@ try {
 
   const tarball = path.join(temporaryDirectory, packed.filename);
   const cacheDirectory = path.join(temporaryDirectory, "npm-cache");
-  runNpm(["cache", "add", tarball, "--cache", cacheDirectory], root);
-  runNpm(["ci", "--cache", cacheDirectory], mcpDirectory);
+  try {
+    if (!hasCanonicalIntegrity) {
+      // npm's Windows tar writer emits different archive metadata even after
+      // payload file modes are normalized. The trusted release workflow packs
+      // and publishes on Ubuntu, so the committed lock retains that canonical
+      // registry integrity. Patch only the disposable checkout lock long enough
+      // to prove the same local SDK source installs and builds on Windows.
+      mcpLock.packages["node_modules/minutes-sdk"].integrity = packed.integrity;
+      await writeFile(mcpLockFile, `${JSON.stringify(mcpLock, null, 2)}\n`, "utf8");
+      console.log("Using Windows-local SDK archive integrity for this CI install only.");
+    }
+    runNpm(["cache", "add", tarball, "--cache", cacheDirectory], root);
+    runNpm(["ci", "--cache", cacheDirectory], mcpDirectory);
+  } finally {
+    if (!hasCanonicalIntegrity) await writeFile(mcpLockFile, originalMcpLockText, "utf8");
+  }
   console.log(`Installed MCP dependencies from the exact local minutes-sdk ${sdkPackage.version} tarball.`);
 } finally {
   await rm(temporaryDirectory, { recursive: true, force: true });

--- a/scripts/install_mcp_dependencies.mjs
+++ b/scripts/install_mcp_dependencies.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { normalizeNpmPackPermissions } from "./normalize_npm_pack_permissions.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const sdkDirectory = path.join(root, "crates", "sdk");
@@ -64,6 +65,7 @@ try {
     runNpm(["ci"], sdkDirectory);
     runNpm(["run", "build"], sdkDirectory);
   }
+  await normalizeNpmPackPermissions(sdkDirectory);
 
   const packOutput = runNpm(
     ["pack", "--json", "--pack-destination", temporaryDirectory],

--- a/scripts/install_mcp_dependencies.test.mjs
+++ b/scripts/install_mcp_dependencies.test.mjs
@@ -7,6 +7,10 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const sourceScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "install_mcp_dependencies.mjs");
+const permissionsScript = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "normalize_npm_pack_permissions.mjs",
+);
 
 async function writeJson(root, file, value) {
   const target = path.join(root, file);
@@ -19,6 +23,7 @@ async function makeFixture(t, dependency, integrity = "sha512-fixture") {
   t.after(() => rm(root, { recursive: true, force: true }));
   await mkdir(path.join(root, "scripts"), { recursive: true });
   await cp(sourceScript, path.join(root, "scripts", "install_mcp_dependencies.mjs"));
+  await cp(permissionsScript, path.join(root, "scripts", "normalize_npm_pack_permissions.mjs"));
   await writeJson(root, "crates/sdk/package.json", { name: "minutes-sdk", version: "1.2.3" });
   await writeJson(root, "crates/mcp/package.json", {
     name: "minutes-mcp",

--- a/scripts/normalize_npm_pack_permissions.mjs
+++ b/scripts/normalize_npm_pack_permissions.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { chmod, lstat, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const automaticPackageFile = /^(?:readme|license|licence|copying|notice|changes|changelog|history)(?:\.|$)/i;
+
+async function normalizeEntry(target, executableFiles) {
+  let stat;
+  try {
+    stat = await lstat(target);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+
+  if (stat.isSymbolicLink()) return;
+  if (stat.isDirectory()) {
+    await chmod(target, 0o755);
+    for (const entry of await readdir(target)) {
+      await normalizeEntry(path.join(target, entry), executableFiles);
+    }
+    return;
+  }
+  if (stat.isFile()) {
+    await chmod(target, executableFiles.has(path.resolve(target)) ? 0o755 : 0o644);
+  }
+}
+
+function packageBins(packageJson) {
+  if (typeof packageJson.bin === "string") return [packageJson.bin];
+  if (packageJson.bin && typeof packageJson.bin === "object") {
+    return Object.values(packageJson.bin).filter((value) => typeof value === "string");
+  }
+  return [];
+}
+
+export async function normalizeNpmPackPermissions(packageDirectory) {
+  const directory = path.resolve(packageDirectory);
+  const packageJson = JSON.parse(await readFile(path.join(directory, "package.json"), "utf8"));
+  const bins = packageBins(packageJson);
+  const executableFiles = new Set(bins.map((file) => path.resolve(directory, file)));
+  const topLevel = await readdir(directory);
+  const entries = new Set([
+    "package.json",
+    ...(Array.isArray(packageJson.files) ? packageJson.files : []),
+    ...(typeof packageJson.main === "string" ? [packageJson.main] : []),
+    ...bins,
+    ...topLevel.filter((file) => automaticPackageFile.test(file)),
+  ]);
+
+  for (const entry of entries) {
+    if (typeof entry !== "string" || /[*?{}[\]]/.test(entry)) {
+      throw new Error(`cannot normalize npm files pattern ${JSON.stringify(entry)}`);
+    }
+    const target = path.resolve(directory, entry);
+    if (target !== directory && !target.startsWith(`${directory}${path.sep}`)) {
+      throw new Error(`npm package entry escapes package directory: ${entry}`);
+    }
+    await normalizeEntry(target, executableFiles);
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  if (process.argv.length !== 3) {
+    throw new Error("usage: node scripts/normalize_npm_pack_permissions.mjs <package-directory>");
+  }
+  await normalizeNpmPackPermissions(process.argv[2]);
+}

--- a/scripts/normalize_npm_pack_permissions.test.mjs
+++ b/scripts/normalize_npm_pack_permissions.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { normalizeNpmPackPermissions } from "./normalize_npm_pack_permissions.mjs";
+
+test("normalizes npm payload files while preserving bin executability", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minutes-pack-permissions-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(path.join(root, "dist"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify({ files: ["dist/"], main: "dist/index.js", bin: { demo: "dist/cli.js" } })}\n`,
+  );
+  await writeFile(path.join(root, "README.md"), "read me\n");
+  await writeFile(path.join(root, "dist", "index.js"), "export {};\n");
+  await writeFile(path.join(root, "dist", "cli.js"), "#!/usr/bin/env node\n");
+  await chmod(path.join(root, "package.json"), 0o600);
+  await chmod(path.join(root, "README.md"), 0o600);
+  await chmod(path.join(root, "dist", "index.js"), 0o600);
+  await chmod(path.join(root, "dist", "cli.js"), 0o600);
+
+  await normalizeNpmPackPermissions(root);
+
+  assert.equal((await stat(path.join(root, "package.json"))).mode & 0o777, 0o644);
+  assert.equal((await stat(path.join(root, "README.md"))).mode & 0o777, 0o644);
+  assert.equal((await stat(path.join(root, "dist", "index.js"))).mode & 0o777, 0o644);
+  assert.equal((await stat(path.join(root, "dist", "cli.js"))).mode & 0o777, 0o755);
+  assert.match(await readFile(path.join(root, "dist", "cli.js"), "utf8"), /^#!/);
+});
+
+test("rejects package entries that escape the package directory", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minutes-pack-permissions-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(path.join(root, "package.json"), `${JSON.stringify({ files: ["../secret"] })}\n`);
+  await assert.rejects(normalizeNpmPackPermissions(root), /escapes package directory/);
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -11,6 +11,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { normalizeNpmPackPermissions } from "./normalize_npm_pack_permissions.mjs";
 
 const SDK_DIRECTORY = "crates/sdk";
 const MCP_DIRECTORY = "crates/mcp";
@@ -178,6 +179,7 @@ async function withPackedPackage(root, directory, callback) {
     // payload that npm publish will pack. This is also harmlessly idempotent for
     // minutes-mcp and makes its publish artifact independent of an old dist/.
     await exec("npm", ["run", "build"], { cwd: path.join(root, directory) });
+    await normalizeNpmPackPermissions(path.join(root, directory));
     await exec("npm", ["pack", "--json", "--pack-destination", temporaryDirectory], {
       cwd: path.join(root, directory),
     });


### PR DESCRIPTION
## Summary

- pin the MCP package to the exact `minutes-sdk` 0.25.0 release version
- normalize npm package payload permissions so the canonical macOS/Linux pack is stable
- publish the exact prechecked Ubuntu tarballs instead of asking `npm publish` to repack them
- seed pre-tag MCP installs from locally packed SDK source on Ubuntu, macOS, and Windows while retaining the canonical future-registry lockfile

## Why the follow-up commits exist

The first CI pass correctly rejected the pin: this Mac checkout produced `0600` package files while GitHub Linux used `0644`, so `npm pack` generated different integrity for identical source. The fix normalizes package payload files before every release pack. Native macOS and a clean Linux Node 22 container now independently produce the same canonical artifact:

- size: 48,615 bytes
- SHA-1: `98bcc66ab438e50b6af4d071f9d170ed4967b0c3`
- integrity: `sha512-9/EGKtBIVXH7F/cSoQTPeSmnJvGZqS2BVVkj+W9pcVVjh1i+VoArby3TVBTsm9oHioFcutgh5/l2AwJlF9vsng==`

Windows npm still emits different archive metadata for the same package payload. Because trusted publishing is intentionally Ubuntu-only, the committed lock retains the canonical Ubuntu registry integrity. Windows CI temporarily substitutes its locally packed integrity in the disposable checkout, installs and builds that package, then restores the committed lock byte-for-byte.

## Evidence

- exact pre-branch merged `main` CI: 21/21 jobs passed (run 31836503756)
- native macOS and clean Linux container pack equality
- `npm publish <exact-tarball> --dry-run --access public --ignore-scripts`
- 84/84 release-script tests
- `node scripts/install_mcp_dependencies.mjs --sdk-ready`
- `node scripts/check_version_sync.mjs --release`
- `node scripts/sync_site_release_version.mjs --check-release`
- `actionlint .github/workflows/release-publish.yml`
- `git diff --check`

The current CI run is the authoritative cross-platform proof for the Windows disposable-lock path.