### PR TITLE
Fix Bluetooth HFP voice-stem PCM decoding

### DIFF
--- a/tauri/src-tauri/src/call_capture.rs
+++ b/tauri/src-tauri/src/call_capture.rs
@@ -645,7 +645,7 @@ fn find_native_call_helper_binary() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     #[cfg(target_os = "macos")]
-    use super::native_call_helper_path;
+    use super::find_native_call_helper_binary;
     use super::{
         finish_microphone_startup_handshake, native_call_helper_args, parse_macos_major_version,
         resolve_microphone_selection, MicrophoneSelection, MicrophoneStartupStatus,
@@ -660,7 +660,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn native_helper_decodes_hfp_pcm_container_layouts() {
-        let helper = native_call_helper_path().expect("native call helper should be built");
+        let helper = find_native_call_helper_binary().expect("native call helper should be built");
         let output = std::process::Command::new(helper)
             .arg("--self-test-pcm-decoder")
             .output()

--- a/tauri/src-tauri/src/call_capture.rs
+++ b/tauri/src-tauri/src/call_capture.rs
@@ -531,6 +531,18 @@ pub fn start_native_call_capture(
                         let _ = microphone_status_tx
                             .send(MicrophoneStartupStatus::Fallback(name.to_string()));
                     }
+                    Some("audio_format") => {
+                        tracing::info!(
+                            audio_format = %value,
+                            "native call source audio format negotiated"
+                        );
+                    }
+                    Some("audio_format_unsupported") => {
+                        tracing::warn!(
+                            audio_format = %value,
+                            "native call source PCM layout is unsupported; stem buffer withheld"
+                        );
+                    }
                     _ => {}
                 }
             }
@@ -632,6 +644,8 @@ fn find_native_call_helper_binary() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "macos")]
+    use super::native_call_helper_path;
     use super::{
         finish_microphone_startup_handshake, native_call_helper_args, parse_macos_major_version,
         resolve_microphone_selection, MicrophoneSelection, MicrophoneStartupStatus,
@@ -642,6 +656,27 @@ mod tests {
         sync::{mpsc, Arc, Mutex},
         time::Duration,
     };
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn native_helper_decodes_hfp_pcm_container_layouts() {
+        let helper = native_call_helper_path().expect("native call helper should be built");
+        let output = std::process::Command::new(helper)
+            .arg("--self-test-pcm-decoder")
+            .output()
+            .expect("PCM decoder self-test should launch");
+
+        assert!(
+            output.status.success(),
+            "PCM decoder self-test failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains(r#""event":"pcm_decoder_self_test""#),
+            "PCM decoder self-test did not emit its success receipt: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
 
     #[test]
     fn parses_major_version_from_product_version() {

--- a/tauri/src-tauri/src/call_capture.rs
+++ b/tauri/src-tauri/src/call_capture.rs
@@ -22,7 +22,100 @@ pub struct CallSourceHealth {
     pub call_audio_live: bool,
     pub mic_level: u32,
     pub call_audio_level: u32,
+    pub mic_frames_silenced: u64,
+    pub system_frames_silenced: u64,
     pub last_update: String,
+}
+
+const HELPER_STDERR_INITIAL_LOG_LIMIT: usize = 5;
+const HELPER_STDERR_LOG_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+struct HelperStderrRateLimiter {
+    initial_lines_logged: usize,
+    suppressed_lines: u64,
+    last_log_at: Instant,
+}
+
+impl HelperStderrRateLimiter {
+    fn new(now: Instant) -> Self {
+        Self {
+            initial_lines_logged: 0,
+            suppressed_lines: 0,
+            last_log_at: now,
+        }
+    }
+
+    /// Returns the number of lines suppressed before the current line when
+    /// the current line should be logged, or `None` when it should be hidden.
+    fn observe(&mut self, now: Instant) -> Option<u64> {
+        if self.initial_lines_logged < HELPER_STDERR_INITIAL_LOG_LIMIT {
+            self.initial_lines_logged += 1;
+            self.last_log_at = now;
+            return Some(0);
+        }
+        if now.duration_since(self.last_log_at) >= HELPER_STDERR_LOG_INTERVAL {
+            let suppressed = std::mem::take(&mut self.suppressed_lines);
+            self.last_log_at = now;
+            return Some(suppressed);
+        }
+        self.suppressed_lines += 1;
+        None
+    }
+}
+
+fn spawn_helper_stderr_drain(stderr: std::process::ChildStderr) {
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        let mut limiter = HelperStderrRateLimiter::new(Instant::now());
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if let Some(suppressed) = limiter.observe(Instant::now()) {
+                        tracing::warn!(
+                            helper_stderr = line,
+                            suppressed_since_last = suppressed,
+                            "native call helper stderr"
+                        );
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "failed to drain native call helper stderr");
+                    break;
+                }
+            }
+        }
+        if limiter.suppressed_lines > 0 {
+            tracing::warn!(
+                suppressed = limiter.suppressed_lines,
+                "native call helper stderr lines suppressed before stream closed"
+            );
+        }
+    });
+}
+
+pub(crate) fn capture_warning_for_audio_format_unsupported(value: &serde_json::Value) -> String {
+    let source = value
+        .get("source")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown source");
+    let field = |name: &str| {
+        value
+            .get(name)
+            .map(serde_json::Value::to_string)
+            .unwrap_or_else(|| "unknown".into())
+    };
+    format!(
+        "Native call capture silenced undecodable {source} audio (ASBD: sample_rate={}, format_id={}, format_flags={}, bits_per_channel={}, bytes_per_packet={}, bytes_per_frame={}, frames_per_packet={}, channels={}).",
+        field("sample_rate"),
+        field("format_id"),
+        field("format_flags"),
+        field("bits_per_channel"),
+        field("bytes_per_packet"),
+        field("bytes_per_frame"),
+        field("frames_per_packet"),
+        field("channels"),
+    )
 }
 
 /// Paths to per-source audio stems written by the native call helper.
@@ -192,6 +285,8 @@ impl NativeCallCaptureSession {
                 call_audio_live: false,
                 mic_level: 0,
                 call_audio_level: 0,
+                mic_frames_silenced: 0,
+                system_frames_silenced: 0,
                 last_update: chrono::Local::now().to_rfc3339(),
             })
     }
@@ -383,6 +478,8 @@ pub fn start_native_call_capture(
         call_audio_live: false,
         mic_level: 0,
         call_audio_level: 0,
+        mic_frames_silenced: 0,
+        system_frames_silenced: 0,
         last_update: chrono::Local::now().to_rfc3339(),
     }));
     let mut command = Command::new(&helper);
@@ -398,6 +495,11 @@ pub fn start_native_call_capture(
         .stdout
         .take()
         .ok_or_else(|| "native call helper did not expose stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "native call helper did not expose stderr".to_string())?;
+    spawn_helper_stderr_drain(stderr);
     let (tx, rx) = mpsc::channel();
     let (microphone_status_tx, microphone_status_rx) = mpsc::channel();
     let microphone_status_expected =
@@ -479,6 +581,14 @@ pub fn start_native_call_capture(
                                 .and_then(|v| v.as_u64())
                                 .map(|v| v as u32)
                                 .unwrap_or(0);
+                            current.mic_frames_silenced = value
+                                .get("mic_frames_silenced")
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0);
+                            current.system_frames_silenced = value
+                                .get("system_frames_silenced")
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0);
                             current.last_update = chrono::Local::now().to_rfc3339();
                         }
                     }
@@ -538,10 +648,16 @@ pub fn start_native_call_capture(
                         );
                     }
                     Some("audio_format_unsupported") => {
+                        let message = capture_warning_for_audio_format_unsupported(&value);
                         tracing::warn!(
                             audio_format = %value,
-                            "native call source PCM layout is unsupported; stem buffer withheld"
+                            "native call source PCM layout is unsupported; stem buffer silenced"
                         );
+                        if let Ok(mut warnings) = warnings_for_thread.lock() {
+                            if !warnings.contains(&message) {
+                                warnings.push(message);
+                            }
+                        }
                     }
                     _ => {}
                 }
@@ -647,15 +763,50 @@ mod tests {
     #[cfg(target_os = "macos")]
     use super::find_native_call_helper_binary;
     use super::{
-        finish_microphone_startup_handshake, native_call_helper_args, parse_macos_major_version,
-        resolve_microphone_selection, MicrophoneSelection, MicrophoneStartupStatus,
+        capture_warning_for_audio_format_unsupported, finish_microphone_startup_handshake,
+        native_call_helper_args, parse_macos_major_version, resolve_microphone_selection,
+        HelperStderrRateLimiter, MicrophoneSelection, MicrophoneStartupStatus,
+        HELPER_STDERR_INITIAL_LOG_LIMIT, HELPER_STDERR_LOG_INTERVAL,
     };
     use std::{
         ffi::OsString,
         path::Path,
         sync::{mpsc, Arc, Mutex},
-        time::Duration,
+        time::{Duration, Instant},
     };
+
+    #[test]
+    fn helper_stderr_rate_limiter_logs_initial_lines_then_periodically() {
+        let start = Instant::now();
+        let mut limiter = HelperStderrRateLimiter::new(start);
+
+        for _ in 0..HELPER_STDERR_INITIAL_LOG_LIMIT {
+            assert_eq!(limiter.observe(start), Some(0));
+        }
+        assert_eq!(limiter.observe(start), None);
+        assert_eq!(limiter.observe(start + Duration::from_secs(9)), None);
+        assert_eq!(limiter.observe(start + HELPER_STDERR_LOG_INTERVAL), Some(2));
+        assert_eq!(limiter.observe(start + HELPER_STDERR_LOG_INTERVAL), None);
+    }
+
+    #[test]
+    fn unsupported_audio_warning_names_source_and_asbd() {
+        let warning = capture_warning_for_audio_format_unsupported(&serde_json::json!({
+            "source": "microphone",
+            "sample_rate": 16_000,
+            "format_id": "lpcm",
+            "format_flags": 4,
+            "bits_per_channel": 16,
+            "bytes_per_packet": 4,
+            "bytes_per_frame": 4,
+            "frames_per_packet": 1,
+            "channels": 1,
+        }));
+        assert!(warning.contains("microphone"));
+        assert!(warning.contains("ASBD"));
+        assert!(warning.contains("sample_rate=16000"));
+        assert!(warning.contains("bits_per_channel=16"));
+    }
 
     #[cfg(target_os = "macos")]
     #[test]
@@ -671,11 +822,12 @@ mod tests {
             "PCM decoder self-test failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
-        assert!(
-            String::from_utf8_lossy(&output.stdout).contains(r#""event":"pcm_decoder_self_test""#),
-            "PCM decoder self-test did not emit its success receipt: {}",
-            String::from_utf8_lossy(&output.stdout)
-        );
+        let receipt: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .expect("PCM decoder self-test should emit one JSON receipt");
+        assert_eq!(receipt["event"], "pcm_decoder_self_test");
+        assert_eq!(receipt["status"], "ok");
+        assert_eq!(receipt["cases"], 7);
+        assert_eq!(receipt["frames_silenced"], 80);
     }
 
     #[test]

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -15063,6 +15063,8 @@ mod tests {
             call_audio_live,
             mic_level,
             call_audio_level,
+            mic_frames_silenced: 0,
+            system_frames_silenced: 0,
             last_update: now.to_rfc3339(),
         }
     }
@@ -16645,6 +16647,55 @@ mod tests {
             input.recovery_health.is_none(),
             "healthy captures must not be marked"
         );
+    }
+
+    #[test]
+    fn unsupported_audio_format_warning_reaches_queued_recording_health() {
+        with_temp_home(|home| {
+            let capture_dir = home.join("native-capture-warning-test");
+            std::fs::create_dir_all(&capture_dir).unwrap();
+            let mov = capture_dir.join("call.mov");
+            std::fs::write(&mov, vec![7_u8; 64_000]).unwrap();
+            write_test_wav(&capture_dir.join("call.voice.wav"), 48_000, 4_000_000);
+            write_test_wav(&capture_dir.join("call.system.wav"), 48_000, 4_000_000);
+
+            let warning = crate::call_capture::capture_warning_for_audio_format_unsupported(
+                &serde_json::json!({
+                    "event": "audio_format_unsupported",
+                    "source": "microphone",
+                    "sample_rate": 16_000,
+                    "format_id": "lpcm",
+                    "format_flags": 4,
+                    "bits_per_channel": 16,
+                    "bytes_per_packet": 4,
+                    "bytes_per_frame": 4,
+                    "frames_per_packet": 1,
+                    "channels": 1,
+                }),
+            );
+            let now = chrono::Local::now();
+            let job = queue_native_call_capture_for_processing(
+                CaptureMode::Meeting,
+                Some("Unsupported format warning".into()),
+                &mov,
+                None,
+                None,
+                now,
+                now,
+                None,
+                None,
+                Some(warning.clone()),
+            )
+            .expect("native call capture should queue");
+
+            let health = job
+                .recording_health
+                .expect("capture warning must be persisted on the queued job");
+            assert!(health
+                .capture_warnings
+                .iter()
+                .any(|capture_warning| capture_warning.message == warning));
+        });
     }
 
     /// An absent stem is not a truncated one. Single-stem captures are a

--- a/tauri/src-tauri/src/system_audio_record.swift
+++ b/tauri/src-tauri/src/system_audio_record.swift
@@ -239,15 +239,9 @@ private func monoFloatBuffer(samples: [Float], sampleRate: Double) -> AVAudioPCM
 
 private func convertMonoBuffer(
     _ sourceBuffer: AVAudioPCMBuffer,
-    to targetFormat: AVAudioFormat
+    to targetFormat: AVAudioFormat,
+    using converter: AVAudioConverter
 ) throws -> AVAudioPCMBuffer {
-    guard let converter = AVAudioConverter(from: sourceBuffer.format, to: targetFormat) else {
-        throw NSError(
-            domain: "MinutesSystemAudioRecord",
-            code: 2,
-            userInfo: [NSLocalizedDescriptionKey: "could not create AVAudioConverter"]
-        )
-    }
     let ratio = targetFormat.sampleRate / sourceBuffer.format.sampleRate
     let capacity =
         AVAudioFrameCount((Double(sourceBuffer.frameLength) * ratio).rounded(.up)) + 1
@@ -289,7 +283,32 @@ private func convertMonoBuffer(
 private final class FixedFormatStemWriter {
     private let url: URL
     private var file: AVAudioFile?
+    private var converter: AVAudioConverter?
+    private var converterInputFormat: AVAudioFormat?
     private(set) var framesSilenced: UInt64 = 0
+
+    /// One converter per (input format → stem format). Recreating it per buffer
+    /// discards the resampler's filter state at every buffer boundary and
+    /// allocates ~50 times a second; reusing it keeps the resampled stream
+    /// continuous across a rate transition.
+    private func converter(
+        from inputFormat: AVAudioFormat,
+        to targetFormat: AVAudioFormat
+    ) throws -> AVAudioConverter {
+        if let converter, let converterInputFormat, converterInputFormat == inputFormat {
+            return converter
+        }
+        guard let created = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+            throw NSError(
+                domain: "MinutesSystemAudioRecord",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "could not create AVAudioConverter"]
+            )
+        }
+        converter = created
+        converterInputFormat = inputFormat
+        return created
+    }
 
     init(url: URL) {
         self.url = url
@@ -306,7 +325,11 @@ private final class FixedFormatStemWriter {
         if buffer.format.sampleRate == file.processingFormat.sampleRate {
             output = buffer
         } else {
-            output = try convertMonoBuffer(buffer, to: file.processingFormat)
+            output = try convertMonoBuffer(
+                buffer,
+                to: file.processingFormat,
+                using: try converter(from: buffer.format, to: file.processingFormat)
+            )
         }
         try file.write(from: output)
         return output.frameLength
@@ -343,6 +366,8 @@ private final class FixedFormatStemWriter {
 
     func close() {
         file = nil
+        converter = nil
+        converterInputFormat = nil
     }
 }
 

--- a/tauri/src-tauri/src/system_audio_record.swift
+++ b/tauri/src-tauri/src/system_audio_record.swift
@@ -139,7 +139,7 @@ private struct LinearPCMLayout {
             return Float(Double(signedValue) / scale)
         }
 
-        let midpoint = Double(mask) / 2.0
+        let midpoint = pow(2.0, Double(bitsPerChannel - 1))
         guard midpoint > 0 else { return nil }
         return Float((Double(raw) - midpoint) / midpoint)
     }
@@ -218,6 +218,134 @@ private func decodedSamples(
     return decoded ? output : nil
 }
 
+private func monoFloatBuffer(samples: [Float], sampleRate: Double) -> AVAudioPCMBuffer? {
+    guard let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: sampleRate,
+        channels: 1,
+        interleaved: false
+    ),
+    let buffer = AVAudioPCMBuffer(
+        pcmFormat: format,
+        frameCapacity: AVAudioFrameCount(samples.count)
+    ),
+    let destination = buffer.floatChannelData?[0] else {
+        return nil
+    }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    destination.update(from: samples, count: samples.count)
+    return buffer
+}
+
+private func convertMonoBuffer(
+    _ sourceBuffer: AVAudioPCMBuffer,
+    to targetFormat: AVAudioFormat
+) throws -> AVAudioPCMBuffer {
+    guard let converter = AVAudioConverter(from: sourceBuffer.format, to: targetFormat) else {
+        throw NSError(
+            domain: "MinutesSystemAudioRecord",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "could not create AVAudioConverter"]
+        )
+    }
+    let ratio = targetFormat.sampleRate / sourceBuffer.format.sampleRate
+    let capacity =
+        AVAudioFrameCount((Double(sourceBuffer.frameLength) * ratio).rounded(.up)) + 1
+    guard let converted = AVAudioPCMBuffer(
+        pcmFormat: targetFormat,
+        frameCapacity: max(capacity, 1)
+    ) else {
+        throw NSError(
+            domain: "MinutesSystemAudioRecord",
+            code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "could not allocate converted audio buffer"]
+        )
+    }
+
+    var providedInput = false
+    var conversionError: NSError?
+    let status = converter.convert(to: converted, error: &conversionError) { _, outStatus in
+        if providedInput {
+            outStatus.pointee = .endOfStream
+            return nil
+        }
+        providedInput = true
+        outStatus.pointee = .haveData
+        return sourceBuffer
+    }
+    if let conversionError {
+        throw conversionError
+    }
+    if status == .error {
+        throw NSError(
+            domain: "MinutesSystemAudioRecord",
+            code: 4,
+            userInfo: [NSLocalizedDescriptionKey: "AVAudioConverter failed"]
+        )
+    }
+    return converted
+}
+
+private final class FixedFormatStemWriter {
+    private let url: URL
+    private var file: AVAudioFile?
+    private(set) var framesSilenced: UInt64 = 0
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    @discardableResult
+    func write(_ buffer: AVAudioPCMBuffer) throws -> AVAudioFrameCount {
+        if file == nil {
+            file = try AVAudioFile(forWriting: url, settings: buffer.format.settings)
+        }
+        guard let file else { return 0 }
+
+        let output: AVAudioPCMBuffer
+        if buffer.format.sampleRate == file.processingFormat.sampleRate {
+            output = buffer
+        } else {
+            output = try convertMonoBuffer(buffer, to: file.processingFormat)
+        }
+        try file.write(from: output)
+        return output.frameLength
+    }
+
+    @discardableResult
+    func writeSilence(
+        sourceFrameCount: AVAudioFrameCount,
+        sourceSampleRate: Double
+    ) throws -> AVAudioFrameCount {
+        guard let file, sourceSampleRate > 0 else { return 0 }
+        let ratio = file.processingFormat.sampleRate / sourceSampleRate
+        let frameCount = max(
+            AVAudioFrameCount((Double(sourceFrameCount) * ratio).rounded()),
+            1
+        )
+        guard let silence = AVAudioPCMBuffer(
+            pcmFormat: file.processingFormat,
+            frameCapacity: frameCount
+        ),
+        let samples = silence.floatChannelData?[0] else {
+            throw NSError(
+                domain: "MinutesSystemAudioRecord",
+                code: 5,
+                userInfo: [NSLocalizedDescriptionKey: "could not allocate silence buffer"]
+            )
+        }
+        silence.frameLength = frameCount
+        samples.initialize(repeating: 0, count: Int(frameCount))
+        try file.write(from: silence)
+        framesSilenced += UInt64(frameCount)
+        return frameCount
+    }
+
+    func close() {
+        file = nil
+    }
+}
+
 private func runPCMDecoderSelfTest() -> Bool {
     let signedPacked = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked
     let signedHighAligned = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsAlignedHigh
@@ -273,14 +401,126 @@ private func runPCMDecoderSelfTest() -> Bool {
         )
     )
 
+    var unsignedSilenceBytes: [UInt8] = []
+    appendLittleEndian(UInt16(0x8000), to: &unsignedSilenceBytes)
+    let unsignedSilence = decodedSamples(
+        bytes: unsignedSilenceBytes,
+        frameCount: 1,
+        asbd: testASBD(
+            channels: 1,
+            bitsPerChannel: 16,
+            bytesPerFrame: 2,
+            flags: kAudioFormatFlagIsPacked
+        )
+    )
+
     let tolerance: Float = 0.000_01
     let cases = [int16, highAligned, int32, stereoFloat]
-    let passed = cases.allSatisfy { samples in
+    let decoderCasesPassed = cases.allSatisfy { samples in
         guard let samples, samples.count == 2 else { return false }
         return abs(samples[0] - 0.5) < tolerance && abs(samples[1] + 0.5) < tolerance
     }
+    let unsignedSilencePassed = unsignedSilence.map {
+        $0.count == 1 && abs($0[0]) < tolerance
+    } ?? false
+
+    var stemCasesPassed = false
+    var selfTestFramesSilenced: UInt64 = 0
+    let temporaryDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("minutes-pcm-self-test-\(UUID().uuidString)")
+    do {
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let rateChangeURL = temporaryDirectory.appendingPathComponent("rate-change.wav")
+        let rateChangeWriter = FixedFormatStemWriter(url: rateChangeURL)
+        guard let firstSegment = monoFloatBuffer(
+            samples: [Float](repeating: 0.25, count: 480),
+            sampleRate: 48_000
+        ) else { throw NSError(domain: "MinutesPCMTest", code: 1) }
+        try rateChangeWriter.write(firstSegment)
+
+        var secondSegmentBytes: [UInt8] = []
+        for _ in 0..<160 {
+            appendLittleEndian(Int32(16_384) << 16, to: &secondSegmentBytes)
+        }
+        guard let secondSamples = decodedSamples(
+            bytes: secondSegmentBytes,
+            frameCount: 160,
+            asbd: testASBD(
+                channels: 1,
+                bitsPerChannel: 16,
+                bytesPerFrame: 4,
+                flags: signedHighAligned
+            )
+        ),
+        let secondSegment = monoFloatBuffer(samples: secondSamples, sampleRate: 16_000) else {
+            throw NSError(domain: "MinutesPCMTest", code: 2)
+        }
+        try rateChangeWriter.write(secondSegment)
+        rateChangeWriter.close()
+
+        let rateChangeFile = try AVAudioFile(forReading: rateChangeURL)
+        guard let rateChangeAudio = AVAudioPCMBuffer(
+            pcmFormat: rateChangeFile.processingFormat,
+            frameCapacity: AVAudioFrameCount(rateChangeFile.length)
+        ) else { throw NSError(domain: "MinutesPCMTest", code: 3) }
+        try rateChangeFile.read(into: rateChangeAudio)
+        let rateChangeLengthPassed = rateChangeFile.fileFormat.sampleRate == 48_000
+            && rateChangeAudio.frameLength >= 900
+        let tailStart = Int(rateChangeAudio.frameLength) * 3 / 4
+        let tailPresent = rateChangeAudio.floatChannelData.map { channels in
+            guard Int(rateChangeAudio.frameLength) > tailStart else { return false }
+            let tail = UnsafeBufferPointer(
+                start: channels[0] + tailStart,
+                count: Int(rateChangeAudio.frameLength) - tailStart
+            )
+            return tail.contains { abs($0) > 0.1 }
+        } ?? false
+
+        let silenceURL = temporaryDirectory.appendingPathComponent("silence-fill.wav")
+        let silenceWriter = FixedFormatStemWriter(url: silenceURL)
+        guard let supported = monoFloatBuffer(
+            samples: [Float](repeating: 0.25, count: 120),
+            sampleRate: 48_000
+        ) else { throw NSError(domain: "MinutesPCMTest", code: 4) }
+        try silenceWriter.write(supported)
+        let silencedFrames = try silenceWriter.writeSilence(
+            sourceFrameCount: 80,
+            sourceSampleRate: 48_000
+        )
+        silenceWriter.close()
+
+        let silenceFile = try AVAudioFile(forReading: silenceURL)
+        guard let silenceAudio = AVAudioPCMBuffer(
+            pcmFormat: silenceFile.processingFormat,
+            frameCapacity: AVAudioFrameCount(silenceFile.length)
+        ) else { throw NSError(domain: "MinutesPCMTest", code: 5) }
+        try silenceFile.read(into: silenceAudio)
+        let silenceSpanPassed = silenceAudio.frameLength == 200
+            && silencedFrames == 80
+            && silenceWriter.framesSilenced == 80
+            && (silenceAudio.floatChannelData.map { channels in
+                (120..<200).allSatisfy { abs(channels[0][$0]) < tolerance }
+            } ?? false)
+
+        stemCasesPassed = rateChangeLengthPassed && tailPresent && silenceSpanPassed
+        selfTestFramesSilenced = silenceWriter.framesSilenced
+    } catch {
+        fputs("PCM stem self-test failed: \(error)\n", stderr)
+    }
+
+    let passed = decoderCasesPassed && unsignedSilencePassed && stemCasesPassed
     if passed {
-        emitJSON(["event": "pcm_decoder_self_test", "status": "ok", "cases": cases.count])
+        emitJSON([
+            "event": "pcm_decoder_self_test",
+            "status": "ok",
+            "cases": cases.count + 3,
+            "frames_silenced": selfTestFramesSilenced,
+        ])
     } else {
         fputs("PCM decoder self-test failed\n", stderr)
     }
@@ -307,12 +547,13 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
     private var latestMicLevel: UInt32 = 0
     private var protocolReady = false
     private var pendingSourceEvents: [[String: Any]] = []
-    private var reportedSourceFormats = Set<String>()
+    private var lastReportedSourceFormats: [String: String] = [:]
     private var reportedDecodeFailures = Set<String>()
+    private var reportedStemWriteFailures = Set<String>()
 
     // Per-source stem writers
-    private var voiceStemFile: AVAudioFile?
-    private var systemStemFile: AVAudioFile?
+    private var voiceStemWriter: FixedFormatStemWriter?
+    private var systemStemWriter: FixedFormatStemWriter?
     // Set once stop() has closed the stems, and never cleared. Both stem files
     // are created lazily on first sample, so without this a sample arriving
     // after the close reopens the file with AVAudioFile(forWriting:), which
@@ -435,6 +676,12 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         let stemDir = outputURL.deletingLastPathComponent()
         voiceStemURL = stemDir.appendingPathComponent("\(baseName).voice.wav")
         systemStemURL = stemDir.appendingPathComponent("\(baseName).system.wav")
+        if let voiceStemURL {
+            voiceStemWriter = FixedFormatStemWriter(url: voiceStemURL)
+        }
+        if let systemStemURL {
+            systemStemWriter = FixedFormatStemWriter(url: systemStemURL)
+        }
 
         try await stream.startCapture()
 
@@ -490,8 +737,8 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         // nil'ing on the main thread races with writes on sampleQueue.
         sampleQueue.sync {
             stemsClosed = true
-            voiceStemFile = nil
-            systemStemFile = nil
+            voiceStemWriter?.close()
+            systemStemWriter?.close()
         }
 
         guard let stream else {
@@ -557,7 +804,9 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
                 "call_audio_live": systemLive,
                 "mic_live": micLive,
                 "call_audio_level": self.latestSystemLevel,
-                "mic_level": self.latestMicLevel
+                "mic_level": self.latestMicLevel,
+                "mic_frames_silenced": self.voiceStemWriter?.framesSilenced ?? 0,
+                "system_frames_silenced": self.systemStemWriter?.framesSilenced ?? 0,
             ]
             if let data = try? JSONSerialization.data(withJSONObject: payload),
                let json = String(data: data, encoding: .utf8) {
@@ -607,14 +856,23 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         default:
             return
         }
-        reportSourceFormatOnce(sourceName: sourceName, asbd: asbd)
-
-        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else {
-            return
-        }
+        reportSourceFormatTransition(sourceName: sourceName, asbd: asbd)
 
         let sampleCount = CMSampleBufferGetNumSamples(sampleBuffer)
         guard sampleCount > 0 else { return }
+        let frameCount = AVAudioFrameCount(sampleCount)
+        let sampleRate = asbd.mSampleRate
+
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else {
+            silenceUndecodableFrames(
+                source: source,
+                sourceName: sourceName,
+                frameCount: frameCount,
+                sampleRate: sampleRate,
+                asbd: asbd
+            )
+            return
+        }
 
         var contiguousLength: Int = 0
         let totalLength = CMBlockBufferGetDataLength(blockBuffer)
@@ -626,9 +884,16 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
             totalLengthOut: nil,
             dataPointerOut: &dataPointer
         )
-        guard totalLength > 0 else { return }
-
-        let sampleRate = asbd.mSampleRate
+        guard totalLength > 0 else {
+            silenceUndecodableFrames(
+                source: source,
+                sourceName: sourceName,
+                frameCount: frameCount,
+                sampleRate: sampleRate,
+                asbd: asbd
+            )
+            return
+        }
 
         // Stems are always mono float32 — mix down if multi-channel
         guard let monoFormat = AVAudioFormat(
@@ -636,15 +901,39 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
             sampleRate: sampleRate,
             channels: 1,
             interleaved: false
-        ) else { return }
+        ) else {
+            silenceUndecodableFrames(
+                source: source,
+                sourceName: sourceName,
+                frameCount: frameCount,
+                sampleRate: sampleRate,
+                asbd: asbd
+            )
+            return
+        }
 
-        let frameCount = AVAudioFrameCount(sampleCount)
         guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: monoFormat, frameCapacity: frameCount) else {
+            silenceUndecodableFrames(
+                source: source,
+                sourceName: sourceName,
+                frameCount: frameCount,
+                sampleRate: sampleRate,
+                asbd: asbd
+            )
             return
         }
         pcmBuffer.frameLength = frameCount
 
-        guard let monoPtr = pcmBuffer.floatChannelData?[0] else { return }
+        guard let monoPtr = pcmBuffer.floatChannelData?[0] else {
+            silenceUndecodableFrames(
+                source: source,
+                sourceName: sourceName,
+                frameCount: frameCount,
+                sampleRate: sampleRate,
+                asbd: asbd
+            )
+            return
+        }
         let decoded: Bool
         if pointerStatus == kCMBlockBufferNoErr,
            let dataPointer,
@@ -679,37 +968,29 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         }
 
         guard decoded else {
-            reportDecodeFailureOnce(sourceName: sourceName, asbd: asbd)
+            silenceUndecodableFrames(
+                source: source,
+                sourceName: sourceName,
+                frameCount: frameCount,
+                sampleRate: sampleRate,
+                asbd: asbd
+            )
             return
         }
 
-        // Lazily create the stem only after the first buffer decodes. An
-        // unsupported source format must not leave a plausible empty WAV.
-        let stemFile: AVAudioFile?
+        // Lazily create the stem only after the first buffer decodes. The
+        // writer then retains that file's processing format for the capture.
+        let stemWriter: FixedFormatStemWriter?
         switch source {
         case .microphone:
-            if voiceStemFile == nil, let url = voiceStemURL {
-                do {
-                    voiceStemFile = try AVAudioFile(forWriting: url, settings: monoFormat.settings)
-                } catch {
-                    fputs("failed to create voice stem file: \(error)\n", stderr)
-                }
-            }
-            stemFile = voiceStemFile
+            stemWriter = voiceStemWriter
         case .audio:
-            if systemStemFile == nil, let url = systemStemURL {
-                do {
-                    systemStemFile = try AVAudioFile(forWriting: url, settings: monoFormat.settings)
-                } catch {
-                    fputs("failed to create system stem file: \(error)\n", stderr)
-                }
-            }
-            stemFile = systemStemFile
+            stemWriter = systemStemWriter
         default:
             return
         }
 
-        guard let file = stemFile else { return }
+        guard let stemWriter else { return }
 
         var sumSquares: Float = 0
         for frame in 0..<Int(frameCount) {
@@ -728,18 +1009,46 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         }
 
         do {
-            try file.write(from: pcmBuffer)
+            try stemWriter.write(pcmBuffer)
         } catch {
-            fputs("stem write failed: \(error)\n", stderr)
+            reportStemWriteFailureOnce(sourceName: sourceName, error: error)
         }
     }
 
-    private func reportSourceFormatOnce(
+    private func silenceUndecodableFrames(
+        source: SCStreamOutputType,
+        sourceName: String,
+        frameCount: AVAudioFrameCount,
+        sampleRate: Double,
+        asbd: AudioStreamBasicDescription
+    ) {
+        reportDecodeFailureOnce(sourceName: sourceName, asbd: asbd)
+        let writer: FixedFormatStemWriter?
+        switch source {
+        case .microphone:
+            writer = voiceStemWriter
+        case .audio:
+            writer = systemStemWriter
+        default:
+            return
+        }
+        do {
+            try writer?.writeSilence(
+                sourceFrameCount: frameCount,
+                sourceSampleRate: sampleRate
+            )
+        } catch {
+            reportStemWriteFailureOnce(sourceName: sourceName, error: error)
+        }
+    }
+
+    private func reportSourceFormatTransition(
         sourceName: String,
         asbd: AudioStreamBasicDescription
     ) {
         let signature = sourceFormatSignature(sourceName: sourceName, asbd: asbd)
-        guard reportedSourceFormats.insert(signature).inserted else { return }
+        guard lastReportedSourceFormats[sourceName] != signature else { return }
+        lastReportedSourceFormats[sourceName] = signature
         let flags = asbd.mFormatFlags
         var payload: [String: Any] = [
             "event": "audio_format",
@@ -776,6 +1085,7 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         let payload: [String: Any] = [
             "event": "audio_format_unsupported",
             "source": sourceName,
+            "sample_rate": asbd.mSampleRate,
             "format_id": formatIDString(asbd.mFormatID),
             "format_flags": asbd.mFormatFlags,
             "bits_per_channel": asbd.mBitsPerChannel,
@@ -786,6 +1096,13 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         ]
         queueSourceEvent(payload)
         fputs("unsupported \(sourceName) PCM layout; stem buffer withheld\n", stderr)
+    }
+
+    private func reportStemWriteFailureOnce(sourceName: String, error: Error) {
+        let description = String(describing: error)
+        let signature = "\(sourceName):\(description)"
+        guard reportedStemWriteFailures.insert(signature).inserted else { return }
+        fputs("stem write failed for \(sourceName): \(description)\n", stderr)
     }
 
     private func sourceFormatSignature(

--- a/tauri/src-tauri/src/system_audio_record.swift
+++ b/tauri/src-tauri/src/system_audio_record.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import AudioToolbox
 import CoreMedia
 import Dispatch
 import Foundation
@@ -12,6 +13,280 @@ private func availableMicrophones() -> [AVCaptureDevice] {
     ).devices
 }
 
+private func emitJSON(_ payload: [String: Any]) {
+    if let data = try? JSONSerialization.data(withJSONObject: payload),
+       let json = String(data: data, encoding: .utf8) {
+        print(json)
+        fflush(stdout)
+    }
+}
+
+private func formatIDString(_ formatID: AudioFormatID) -> String {
+    let bytes: [UInt8] = [
+        UInt8((formatID >> 24) & 0xff),
+        UInt8((formatID >> 16) & 0xff),
+        UInt8((formatID >> 8) & 0xff),
+        UInt8(formatID & 0xff),
+    ]
+    return String(bytes: bytes, encoding: .ascii) ?? String(formatID)
+}
+
+private struct LinearPCMLayout {
+    let channels: Int
+    let bitsPerChannel: Int
+    let bytesPerFrame: Int
+    let bytesPerSample: Int
+    let isFloat: Bool
+    let isSignedInteger: Bool
+    let isBigEndian: Bool
+    let isNonInterleaved: Bool
+    let isAlignedHigh: Bool
+
+    init?(_ asbd: AudioStreamBasicDescription) {
+        guard asbd.mFormatID == kAudioFormatLinearPCM else { return nil }
+
+        let channels = Int(asbd.mChannelsPerFrame)
+        let bitsPerChannel = Int(asbd.mBitsPerChannel)
+        let bytesPerFrame = Int(asbd.mBytesPerFrame)
+        guard channels > 0,
+              bitsPerChannel > 0,
+              bitsPerChannel <= 64,
+              bytesPerFrame > 0 else {
+            return nil
+        }
+
+        let flags = asbd.mFormatFlags
+        let isNonInterleaved = (flags & kAudioFormatFlagIsNonInterleaved) != 0
+        let bytesPerSample: Int
+        if isNonInterleaved {
+            bytesPerSample = bytesPerFrame
+        } else {
+            guard bytesPerFrame % channels == 0 else { return nil }
+            bytesPerSample = bytesPerFrame / channels
+        }
+        guard bytesPerSample > 0,
+              bytesPerSample <= 8,
+              bitsPerChannel <= bytesPerSample * 8 else {
+            return nil
+        }
+
+        self.channels = channels
+        self.bitsPerChannel = bitsPerChannel
+        self.bytesPerFrame = bytesPerFrame
+        self.bytesPerSample = bytesPerSample
+        self.isFloat = (flags & kAudioFormatFlagIsFloat) != 0
+        self.isSignedInteger = (flags & kAudioFormatFlagIsSignedInteger) != 0
+        self.isBigEndian = (flags & kAudioFormatFlagIsBigEndian) != 0
+        self.isNonInterleaved = isNonInterleaved
+        self.isAlignedHigh = (flags & kAudioFormatFlagIsAlignedHigh) != 0
+    }
+
+    func sampleOffset(frame: Int, channel: Int, frameCount: Int) -> Int {
+        if isNonInterleaved {
+            return channel * frameCount * bytesPerFrame + frame * bytesPerFrame
+        }
+        return frame * bytesPerFrame + channel * bytesPerSample
+    }
+
+    func decodeSample(_ bytes: UnsafeRawBufferPointer, offset: Int) -> Float? {
+        guard offset >= 0, offset + bytesPerSample <= bytes.count else { return nil }
+
+        var raw: UInt64 = 0
+        if isBigEndian {
+            for index in 0..<bytesPerSample {
+                raw = (raw << 8) | UInt64(bytes[offset + index])
+            }
+        } else {
+            for index in 0..<bytesPerSample {
+                raw |= UInt64(bytes[offset + index]) << UInt64(index * 8)
+            }
+        }
+
+        let containerBits = bytesPerSample * 8
+        if isAlignedHigh, containerBits > bitsPerChannel {
+            raw >>= UInt64(containerBits - bitsPerChannel)
+        }
+
+        if isFloat {
+            let sample: Double
+            switch bitsPerChannel {
+            case 32:
+                sample = Double(Float(bitPattern: UInt32(truncatingIfNeeded: raw)))
+            case 64:
+                sample = Double(bitPattern: raw)
+            default:
+                return nil
+            }
+            return sample.isFinite ? Float(sample) : 0
+        }
+
+        let mask: UInt64 = bitsPerChannel == 64
+            ? UInt64.max
+            : (UInt64(1) << UInt64(bitsPerChannel)) - 1
+        raw &= mask
+
+        if isSignedInteger {
+            let signBit = UInt64(1) << UInt64(bitsPerChannel - 1)
+            let signedValue: Int64
+            if bitsPerChannel == 64 {
+                signedValue = Int64(bitPattern: raw)
+            } else if (raw & signBit) != 0 {
+                signedValue = Int64(bitPattern: raw | ~mask)
+            } else {
+                signedValue = Int64(raw)
+            }
+            let scale = pow(2.0, Double(bitsPerChannel - 1))
+            return Float(Double(signedValue) / scale)
+        }
+
+        let midpoint = Double(mask) / 2.0
+        guard midpoint > 0 else { return nil }
+        return Float((Double(raw) - midpoint) / midpoint)
+    }
+}
+
+private func decodeLinearPCMToMono(
+    bytes: UnsafeRawBufferPointer,
+    frameCount: Int,
+    asbd: AudioStreamBasicDescription,
+    output: UnsafeMutablePointer<Float>
+) -> Bool {
+    guard frameCount > 0, let layout = LinearPCMLayout(asbd) else { return false }
+
+    for frame in 0..<frameCount {
+        var sum: Float = 0
+        for channel in 0..<layout.channels {
+            let offset = layout.sampleOffset(
+                frame: frame,
+                channel: channel,
+                frameCount: frameCount
+            )
+            guard let sample = layout.decodeSample(bytes, offset: offset) else {
+                return false
+            }
+            sum += sample
+        }
+        output[frame] = sum / Float(layout.channels)
+    }
+    return true
+}
+
+private func testASBD(
+    channels: UInt32,
+    bitsPerChannel: UInt32,
+    bytesPerFrame: UInt32,
+    flags: AudioFormatFlags
+) -> AudioStreamBasicDescription {
+    var asbd = AudioStreamBasicDescription()
+    asbd.mSampleRate = 16_000
+    asbd.mFormatID = kAudioFormatLinearPCM
+    asbd.mFormatFlags = flags
+    asbd.mBytesPerPacket = bytesPerFrame
+    asbd.mFramesPerPacket = 1
+    asbd.mBytesPerFrame = bytesPerFrame
+    asbd.mChannelsPerFrame = channels
+    asbd.mBitsPerChannel = bitsPerChannel
+    return asbd
+}
+
+private func appendLittleEndian<T: FixedWidthInteger>(_ value: T, to bytes: inout [UInt8]) {
+    var littleEndian = value.littleEndian
+    withUnsafeBytes(of: &littleEndian) { bytes.append(contentsOf: $0) }
+}
+
+private func appendFloat32(_ value: Float, to bytes: inout [UInt8]) {
+    appendLittleEndian(value.bitPattern, to: &bytes)
+}
+
+private func decodedSamples(
+    bytes: [UInt8],
+    frameCount: Int,
+    asbd: AudioStreamBasicDescription
+) -> [Float]? {
+    var output = [Float](repeating: 0, count: frameCount)
+    let decoded = bytes.withUnsafeBytes { input in
+        output.withUnsafeMutableBufferPointer { destination in
+            guard let baseAddress = destination.baseAddress else { return false }
+            return decodeLinearPCMToMono(
+                bytes: input,
+                frameCount: frameCount,
+                asbd: asbd,
+                output: baseAddress
+            )
+        }
+    }
+    return decoded ? output : nil
+}
+
+private func runPCMDecoderSelfTest() -> Bool {
+    let signedPacked = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked
+    let signedHighAligned = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsAlignedHigh
+
+    var int16Bytes: [UInt8] = []
+    appendLittleEndian(Int16(16_384), to: &int16Bytes)
+    appendLittleEndian(Int16(-16_384), to: &int16Bytes)
+    let int16 = decodedSamples(
+        bytes: int16Bytes,
+        frameCount: 2,
+        asbd: testASBD(channels: 1, bitsPerChannel: 16, bytesPerFrame: 2, flags: signedPacked)
+    )
+
+    // Bluetooth/HFP paths can expose 16 significant bits high-aligned inside
+    // a 32-bit Core Audio container. The old decoder read the low padding as
+    // Int16, turning valid speech into a near-silent stem (issue #814).
+    var highAlignedBytes: [UInt8] = []
+    appendLittleEndian(Int32(16_384) << 16, to: &highAlignedBytes)
+    appendLittleEndian(Int32(-16_384) << 16, to: &highAlignedBytes)
+    let highAligned = decodedSamples(
+        bytes: highAlignedBytes,
+        frameCount: 2,
+        asbd: testASBD(
+            channels: 1,
+            bitsPerChannel: 16,
+            bytesPerFrame: 4,
+            flags: signedHighAligned
+        )
+    )
+
+    var int32Bytes: [UInt8] = []
+    appendLittleEndian(Int32(1_073_741_824), to: &int32Bytes)
+    appendLittleEndian(Int32(-1_073_741_824), to: &int32Bytes)
+    let int32 = decodedSamples(
+        bytes: int32Bytes,
+        frameCount: 2,
+        asbd: testASBD(channels: 1, bitsPerChannel: 32, bytesPerFrame: 4, flags: signedPacked)
+    )
+
+    var stereoFloatBytes: [UInt8] = []
+    appendFloat32(0.75, to: &stereoFloatBytes)
+    appendFloat32(0.25, to: &stereoFloatBytes)
+    appendFloat32(-0.75, to: &stereoFloatBytes)
+    appendFloat32(-0.25, to: &stereoFloatBytes)
+    let stereoFloat = decodedSamples(
+        bytes: stereoFloatBytes,
+        frameCount: 2,
+        asbd: testASBD(
+            channels: 2,
+            bitsPerChannel: 32,
+            bytesPerFrame: 8,
+            flags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked
+        )
+    )
+
+    let tolerance: Float = 0.000_01
+    let cases = [int16, highAligned, int32, stereoFloat]
+    let passed = cases.allSatisfy { samples in
+        guard let samples, samples.count == 2 else { return false }
+        return abs(samples[0] - 0.5) < tolerance && abs(samples[1] + 0.5) < tolerance
+    }
+    if passed {
+        emitJSON(["event": "pcm_decoder_self_test", "status": "ok", "cases": cases.count])
+    } else {
+        fputs("PCM decoder self-test failed\n", stderr)
+    }
+    return passed
+}
+
 @available(macOS 15.0, *)
 final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOutput {
     private var stream: SCStream?
@@ -20,6 +295,7 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
     private let requestedMicrophoneName: String?
     private var selectedMicrophoneID: String?
     private var selectedMicrophoneName: String?
+    private var selectedMicrophoneDeviceSampleRate: Double?
     private var microphoneSelectionEvent: [String: Any]?
     private let sampleQueue = DispatchQueue(label: "minutes.system-audio.samples")
     private var monitorTimer: DispatchSourceTimer?
@@ -29,6 +305,10 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
     private var lastReportedMicLive = false
     private var latestSystemLevel: UInt32 = 0
     private var latestMicLevel: UInt32 = 0
+    private var protocolReady = false
+    private var pendingSourceEvents: [[String: Any]] = []
+    private var reportedSourceFormats = Set<String>()
+    private var reportedDecodeFailures = Set<String>()
 
     // Per-source stem writers
     private var voiceStemFile: AVAudioFile?
@@ -120,6 +400,11 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
             configuration.microphoneCaptureDeviceID = microphone.uniqueID
             selectedMicrophoneID = microphone.uniqueID
             selectedMicrophoneName = microphone.localizedName
+            if let deviceASBD = CMAudioFormatDescriptionGetStreamBasicDescription(
+                microphone.activeFormat.formatDescription
+            )?.pointee {
+                selectedMicrophoneDeviceSampleRate = deviceASBD.mSampleRate
+            }
             if requestedMicrophoneName != nil {
                 NotificationCenter.default.addObserver(
                     self,
@@ -313,6 +598,17 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
             return
         }
 
+        let sourceName: String
+        switch source {
+        case .microphone:
+            sourceName = "microphone"
+        case .audio:
+            sourceName = "system"
+        default:
+            return
+        }
+        reportSourceFormatOnce(sourceName: sourceName, asbd: asbd)
+
         guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else {
             return
         }
@@ -320,17 +616,19 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
         let sampleCount = CMSampleBufferGetNumSamples(sampleBuffer)
         guard sampleCount > 0 else { return }
 
-        var lengthAtOffset: Int = 0
-        var totalLength: Int = 0
+        var contiguousLength: Int = 0
+        let totalLength = CMBlockBufferGetDataLength(blockBuffer)
         var dataPointer: UnsafeMutablePointer<Int8>?
-        let status = CMBlockBufferGetDataPointer(blockBuffer, atOffset: 0, lengthAtOffsetOut: &lengthAtOffset, totalLengthOut: &totalLength, dataPointerOut: &dataPointer)
-        guard status == kCMBlockBufferNoErr, let data = dataPointer else {
-            return
-        }
+        let pointerStatus = CMBlockBufferGetDataPointer(
+            blockBuffer,
+            atOffset: 0,
+            lengthAtOffsetOut: &contiguousLength,
+            totalLengthOut: nil,
+            dataPointerOut: &dataPointer
+        )
+        guard totalLength > 0 else { return }
 
-        let channelCount = Int(asbd.mChannelsPerFrame)
         let sampleRate = asbd.mSampleRate
-        let isFloat = (asbd.mFormatFlags & kAudioFormatFlagIsFloat) != 0
 
         // Stems are always mono float32 — mix down if multi-channel
         guard let monoFormat = AVAudioFormat(
@@ -340,7 +638,53 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
             interleaved: false
         ) else { return }
 
-        // Lazily create the stem file on first samples
+        let frameCount = AVAudioFrameCount(sampleCount)
+        guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: monoFormat, frameCapacity: frameCount) else {
+            return
+        }
+        pcmBuffer.frameLength = frameCount
+
+        guard let monoPtr = pcmBuffer.floatChannelData?[0] else { return }
+        let decoded: Bool
+        if pointerStatus == kCMBlockBufferNoErr,
+           let dataPointer,
+           contiguousLength >= totalLength {
+            decoded = decodeLinearPCMToMono(
+                bytes: UnsafeRawBufferPointer(start: dataPointer, count: totalLength),
+                frameCount: Int(frameCount),
+                asbd: asbd,
+                output: monoPtr
+            )
+        } else {
+            var copiedBytes = [UInt8](repeating: 0, count: totalLength)
+            let copyStatus: OSStatus = copiedBytes.withUnsafeMutableBytes { destination in
+                guard let baseAddress = destination.baseAddress else {
+                    return -1
+                }
+                return CMBlockBufferCopyDataBytes(
+                    blockBuffer,
+                    atOffset: 0,
+                    dataLength: totalLength,
+                    destination: baseAddress
+                )
+            }
+            decoded = copyStatus == kCMBlockBufferNoErr && copiedBytes.withUnsafeBytes { bytes in
+                decodeLinearPCMToMono(
+                    bytes: bytes,
+                    frameCount: Int(frameCount),
+                    asbd: asbd,
+                    output: monoPtr
+                )
+            }
+        }
+
+        guard decoded else {
+            reportDecodeFailureOnce(sourceName: sourceName, asbd: asbd)
+            return
+        }
+
+        // Lazily create the stem only after the first buffer decodes. An
+        // unsupported source format must not leave a plausible empty WAV.
         let stemFile: AVAudioFile?
         switch source {
         case .microphone:
@@ -367,60 +711,6 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
 
         guard let file = stemFile else { return }
 
-        // Mix multi-channel source data to mono float32.
-        // ScreenCaptureKit may deliver interleaved or non-interleaved audio.
-        let isNonInterleaved = (asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved) != 0
-        let frameCount = AVAudioFrameCount(sampleCount)
-        guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: monoFormat, frameCapacity: frameCount) else {
-            return
-        }
-        pcmBuffer.frameLength = frameCount
-
-        guard let monoPtr = pcmBuffer.floatChannelData?[0] else { return }
-        let bytesPerSample = isFloat ? 4 : 2
-
-        if isNonInterleaved {
-            // Non-interleaved: each channel is a separate plane of `frameCount` samples.
-            // The CMBlockBuffer contains them sequentially: [ch0 frames][ch1 frames]...
-            let planeSize = Int(frameCount) * bytesPerSample
-            for frame in 0..<Int(frameCount) {
-                var sum: Float = 0.0
-                for ch in 0..<channelCount {
-                    let offset = ch * planeSize + frame * bytesPerSample
-                    guard offset + bytesPerSample <= totalLength else { break }
-                    if isFloat {
-                        var val: Float = 0.0
-                        memcpy(&val, data.advanced(by: offset), 4)
-                        sum += val
-                    } else {
-                        var val: Int16 = 0
-                        memcpy(&val, data.advanced(by: offset), 2)
-                        sum += Float(val) / 32768.0
-                    }
-                }
-                monoPtr[frame] = sum / Float(channelCount)
-            }
-        } else {
-            // Interleaved: samples are [ch0 ch1 ch0 ch1 ...]
-            for frame in 0..<Int(frameCount) {
-                var sum: Float = 0.0
-                for ch in 0..<channelCount {
-                    let offset = (frame * channelCount + ch) * bytesPerSample
-                    guard offset + bytesPerSample <= totalLength else { break }
-                    if isFloat {
-                        var val: Float = 0.0
-                        memcpy(&val, data.advanced(by: offset), 4)
-                        sum += val
-                    } else {
-                        var val: Int16 = 0
-                        memcpy(&val, data.advanced(by: offset), 2)
-                        sum += Float(val) / 32768.0
-                    }
-                }
-                monoPtr[frame] = sum / Float(channelCount)
-            }
-        }
-
         var sumSquares: Float = 0
         for frame in 0..<Int(frameCount) {
             let sample = monoPtr[frame]
@@ -441,6 +731,85 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
             try file.write(from: pcmBuffer)
         } catch {
             fputs("stem write failed: \(error)\n", stderr)
+        }
+    }
+
+    private func reportSourceFormatOnce(
+        sourceName: String,
+        asbd: AudioStreamBasicDescription
+    ) {
+        let signature = sourceFormatSignature(sourceName: sourceName, asbd: asbd)
+        guard reportedSourceFormats.insert(signature).inserted else { return }
+        let flags = asbd.mFormatFlags
+        var payload: [String: Any] = [
+            "event": "audio_format",
+            "source": sourceName,
+            "sample_rate": asbd.mSampleRate,
+            "format_id": formatIDString(asbd.mFormatID),
+            "format_flags": flags,
+            "bits_per_channel": asbd.mBitsPerChannel,
+            "bytes_per_packet": asbd.mBytesPerPacket,
+            "bytes_per_frame": asbd.mBytesPerFrame,
+            "frames_per_packet": asbd.mFramesPerPacket,
+            "channels": asbd.mChannelsPerFrame,
+            "is_float": (flags & kAudioFormatFlagIsFloat) != 0,
+            "is_signed_integer": (flags & kAudioFormatFlagIsSignedInteger) != 0,
+            "is_big_endian": (flags & kAudioFormatFlagIsBigEndian) != 0,
+            "is_non_interleaved": (flags & kAudioFormatFlagIsNonInterleaved) != 0,
+            "is_aligned_high": (flags & kAudioFormatFlagIsAlignedHigh) != 0,
+        ]
+        if sourceName == "microphone" {
+            payload["device_name"] = selectedMicrophoneName ?? ""
+            if let selectedMicrophoneDeviceSampleRate {
+                payload["device_sample_rate"] = selectedMicrophoneDeviceSampleRate
+            }
+        }
+        queueSourceEvent(payload)
+    }
+
+    private func reportDecodeFailureOnce(
+        sourceName: String,
+        asbd: AudioStreamBasicDescription
+    ) {
+        let signature = sourceFormatSignature(sourceName: sourceName, asbd: asbd)
+        guard reportedDecodeFailures.insert(signature).inserted else { return }
+        let payload: [String: Any] = [
+            "event": "audio_format_unsupported",
+            "source": sourceName,
+            "format_id": formatIDString(asbd.mFormatID),
+            "format_flags": asbd.mFormatFlags,
+            "bits_per_channel": asbd.mBitsPerChannel,
+            "bytes_per_packet": asbd.mBytesPerPacket,
+            "bytes_per_frame": asbd.mBytesPerFrame,
+            "frames_per_packet": asbd.mFramesPerPacket,
+            "channels": asbd.mChannelsPerFrame,
+        ]
+        queueSourceEvent(payload)
+        fputs("unsupported \(sourceName) PCM layout; stem buffer withheld\n", stderr)
+    }
+
+    private func sourceFormatSignature(
+        sourceName: String,
+        asbd: AudioStreamBasicDescription
+    ) -> String {
+        [
+            sourceName,
+            String(asbd.mFormatID),
+            String(asbd.mFormatFlags),
+            String(asbd.mSampleRate),
+            String(asbd.mBitsPerChannel),
+            String(asbd.mBytesPerPacket),
+            String(asbd.mBytesPerFrame),
+            String(asbd.mFramesPerPacket),
+            String(asbd.mChannelsPerFrame),
+        ].joined(separator: ":")
+    }
+
+    private func queueSourceEvent(_ payload: [String: Any]) {
+        if protocolReady {
+            emitJSON(payload)
+        } else {
+            pendingSourceEvents.append(payload)
         }
     }
 
@@ -467,6 +836,13 @@ final class NativeCallRecorder: NSObject, SCRecordingOutputDelegate, SCStreamOut
            let json = String(data: data, encoding: .utf8) {
             print(json)
             fflush(stdout)
+        }
+
+        sampleQueue.async { [weak self] in
+            guard let self else { return }
+            self.protocolReady = true
+            self.pendingSourceEvents.forEach(emitJSON)
+            self.pendingSourceEvents.removeAll()
         }
     }
 
@@ -512,6 +888,11 @@ struct NativeCallRecordMain {
     }
 
     static func run() async {
+        if CommandLine.arguments.count == 2,
+           CommandLine.arguments[1] == "--self-test-pcm-decoder" {
+            exit(runPCMDecoderSelfTest() ? 0 : 1)
+        }
+
         guard #available(macOS 15.0, *) else {
             fputs("ScreenCaptureKit recording output requires macOS 15.0 or newer.\n", stderr)
             exit(1)


### PR DESCRIPTION
Fixes #814

## Summary

- decode ScreenCaptureKit linear PCM from the complete negotiated ASBD instead of treating every non-float buffer as packed Int16
- support high-aligned 16-bit samples in 32-bit containers, signed Int32, Float32/64, endian flags, interleaved/non-interleaved layouts, and segmented CMBlockBuffers
- log the exact negotiated source ASBD plus the selected microphone's active-format sample rate, including format changes during capture
- withhold unsupported buffers instead of writing a plausible but empty stem
- add a macOS helper self-test containing the HFP-shaped 16-in-32 regression case

## Why this fits #814

The reported voice stem is already 16 kHz, so ScreenCaptureKit did negotiate the headset's HFP rate. The old code then ignored `mBitsPerChannel`, `mBytesPerFrame`, alignment, integer width, and endianness. A 16-bit sample high-aligned in a 32-bit Core Audio container would therefore be read from its low padding and become the full-duration near-silence reported in #814. This patch handles that layout and also records the actual ASBD so hardware validation can confirm or falsify the diagnosis.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- local `cargo test -p minutes-app --no-default-features call_capture::tests -- --test-threads=1` (6 passed on Linux; macOS-only helper case skipped)
- local `cargo clippy -p minutes-app --no-default-features --tests --no-deps` (passes; pre-existing warnings remain)
- GitHub CI run 32490127800: every required check passed on exact head `0f4ae6449251c2c0ac7a0392629028f9412688b1`
- macOS full workspace build passed, compiling the Swift helper
- macOS `native_helper_decodes_hfp_pcm_container_layouts` passed
- macOS desktop suite: 350 passed, 0 failed
- macOS integration, full-workspace clippy, format, and desktop capture-relay checks passed
- broad local core run: 1,730 passed, 17 failed, 1 ignored; the failures were unrelated harness/environment prerequisites (mostly no worker-capable `minutes-cli` beside the test harness, plus existing knowledge fixture failures); the clean GitHub platform suites supersede that local environment limitation

## Remaining validation gate

This remains draft until a real Bluetooth HFP capture from the #814 reporter (or equivalent hardware) confirms the voice stem contains speech. CI proves the helper compiles and the suspected container layout decodes correctly; it cannot prove the reporter's headset actually negotiates that layout.

## Hardening (adversarial review, 2026-08-27)

An adversarial pass on the first revision found three real gaps and one math slip, all fixed in `3c90fa38` / `9611e2b4`:

- **Sample-rate change mid-capture** (AirPods A2DP 48 kHz → HFP 16 kHz when the mic engages) previously left the stem `AVAudioFile` at the first buffer's rate, so every later write threw and the stem truncated silently — pre-existing on `main`, but exactly this hardware. Each stem now keeps one processing format and resamples incoming buffers through a single cached `AVAudioConverter`.
- **Withheld buffers** used to vanish, time-compressing the stem against its sibling with no health signal. Undecodable buffers after the stem exists are now written as duration-preserving silence, counted (`mic_frames_silenced` / `system_frames_silenced` in the helper's health JSON), and surfaced as a persisted capture warning naming the source and full ASBD.
- **Helper stderr** was piped but never drained, so a flood of write errors could block the helper's sample queue. It is now drained on a thread with rate-limited tracing (first 5 lines, then one per 10 s with a suppressed count); the helper also reports each write failure once per (source, error).
- **Unsigned PCM normalization** was off by half an LSB (digital silence decoded to 1/65535).

Tests: 9 `call_capture::tests` on macOS including the real helper self-test (rate-change, silence-fill, unsigned-silence cases), the stderr rate limiter, and warning persistence into the queued job.

## Hardware validation

Pending: a Bluetooth HFP capture on AirPods Pro with this build (stem levels + the negotiated-ASBD log line) — will be attached here before the draft is lifted.