### PR TITLE
fix(sdk,mcp): stop the test harness racing the operation it measures

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -1544,5 +1544,5 @@ describe("stable corpus lease", () => {
         withStableCorpusLease(root, () => "must not reuse")
       ).rejects.toThrow("killed without confirming it died");
     });
-  }, 10_000);
+  });
 });

--- a/crates/mcp/vitest.config.ts
+++ b/crates/mcp/vitest.config.ts
@@ -4,6 +4,19 @@ export default defineConfig({
   test: {
     root: ".",
     include: ["src/**/*.test.ts", "ui/src/**/*.test.ts"],
-    testTimeout: 15_000,
+    // Above every operation deadline the suites exercise, deliberately.
+    //
+    // DEFAULT_BOUND_READ_TIMEOUT_MS and DEFAULT_AUTHORIZATION_TIMEOUT_MS are
+    // both 15_000, so at 15_000 here the harness and the operation it measures
+    // shared a deadline and vitest won it, because its clock starts first. A
+    // read or lease that ran to its own limit was killed roughly 10ms short of
+    // reporting why, and the suite printed "Test timed out in 15000ms" with no
+    // cause. 30 of the 49 corpus-lease cases inherited that collision, which is
+    // why the case that failed moved around and never explained itself (#617).
+    //
+    // Demonstrated rather than reasoned about: an operation stalled to its own
+    // timeout fails here at 15_000 and passes at 30_000, unchanged otherwise.
+    // A harness must outlive what it measures, or it reports itself.
+    testTimeout: 30_000,
   },
 });

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -1544,5 +1544,5 @@ describe("stable corpus lease", () => {
         withStableCorpusLease(root, () => "must not reuse")
       ).rejects.toThrow("killed without confirming it died");
     });
-  }, 10_000);
+  });
 });

--- a/crates/sdk/vitest.config.ts
+++ b/crates/sdk/vitest.config.ts
@@ -4,6 +4,19 @@ export default defineConfig({
   test: {
     root: ".",
     include: ["src/**/*.test.ts"],
-    testTimeout: 15_000,
+    // Above every operation deadline the suites exercise, deliberately.
+    //
+    // DEFAULT_BOUND_READ_TIMEOUT_MS and DEFAULT_AUTHORIZATION_TIMEOUT_MS are
+    // both 15_000, so at 15_000 here the harness and the operation it measures
+    // shared a deadline and vitest won it, because its clock starts first. A
+    // read or lease that ran to its own limit was killed roughly 10ms short of
+    // reporting why, and the suite printed "Test timed out in 15000ms" with no
+    // cause. 30 of the 49 corpus-lease cases inherited that collision, which is
+    // why the case that failed moved around and never explained itself (#617).
+    //
+    // Demonstrated rather than reasoned about: an operation stalled to its own
+    // timeout fails here at 15_000 and passes at 30_000, unchanged otherwise.
+    // A harness must outlive what it measures, or it reports itself.
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Root cause for #617, found by asking why the failures never explained themselves rather than by chasing contention.

## The symptom that pointed at it

Every #617 failure is a 15s timeout on a case that could not have caused it, and the case moves around between suites, platforms and runs. That is not what a contended resource looks like. It is what a **shared deadline** looks like.

```
vitest testTimeout                 15_000
DEFAULT_BOUND_READ_TIMEOUT_MS      15_000
DEFAULT_AUTHORIZATION_TIMEOUT_MS   15_000
```

**30 of the 49** corpus-lease cases call those APIs without passing a shorter timeout, so they inherit exactly the harness's own deadline. When an operation runs to its limit, vitest kills the test first, because its clock started first. The operation is roughly 10ms short of reporting why.

## It is a false failure, not just a bad message

This is the part that makes it worth fixing rather than instrumenting. The operation was behaving correctly and was about to reject with its own error. The test failed for being slightly slow, not for being wrong.

Demonstrated, with nothing else changed:

| harness deadline | result |
|---|---|
| 15,000 ms | `× Test timed out in 15000ms` at **15010 ms** |
| 30,000 ms | `✓ passed` |

That also explains the Windows-only bias without needing Windows to be special in kind: it is only slow enough there for these operations to get close enough to 15s to lose the race.

## The change

`testTimeout` to 30_000 in both configs, above every operation deadline the suites exercise, with the reasoning recorded where the number lives.

Also removes the inverse collision: `poisons admission when an asynchronous projection ignores cancellation` wrapped a **10s** per-test deadline around a **15s** operation. Its own `expect(Date.now() - started).toBeLessThan(2_500)` is what actually enforces promptness there, and it is untouched, so the intent survives.

## What I did first, and why it is not in this PR

I tried to reproduce by contention: pinned to 2 cores with three busy loops competing. Three runs, all green, and the duration barely moved (37.3s against 39.2s unloaded). That is the evidence that sent me here: the suite is timer-bound, not CPU-bound, so contention was never going to be the lever and the Windows VM would have cost an hour to tell me the same thing.

## Honest scope

This fixes the class of #617 failures where an operation loses a photo finish with the harness, which is what both failures I have logs for look like: the budget error on `charges paced protocol transients` and the timeout on `fails closed when every bounded reader at the cap is active`.

It does not prove there is no second cause. If #617 recurs after this, the failure will now carry the operation's own error rather than an anonymous timeout, which is the thing that has been missing.

I would not close #617 on this PR. I would let it run and close it on evidence.

SDK 153 passed, MCP 314 passed, durations unchanged, sdk/mcp mirror guard reports all six files identical.