### PR TITLE
fix(capture): stop a late sample buffer from truncating a finished stem (#792)

### DIFF
--- a/tauri/src-tauri/src/system_audio_record.swift
+++ b/tauri/src-tauri/src/system_audio_record.swift
@@ -305,7 +305,7 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         // Runs on sampleQueue, the same queue stop() closes the stems on, so
         // this either sees the closed latch or ran entirely before it was set.
         // Dropping these late samples loses at most the few milliseconds
-        // between the close and stopCapture() returning; honouring them
+        // between the close and stopCapture() returning; honoring them
         // destroys the whole recording.
         if stemsClosed { return }
         guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),

--- a/tauri/src-tauri/src/system_audio_record.swift
+++ b/tauri/src-tauri/src/system_audio_record.swift
@@ -33,6 +33,14 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
     // Per-source stem writers
     private var voiceStemFile: AVAudioFile?
     private var systemStemFile: AVAudioFile?
+    // Set once stop() has closed the stems, and never cleared. Both stem files
+    // are created lazily on first sample, so without this a sample arriving
+    // after the close reopens the file with AVAudioFile(forWriting:), which
+    // truncates it. Closing the stems does not stop the stream: stopCapture()
+    // is awaited afterwards and ScreenCaptureKit keeps delivering until it
+    // returns, so that window is not rare, it is every stop where remote audio
+    // is still playing. Mutated and read only on sampleQueue (issue #792).
+    private var stemsClosed = false
     private var voiceStemURL: URL?
     private var systemStemURL: URL?
 
@@ -196,6 +204,7 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         // with any in-flight writeStemSamples calls. Without this,
         // nil'ing on the main thread races with writes on sampleQueue.
         sampleQueue.sync {
+            stemsClosed = true
             voiceStemFile = nil
             systemStemFile = nil
         }
@@ -293,6 +302,12 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
     }
 
     private func writeStemSamples(_ sampleBuffer: CMSampleBuffer, source: SCStreamOutputType) {
+        // Runs on sampleQueue, the same queue stop() closes the stems on, so
+        // this either sees the closed latch or ran entirely before it was set.
+        // Dropping these late samples loses at most the few milliseconds
+        // between the close and stopCapture() returning; honouring them
+        // destroys the whole recording.
+        if stemsClosed { return }
         guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),
               let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription)?.pointee else {
             return


### PR DESCRIPTION
Fixes bug 1 of #792. The other five bugs in that report are untouched here.

## Root cause

`stop()` closes the stem files on `sampleQueue` and only then awaits `stopCapture()`:

```swift
sampleQueue.sync {
    voiceStemFile = nil
    systemStemFile = nil
}
...
try await stream.stopCapture()
```

ScreenCaptureKit keeps delivering until `stopCapture()` returns, and both stream outputs are registered on that same queue, so buffers arrive after the close. Both stems are created lazily on first sample:

```swift
if systemStemFile == nil, let url = systemStemURL {
    systemStemFile = try AVAudioFile(forWriting: url, settings: monoFormat.settings)
}
```

So a late buffer finds the file nil and reopens it, and `AVAudioFile(forWriting:)` truncates. The completed recording is replaced by the few milliseconds that arrived during shutdown. `native-captures/` is then deleted, so the audio is unrecoverable.

The `sampleQueue.sync` block was added to stop nil'ing from racing in-flight writes, and it does that correctly. What it does not do is stop a later write from resurrecting the file.

## Measured, not reasoned about

Writing and closing a 30 second mono float32 WAV the way the helper writes stems, then reopening it with `AVAudioFile(forWriting:)` and writing one buffer:

```
after full 30s recording, closed: 5764096 bytes
after one late buffer reopened it: 12032 bytes
data survived: 0%
```

That also explains the exact number in the report. `AVAudioFile` writes a 4,096 byte header, so the 7,936 byte file is `4096 + 960 frames x 4 bytes`, and 960 frames at 48 kHz is 0.020 s, matching the reported duration exactly.

## The fix

A latch set where the stems are closed and checked before any stem write, both on `sampleQueue`, so a late buffer either sees the latch or ran entirely before it was set. Dropping those samples loses at most the few milliseconds between the close and `stopCapture()` returning. Honoring them loses the recording.

## Verification

- Compiles with the exact invocation `build.rs` uses: `swiftc -parse-as-library -target arm64-apple-macos14.0`.
- The truncation mechanism is demonstrated above rather than inferred.
- End-to-end confirmation needs a real dual-source capture with remote audio still playing at stop. The reporter has scripted repros and offered to test patches, so that is the fastest route to closing the loop.

## Not addressed here

The report also asks that we not delete the `native-captures/` source until the `jobs/` copy is validated, and that a 0.02 s stem after a preflight reporting `system_audio_ready: true` be a hard error rather than an inferred "missing or silent" warning. Both are worth doing as defense in depth, and neither is needed to stop the data loss once the stem is no longer truncated. Filed thinking, not code, so they are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
