### PR TITLE
test(bounded-child): stop the setsid escape test racing the scheduler

### DIFF
--- a/crates/core/src/bounded_child.rs
+++ b/crates/core/src/bounded_child.rs
@@ -2365,10 +2365,27 @@ mod tests {
         let directory = tempfile::TempDir::new().unwrap();
         let pid_path = directory.path().join("escaped-writer.pid");
         let mut command = BoundedCommand::new("sh");
+        // Two things had to change to stop this racing the scheduler rather
+        // than testing the invariant. It failed on unrelated pull requests by
+        // returning Ok with empty stdout from an already-exited launcher.
+        //
+        // The escapee now writes past the 1024 byte budget before publishing
+        // its pid, and the launcher waits for that pid before exiting, so
+        // `run` can never observe a finished parent with nothing in the pipe.
+        //
+        // The wall clock budget is seconds rather than 150ms because the
+        // budget error fires on byte count, not on the deadline: giving the
+        // escapee room to be scheduled cannot slow the passing path down, it
+        // only stops a loaded runner from hitting the deadline first and
+        // reporting the wrong error. The elapsed assertion below still proves
+        // the escapee cannot hold the pipe workers open, which is the point.
         command
             .args([
                 "-c",
-                "setsid sh -c 'echo $$ > \"$1\"; while :; do printf x; done' escaped \"$1\" & exit 0",
+                "setsid sh -c 'printf \"%02048d\" 0; echo $$ > \"$1\"; while :; do printf x; done' escaped \"$1\" & \
+                 attempts=0; \
+                 while [ ! -s \"$1\" ] && [ \"$attempts\" -lt 500 ]; do sleep 0.01; attempts=$((attempts+1)); done; \
+                 exit 0",
                 "minutes-setsid-writer-launcher",
             ])
             .arg(&pid_path);
@@ -2378,12 +2395,15 @@ mod tests {
             &mut command,
             None,
             StdoutTarget::Capture { max_bytes: 1024 },
-            budget(150),
+            budget(5_000),
         )
         .unwrap_err();
 
-        assert!(error.to_string().contains("stdout resource budget"));
-        assert!(started.elapsed() < Duration::from_secs(5));
+        assert!(
+            error.to_string().contains("stdout resource budget"),
+            "expected the stdout budget to trip, got: {error}"
+        );
+        assert!(started.elapsed() < Duration::from_secs(10));
         let escaped_pid = std::fs::read_to_string(pid_path)
             .unwrap()
             .trim()

--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -599,7 +599,14 @@ describe("stable corpus lease", () => {
     } finally {
       rmSync(parent, { recursive: true, force: true });
     }
-  }, 30_000);
+    // 80 corpus lifetimes means 80 worker process lifecycles, and process
+    // creation on the Windows runners is slow enough that this lands at
+    // 30024ms against a 30s limit: failing by 24 milliseconds, then taking the
+    // rest of the file down with it. The iteration count is load bearing, it
+    // has to exceed the 64 slot bound this test exists to check, so the limit
+    // is what gives. Four minutes is not a performance budget, it is headroom
+    // against a slow runner; the assertion is about slot reuse, not speed.
+  }, 240_000);
 
   // Not "across retry attempts": the parent's cumulative timer kills the
   // worker while it is still awaiting a hook, so the phase-result that would

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -599,7 +599,14 @@ describe("stable corpus lease", () => {
     } finally {
       rmSync(parent, { recursive: true, force: true });
     }
-  }, 30_000);
+    // 80 corpus lifetimes means 80 worker process lifecycles, and process
+    // creation on the Windows runners is slow enough that this lands at
+    // 30024ms against a 30s limit: failing by 24 milliseconds, then taking the
+    // rest of the file down with it. The iteration count is load bearing, it
+    // has to exceed the 64 slot bound this test exists to check, so the limit
+    // is what gives. Four minutes is not a performance budget, it is headroom
+    // against a slow runner; the assertion is about slot reuse, not speed.
+  }, 240_000);
 
   // Not "across retry attempts": the parent's cumulative timer kills the
   // worker while it is still awaiting a hook, so the phase-result that would


### PR DESCRIPTION
`bounded_child::tests::continuously_writing_setsid_escape_cannot_hold_pipe_workers` failed on three unrelated pull requests today, including a contributor PR (#797) that touches nothing near it. It is a race in the test, not the invariant.

## What it was doing

The launcher exits immediately after backgrounding a `setsid` escapee that writes forever. On a loaded runner the launcher can exit before the escapee is scheduled, so `run` collects an empty stdout from an already-finished parent and returns `Ok`. The failure reads:

```
called `Result::unwrap_err()` on an `Ok` value: ChildRun { output: Output {
  status: ExitStatus(unix_wait_status(0)), stdout: "", stderr: "" }, timed_out: false }
```

Separately, the wall clock budget was 150ms, tight enough that a loaded runner could hit the deadline before the escapee produced anything, which reports a different error than the one asserted.

## What changed

The escapee writes past the 1024 byte stdout budget before publishing its pid, and the launcher waits for that pid before exiting, so `run` can never observe a finished parent with an empty pipe. The wait is bounded, so a genuinely dead escapee still fails the test rather than hanging it.

The budget is now seconds instead of 150ms. That cannot slow the passing path down, because the budget error fires on byte count rather than on the deadline, so it trips as soon as the escapee writes. It only stops a loaded runner from hitting the deadline first. The elapsed assertion still proves the escapee cannot hold the pipe workers open, which is the actual invariant.

## Measured, before and after

Same machine, same load, CPU saturated with one busy loop per core to recreate the runner condition:

```
ORIGINAL TEST under full CPU load: 6 failures out of 25
FIXED    TEST under full CPU load: 0 failures out of 25
```

The fixed test completes in 0.04s, which confirms the byte budget still trips immediately rather than the test now waiting out a longer deadline.

## A correction

I previously suggested this failure might be caused by a test of mine that wrote 8193 files, and changed that test partly on that basis. That was wrong: this failed on #797, which does not contain my change. The reasoning was mine to check and I did not check it before saying it. The test change it prompted was still an improvement on its own merits, but the causal claim was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
