### PR TITLE
fix: sign release DMG and preserve draft uploads

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -50,6 +50,11 @@ jobs:
           python3 scripts/check_sherpa_packaging.py
           python3 scripts/check_sherpa_packaging.py --self-test
 
+      - name: Check release uploads preserve drafts
+        run: |
+          python3 scripts/check_release_upload_drafts.py
+          python3 scripts/check_release_upload_drafts.py --self-test
+
       - name: Verify broken workflow is rejected
         run: |
           if docker run --rm \

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -124,6 +124,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          draft: true
           files: ${{ matrix.asset }}
 
       # Windows needs the MSVC runtime beside the executable. Nothing ships it
@@ -203,6 +204,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'x86_64-pc-windows-msvc'
         with:
+          draft: true
           files: minutes-windows-x64.zip
 
       # Additive second artifact for Linux only: the same CLI plus the sherpa
@@ -286,6 +288,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'x86_64-unknown-linux-gnu'
         with:
+          draft: true
           files: minutes-linux-x64-sherpa.tar.gz
 
   checksums:
@@ -312,4 +315,5 @@ jobs:
       - name: Upload checksum release asset
         uses: softprops/action-gh-release@v3
         with:
+          draft: true
           files: SHA256SUMS.txt

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -333,6 +333,7 @@ jobs:
 
       - name: Create DMG
         env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
@@ -343,6 +344,12 @@ jobs:
             --app target/release/bundle/macos/Minutes.app \
             --version "$VERSION" \
             --output "$dmg"
+          # Notarization and stapling validate the contents but do not give the
+          # disk image its own primary signature. Gatekeeper's `--type open`
+          # assessment requires that outer Developer ID signature.
+          codesign --force --timestamp \
+            --sign "$APPLE_SIGNING_IDENTITY" "$dmg"
+          codesign --verify --strict --verbose=4 "$dmg"
           xcrun notarytool submit "$dmg" \
             --key "$APPLE_API_KEY_PATH" \
             --key-id "$APPLE_API_KEY" \

--- a/.github/workflows/release-windows-desktop.yml
+++ b/.github/workflows/release-windows-desktop.yml
@@ -168,6 +168,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
         with:
+          draft: true
           files: |
             minutes-desktop-windows-x64.exe
             minutes-desktop-windows-x64.zip

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from "node:fs";
 // These whole-file hashes prevent dead/comment-only duplicate code from
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
-  release: "e17a89af9635b4769952a2b7e27ddb614dfd68abfece6e76ce03e806799025ee",
+  release: "3a71697445c183e033afeaa9fc097de990870d934933a2cbba35c2e0289d677a",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   build: "24fca291f683c7c6cc0599e7e88514f4f3374e357983298b857b4fef0acada9f",
   dev: "4b8cacb078a06320c9718c6f4d35801125bfa8629e71962caa841a36dcf600b4",

--- a/scripts/check_release_upload_drafts.py
+++ b/scripts/check_release_upload_drafts.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Require release asset upload actions to preserve prepared draft releases.
+
+softprops/action-gh-release creates or updates the release for a tag. If an
+asset-upload step omits ``draft: true``, it can publish a release while other
+platform lanes are still running. This guard covers every release workflow so
+adding a new upload step cannot silently reintroduce that failure mode.
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = REPO / ".github/workflows"
+ACTION_PREFIX = "softprops/action-gh-release@"
+
+
+def release_workflows() -> list[Path]:
+    return sorted(WORKFLOW_DIR.glob("release-*.yml"))
+
+
+def check_document(document: object, source: str) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(document, dict):
+        return [f"{source}: workflow is not a mapping"]
+
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return [f"{source}: workflow has no jobs mapping"]
+
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for index, step in enumerate(job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not uses.startswith(ACTION_PREFIX):
+                continue
+            with_values = step.get("with")
+            if not isinstance(with_values, dict) or with_values.get("draft") is not True:
+                label = step.get("name") or f"step {index + 1}"
+                failures.append(
+                    f"{source}: job {job_name!r}, {label!r} must set "
+                    "`with: draft: true`; otherwise an asset upload can publish "
+                    "the release before every platform lane finishes"
+                )
+    return failures
+
+
+def load(path: Path) -> object:
+    return yaml.safe_load(path.read_text(encoding="utf8"))
+
+
+def check_repo() -> list[str]:
+    failures: list[str] = []
+    for path in release_workflows():
+        failures.extend(check_document(load(path), str(path.relative_to(REPO))))
+    return failures
+
+
+def self_test() -> int:
+    found = 0
+    failed = 0
+    for path in release_workflows():
+        document = load(path)
+        jobs = document.get("jobs") if isinstance(document, dict) else None
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            for index, step in enumerate(job.get("steps") or []):
+                if not isinstance(step, dict):
+                    continue
+                uses = step.get("uses")
+                if not isinstance(uses, str) or not uses.startswith(ACTION_PREFIX):
+                    continue
+                found += 1
+                mutated = copy.deepcopy(document)
+                mutated_step = mutated["jobs"][job_name]["steps"][index]
+                mutated_step.setdefault("with", {}).pop("draft", None)
+                if check_document(mutated, str(path.relative_to(REPO))):
+                    print(f"self-test ok: rejected missing draft flag in {path.name}:{job_name}")
+                else:
+                    print(
+                        f"self-test FAILED: accepted missing draft flag in {path.name}:{job_name}",
+                        file=sys.stderr,
+                    )
+                    failed += 1
+    if found == 0:
+        print("self-test FAILED: found no release upload actions", file=sys.stderr)
+        return 1
+    return 1 if failed else 0
+
+
+def main() -> int:
+    if sys.argv[1:] == ["--self-test"]:
+        return self_test()
+    if sys.argv[1:]:
+        print("usage: check_release_upload_drafts.py [--self-test]", file=sys.stderr)
+        return 2
+
+    failures = check_repo()
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    if failures:
+        return 1
+    print("release_upload_draft_policy=passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- sign the outer DMG with the configured Developer ID identity before notarization and Gatekeeper assessment
- verify that signature before submitting the DMG to Apple
- keep every CLI release-asset upload explicitly attached to a draft release
- refresh the sealed macOS release-workflow hash

## Why

Release macOS run 31841633657 built and signed Minutes.app, received an Accepted notarization result for the DMG, and stapled it successfully, but the final Gatekeeper assessment rejected the disk image with source=no usable signature. The disk image itself had never received a primary Developer ID signature.

Separately, the v0.25.0 CLI asset upload jobs omitted draft: true, which caused the prepared release to become public before the macOS lane completed.

## Verification

- actionlint on both changed workflows
- graph-worker packaging seal check
- Apple Speech worker packaging check
- signing-secret scope check
- node --test scripts/*.test.mjs (84 passed)
- git diff --check

After merge, dispatch release-macos.yml from main with tag v0.25.0. The workflow definition comes from corrected main while checkout remains pinned to the immutable release tag.