### PR TITLE
ci: bound and retry apt installs so a stuck runner fails instead of hanging

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -20,10 +20,14 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Sized so all three attempts fit inside the twenty minute step backstop:
+# 3 x (120 + 240) seconds of work plus 45 seconds of pauses is 18m45s. Without
+# that the backstop would fire mid-retry and the third attempt would never run,
+# which is the opposite of the point.
 attempts=3
 for attempt in $(seq 1 "${attempts}"); do
-  if sudo timeout 300 apt-get update \
-    && sudo timeout 600 apt-get install -y "$@"; then
+  if sudo timeout 120 apt-get update \
+    && sudo timeout 240 apt-get install -y "$@"; then
     exit 0
   fi
 

--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Install apt packages on a CI runner, tolerating the two ways this step fails
+# on GitHub's Linux images.
+#
+# The first is a transient mirror or DNS error, which exits non-zero quickly.
+# The second is apt blocking on a dpkg or apt lock still held by the runner's
+# own unattended-upgrades, which does not exit at all: the step simply produces
+# no further output and the job sits there until the six hour job timeout. On
+# 2026-08-18 that held every Linux job on the repo for over half an hour at a
+# stretch, across three separate pull requests, with no failure to react to.
+#
+# Both cases are handled the same way: bound each apt invocation with `timeout`
+# so a hang becomes a failure, then retry with a widening pause.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <package> [package...]" >&2
+  exit 2
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+attempts=3
+for attempt in $(seq 1 "${attempts}"); do
+  if sudo timeout 300 apt-get update \
+    && sudo timeout 600 apt-get install -y "$@"; then
+    exit 0
+  fi
+
+  if [ "${attempt}" -lt "${attempts}" ]; then
+    pause=$((attempt * 15))
+    echo "::warning::apt attempt ${attempt} of ${attempts} failed or timed out, retrying in ${pause}s"
+    sleep "${pause}"
+  fi
+done
+
+echo "::error::apt failed after ${attempts} attempts: $*"
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,8 @@ jobs:
 
       - name: Install audio dev headers (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
+        timeout-minutes: 20
+        run: .github/scripts/apt-install.sh libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Set CXXFLAGS for whisper.cpp (macOS)
         if: runner.os == 'macOS'
@@ -171,7 +172,8 @@ jobs:
 
       - name: Ensure cmake for sherpa-rs (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake
+        timeout-minutes: 20
+        run: .github/scripts/apt-install.sh cmake
 
       - name: Build core with sherpa engine (all platforms)
         # Opt-in sherpa-onnx engine (engine-sherpa). sherpa-rs-sys cmake-builds
@@ -315,7 +317,8 @@ jobs:
 
       - name: Install audio dev headers (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
+        timeout-minutes: 20
+        run: .github/scripts/apt-install.sh libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
 
       # Per-image cache scope (ImageOS + ImageVersion); see the test job comment.
       # These are runner-injected vars absent from the ${{ env }} context, so we
@@ -366,17 +369,17 @@ jobs:
       - name: Install Linux build + audio dev deps
         # ubuntu-latest happens to ship clang preinstalled, but we declare it
         # explicitly so this job stays portable to other Linux runner images.
+        timeout-minutes: 20
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          .github/scripts/apt-install.sh \
             clang libclang-dev \
             cmake build-essential pkg-config \
             libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Install Linux desktop check deps
+        timeout-minutes: 20
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          .github/scripts/apt-install.sh \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       # Per-image cache scope (ImageOS + ImageVersion); see the test job comment.
@@ -842,7 +845,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install audio dev headers (Linux)
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
+        timeout-minutes: 20
+        run: .github/scripts/apt-install.sh libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Replay executable fixtures twice through actual core reducer
         run: cargo test -p minutes-core --no-default-features --test live_sidekick_eval -- --test-threads=1

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -74,7 +74,8 @@ jobs:
 
       - name: Install Linux audio dev headers
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
+        timeout-minutes: 20
+        run: .github/scripts/apt-install.sh libasound2-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Set CXXFLAGS for whisper.cpp (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -228,9 +228,9 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Install Linux build dependencies
+        timeout-minutes: 20
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          .github/scripts/apt-install.sh \
             libasound2-dev libpipewire-0.3-dev libspa-0.2-dev \
             clang libclang-dev cmake build-essential pkg-config
 
@@ -238,7 +238,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux build dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev cmake
+        timeout-minutes: 20
+        run: .github/scripts/apt-install.sh libasound2-dev cmake
 
       - name: Authenticate to crates.io with OIDC
         id: crates-auth


### PR DESCRIPTION
Every Linux job installs its dependencies with a bare apt-get update followed by apt-get install, with no timeout on the step. That has two failure modes on GitHub images. A transient mirror or DNS error exits non-zero straight away, which is visible and merely annoying. Apt blocking on a dpkg or apt lock still held by the runner unattended-upgrades does not exit at all: the step stops producing output and the job sits until the six hour job timeout.

The second one happened today, which is why this exists. Build CLI and the Live Sidekick evals sat on their install steps for over half an hour each, across #791, #793 and #794, and a cancel plus automatic restart landed in exactly the same state. No check failed, so there was nothing to react to. Those pull requests were simply not mergeable and gave no reason for it.

## What changes

Both cases now go through `.github/scripts/apt-install.sh`, which bounds each apt invocation with `timeout` so a hang becomes a failure, then retries three times with a widening pause. Steps also carry `timeout-minutes: 20` as a backstop. Worst case becomes a job that fails in twenty minutes rather than one that blocks a merge for six hours.

Applied to every apt call site in the workflows, not only the two that hung today: `ci.yml`, `release-cli.yml`, `release-publish.yml`.

## What does not change

Same packages, same order, and deliberately no `--no-install-recommends`, so nothing that builds today stops building. The script is `shellcheck` clean.

## Honest limits

A retry cannot fix a genuinely broken mirror, it just turns a six hour hang into a clear failure after three attempts. If today was an upstream incident, this will not have prevented it, only made it legible and bounded. That is still the difference between a red check you can act on and a pull request that silently will not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
