### PR TITLE
feat(release): build and attach the Desktop Extension bundle

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -291,9 +291,79 @@ jobs:
           draft: true
           files: minutes-linux-x64-sherpa.tar.gz
 
+  # The Desktop Extension bundle. Built here rather than by hand because it is
+  # the artifact the Claude Desktop directory serves, and a hand step is one
+  # that gets skipped: v0.25.1 shipped every other asset automatically and was
+  # missing this one until someone counted the assets against the previous
+  # release. That release existed specifically to fix the extension.
+  mcpb:
+    name: Desktop Extension bundle
+    runs-on: ubuntu-latest
+    needs: release_readiness
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: Build the MCP server
+        working-directory: crates/mcp
+        run: |
+          npm ci
+          npm run build
+
+      - name: Pack the bundle
+        run: |
+          npm install -g @anthropic-ai/mcpb
+          ./scripts/pack_mcpb.sh minutes.mcpb
+
+      - name: The bundle must be healthy and match this tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+          # The same guard CI runs, so a dev-only package leaking into the
+          # bundle fails the release rather than shipping it.
+          ./scripts/check_mcpb_bundle.sh minutes.mcpb
+
+          bundled=$(python3 -c "import zipfile,json;print(json.loads(zipfile.ZipFile('minutes.mcpb').read('manifest.json'))['version'])")
+          echo "bundle manifest version: $bundled"
+
+          # Only a tag run has a version to compare against. On
+          # workflow_dispatch, ref_name is a branch, and comparing the bundle
+          # to "main" would fail a build that is otherwise fine.
+          if [ "${REF_TYPE:-}" = "tag" ]; then
+            expected="${REF_NAME#v}"
+            if [ "$bundled" != "$expected" ]; then
+              echo "::error::bundle manifest says $bundled but this tag is $expected"
+              exit 1
+            fi
+            echo "bundle matches tag $expected"
+          else
+            echo "not a tag run, skipping the version comparison"
+          fi
+
+      # Through the artifact store as well, so the checksums job includes it in
+      # SHA256SUMS.txt. Every other published asset has a checksum; this one
+      # never has, because it was uploaded by hand after the fact.
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: minutes.mcpb
+          path: minutes.mcpb
+
+      - name: Upload bundle release asset
+        uses: softprops/action-gh-release@v3
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          files: minutes.mcpb
+
   checksums:
     name: Publish CLI checksums
-    needs: [release_readiness, build]
+    needs: [release_readiness, build, mcpb]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/docs/release/procedure.md
+++ b/docs/release/procedure.md
@@ -173,10 +173,31 @@ followers' feeds and becomes "latest". If any release workflow fails, do not
 move or replace the tag; rerun an idempotent job where appropriate, or follow
 the immutable-tag recovery policy in `channels.md` and cut a new patch release.
 
-### 12. Build and upload .mcpb
+### 12. Confirm the .mcpb was built and attached
+
+The `Desktop Extension bundle` job in `Release CLI Binaries` packs it, runs the
+bundle guard, asserts the manifest version equals the tag, and attaches it to
+the draft. Its checksum lands in `SHA256SUMS.txt` like every other asset.
+
+**Confirm it, do not assume it.** This was a manual step until v0.25.1, where
+every other asset was attached automatically and the `.mcpb` was missing, in a
+release that existed specifically to fix the extension. Nothing failed; the step
+was simply skipped, and it was noticed only by counting assets against the
+previous release.
+
 ```bash
-./scripts/pack_mcpb.sh   # use this, not `mcpb pack .`; it swaps manifest.mcpb.json's Claude listing into the bundle
-./scripts/check_mcpb_bundle.sh minutes.mcpb   # same guard CI runs; catches manifest drift before upload
+gh release view vX.Y.Z --json assets --jq '.assets[].name' | grep mcpb
+grep mcpb SHA256SUMS.txt      # the bundle now has a published checksum
+```
+
+If you ever need to build it by hand, for a re-upload or a listing fix, note
+that the Claude Desktop listing renders `manifest.mcpb.json`, not
+`manifest.json`, and `pack_mcpb.sh` swaps the former into the bundle. Editing
+only `manifest.json` leaves the listing text unchanged.
+
+```bash
+./scripts/pack_mcpb.sh minutes.mcpb   # not `mcpb pack .`
+./scripts/check_mcpb_bundle.sh minutes.mcpb
 gh release upload vX.Y.Z minutes.mcpb --clobber
 ```
 


### PR DESCRIPTION
Closes the last hand-uploaded asset in the release path, and it is the one that matters most right now: the `.mcpb` is what the Claude Desktop directory serves.

## Why

v0.25.1 attached every other asset automatically and shipped without the `.mcpb`, in a release that existed specifically to fix the Desktop Extension. Nothing failed. The step was simply skipped, and it was noticed only because I counted the assets against the previous release. Had I not, the release would have fixed the extension and published the broken bundle.

That is the same shape as the frozen Homebrew cask, the sherpa archive, and the bump script: a step that only runs at release time, kept alive by memory.

## What the job does

A `Desktop Extension bundle` job in `Release CLI Binaries`:

1. Builds the MCP server and packs the bundle with `pack_mcpb.sh`
2. Runs `check_mcpb_bundle.sh`, the same guard CI runs, so a dev-only package leaking into the bundle fails the release instead of shipping
3. Asserts the bundled manifest version equals the tag
4. Uploads through the artifact store **and** as a release asset with `draft: true`

Two details worth calling out.

**The checksum.** Going through the artifact store means `checksums` picks it up, so the bundle appears in `SHA256SUMS.txt`. Every other published asset had a checksum and this one never did, because it arrived by hand after the fact.

**`draft: true`.** Required, and not incidental: omitting it is exactly what published the v0.25.0 draft prematurely and suppressed the Homebrew automation (#770).

## The version assertion

Packing reads the working tree, so a stale checkout would ship a bundle wearing the wrong version, and nothing downstream would notice. Verified by simulation rather than assumed: a bundle reading `0.25.1` against tag `v0.26.0` fails the step with the versions named.

It is skipped on `workflow_dispatch`, where `ref_name` is a branch. Comparing a bundle against `"main"` would fail a build that is otherwise sound, and my first draft of the condition did exactly that.

## Verification

The job's steps were run locally, not only linted: `rm -rf node_modules`, clean `npm ci`, build, pack, guard exit 0, and both branches of the version assertion checked. actionlint clean by exit code.

## Procedure

Step 12 now says to **confirm** the asset rather than produce it, with the commands to check both the asset and its checksum. It also records that the Claude Desktop listing renders `manifest.mcpb.json` rather than `manifest.json`, which is how the v0.25.1 setup text initially landed in the wrong file and had to be rebuilt.