### PR TITLE
fix(deps): take the patched nanoid in the two lagging lockfiles

### DIFF
--- a/crates/sdk/package-lock.json
+++ b/crates/sdk/package-lock.json
@@ -1374,9 +1374,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/docs/demo/package-lock.json
+++ b/docs/demo/package-lock.json
@@ -2929,9 +2929,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Clears the Dependabot failure that has been red on main since 2026-08-13.

## It was not a configuration fault

The updater was right and could not act. nanoid 3.3.18 patches the advisory, and the existing `^3.3.16` range already permits it, but the security job runs with `allowed-updates` restricted to **direct** dependencies while nanoid is transitive (`vitest -> vite -> postcss`). So it reported a conflicting dependency and exited non-zero. Its own message named the remedy: update the parent or pin an override.

Note `/docs/demo` is not in `dependabot.yml` at all. Security updates work from the dependency graph rather than that config, which is why a directory nobody configured was failing the job.

## Impact is build-time only

Worth stating plainly rather than letting a security advisory imply more than it should:

| lockfile | nanoid | shipped? |
|---|---|---|
| `crates/sdk` | 3.3.16 -> 3.3.18 | no, marked `dev`, via vitest. The published package's only runtime dependency is `yaml` |
| `docs/demo` | 3.3.17 -> 3.3.18 | no, local Remotion demo |
| `crates/mcp`, `site`, `docs/demo-video` | already 3.3.18 | n/a |

No consumer of `minutes-sdk` or `minutes-mcp` was exposed. The reason to fix it is that a permanently failing security updater hides the next real alert behind it.

## Surgical, not regenerated

`npm update nanoid --package-lock-only` produces the right version but also strips `libc` metadata from optional platform binaries, because this machine's npm (10.9.8) is older than whatever wrote these files. That churn is unrelated to the advisory and would quietly change which prebuilt binary npm selects on musl versus glibc, so I reverted it and edited the two nanoid entries directly.

The diff is six lines: `version`, `resolved` and `integrity` on each entry, with the integrity taken from the registry rather than computed locally.

## Verification

`npm ci` accepts the hand-edited lockfile and installs 3.3.18, which is the check that matters for a hand edit. The SDK typechecks and its 153 tests pass. `npm ci` did not rewrite the lockfile afterwards.

I have not touched `.github/dependabot.yml`. Adding `/docs/demo` there is a separate judgment about whether that demo should get weekly version updates at all, and this PR should not decide it.