### PR TITLE
fix: pack MCP against unpublished release SDK

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -170,10 +170,21 @@ async function assertTreeVersion(root, version) {
   }
 }
 
-async function withPackedPackage(root, directory, callback) {
+async function withPackedPackage(root, directory, callback, { localSdkTarball } = {}) {
   const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "minutes-release-pack-"));
   try {
-    await exec("npm", ["ci"], { cwd: path.join(root, directory) });
+    if (localSdkTarball === undefined) {
+      await exec("npm", ["ci"], { cwd: path.join(root, directory) });
+    } else {
+      if (directory !== MCP_DIRECTORY) {
+        throw new Error("a local SDK tarball may only be used while packing minutes-mcp");
+      }
+      await exec(
+        "npm",
+        ["install", localSdkTarball, "--no-save", "--package-lock=false"],
+        { cwd: path.join(root, directory) },
+      );
+    }
     // minutes-sdk builds in prepublishOnly, a lifecycle that npm pack does not
     // run. Build explicitly so the provenance tarball contains the same dist/
     // payload that npm publish will pack. This is also harmlessly idempotent for
@@ -196,8 +207,8 @@ async function withPackedPackage(root, directory, callback) {
   }
 }
 
-async function packPackage(root, directory) {
-  return withPackedPackage(root, directory, ({ integrity }) => integrity);
+async function packPackage(root, directory, options) {
+  return withPackedPackage(root, directory, ({ integrity }) => integrity, options);
 }
 
 async function testMcpAgainstSdkTarball(root, tarball, sdkIntegrity) {
@@ -424,11 +435,16 @@ async function tagRelease(root, version, skipCiCheck) {
   await assertCiGreen(root, head, skipCiCheck);
   await runVersionCheck(root, true);
   await assertTreeVersion(root, version);
-  const sdkIntegrity = await packPackage(root, SDK_DIRECTORY);
+  let sdkIntegrity;
+  let mcpIntegrity;
+  await withPackedPackage(root, SDK_DIRECTORY, async ({ tarball, integrity }) => {
+    sdkIntegrity = integrity;
 
-  // Build and pack MCP before creating the tag. npm publish has no MCP build
-  // lifecycle, so prove both registry inputs pack before freezing the tag.
-  const mcpIntegrity = await packPackage(root, MCP_DIRECTORY);
+    // Build and pack MCP against this exact, still-unpublished SDK artifact
+    // before creating the tag. The trusted workflow publishes SDK first, but
+    // the pre-tag proof cannot depend on a registry version that does not exist.
+    mcpIntegrity = await packPackage(root, MCP_DIRECTORY, { localSdkTarball: tarball });
+  });
 
   const tag = await ensureAnnotatedTag(root, version, head);
   console.log(`Push it only after the draft GitHub release is ready:\n  git push origin ${tag}`);

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -251,6 +251,7 @@ test("happy path preflights, pins, and tags without publishing before the tag pu
   assert.equal(mcpPackage.dependencies["minutes-sdk"], version);
   const log = await readFile(fixture.log, "utf8");
   assert.match(log, /npm pack .*crates\/sdk/);
+  assert.match(log, /npm install .*minutes-sdk-1\.2\.3\.tgz --no-save --package-lock=false .*crates\/mcp/);
   assert.match(log, /npm pack .*crates\/mcp/);
   assert.doesNotMatch(log, /npm publish/);
 });
@@ -303,6 +304,7 @@ test("phase1 is optional and tag packs current inputs without publishing", async
   assert.match(result.stdout, /Packed minutes-sdk .* and minutes-mcp .* without publishing/);
   assert.equal(git(fixture.root, "tag", "--list", `v${version}`).stdout.trim(), `v${version}`);
   const log = await readFile(fixture.log, "utf8");
+  assert.match(log, /npm install .*minutes-sdk-1\.2\.3\.tgz --no-save --package-lock=false .*crates\/mcp/);
   assert.doesNotMatch(log, /npm publish/);
 });
 


### PR DESCRIPTION
## Summary

- keep the freshly packed SDK tarball alive during the pre-tag release check
- install MCP dependencies from that exact local SDK artifact instead of querying npm for the intentionally unpublished 0.25.0 version
- build and pack MCP before creating the local tag

## Why

The release pin is deliberately committed before registry publication, and registry publication deliberately begins only after the tag push. Plain `npm ci` in the tag command therefore cannot resolve `minutes-sdk@0.25.0`. This closes that final ordering gap without publishing anything pre-tag.

## Evidence

- 84/84 release-script tests
- tests assert both tag paths install `minutes-sdk-1.2.3.tgz` locally before packing MCP
- real clean-main proof: canonical SDK 0.25.0 pack succeeded
- real MCP install from that tarball: zero vulnerabilities
- real MCP build and 0.25.0 pack succeeded
- release version and site-release checks pass
- `git diff --check`