### PR TITLE
release: pin minutes-sdk 0.25.2 for mcp

### DIFF
--- a/crates/mcp/package-lock.json
+++ b/crates/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "minutes-sdk": "0.25.1",
+        "minutes-sdk": "0.25.2",
         "yaml": "^2.8.3",
         "zod": "^3.25 || ^4.0"
       },
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/minutes-sdk": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.1.tgz",
-      "integrity": "sha512-BM1K5k2/IaRiIg6z6l8cFuAMfrarLon7tF2U3MKPvi8IsU5HPJV7xGDDWhGvAizJ6yU1ce2dWkpf0nqEqv9OPw==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.2.tgz",
+      "integrity": "sha512-3uVt1StFrqBykNZm+MgUgG3rGuSVtRMP/ktbNaxMu0M65BWD6kvcvis53MV3gC+tRll4rd1GH/O5ye3qn83svA==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "minutes-sdk": "0.25.1",
+    "minutes-sdk": "0.25.2",
     "yaml": "^2.8.3",
     "zod": "^3.25 || ^4.0"
   },


### PR DESCRIPTION
## Summary

- pin `minutes-mcp@0.25.2` to the exact `minutes-sdk@0.25.2` release input
- commit the registry URL and canonical Linux-packed integrity for the SDK tarball
- preserve the guarded Phase 2 boundary: exactly `crates/mcp/package.json` and `crates/mcp/package-lock.json` change

## Provenance

The current-main Phase 2 helper generated this commit from the local SDK artifact while `minutes-sdk@0.25.2` is intentionally not yet published. Independent `npm pack --dry-run --json` reproduced the committed integrity exactly:

`sha512-3uVt1StFrqBykNZm+MgUgG3rGuSVtRMP/ktbNaxMu0M65BWD6kvcvis53MV3gC+tRll4rd1GH/O5ye3qn83svA==`

The trusted tag workflow will publish that same SDK artifact before publishing MCP. No registry mutation occurs in this PR.

## Verification

- release-mode version policy: Domain 1 `0.25.2`, MCP SDK dependency `0.25.2`
- release site constants: 34 tools, 11 resources, 6 prompts, 58 CLI commands, 2,911 tests
- release, unpublished-SDK fallback, and site-sync regressions: 16/16 passed
- actual unpublished-SDK install via `scripts/install_mcp_dependencies.mjs --sdk-ready`
- MCP TypeScript/Vite production build
- packed MCPB manifest and structural checks
- live MCPB protocol handshake: server `minutes@0.25.2`, protocol `2025-11-25`
- exact two-file diff and `git diff --check`

## Boundary

This PR does not create or push a tag, publish any package, create or publish a GitHub release, deploy the site, or update Homebrew. After landing and fresh main CI, those remain separate release gates.
