### PR TITLE
fix(core): chunk system-audio tap output to whole mixer slots (#792)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,15 @@ jobs:
         run: cargo test -p minutes-core --no-default-features --lib -- --test-threads=1 --nocapture
         timeout-minutes: 15
 
+      - name: Unit tests (streaming feature)
+        # The step above runs with streaming off, so every #[cfg(test)] module
+        # inside a streaming-gated file was compiled by "Build core with
+        # streaming only" and then never executed. That covered the dual-source
+        # chunking invariants in streaming.rs and the mic-mute tests. Run the
+        # same suite once more with the feature on.
+        run: cargo test -p minutes-core --no-default-features --features streaming --lib -- --test-threads=1 --nocapture
+        timeout-minutes: 15
+
       - name: Copilot attach, routing, and window-contract tests
         # On Windows this executes the real named-pipe connect/reconnect path.
         # On Unix it also asserts owner-only socket/discovery permissions.

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -950,8 +950,12 @@ fn try_reconnect(
     }
 }
 
+/// One mixer slot is one `AudioChunk` from each source. Kept equal to
+/// `streaming::CHUNK_SAMPLES` by construction: `padded_slot` pads every slot
+/// to this length, so a producer emitting a different chunk size writes a
+/// zero-stuffed stem (#792).
 #[cfg(feature = "streaming")]
-const DUAL_SOURCE_SLOT_SAMPLES: usize = 1600;
+const DUAL_SOURCE_SLOT_SAMPLES: usize = crate::streaming::CHUNK_SAMPLES;
 
 #[cfg(feature = "streaming")]
 struct DualCaptureWriters {

--- a/crates/core/src/streaming.rs
+++ b/crates/core/src/streaming.rs
@@ -54,6 +54,74 @@ pub struct AudioChunk {
     pub source: SourceRole,
 }
 
+/// Samples in one `AudioChunk`: 100 ms of 16 kHz mono audio.
+///
+/// Every producer of `AudioChunk` must emit exactly this many samples per
+/// chunk. Dual-source capture derives its mixer slots from
+/// `AudioChunk::index` and pads each slot out to this length, so a producer
+/// that forwards whatever its driver callback happened to deliver both
+/// zero-stuffs its own stem and inflates the slot count for every other
+/// source sharing the mixer. Use `ChunkAccumulator` rather than chunking by
+/// hand. See issue #792.
+pub const CHUNK_SAMPLES: usize = 1600;
+
+/// Buffers a producer's resampled 16 kHz mono samples into fixed-size
+/// `CHUNK_SAMPLES` chunks carrying a monotonic per-producer index.
+///
+/// Driver callbacks deliver whatever their IO buffer size dictates — a Core
+/// Audio process tap on a 48 kHz output device hands over 512 frames per
+/// callback, which is 170.67 samples once decimated to 16 kHz. Emitting that
+/// directly as an `AudioChunk` is what produced the zero-stuffed system stems
+/// in #792: the dual-source mixer padded each 171-sample chunk out to a
+/// 1600-sample slot, leaving ~89% zeros, and advanced the slot counter ~9.4x
+/// faster than the microphone did.
+///
+/// The trailing partial chunk stays buffered rather than being emitted short.
+/// At most `CHUNK_SAMPLES - 1` samples (<100 ms) are dropped when a stream
+/// stops, matching what the microphone path has always done.
+pub struct ChunkAccumulator {
+    buf: Vec<f32>,
+    next_index: u64,
+}
+
+impl Default for ChunkAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChunkAccumulator {
+    pub fn new() -> Self {
+        Self {
+            // Two chunks of headroom: a callback can straddle a boundary and
+            // leave a remainder without forcing a realloc.
+            buf: Vec::with_capacity(CHUNK_SAMPLES * 2),
+            next_index: 0,
+        }
+    }
+
+    /// Append `samples`, invoking `emit(index, chunk)` once per complete
+    /// `CHUNK_SAMPLES`-sample chunk. Called from real-time audio callbacks,
+    /// so it allocates only the emitted chunks themselves.
+    pub fn push<F>(&mut self, samples: &[f32], mut emit: F)
+    where
+        F: FnMut(u64, Vec<f32>),
+    {
+        self.buf.extend_from_slice(samples);
+        while self.buf.len() >= CHUNK_SAMPLES {
+            let chunk: Vec<f32> = self.buf.drain(..CHUNK_SAMPLES).collect();
+            let index = self.next_index;
+            self.next_index += 1;
+            emit(index, chunk);
+        }
+    }
+
+    /// Samples held back awaiting a full chunk.
+    pub fn buffered(&self) -> usize {
+        self.buf.len()
+    }
+}
+
 /// Shared audio level (0–100) for UI visualization.
 /// Separate from capture.rs AUDIO_LEVEL to allow both APIs to coexist.
 static STREAM_AUDIO_LEVEL: AtomicU32 = AtomicU32::new(0);
@@ -199,35 +267,26 @@ impl AudioStream {
 
         let stop = Arc::new(AtomicBool::new(false));
         let err_flag = Arc::new(AtomicBool::new(false));
-        let chunk_size: usize = 1600; // 100ms at 16kHz
 
-        let mut chunk_buf: Vec<f32> = Vec::with_capacity(chunk_size);
-        let mut chunk_counter: u64 = 0;
+        let mut accumulator = ChunkAccumulator::new();
 
         let (stream, device_name, _config) = crate::resample::build_resampled_input_stream(
             &device,
             &stop,
             &err_flag,
             move |resampled: &[f32]| {
-                for &sample in resampled {
-                    chunk_buf.push(sample);
-
-                    if chunk_buf.len() >= chunk_size {
-                        let samples: Vec<f32> = chunk_buf.drain(..chunk_size).collect();
-                        let rms = compute_rms(&samples);
-                        let level = (rms * 2000.0).min(100.0) as u32;
-                        STREAM_AUDIO_LEVEL.store(level, Ordering::Relaxed);
-                        let idx = chunk_counter;
-                        chunk_counter += 1;
-                        let _ = tx.try_send(AudioChunk {
-                            samples,
-                            rms,
-                            timestamp: Instant::now(),
-                            index: idx,
-                            source: SourceRole::Default,
-                        });
-                    }
-                }
+                accumulator.push(resampled, |index, samples| {
+                    let rms = compute_rms(&samples);
+                    let level = (rms * 2000.0).min(100.0) as u32;
+                    STREAM_AUDIO_LEVEL.store(level, Ordering::Relaxed);
+                    let _ = tx.try_send(AudioChunk {
+                        samples,
+                        rms,
+                        timestamp: Instant::now(),
+                        index,
+                        source: SourceRole::Default,
+                    });
+                });
             },
         )?;
 
@@ -357,6 +416,110 @@ impl Drop for MultiAudioStream {
         self.stop.store(true, Ordering::Relaxed);
         self.voice.stop();
         self.call.stop();
+    }
+}
+
+#[cfg(test)]
+mod chunk_accumulator_tests {
+    use super::*;
+
+    /// A Core Audio process tap on a 48 kHz output device delivers 512 frames
+    /// per IO callback; decimated to 16 kHz that is 512/3 samples. This is the
+    /// callback size measured on the recordings in #792.
+    const TAP_CALLBACK_SAMPLES: usize = 171;
+
+    fn drain(accumulator: &mut ChunkAccumulator, samples: &[f32]) -> Vec<(u64, Vec<f32>)> {
+        let mut out = Vec::new();
+        accumulator.push(samples, |index, chunk| out.push((index, chunk)));
+        out
+    }
+
+    #[test]
+    fn emits_nothing_until_a_full_chunk_is_available() {
+        let mut accumulator = ChunkAccumulator::new();
+        let almost_a_chunk = vec![0.5; CHUNK_SAMPLES - 1];
+        let emitted = drain(&mut accumulator, &almost_a_chunk);
+        assert!(emitted.is_empty());
+        assert_eq!(accumulator.buffered(), CHUNK_SAMPLES - 1);
+
+        let emitted = drain(&mut accumulator, &[0.5]);
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].1.len(), CHUNK_SAMPLES);
+        assert_eq!(accumulator.buffered(), 0);
+    }
+
+    #[test]
+    fn every_emitted_chunk_is_exactly_chunk_samples_long() {
+        let mut accumulator = ChunkAccumulator::new();
+        for size in [1usize, 171, 512, 1600, 4801] {
+            let callback = vec![0.25; size];
+            for (_, chunk) in drain(&mut accumulator, &callback) {
+                assert_eq!(chunk.len(), CHUNK_SAMPLES);
+            }
+        }
+    }
+
+    #[test]
+    fn indices_are_monotonic_and_gapless() {
+        let mut accumulator = ChunkAccumulator::new();
+        let mut indices = Vec::new();
+        let callback = vec![0.1; TAP_CALLBACK_SAMPLES];
+        for _ in 0..100 {
+            for (index, _) in drain(&mut accumulator, &callback) {
+                indices.push(index);
+            }
+        }
+        assert!(!indices.is_empty());
+        assert_eq!(indices, (0..indices.len() as u64).collect::<Vec<_>>());
+    }
+
+    /// Regression for #792. Feeding tap-sized callbacks used to produce one
+    /// `AudioChunk` per callback, which the dual-source mixer then padded out
+    /// to a full slot — yielding a system stem that was ~89% zero samples and
+    /// a slot counter running ~9.4x too fast. Chunks must now be dense.
+    #[test]
+    fn tap_sized_callbacks_produce_dense_chunks_not_zero_stuffed_ones() {
+        let mut accumulator = ChunkAccumulator::new();
+        let mut chunks = Vec::new();
+        // ~10 seconds of tap callbacks carrying continuously nonzero audio.
+        let callback = vec![0.3; TAP_CALLBACK_SAMPLES];
+        for _ in 0..1000 {
+            for (_, chunk) in drain(&mut accumulator, &callback) {
+                chunks.push(chunk);
+            }
+        }
+
+        assert!(!chunks.is_empty());
+        let total: usize = chunks.iter().map(Vec::len).sum();
+        let nonzero: usize = chunks
+            .iter()
+            .flatten()
+            .filter(|sample| **sample != 0.0)
+            .count();
+        assert_eq!(
+            nonzero, total,
+            "every sample from a continuously-nonzero source must survive chunking"
+        );
+
+        // No slot inflation: emitted samples must account for the input,
+        // minus at most one partial chunk still buffered.
+        let pushed = 1000 * TAP_CALLBACK_SAMPLES;
+        assert_eq!(total + accumulator.buffered(), pushed);
+    }
+
+    /// A callback larger than one chunk must be split, not truncated. The
+    /// mixer's `padded_slot` silently drops anything past a slot boundary, so
+    /// an oversized chunk would lose audio outright.
+    #[test]
+    fn oversized_callbacks_are_split_rather_than_truncated() {
+        let mut accumulator = ChunkAccumulator::new();
+        let pushed = CHUNK_SAMPLES * 3 + 7;
+        let oversized = vec![0.75; pushed];
+        let emitted = drain(&mut accumulator, &oversized);
+        assert_eq!(emitted.len(), 3);
+        let total: usize = emitted.iter().map(|(_, chunk)| chunk.len()).sum();
+        assert_eq!(total + accumulator.buffered(), pushed);
+        assert_eq!(accumulator.buffered(), 7);
     }
 }
 

--- a/crates/core/src/system_audio_backend.rs
+++ b/crates/core/src/system_audio_backend.rs
@@ -445,7 +445,7 @@ struct CoreAudioTapCallbackContext {
     interleaved: bool,
     resample_pos: f64,
     input_samples: Vec<f32>,
-    chunk_index: u64,
+    accumulator: crate::streaming::ChunkAccumulator,
 }
 
 #[cfg(all(target_os = "macos", feature = "streaming"))]
@@ -463,7 +463,7 @@ impl CoreAudioTapCallbackContext {
             interleaved: asbd.is_interleaved(),
             resample_pos: 0.0,
             input_samples: Vec::new(),
-            chunk_index: 0,
+            accumulator: crate::streaming::ChunkAccumulator::new(),
         }
     }
 
@@ -494,20 +494,33 @@ impl CoreAudioTapCallbackContext {
             return;
         }
 
-        let rms = (resampled
-            .iter()
-            .map(|sample| (*sample as f64) * (*sample as f64))
-            .sum::<f64>()
-            / resampled.len() as f64)
-            .sqrt() as f32;
-        let index = self.chunk_index;
-        self.chunk_index += 1;
-        let _ = self.sink.try_send(AudioChunk {
-            samples: resampled,
-            rms,
-            timestamp: std::time::Instant::now(),
-            index,
-            source: SourceRole::Call,
+        // Buffer to whole `CHUNK_SAMPLES` chunks instead of sending one chunk
+        // per IO callback. A tap on a 48 kHz output device delivers 512 frames
+        // per callback, which decimates to ~171 samples — about a ninth of a slot.
+        // Emitting those directly made the dual-source mixer zero-pad every
+        // system slot to 1600 samples (~89% zeros) and advance the slot
+        // counter ~9.4x faster than the microphone, inflating the declared
+        // duration of every stem in the recording (#792).
+        //
+        // Split the borrow so the emit closure can use `sink` while
+        // `accumulator` is mutably borrowed by `push`.
+        let Self {
+            sink, accumulator, ..
+        } = self;
+        accumulator.push(&resampled, |index, samples| {
+            let rms = (samples
+                .iter()
+                .map(|sample| (*sample as f64) * (*sample as f64))
+                .sum::<f64>()
+                / samples.len() as f64)
+                .sqrt() as f32;
+            let _ = sink.try_send(AudioChunk {
+                samples,
+                rms,
+                timestamp: std::time::Instant::now(),
+                index,
+                source: SourceRole::Call,
+            });
         });
     }
 }


### PR DESCRIPTION
Fixes the zero-stuffed system stem reported in #792 (Bug 2 there), and the duration inflation filed alongside it as Bug 3, which turns out to be the same defect.

## Root cause

`AudioStream::start` accumulates microphone samples and emits an `AudioChunk` only once it holds exactly 1600 of them. The Core Audio process tap does not: `CoreAudioTapCallbackContext::ingest` sends one `AudioChunk` per IO callback, carrying however many samples that callback produced.

A tap on a 48 kHz output device delivers 512 frames per callback, which is ~171 samples once decimated to 16 kHz.

Dual-source capture keys its mixer slots off `AudioChunk::index` and pads every slot out to `DUAL_SOURCE_SLOT_SAMPLES` (1600) via `padded_slot`. So each ~171-sample tap chunk claimed a whole slot and was zero-filled for the remaining ~1429 samples, and the system stream's slot counter advanced ~9.4x faster than the microphone's.

That single mismatch produces both reported symptoms:

- **Zero-stuffing.** The system stem measures 8-11% nonzero samples where ~99.7% is expected. Extracting only the nonzero samples and replaying them reconstructs intelligible speech, so the audio was captured and then diluted on write. Decoded as written, the remote side of a call transcribes as `[tapping]` / `[MUSIC PLAYING]`.
- **Duration inflation.** The declared duration of every stem in the recording scales with the slot count, so it inflates by the same ratio. `1 / 0.106 ≈ 9.4` matches the 4.9x-8.9x inflation observed in #792.

It also explains the case in #792 that looked like a counterexample: a recording with a correct 1.03x duration that was still zero-stuffed. Slots are flushed at `min(max_voice_slot, max_system_slot) - 1`, so while both streams are live the microphone gates the slot count and the duration stays right — the system stem is zero-stuffed regardless.

## Evidence

Measuring nonzero density by position within each 1600-sample slot on an affected recording, over a 20 s window (200 slots):

```
samples=320000  nonzero=7.89%
nonzero density: flat through position 170, exactly 0 from position 171 onward
per-slot leading nonzero run: 171, 171, 170, ...
nonzero samples after the run, in any slot: 0
```

171 ≈ 512/3. A boundary landing on the same offset inside every slot of a 1600-sample grid is the `padded_slot` signature, not an acoustic property of the source.

## The change

Fix the producer rather than the mixer, since the mixer's contract (one chunk per source per slot) is the reasonable one.

- `streaming::ChunkAccumulator` buffers a source's resampled samples and emits exactly `CHUNK_SAMPLES` per chunk with a gapless index.
- The Core Audio tap now goes through it.
- The microphone path, which already did this by hand, now shares the same implementation instead of duplicating it.
- `CHUNK_SAMPLES` is public, and `DUAL_SOURCE_SLOT_SAMPLES` is defined in terms of it so the two cannot drift apart.

Two secondary fixes fall out:

- Oversized callbacks are now split across chunks. Previously `padded_slot`'s `.take(DUAL_SOURCE_SLOT_SAMPLES)` silently discarded anything past a slot boundary.
- `pending_system` no longer accumulates the ~90% of system chunks whose index runs ahead of the microphone's for the length of the recording.

A trailing partial chunk (<100 ms) is dropped when a stream stops. That is what the microphone path has always done; this makes the tap consistent with it.

## Testing

New unit tests in `streaming.rs` covering the accumulator, including a regression test that feeds tap-sized (171-sample) callbacks and asserts the emitted chunks are dense rather than zero-stuffed, and that total emitted samples account for the input with no slot inflation. Also: empty-until-full, exact chunk length across callback sizes, gapless indices, and oversized-callback splitting.

A second commit adds a CI step, because those tests would not otherwise have run. `Unit tests (no whisper)` invokes `cargo test -p minutes-core --no-default-features`, so every `#[cfg(test)]` module inside a streaming-gated file is compiled by `Build core with streaming only` and then never executed — that covered the new tests here and the existing `mic_mute_tests`. The new step runs the same suite with `--features streaming`.

Verified on CI: `Build core with streaming only (downstream consumer path)` passes on `macos-latest`, which is the configuration that compiles both the Core Audio tap and the dual-source mixer.

I have a shell harness that plays a known `say`-generated signal through the default output device, records, and asserts nonzero ratio, slot-density profile, and declared-vs-wall-clock duration on the resulting stems. Happy to contribute it under `scripts/` if that is useful.

---

Related: this is one of two independent PRs for #792. The other reports a truncated native-call stem instead of inferring it; they touch different files and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
