### PR TITLE
fix(tauri): report a truncated native-call stem instead of inferring it (#792)

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2981,18 +2981,47 @@ fn viable_native_call_stem(path: &Path) -> bool {
         .is_ok_and(|metadata| metadata.len() >= min_viable_stem_bytes(path))
 }
 
-fn native_call_capture_warning_health(
-    message: impl Into<String>,
-) -> minutes_core::markdown::RecordingHealth {
-    let mut health = minutes_core::markdown::RecordingHealth {
+fn empty_native_call_health() -> minutes_core::markdown::RecordingHealth {
+    minutes_core::markdown::RecordingHealth {
         voice_stem_active_ratio: None,
         system_stem_active_ratio: None,
         system_dominant_ratio: None,
         capture_warnings: Vec::new(),
         diarization_path: Some(minutes_core::markdown::DiarizationPath::None),
-    };
+    }
+}
+
+fn native_call_capture_warning_health(
+    message: impl Into<String>,
+) -> minutes_core::markdown::RecordingHealth {
+    let mut health = empty_native_call_health();
     minutes_core::health::append_native_call_capture_warning(&mut health, message);
     health
+}
+
+/// Describe a stem that exists on disk but finalized below the viability
+/// threshold, or `None` when the stem is absent or long enough to use.
+///
+/// This is a materially different failure from "the stem was never written":
+/// capture ran for the whole session and the bytes were lost when the file was
+/// closed. Issue #792 reports the system stem repeatedly finalizing at 7,936
+/// bytes -- a page-aligned WAV header plus 0.02 s of audio -- after growing
+/// normally for half an hour.
+fn truncated_native_call_stem_reason(path: &Path) -> Option<String> {
+    let len = path.metadata().ok()?.len();
+    let min_bytes = min_viable_stem_bytes(path);
+    if len >= min_bytes {
+        return None;
+    }
+    let byte_rate = read_wav_byte_rate(path)
+        .unwrap_or(FALLBACK_WAV_BYTE_RATE)
+        .max(1);
+    // Approximate: everything past the header is treated as audio. Good enough
+    // to tell "0.02 s" from "0.5 s" in a diagnostic message.
+    let observed_secs = len as f64 / byte_rate as f64;
+    Some(format!(
+        "stem finalized at {len} bytes (~{observed_secs:.3}s of audio); at least          {MIN_VIABLE_STEM_DURATION_SECS:.1}s is required for a stem to be usable"
+    ))
 }
 
 fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProcessingInput> {
@@ -3024,7 +3053,7 @@ fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProc
         ));
     }
 
-    let recovery_health = if !primary_has_bytes {
+    let mut recovery_health = if !primary_has_bytes {
         // The .mov is the grouping anchor that lets the queue move primary and
         // both stems together. The worker never decodes this synthetic anchor.
         std::fs::write(output_path, b"minutes native-call stem anchor")?;
@@ -3034,6 +3063,35 @@ fn native_call_processing_input(output_path: &Path) -> io::Result<NativeCallProc
     } else {
         None
     };
+
+    // One viable stem is enough to proceed, so the check above stays silent
+    // whenever the surviving sibling is healthy. That silence is the problem
+    // reported in #792: a system stem truncated at finalization left the job
+    // queued as if nothing was wrong, and the only signal reaching the user
+    // was a downstream `Inferred` "call audio was missing or silent" note --
+    // indistinguishable from a call where nobody spoke.
+    //
+    // A stem that is present on disk but too short to use is direct evidence
+    // of a finalization failure, not something to infer. Record it as a
+    // `High`-confidence invalid-stem warning carrying the measured size, while
+    // still processing the sibling so usable audio is never discarded.
+    for (path, source) in [
+        (system, minutes_core::diarize::CaptureSource::System),
+        (voice, minutes_core::diarize::CaptureSource::Voice),
+    ] {
+        let Some(path) = path else { continue };
+        let Some(reason) = truncated_native_call_stem_reason(path) else {
+            continue;
+        };
+        tracing::error!(
+            stem = %path.display(),
+            ?source,
+            reason = %reason,
+            "native call capture finalized a truncated stem"
+        );
+        let health = recovery_health.get_or_insert_with(empty_native_call_health);
+        minutes_core::health::append_native_call_invalid_stem_warning(health, source, &reason);
+    }
 
     Ok(NativeCallProcessingInput {
         path: output_path.to_path_buf(),
@@ -15224,6 +15282,109 @@ mod tests {
         if pad > 0 {
             file.write_all(&vec![0u8; pad]).expect("pad");
         }
+    }
+
+    /// #792: a system stem that finalized truncated while the microphone stem
+    /// stayed healthy used to queue silently. `native_call_processing_input`
+    /// only errors when *both* stems are unusable, so a half-hour call whose
+    /// remote audio was lost at close produced a mic-only transcript whose
+    /// only marking was a downstream `Inferred` "missing or silent" note.
+    #[test]
+    fn truncated_system_stem_records_a_high_confidence_invalid_stem_warning() {
+        let dir = TempDir::new().unwrap();
+        let mov = dir.path().join("2026-06-02-083135-call.mov");
+        std::fs::write(&mov, vec![7_u8; 64_000]).unwrap();
+        write_test_wav(
+            &dir.path().join("2026-06-02-083135-call.voice.wav"),
+            48_000,
+            4_000_000,
+        );
+        // The exact size reported in #792: a page-aligned WAV header plus
+        // 0.02 s of audio, written after 30+ minutes of healthy capture.
+        write_test_wav(
+            &dir.path().join("2026-06-02-083135-call.system.wav"),
+            48_000,
+            7_936,
+        );
+
+        let input = native_call_processing_input(&mov).expect("healthy voice stem is viable");
+        let health = input
+            .recovery_health
+            .expect("a truncated stem must be reported, not passed over");
+        let warning = health
+            .capture_warnings
+            .iter()
+            .find(|warning| {
+                matches!(
+                    &warning.kind,
+                    minutes_core::diarize::FailureKind::Other { code }
+                        if code == minutes_core::health::NATIVE_CALL_INVALID_STEM_CODE
+                )
+            })
+            .expect("invalid-stem warning");
+
+        assert_eq!(warning.source, minutes_core::diarize::CaptureSource::System);
+        assert_eq!(
+            warning.diagnostic_confidence,
+            minutes_core::diarize::DiagnosticConfidence::High,
+            "a stem measured on disk is observed, not inferred"
+        );
+        assert!(
+            warning.message.contains("7936"),
+            "message should carry the measured size: {}",
+            warning.message
+        );
+    }
+
+    /// The mirror case: a truncated microphone stem next to a healthy system
+    /// stem must be reported against the voice source.
+    #[test]
+    fn truncated_voice_stem_is_attributed_to_the_voice_source() {
+        let dir = TempDir::new().unwrap();
+        let mov = dir.path().join("call.mov");
+        std::fs::write(&mov, vec![7_u8; 64_000]).unwrap();
+        write_test_wav(&dir.path().join("call.voice.wav"), 48_000, 7_936);
+        write_test_wav(&dir.path().join("call.system.wav"), 48_000, 4_000_000);
+
+        let input = native_call_processing_input(&mov).expect("healthy system stem is viable");
+        let health = input
+            .recovery_health
+            .expect("truncated stem must be reported");
+        assert!(health
+            .capture_warnings
+            .iter()
+            .any(|warning| warning.source == minutes_core::diarize::CaptureSource::Voice));
+    }
+
+    /// A healthy pair must stay quiet — this path runs on every successful
+    /// call capture, so a false positive here would mark every recording.
+    #[test]
+    fn healthy_stem_pair_records_no_capture_warning() {
+        let dir = TempDir::new().unwrap();
+        let mov = dir.path().join("call.mov");
+        std::fs::write(&mov, vec![7_u8; 64_000]).unwrap();
+        write_test_wav(&dir.path().join("call.voice.wav"), 48_000, 4_000_000);
+        write_test_wav(&dir.path().join("call.system.wav"), 48_000, 4_000_000);
+
+        let input = native_call_processing_input(&mov).expect("both stems viable");
+        assert!(
+            input.recovery_health.is_none(),
+            "healthy captures must not be marked"
+        );
+    }
+
+    /// An absent stem is not a truncated one. Single-stem captures are a
+    /// supported outcome and already carry their own recovery reporting; they
+    /// must not also be labelled as a finalization failure.
+    #[test]
+    fn missing_system_stem_is_not_reported_as_truncated() {
+        let dir = TempDir::new().unwrap();
+        let mov = dir.path().join("call.mov");
+        std::fs::write(&mov, vec![7_u8; 64_000]).unwrap();
+        write_test_wav(&dir.path().join("call.voice.wav"), 48_000, 4_000_000);
+
+        let input = native_call_processing_input(&mov).expect("voice stem is viable");
+        assert!(input.recovery_health.is_none());
     }
 
     fn write_signal_wav(path: &Path, audible: bool) {


### PR DESCRIPTION
Addresses the reporting half of #792 Bug 1: a native call capture whose system stem is lost at finalization queues silently, and the user's only signal is a guess.

## The gap

`native_call_processing_input` refuses a capture only when **both** PCM stems fail `viable_native_call_stem`:

```rust
if !voice_viable && !system_viable {
    return Err(...);
}
```

When one stem finalizes truncated and its sibling is healthy — which is the common case, since the microphone stem survives — the function returns `Ok` with `recovery_health: None`. Nothing marks the capture. The only thing that eventually reaches the user is a downstream warning:

```json
{"kind":{"other":{"code":"native-call-system-stem-recovery"}},
 "source":"voice",
 "message":"Call/remote audio was missing or silent. This transcript contains local microphone audio only.",
 "diagnostic_confidence":"inferred"}
```

"Missing or silent", inferred — indistinguishable from a call where the remote side genuinely said nothing.

## Why the stem is not merely "missing"

#792 reports the system stem finalizing at exactly 7,936 bytes across multiple sessions, including one reproduced on demand and one from ten weeks earlier on the same machine. The header on such a file explains it:

```
RIFF f80f0000  -> declares 4,096 bytes
WAVE
JUNK (28 bytes)
fmt  format=3 (IEEE float) channels=1 rate=48000 byte_rate=192000 bits=32
FLLR (4,008 bytes of Apple page-alignment filler)
...4,096-byte aligned header, then ~0.02 s of audio
```

The RIFF size field still declares the 4,096-byte page-aligned header block the writer laid down before any audio was appended. The file was never finalized — but capture did run, and the `native-captures/` stem was verified growing normally with ~99.7% nonzero samples for the whole session before this.

So a stem that is present on disk and below the viability threshold is *observed* evidence of a finalization failure, not something to infer.

## The change

In `native_call_processing_input`, after the existing both-stems-failed check, detect a stem that exists but finalized below `MIN_VIABLE_STEM_DURATION_SECS` and record it as a `High`-confidence `native-call-invalid-stem` warning carrying the measured byte count and approximate duration, plus an error-level log line.

`health::append_native_call_invalid_stem_warning` already models exactly this case and already uses `DiagnosticConfidence::High`. Nothing on the truncated-stem path was reaching it.

`truncated_native_call_stem_reason` returns `None` for an absent stem, so single-stem captures — a supported outcome with its own recovery reporting — are not relabelled as finalization failures.

## What this deliberately does not do

The issue asks for a hard error when a 0.02 s stem appears after preflight reported `system_audio_ready: true`. I did not make it fail the job: the surviving sibling is typically a full-length microphone recording, and refusing to queue would destroy usable audio in order to punish a partial capture. The recording still processes; it is now labelled accurately and at the right confidence, which is what makes the failure actionable.

This is reporting only. It does not stop the stem from being truncated — that is upstream in the native call helper's finalize path, and worth a separate fix.

## Testing

Four new unit tests, all confirmed executing on `macos-latest` CI: truncated system stem produces a `High`-confidence warning attributed to `System` and carrying the measured size; the mirrored voice case; a healthy pair produces no warning (this path runs on every successful capture, so a false positive would mark every recording); and an absent stem is not reported as truncated.

---

Related: this is one of two independent PRs for #792. The other fixes the zero-stuffed system stem at its root; they touch different files and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
