### PR TITLE
[diagnostic, do not merge] name which owner-only DACL condition fails (#800)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,13 @@ jobs:
         run: cargo test -p minutes-core --no-default-features --lib -- --test-threads=1 --nocapture
         timeout-minutes: 15
 
+      - name: Unit tests (streaming feature)
+        # Temporary, to reproduce #800 where it actually happens. The permanent
+        # version of this step is MrFreekour's in #797; this branch is a
+        # diagnostic and is not for merge.
+        run: cargo test -p minutes-core --no-default-features --features streaming --lib -- --test-threads=1 --nocapture
+        timeout-minutes: 20
+
       - name: Copilot attach, routing, and window-contract tests
         # On Windows this executes the real named-pipe connect/reconnect path.
         # On Unix it also asserts owner-only socket/discovery permissions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,12 +249,26 @@ jobs:
         run: cargo test -p minutes-core --no-default-features --lib -- --test-threads=1 --nocapture
         timeout-minutes: 15
 
-      - name: Unit tests (streaming feature)
-        # Temporary, to reproduce #800 where it actually happens. The permanent
-        # version of this step is MrFreekour's in #797; this branch is a
-        # diagnostic and is not for merge.
-        run: cargo test -p minutes-core --no-default-features --features streaming --lib -- --test-threads=1 --nocapture
-        timeout-minutes: 20
+      - name: Repeat the racing audit test to catch #800
+        # Diagnostic, not for merge. #800 is intermittent: it failed on four of
+        # eight concurrent processes in one run and passed entirely in the
+        # next. Running the racing test once tells us almost nothing, so run it
+        # repeatedly and stop at the first failure, which is the run whose
+        # output we actually want.
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          for attempt in $(seq 1 25); do
+            echo "=== attempt $attempt ==="
+            if ! cargo test -p minutes-core --no-default-features --features streaming --lib \
+                 -- --test-threads=1 --nocapture \
+                 policy_fs::tests::restricted_override_audit; then
+              echo "::warning::#800 reproduced on attempt $attempt"
+              exit 1
+            fi
+          done
+          echo "::warning::#800 did not reproduce in 25 attempts"
+        timeout-minutes: 45
 
       - name: Copilot attach, routing, and window-contract tests
         # On Windows this executes the real named-pipe connect/reconnect path.

--- a/crates/core/src/overlays.rs
+++ b/crates/core/src/overlays.rs
@@ -452,25 +452,58 @@ mod windows_private {
             let mut control = 0u16;
             let mut revision = 0u32;
             let mut info = unsafe { zeroed::<ACL_SIZE_INFORMATION>() };
-            if owner.is_null()
-                || unsafe { EqualSid(owner, self.sid()) } == 0
-                || dacl.is_null()
-                || unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) }
-                    == 0
-                || control & SE_DACL_PROTECTED == 0
-                || unsafe {
+            // Evaluated one condition at a time so the error can say which
+            // one failed. The single combined message cost real debugging time
+            // on #800, where the attestation failed on four of eight
+            // concurrent processes and the message could not distinguish "the
+            // owner is somebody else" from "the DACL is inheritable" from
+            // "there is more than one entry".
+            let owner_missing = owner.is_null();
+            let owner_mismatch = !owner_missing && unsafe { EqualSid(owner, self.sid()) } == 0;
+            let dacl_missing = dacl.is_null();
+            let control_unreadable = !dacl_missing
+                && unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) }
+                    == 0;
+            let dacl_inheritable =
+                !dacl_missing && !control_unreadable && control & SE_DACL_PROTECTED == 0;
+            let acl_info_unreadable = !dacl_missing
+                && unsafe {
                     GetAclInformation(
                         dacl,
                         (&mut info as *mut ACL_SIZE_INFORMATION).cast(),
                         size_of::<ACL_SIZE_INFORMATION>() as u32,
                         AclSizeInformation,
                     )
-                } == 0
-                || info.AceCount != 1
+                } == 0;
+            let wrong_ace_count = !acl_info_unreadable && info.AceCount != 1;
+
+            if owner_missing
+                || owner_mismatch
+                || dacl_missing
+                || control_unreadable
+                || dacl_inheritable
+                || acl_info_unreadable
+                || wrong_ace_count
             {
-                return Err(io::Error::other(
-                    "private correction store DACL is not owner-only",
-                ));
+                let reason = if owner_missing {
+                    "the object has no owner"
+                } else if owner_mismatch {
+                    "the object is owned by another account"
+                } else if dacl_missing {
+                    "the object has no DACL"
+                } else if control_unreadable {
+                    "the security descriptor control word could not be read"
+                } else if dacl_inheritable {
+                    "the DACL is not protected, so it can inherit entries"
+                } else if acl_info_unreadable {
+                    "the ACL size information could not be read"
+                } else {
+                    "the DACL has more than one entry"
+                };
+                return Err(io::Error::other(format!(
+                    "private correction store DACL is not owner-only: {reason}                      (control=0x{control:04x}, aces={})",
+                    info.AceCount
+                )));
             }
             let mut ace_ptr: *mut c_void = null_mut();
             if unsafe { GetAce(dacl, 0, &mut ace_ptr) } == 0 || ace_ptr.is_null() {


### PR DESCRIPTION
**Diagnostic only. Not for merge.** Open as a draft so CI runs it on Windows, which is the only place #800 reproduces.

## Why

The owner-only attestation in `overlays.rs` returns one message for seven distinct failure conditions:

```
private correction store DACL is not owner-only
```

That is why #800 currently has no diagnosis. Four of eight concurrent processes failed and the message cannot distinguish "the object is owned by another account" from "the DACL is inheritable" from "the DACL has more than one entry". Those point at completely different bugs.

## What this does

Evaluates each condition separately and names the one that tripped, with the observed control word and entry count. It also carries a temporary copy of the streaming test step from #797, because #797 is not merged yet and the failure does not reproduce without it.

## What happens next

Read the Windows job output, learn which condition actually fails, then close this branch. The improved error message is worth keeping on its own and will be reproposed as a normal PR without the temporary CI step, since an attestation that refuses a store should say what it objected to.

Credit for the CI step to @MrFreekour in #797; it is copied here only so this branch reproduces the failure.
