### PR TITLE
docs(readme): fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,7 +1365,7 @@ const results = await searchMeetings("~/meetings", "pricing");
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=silverstein/minutes&type=Date)](https://star-history.com/#silverstein/minutes&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=silverstein/minutes&type=Date)](https://star-history.dera.page/#silverstein/minutes&Date)
 
 ## Contributing
 


### PR DESCRIPTION
The README star history chart is currently broken. The upstream service that produced it now trips GitHub stargazer API restrictions, so the badge renders nothing. This swaps the chart over to a maintained mirror that uses a token-free data source, restoring the chart. The link target and image were both updated, and the wrapping link now uses the hash-based URL format.