### PR TITLE
feat(pid): address the stop sentinel to a recording (#804)

### DIFF
--- a/crates/core/src/pid.rs
+++ b/crates/core/src/pid.rs
@@ -609,25 +609,119 @@ pub fn stop_sentinel_path() -> PathBuf {
     Config::minutes_dir().join("recording.stop")
 }
 
-/// Write the sentinel file to signal the recording process to stop.
+/// Prefix of an addressed sentinel. Anything else is treated as the legacy
+/// unaddressed form.
+const STOP_SENTINEL_TARGET_PREFIX: &str = "stop-pid:";
+
+/// Write an unaddressed sentinel: stop whoever is recording.
+///
+/// Kept because it is the honest representation of `minutes stop`, which
+/// intends to stop the current recording whatever it is, and because older
+/// builds sharing `~/.minutes` only understand this form.
 pub fn write_stop_sentinel() -> std::io::Result<()> {
+    write_sentinel_bytes("stop")
+}
+
+/// Write a sentinel addressed to one recording.
+///
+/// A sentinel is a file in a directory shared by every Minutes process on the
+/// machine, and the reader used to be "does this file exist". That is how the
+/// desktop app terminated a CLI recording it had never started and was not
+/// itself recording (#804): the message had no addressee, so the wrong process
+/// answered it.
+///
+/// Addressing does not help against a reader too old to look, which is why
+/// #805 also guards the writer. It does mean two current builds cannot stop
+/// each other by accident, and that a sentinel meant for a process that has
+/// since exited is recognizable as stale rather than consumed by the next
+/// recording to start.
+pub fn write_stop_sentinel_for(target_pid: u32) -> std::io::Result<()> {
+    write_sentinel_bytes(&format!("{STOP_SENTINEL_TARGET_PREFIX}{target_pid}"))
+}
+
+fn write_sentinel_bytes(contents: &str) -> std::io::Result<()> {
     let path = stop_sentinel_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(&path, "stop")
+    fs::write(&path, contents)
+}
+
+/// Who a sentinel is addressed to, if anyone.
+#[derive(Debug, PartialEq, Eq)]
+enum SentinelAddressee {
+    /// Legacy or unreadable payload: stop whoever is recording.
+    Anyone,
+    /// Addressed to exactly this process.
+    Pid(u32),
+}
+
+fn parse_sentinel(contents: &str) -> SentinelAddressee {
+    contents
+        .trim()
+        .strip_prefix(STOP_SENTINEL_TARGET_PREFIX)
+        .and_then(|pid| pid.trim().parse::<u32>().ok())
+        .map_or(SentinelAddressee::Anyone, SentinelAddressee::Pid)
+}
+
+/// Decide what a reader should do with a sentinel it found.
+///
+/// Split out from the filesystem so the contract is testable, since getting it
+/// wrong means either recordings that cannot be stopped or recordings stopped
+/// by somebody else.
+fn sentinel_action(
+    contents: &str,
+    self_pid: u32,
+    target_is_alive: impl FnOnce(u32) -> bool,
+) -> SentinelAction {
+    match parse_sentinel(contents) {
+        // Unaddressed. Honor it: `minutes stop` and every build that predates
+        // addressing writes this, and refusing would leave those users unable
+        // to stop a recording at all.
+        SentinelAddressee::Anyone => SentinelAction::StopUs,
+        SentinelAddressee::Pid(pid) if pid == self_pid => SentinelAction::StopUs,
+        // Addressed to a process that is gone. Nobody is coming to collect it,
+        // and leaving it would stop the next recording that reads it.
+        SentinelAddressee::Pid(pid) if !target_is_alive(pid) => SentinelAction::ClearStale,
+        // Addressed to a live process that is not us. Leave it for them.
+        SentinelAddressee::Pid(_) => SentinelAction::Leave,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum SentinelAction {
+    StopUs,
+    ClearStale,
+    Leave,
+}
+
+/// Check whether a stop was requested of *this* process, clearing the sentinel
+/// when it was.
+///
+/// A sentinel addressed to another live process is left in place rather than
+/// consumed, so the process it was meant for still sees it.
+pub fn check_and_clear_sentinel_for(self_pid: u32) -> bool {
+    let path = stop_sentinel_path();
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return false;
+    };
+    match sentinel_action(&contents, self_pid, is_process_alive) {
+        SentinelAction::StopUs => {
+            fs::remove_file(&path).ok();
+            true
+        }
+        SentinelAction::ClearStale => {
+            fs::remove_file(&path).ok();
+            false
+        }
+        SentinelAction::Leave => false,
+    }
 }
 
 /// Check if the stop sentinel exists and remove it.
 /// Returns true if it was present (stop was requested).
 pub fn check_and_clear_sentinel() -> bool {
-    let path = stop_sentinel_path();
-    if path.exists() {
-        fs::remove_file(&path).ok();
-        true
-    } else {
-        false
-    }
+    check_and_clear_sentinel_for(std::process::id())
 }
 
 /// Spawn a background thread that polls for the sentinel file and sets the stop flag.
@@ -1019,5 +1113,78 @@ mod tests {
 
         drop(guard);
         assert_eq!(inspect_pid_file(&path), PidFileState::Inactive);
+    }
+}
+
+#[cfg(test)]
+mod sentinel_addressing_tests {
+    use super::{parse_sentinel, sentinel_action, SentinelAction, SentinelAddressee};
+
+    #[test]
+    fn a_legacy_sentinel_still_stops_us() {
+        // Every build that predates addressing writes "stop", and `minutes
+        // stop` means "stop whatever is recording". Refusing these would leave
+        // those users unable to stop a recording at all, which is a worse bug
+        // than the one being fixed.
+        assert_eq!(parse_sentinel("stop"), SentinelAddressee::Anyone);
+        assert_eq!(
+            sentinel_action("stop", 4242, |_| true),
+            SentinelAction::StopUs
+        );
+    }
+
+    #[test]
+    fn an_unreadable_payload_is_treated_as_unaddressed_rather_than_ignored() {
+        // Failing open here is deliberate. A sentinel we cannot parse still
+        // means somebody asked for a stop, and ignoring it would strand a
+        // recording that the user is actively trying to end.
+        for payload in ["", "garbage", "stop-pid:", "stop-pid:not-a-number"] {
+            assert_eq!(
+                sentinel_action(payload, 7, |_| true),
+                SentinelAction::StopUs,
+                "payload {payload:?} must still stop us"
+            );
+        }
+    }
+
+    #[test]
+    fn a_sentinel_addressed_to_us_stops_us() {
+        assert_eq!(parse_sentinel("stop-pid:99"), SentinelAddressee::Pid(99));
+        assert_eq!(
+            sentinel_action("stop-pid:99", 99, |_| true),
+            SentinelAction::StopUs
+        );
+    }
+
+    #[test]
+    fn a_sentinel_for_another_live_process_is_left_alone() {
+        // #804: the desktop app stopped a CLI recording it had never started.
+        // Leaving rather than clearing matters as much as not stopping: the
+        // process it was addressed to still has to receive it.
+        assert_eq!(
+            sentinel_action("stop-pid:1234", 5678, |pid| {
+                assert_eq!(pid, 1234, "liveness must be checked for the addressee");
+                true
+            }),
+            SentinelAction::Leave
+        );
+    }
+
+    #[test]
+    fn a_sentinel_for_a_dead_process_is_cleared_without_stopping_us() {
+        // Otherwise it outlives its addressee and the next recording to read
+        // it stops immediately for no reason anyone can see.
+        assert_eq!(
+            sentinel_action("stop-pid:1234", 5678, |_| false),
+            SentinelAction::ClearStale
+        );
+    }
+
+    #[test]
+    fn whitespace_around_the_target_does_not_change_who_it_is_for() {
+        assert_eq!(
+            sentinel_action("  stop-pid: 4321 \n", 4321, |_| true),
+            SentinelAction::StopUs
+        );
     }
 }

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3942,7 +3942,11 @@ pub fn request_stop(
                 recording.store(true, Ordering::Relaxed);
                 Ok(())
             } else {
-                minutes_core::pid::write_stop_sentinel().map_err(|e| e.to_string())?;
+                // Address it to the recording we actually looked up. An
+                // unaddressed sentinel is read by whoever gets there first,
+                // which is how this path terminated a CLI recording the app
+                // had never started (#804).
+                minutes_core::pid::write_stop_sentinel_for(pid).map_err(|e| e.to_string())?;
 
                 #[cfg(unix)]
                 {

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -3873,6 +3873,43 @@ pub fn recording_active(recording: &Arc<AtomicBool>) -> bool {
     recording.load(Ordering::Relaxed) || minutes_core::pid::status().recording
 }
 
+/// Whether to signal a recording owned by some other process.
+///
+/// Stopping an externally started recording from the tray is a feature: the
+/// user runs `minutes record`, then hits Stop in the app, and expects it to
+/// work. What is not a feature is the app stopping a recording it does not own
+/// while believing that recording is its own.
+///
+/// That combination is what issue #792 bug 5 reports. The desktop app showed a
+/// recording in progress while capturing nothing, and the only recording on
+/// the machine belonged to a separate CLI process, which it then terminated
+/// after 202 seconds. The user loses a recording the app never made.
+///
+/// The app can legitimately own a recording under a different PID, which is
+/// why ownership is asked about rather than assumed from the PID alone.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExternalStopDecision {
+    /// Signal it. Either the app knows it is not the one recording, so this is
+    /// a deliberate stop of someone else, or the recording is ours under
+    /// another PID.
+    Signal,
+    /// Refuse. The app believes it is recording, yet the recording belongs to
+    /// a process that is not ours, so these are two different recordings and
+    /// stopping this one is not what was asked for.
+    RefuseForeign,
+}
+
+pub(crate) fn external_stop_decision(
+    app_believes_it_is_recording: bool,
+    desktop_app_owns_recording: bool,
+) -> ExternalStopDecision {
+    if app_believes_it_is_recording && !desktop_app_owns_recording {
+        ExternalStopDecision::RefuseForeign
+    } else {
+        ExternalStopDecision::Signal
+    }
+}
+
 pub fn request_stop(
     recording: &Arc<AtomicBool>,
     stop_flag: &Arc<AtomicBool>,
@@ -3884,11 +3921,34 @@ pub fn request_stop(
                 recording.store(true, Ordering::Relaxed);
                 Ok(())
             } else {
+                #[cfg(unix)]
+                let desktop_owns = minutes_core::desktop_control::desktop_app_owns_pid(pid);
+                // Without the ownership probe there is nothing to distinguish
+                // our own out-of-process recording from someone else's, so
+                // keep the previous behavior rather than refuse a legitimate
+                // stop.
+                #[cfg(not(unix))]
+                let desktop_owns = true;
+
+                if external_stop_decision(recording.load(Ordering::Relaxed), desktop_owns)
+                    == ExternalStopDecision::RefuseForeign
+                {
+                    // Leave the other process alone and correct our own state,
+                    // which is the part that is actually wrong here.
+                    recording.store(false, Ordering::Relaxed);
+                    eprintln!(
+                        "refusing to stop recording PID {pid}: it belongs to another process, and this app believed it was recording. Not stopping it."
+                    );
+                    return Err(format!(
+                        "This app thought it was recording, but the active recording (PID {pid}) belongs to another process. It was left running. Stop it where it was started, or restart the app if its state looks wrong."
+                    ));
+                }
+
                 minutes_core::pid::write_stop_sentinel().map_err(|e| e.to_string())?;
 
                 #[cfg(unix)]
                 {
-                    if minutes_core::desktop_control::desktop_app_owns_pid(pid) {
+                    if desktop_owns {
                         eprintln!(
                             "recording PID {} is owned by the desktop app; using sentinel-only stop",
                             pid
@@ -22128,6 +22188,48 @@ mod dictation_hud_position_tests {
         assert_eq!(
             nearest_dictation_hud_anchor(1100.0, 100.0, 0.0, 0.0, 1200.0, 800.0),
             "top_right"
+        );
+    }
+}
+
+#[cfg(test)]
+mod external_stop_tests {
+    use super::{external_stop_decision, ExternalStopDecision};
+
+    #[test]
+    fn stopping_someone_elses_recording_from_the_tray_still_works() {
+        // The user runs `minutes record` in a terminal, then hits Stop in the
+        // app. The app knows it is not the one recording, so this is a
+        // deliberate stop of another process and must keep working.
+        assert_eq!(
+            external_stop_decision(false, false),
+            ExternalStopDecision::Signal
+        );
+    }
+
+    #[test]
+    fn our_own_recording_under_another_pid_is_still_ours_to_stop() {
+        // The desktop app can own a recording that runs under a different PID.
+        // Refusing that would break stopping our own capture.
+        assert_eq!(
+            external_stop_decision(true, true),
+            ExternalStopDecision::Signal
+        );
+        assert_eq!(
+            external_stop_decision(false, true),
+            ExternalStopDecision::Signal
+        );
+    }
+
+    #[test]
+    fn a_foreign_recording_is_not_stopped_while_we_think_we_are_recording() {
+        // Issue #792 bug 5. The app showed a recording in progress while
+        // capturing nothing, the only real recording belonged to a separate
+        // CLI process, and the app terminated it after 202 seconds. Two
+        // different recordings, and the wrong one was stopped.
+        assert_eq!(
+            external_stop_decision(true, false),
+            ExternalStopDecision::RefuseForeign
         );
     }
 }


### PR DESCRIPTION
The reader-side guard suggested by @MrFreekour in #804. #805 is the writer-side one; both are worth having, for reasons at the bottom.

## The problem

The stop sentinel is a file in a directory shared by every Minutes process on the machine, and the reader was `path.exists()`. A message with no addressee is answered by whoever reads it first. That is how the desktop app terminated a CLI recording it had never started, while capturing nothing itself.

## The contract now

A sentinel may name the recording it is for. A reader honors it only when it is addressed to itself, or unaddressed.

Three cases, each chosen deliberately rather than falling out of the implementation:

**Unaddressed payloads still stop us.** `minutes stop` genuinely means "stop whatever is recording", and every build predating this writes that form, including the 0.18.2 CLI in the report. Refusing them would leave those users unable to stop a recording at all, which is a worse bug than the one being fixed. An unparseable payload is treated identically, because it still means somebody asked for a stop, and stranding a recording the user is actively trying to end is the wrong way to fail.

**A sentinel addressed to another live process is left in place, not cleared.** Not consuming it matters as much as not obeying it: the process it was meant for still has to receive it.

**A sentinel addressed to a dead process is cleared without stopping anything.** Otherwise it outlives its addressee and stops the next recording that reads it, which would be a new silent-loss bug introduced by the fix for a silent-loss bug.

## Why both this and #805

Addressing does not protect a reader too old to look: a 0.18.2 CLI still stops on existence alone, so the exact pairing in #804 needs the writer guard in #805 as well. Conversely, guarding one writer does not cover a writer nobody has thought of, including future code and builds already in the wild. One guards the sender, the other the receiver.

## Verification

Six tests over the decision function, which is split out from the filesystem precisely so this contract is testable. Mutation-verified in both directions: clearing sentinels addressed elsewhere, which is the reported behavior, fails the foreign-recording test; refusing unaddressed sentinels fails the legacy and unparseable tests.

`minutes-core` pid tests, the CLI suite (115) and the desktop suite (346) all pass. clippy and fmt clean.

Not done here, and worth its own change: the startup warning for a version-skewed CLI sharing `~/.minutes`, which is the third suggestion in #804. With addressing in place the skew is no longer dangerous, so that becomes informational rather than protective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
