### PR TITLE
fix(core): say why diarization produced no speaker labels

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6502,8 +6502,8 @@ fn cmd_diagnose(path: &Path, title: Option<&str>, config: &Config) -> Result<()>
             );
             std::collections::HashMap::new()
         }
-        minutes_core::diarize::DiarizationOutcome::NotConfigured => {
-            eprintln!("  No diarization result (disabled or failed).");
+        minutes_core::diarize::DiarizationOutcome::NotConfigured { reason } => {
+            eprintln!("  No diarization result: {}", reason.detail());
             std::collections::HashMap::new()
         }
     };

--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -346,18 +346,104 @@ pub struct TranscriptWindow {
     pub end_secs: f32,
 }
 
+/// Why a diarization attempt produced no speaker labels.
+///
+/// `DiarizationOutcome::NotConfigured` used to be reason-free, which made
+/// "the operator set `engine = \"none\"`" indistinguishable in the logs from
+/// "this recording is longer than `MAX_DIARIZATION_SECONDS` so the decode
+/// refused it". Both shipped a transcript with no speaker labels and logged
+/// the same bare `{"skipped": true}`. Carrying the reason is what lets the
+/// pipeline both log it and write a `ProcessingWarning`, the same way #633
+/// did for transcription-engine fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiarizationUnavailable {
+    /// `[diarization] engine = "none"`.
+    Disabled,
+    /// No engine resolved: models are not downloaded, or this build has no
+    /// `diarize` feature compiled in.
+    EngineUnresolved,
+    /// The engine ran and returned an error. The string is the only place the
+    /// `MAX_DIARIZATION_SECONDS` refusal is currently visible.
+    EngineFailed(String),
+    /// Source-aware diarization over a system-stem-only capture failed and
+    /// there was no full-audio path to fall back to.
+    SystemStemOnlyFailed,
+    /// A previous diarization worker still held the process-global lease.
+    WorkerBusy,
+    /// The worker outlived `DIARIZATION_WORKER_DEADLINE`.
+    WorkerTimedOut,
+    /// The worker thread panicked.
+    WorkerPanicked,
+    /// A private-audio capability failed revalidation before any work began.
+    CapabilityRejected,
+}
+
+impl DiarizationUnavailable {
+    /// Stable, greppable token for structured logs and frontmatter.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            DiarizationUnavailable::Disabled => "disabled",
+            DiarizationUnavailable::EngineUnresolved => "engine_unresolved",
+            DiarizationUnavailable::EngineFailed(_) => "engine_failed",
+            DiarizationUnavailable::SystemStemOnlyFailed => "system_stem_only_failed",
+            DiarizationUnavailable::WorkerBusy => "worker_busy",
+            DiarizationUnavailable::WorkerTimedOut => "worker_timed_out",
+            DiarizationUnavailable::WorkerPanicked => "worker_panicked",
+            DiarizationUnavailable::CapabilityRejected => "capability_rejected",
+        }
+    }
+
+    /// Human-readable detail for `ProcessingWarning::message`.
+    pub fn detail(&self) -> String {
+        match self {
+            DiarizationUnavailable::Disabled => {
+                "diarization is disabled (`[diarization] engine = \"none\"`)".to_string()
+            }
+            DiarizationUnavailable::EngineUnresolved => {
+                "no diarization engine is available (models not downloaded, or this build has no `diarize` feature)"
+                    .to_string()
+            }
+            DiarizationUnavailable::EngineFailed(error) => {
+                format!("the diarization engine failed: {error}")
+            }
+            DiarizationUnavailable::SystemStemOnlyFailed => {
+                "source-aware diarization failed on a system-stem-only capture".to_string()
+            }
+            DiarizationUnavailable::WorkerBusy => {
+                "a previous diarization worker still held the process-global lease".to_string()
+            }
+            DiarizationUnavailable::WorkerTimedOut => format!(
+                "diarization exceeded its {}s deadline",
+                DIARIZATION_WORKER_DEADLINE.as_secs()
+            ),
+            DiarizationUnavailable::WorkerPanicked => "the diarization worker panicked".to_string(),
+            DiarizationUnavailable::CapabilityRejected => {
+                "the private-audio capability failed revalidation".to_string()
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum DiarizationOutcome {
     Result(DiarizationResult),
     Skipped { reason: DegradedCapture },
-    NotConfigured,
+    NotConfigured { reason: DiarizationUnavailable },
 }
 
 impl DiarizationOutcome {
     pub fn result_for_auxiliary_use(&self) -> Option<&DiarizationResult> {
         match self {
             DiarizationOutcome::Result(result) => Some(result),
-            DiarizationOutcome::Skipped { .. } | DiarizationOutcome::NotConfigured => None,
+            DiarizationOutcome::Skipped { .. } | DiarizationOutcome::NotConfigured { .. } => None,
+        }
+    }
+
+    /// The reason no labels were produced, when there is one.
+    pub fn unavailable_reason(&self) -> Option<&DiarizationUnavailable> {
+        match self {
+            DiarizationOutcome::NotConfigured { reason } => Some(reason),
+            _ => None,
         }
     }
 }
@@ -1987,7 +2073,7 @@ fn run_diarization_engine(
     audio_path: &Path,
     config: &Config,
     resolved_engine: &str,
-) -> Option<DiarizationResult> {
+) -> Result<DiarizationResult, DiarizationUnavailable> {
     tracing::info!(
         engine = %resolved_engine,
         file = %crate::pipeline::private_audio_diagnostic_label(audio_path),
@@ -2012,23 +2098,23 @@ fn run_diarization_engine(
                 segments = result.segments.len(),
                 "diarization complete"
             );
-            Some(result)
+            Ok(result)
         }
         Ok(Err(e)) => {
             tracing::error!(error = %e, "diarization failed, continuing without speaker labels");
-            None
+            Err(DiarizationUnavailable::EngineFailed(e))
         }
         Err(DiarizationWorkerError::Busy) => {
             tracing::error!("diarization skipped because a previous worker is still active");
-            None
+            Err(DiarizationUnavailable::WorkerBusy)
         }
         Err(DiarizationWorkerError::TimedOut) => {
             tracing::error!("diarization exceeded its bounded deadline; worker remains isolated");
-            None
+            Err(DiarizationUnavailable::WorkerTimedOut)
         }
         Err(DiarizationWorkerError::Panicked) => {
             tracing::error!("diarization thread panicked");
-            None
+            Err(DiarizationUnavailable::WorkerPanicked)
         }
     }
 }
@@ -2668,7 +2754,10 @@ fn degraded_voice_stem_ml_fallback(
         resolved_engine,
         reason,
         ctx,
-        run_diarization_engine,
+        // This fallback only needs "did it work"; the reason is reported by
+        // the caller that owns the outcome, so adapt rather than widen the
+        // runner bound (and its tests) to carry an error it discards.
+        |path, config, engine| run_diarization_engine(path, config, engine).ok(),
     )
 }
 
@@ -2692,12 +2781,16 @@ pub fn diarize_with_context(
 ) -> DiarizationOutcome {
     if crate::pipeline::is_reserved_private_audio_path(audio_path) {
         tracing::warn!("private audio token rejected by ordinary diarization entry point");
-        return DiarizationOutcome::NotConfigured;
+        return DiarizationOutcome::NotConfigured {
+            reason: DiarizationUnavailable::CapabilityRejected,
+        };
     }
     let engine = &config.diarization.engine;
 
     if engine == "none" {
-        return DiarizationOutcome::NotConfigured;
+        return DiarizationOutcome::NotConfigured {
+            reason: DiarizationUnavailable::Disabled,
+        };
     }
 
     let resolved_engine = resolve_diarization_engine(config);
@@ -2735,8 +2828,7 @@ pub fn diarize_with_context(
                     system_stem = %stems.system.display(),
                     "source-aware stem diarization failed, falling back to system-stem ML diarization"
                 );
-                if let Some(result) = run_diarization_engine(&stems.system, config, resolved_engine)
-                {
+                if let Ok(result) = run_diarization_engine(&stems.system, config, resolved_engine) {
                     return DiarizationOutcome::Result(result);
                 }
             }
@@ -2756,7 +2848,9 @@ pub fn diarize_with_context(
                         system_stem = %crate::pipeline::private_audio_diagnostic_label(&system_stem),
                         "system-stem-only diarization failed; keeping the transcript unlabeled"
                     );
-                    return DiarizationOutcome::NotConfigured;
+                    return DiarizationOutcome::NotConfigured {
+                        reason: DiarizationUnavailable::SystemStemOnlyFailed,
+                    };
                 }
                 tracing::warn!(
                     system_stem = %crate::pipeline::private_audio_diagnostic_label(&system_stem),
@@ -2764,8 +2858,8 @@ pub fn diarize_with_context(
                     "system-stem-only diarization failed, falling back to full-audio ML diarization"
                 );
                 return match run_diarization_engine(audio_path, config, resolved_engine) {
-                    Some(result) => DiarizationOutcome::Result(result),
-                    None => DiarizationOutcome::NotConfigured,
+                    Ok(result) => DiarizationOutcome::Result(result),
+                    Err(reason) => DiarizationOutcome::NotConfigured { reason },
                 };
             }
         }
@@ -2804,11 +2898,13 @@ pub fn diarize_with_context(
     }
 
     let Some(resolved_engine) = resolved_engine else {
-        return DiarizationOutcome::NotConfigured;
+        return DiarizationOutcome::NotConfigured {
+            reason: DiarizationUnavailable::EngineUnresolved,
+        };
     };
     match run_diarization_engine(audio_path, config, resolved_engine) {
-        Some(result) => DiarizationOutcome::Result(result),
-        None => DiarizationOutcome::NotConfigured,
+        Ok(result) => DiarizationOutcome::Result(result),
+        Err(reason) => DiarizationOutcome::NotConfigured { reason },
     }
 }
 
@@ -2823,17 +2919,23 @@ pub(crate) fn diarize_proof_bound_audio(
 ) -> DiarizationOutcome {
     if let Err(error) = input.verify_pipeline_binding() {
         tracing::warn!(error = %error, "authorized diarization capability failed revalidation");
-        return DiarizationOutcome::NotConfigured;
+        return DiarizationOutcome::NotConfigured {
+            reason: DiarizationUnavailable::CapabilityRejected,
+        };
     }
     if config.diarization.engine == "none" {
-        return DiarizationOutcome::NotConfigured;
+        return DiarizationOutcome::NotConfigured {
+            reason: DiarizationUnavailable::Disabled,
+        };
     }
     let Some(resolved_engine) = resolve_diarization_engine(config) else {
-        return DiarizationOutcome::NotConfigured;
+        return DiarizationOutcome::NotConfigured {
+            reason: DiarizationUnavailable::EngineUnresolved,
+        };
     };
     match run_diarization_engine(input.processing_path(), config, resolved_engine) {
-        Some(result) => DiarizationOutcome::Result(result),
-        None => DiarizationOutcome::NotConfigured,
+        Ok(result) => DiarizationOutcome::Result(result),
+        Err(reason) => DiarizationOutcome::NotConfigured { reason },
     }
 }
 
@@ -2847,7 +2949,7 @@ pub fn diarize(audio_path: &Path, config: &Config) -> Option<DiarizationResult> 
         },
     ) {
         DiarizationOutcome::Result(result) => Some(result),
-        DiarizationOutcome::Skipped { .. } | DiarizationOutcome::NotConfigured => None,
+        DiarizationOutcome::Skipped { .. } | DiarizationOutcome::NotConfigured { .. } => None,
     }
 }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -229,6 +229,35 @@ fn detect_engine_fallback_warning(config: &Config) -> Option<ProcessingWarning> 
     })
 }
 
+/// Records a [`ProcessingWarning`] when diarization ran but produced no
+/// speaker labels.
+///
+/// Same rationale as [`detect_engine_fallback_warning`] (#633): the desktop
+/// app installs no `tracing_subscriber`, so the `tracing::error!` inside
+/// `run_diarization_engine` is dropped and the failure is invisible. A
+/// transcript that silently lost its speaker labels is a materially different
+/// artifact, so the file itself carries the record.
+///
+/// `Disabled` is deliberately not warned about: an operator who set
+/// `engine = "none"` already knows.
+fn detect_diarization_warning(
+    reason: Option<&crate::diarize::DiarizationUnavailable>,
+) -> Option<ProcessingWarning> {
+    let reason = reason?;
+    if matches!(reason, crate::diarize::DiarizationUnavailable::Disabled) {
+        return None;
+    }
+    Some(ProcessingWarning {
+        step: "diarize".to_string(),
+        reason: reason.reason_code().to_string(),
+        timeout_secs: None,
+        message: Some(format!(
+            "Speaker diarization produced no labels ({}); the transcript is unlabeled.",
+            reason.detail()
+        )),
+    })
+}
+
 const SILENT_REMOTE_WARNING_MESSAGE: &str =
     "Call/remote audio was not captured (system stem silent); transcript reflects only your microphone";
 const SILENT_MICROPHONE_WARNING_MESSAGE: &str =
@@ -3856,7 +3885,7 @@ mod authorized_process_input_tests {
                     transcript_windows: None,
                 },
             ),
-            crate::diarize::DiarizationOutcome::NotConfigured
+            crate::diarize::DiarizationOutcome::NotConfigured { .. }
         ));
         assert!(resolve_screen_context_directory(
             context.context_session_id.as_deref(),
@@ -5009,6 +5038,7 @@ where
     let mut transcript = artifact.transcript.clone();
     let mut diarization_num_speakers = 0usize;
     let mut diarization_from_stems = false;
+    let mut diarization_unavailable: Option<crate::diarize::DiarizationUnavailable> = None;
     let mut degraded_ml_fallback = false;
     let mut diarization_embeddings: std::collections::HashMap<String, Vec<f32>> =
         std::collections::HashMap::new();
@@ -5080,12 +5110,20 @@ where
                 );
                 recording_health = Some(reason.into());
             }
-            diarize::DiarizationOutcome::NotConfigured => {
+            diarize::DiarizationOutcome::NotConfigured { reason } => {
+                // A bare `{"skipped": true}` here made an operator-disabled
+                // engine indistinguishable from a recording that exceeded
+                // `MAX_DIARIZATION_SECONDS`. Both ship unlabeled transcripts.
+                diarization_unavailable = Some(reason.clone());
                 logging::log_step(
                     "diarize",
                     &diagnostic_audio_target,
                     diarize_start.elapsed().as_millis() as u64,
-                    serde_json::json!({"skipped": true}),
+                    serde_json::json!({
+                        "skipped": true,
+                        "reason": reason.reason_code(),
+                        "detail": reason.detail(),
+                    }),
                 );
             }
         }
@@ -5362,6 +5400,9 @@ where
         summarization_warnings.push(warning);
     }
     if let Some(warning) = detect_engine_fallback_warning(config) {
+        summarization_warnings.push(warning);
+    }
+    if let Some(warning) = detect_diarization_warning(diarization_unavailable.as_ref()) {
         summarization_warnings.push(warning);
     }
     if !descriptor_authorized {
@@ -5740,7 +5781,7 @@ where
                 recording_health = merge_recording_health(Some(reason.into()), recording_health);
                 transcript
             }
-            diarize::DiarizationOutcome::NotConfigured => transcript,
+            diarize::DiarizationOutcome::NotConfigured { .. } => transcript,
         }
     } else {
         transcript
@@ -8534,6 +8575,63 @@ mod tests {
             .as_ref()
             .unwrap()
             .contains("engine `claude`"));
+    }
+
+    #[test]
+    fn diarization_warning_names_the_reason_labels_were_lost() {
+        // The regression this guards: a recording longer than
+        // MAX_DIARIZATION_SECONDS is refused by the decode, the pipeline
+        // reports NotConfigured, and the meeting silently ships with no
+        // speaker labels. Before this warning existed the only trace was a
+        // bare `{"skipped": true}` in the JSON log, which the desktop app's
+        // missing tracing_subscriber made the *only* trace anywhere.
+        let reason = crate::diarize::DiarizationUnavailable::EngineFailed(
+            "audio exceeds the diarization sample budget".to_string(),
+        );
+        let warning = detect_diarization_warning(Some(&reason)).expect("warning expected");
+        assert_eq!(warning.step, "diarize");
+        assert_eq!(warning.reason, "engine_failed");
+        let message = warning.message.as_ref().unwrap();
+        assert!(message.contains("no labels"), "message: {message}");
+        assert!(
+            message.contains("audio exceeds the diarization sample budget"),
+            "the underlying engine error must survive into the file: {message}"
+        );
+    }
+
+    #[test]
+    fn diarization_warning_absent_when_operator_disabled_it() {
+        // `engine = "none"` is a choice, not a degradation.
+        assert!(detect_diarization_warning(Some(
+            &crate::diarize::DiarizationUnavailable::Disabled
+        ))
+        .is_none());
+    }
+
+    #[test]
+    fn diarization_warning_absent_when_labels_were_produced() {
+        assert!(detect_diarization_warning(None).is_none());
+    }
+
+    #[test]
+    fn diarization_reason_codes_are_distinct_and_stable() {
+        use crate::diarize::DiarizationUnavailable as U;
+        let codes = [
+            U::Disabled.reason_code(),
+            U::EngineUnresolved.reason_code(),
+            U::EngineFailed(String::new()).reason_code(),
+            U::SystemStemOnlyFailed.reason_code(),
+            U::WorkerBusy.reason_code(),
+            U::WorkerTimedOut.reason_code(),
+            U::WorkerPanicked.reason_code(),
+            U::CapabilityRejected.reason_code(),
+        ];
+        let unique: std::collections::HashSet<_> = codes.iter().collect();
+        assert_eq!(
+            unique.len(),
+            codes.len(),
+            "reason codes are the greppable contract; they must not collide"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Half of #789 — the observability half. Does **not** touch the two-hour cap or the sealed audio path.

## The problem

A recording past `MAX_DIARIZATION_SECONDS` is refused by the decode, `diarize_with_context` reports `NotConfigured`, and the meeting ships with no speaker labels. The only trace was:

```json
{"step":"diarize","duration_ms":38712,"extra":{"skipped":true}}
```

That is byte-identical to the line emitted when an operator sets `engine = "none"`. Eight distinct causes — disabled, models missing, worker busy, worker timed out, worker panicked, capability rejected, engine error, system-stem-only failure — all collapsed into one silent variant, and none of them reached `processing_warnings`.

`run_diarization_engine` already had the reason in a `tracing::error!`, but the desktop app installs no `tracing_subscriber`, so that event is dropped and the failure is invisible there. Same cause and same fix shape as #633 for transcription-engine fallback — `detect_engine_fallback_warning` was the template.

Found the hard way: a 2h33m meeting produced a plausible-looking file with no attribution, and downstream notes credited a proposal to the wrong participant as a direct result.

## Changes

- `DiarizationUnavailable` reason carried on `DiarizationOutcome::NotConfigured`, with a stable `reason_code()` for logs and a `detail()` for humans.
- `run_diarization_engine` returns `Result` instead of `Option`, so the engine's own error text survives to the caller. This is currently the only place the cap refusal is visible at all.
- `diarize` `log_step` gains `reason` and `detail`.
- New `detect_diarization_warning` emits a `ProcessingWarning` so the file itself records that it lost its labels. `Disabled` is deliberately not warned about — an operator who set `engine = "none"` already knows.
- CLI prints the reason instead of `"No diarization result (disabled or failed)"`, which was the same ambiguity in the user-facing surface.

## Deliberately not in scope

Windowing the decode so 2h+ recordings actually keep their labels. That touches the code that exists to hold a security property and deserves its own review — including how N windows interact with `DIARIZATION_WORKER_DEADLINE`, which is currently a whole-job budget. Tracked in #789.

Worth restating from that issue: **raising `MAX_DIARIZATION_SECONDS` is not the fix.** The bound exists because `da4a655b` ("seal private audio processing") replaced the ffmpeg preprocessing hop with in-process decode, where samples materialise with no address-space ceiling. Raising it re-opens exactly what that commit closed.

## Risk

Observability only. No behaviour change to the audio path, the cap, or the diarization engines. The callback in `degraded_voice_stem_ml_fallback` gets an adapting closure rather than a widened bound, so that helper and its tests are untouched.

## Verification

- `cargo check --workspace --features diarize` clean
- `cargo clippy -p minutes-core -p minutes-cli --features diarize -- -D warnings` clean
- `cargo fmt --check` clean
- 4 new tests, all passing
- Pre-existing failures unchanged: `compressed_diarization_input_routes_through_the_worker_when_ffmpeg_is_missing`, `ffmpeg_preprocess_stream_builds_parseable_bounded_wav`, and `the_diarization_fallback_reads_the_pipeline_config_not_the_one_on_disk` fail identically on unmodified `main` in this environment (they need ffmpeg / the decode worker). Baselined by stashing before and after.
