### PR TITLE
docs(site): refresh v0.25.2 release copy

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -28,7 +28,7 @@ const featureGrid = [
     label: "For meetings",
     title: "Capture what matters",
     description:
-      "One-click recording, streaming transcription, speaker separation, decisions, and action items without shipping your audio to a SaaS vendor.",
+      "One-click recording keeps voice and system audio failure-isolated, reports source dropouts and mostly-zero stems, and preserves the WAV for recovery.",
   },
   {
     label: "For voice memos",
@@ -116,7 +116,7 @@ const capabilityColumns = [
   },
 ] as const;
 
-// Competitor cells reflect public docs as of June 2026. Refresh quarterly.
+// Competitor cells reflect public docs spot-checked in August 2026. Refresh quarterly.
 const comparisons = [
   ["Local transcription", "No (cloud)", "No (cloud)", "Yes", "Yes"],
   ["Open source", "No", "No", "MIT", "MIT"],
@@ -383,9 +383,9 @@ export default function Home() {
         <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
           <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
           adds{" "}
-          <span className="text-[var(--text)]">minutes resummarize</span> to
-          re-run the AI pass on an edited transcript, refreshes derived views
-          after an applied pass, and fixes a dictation double-paste.{" "}
+          reliable dual-source capture across mismatched mixer buffers and late
+          shutdown samples, prevents the desktop from stopping a separate CLI
+          recording, and surfaces source-dropout and mostly-zero-stem warnings.{" "}
           <a
             href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
             className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -1,9 +1,10 @@
 // Social-proof constants. Hand-refreshed at release time (see docs/release/procedure.md
-// step 12) from the GitHub and npm APIs. Coarse on purpose: better slightly
+// step 15) from the GitHub and npm APIs. Coarse on purpose: better slightly
 // stale and reliable than a flaky build-time fetch.
-// Last refreshed: 2026-07-23.
+// Contributors excludes anonymous entries and dependency automation.
+// Last refreshed: 2026-08-21.
 
-export const GITHUB_STARS = "1,374";
-export const GITHUB_FORKS = "144";
-export const GITHUB_CONTRIBUTORS = "24";
+export const GITHUB_STARS = "1,441";
+export const GITHUB_FORKS = "156";
+export const GITHUB_CONTRIBUTORS = "29";
 export const NPM_MONTHLY_DOWNLOADS = "4,400";


### PR DESCRIPTION
## Summary
- replace the stale v0.25.1 homepage strip with the capture-reliability work shipped in v0.25.2
- align the meeting-capture feature blurb with the new source-dropout and mostly-zero-stem receipts
- refresh GitHub and npm social-proof constants and record the comparison spot-check date

## Verification
- `node scripts/sync_site_release_version.mjs`
- `npm --prefix site ci`
- `npm --prefix site run check:llms`
- `npm --prefix site run build` (44 static routes)