### PR TITLE
fix(release): cap standalone Windows CPU baseline (#818)

### DIFF
--- a/.github/scripts/export-windows-cpu-baseline.sh
+++ b/.github/scripts/export-windows-cpu-baseline.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shipped Windows binaries must run on ordinary x86-64 consumer CPUs. GitHub's
+# Windows runners can expose AVX-512, and whisper-rs-sys forwards these GGML_*
+# variables into CMake. Without an explicit ceiling, a runner-specific native
+# build can fault with STATUS_ILLEGAL_INSTRUCTION on machines such as Intel
+# Arrow Lake and Lunar Lake, which intentionally do not implement AVX-512.
+: "${GITHUB_ENV:?GITHUB_ENV must point to the GitHub Actions environment file}"
+
+{
+  echo "GGML_NATIVE=OFF"
+  echo "GGML_AVX=ON"
+  echo "GGML_AVX2=ON"
+  echo "GGML_AVX512=OFF"
+  echo "GGML_AVX512_VBMI=OFF"
+  echo "GGML_AVX512_VNNI=OFF"
+  echo "GGML_AVX512_BF16=OFF"
+} >> "$GITHUB_ENV"
+
+echo "Windows native CPU baseline: AVX2 maximum; AVX-512 disabled"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
               # without this a PR editing lint policy skipped every Rust job and
               # reported green. crates/core/clippy.toml is covered by crates/**.
               - 'clippy.toml'
+              # Shared by the standalone and desktop Windows release builds;
+              # changing the CPU ceiling must exercise the Windows artifact.
+              - '.github/scripts/export-windows-cpu-baseline.sh'
               # Sets rustflags and build env per target, so it changes how every
               # Rust target compiles. Omitting it meant a change that statically
               # linked the Windows CRT skipped every Rust job and reported green
@@ -463,6 +466,10 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "2.10.1" --locked
 
+      - name: Configure portable Windows CPU baseline
+        shell: bash
+        run: .github/scripts/export-windows-cpu-baseline.sh
+
       - name: Check Windows desktop capture-relay + window contract
         # Compiles Tauri's owner side against the Windows named-pipe relay
         # before the slower installer build.
@@ -473,15 +480,6 @@ jobs:
         run: cargo tauri build --ci --bundles nsis --no-sign
         env:
           CARGO_NET_RETRY: 3
-          # Keep the CI desktop artifact aligned with release builds: AVX2 max,
-          # never host-native or AVX-512 from the runner CPU.
-          GGML_NATIVE: "OFF"
-          GGML_AVX: "ON"
-          GGML_AVX2: "ON"
-          GGML_AVX512: "OFF"
-          GGML_AVX512_VBMI: "OFF"
-          GGML_AVX512_VNNI: "OFF"
-          GGML_AVX512_BF16: "OFF"
 
       - name: The desktop binary must not outgrow its packaged runtime (#657)
         # release-windows-desktop.yml refuses to zip a desktop build whose
@@ -670,6 +668,9 @@ jobs:
 
       - name: Test CI rust filter guard
         run: node --test scripts/check_ci_rust_filter.test.mjs
+
+      - name: Test Windows CPU-baseline release guard
+        run: node --test scripts/check_windows_cpu_baseline.test.mjs
 
       - name: Test transactional version bump
         run: node --test scripts/bump_version.test.mjs

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -81,6 +81,11 @@ jobs:
         if: runner.os == 'macOS'
         run: echo "CXXFLAGS=-I$(xcrun --show-sdk-path)/usr/include/c++/v1" >> "$GITHUB_ENV"
 
+      - name: Configure portable Windows CPU baseline
+        if: runner.os == 'Windows'
+        shell: bash
+        run: .github/scripts/export-windows-cpu-baseline.sh
+
       - name: Resolve runner image for cache scope
         id: runner-image
         shell: bash

--- a/.github/workflows/release-windows-desktop.yml
+++ b/.github/workflows/release-windows-desktop.yml
@@ -105,21 +105,15 @@ jobs:
         shell: bash
         run: cargo install tauri-cli --version "${TAURI_CLI_VERSION}" --locked
 
+      - name: Configure portable Windows CPU baseline
+        shell: bash
+        run: .github/scripts/export-windows-cpu-baseline.sh
+
       - name: Build desktop installer (unsigned)
         working-directory: tauri/src-tauri
         run: cargo tauri build --features parakeet --ci --bundles nsis --no-sign
         env:
           CARGO_NET_RETRY: 3
-          # Cap ggml/whisper.cpp at AVX2-class instructions for the shipped
-          # Windows binary. GitHub's Windows runners may expose AVX-512, and
-          # whisper-rs-sys forwards GGML_* env vars straight into CMake.
-          GGML_NATIVE: "OFF"
-          GGML_AVX: "ON"
-          GGML_AVX2: "ON"
-          GGML_AVX512: "OFF"
-          GGML_AVX512_VBMI: "OFF"
-          GGML_AVX512_VNNI: "OFF"
-          GGML_AVX512_BF16: "OFF"
 
       - name: Rename desktop binary
         shell: bash

--- a/docs/release/pre-release-checklist.md
+++ b/docs/release/pre-release-checklist.md
@@ -204,7 +204,7 @@ Anyone running `brew install --cask silverstein/tap/minutes` is silently stuck o
 - `CXXFLAGS += -I<sdk>/usr/include/c++/v1` and `CPLUS_INCLUDE_PATH` — required for whisper.cpp's `std::filesystem` usage on macOS 15+/Xcode 26+ (silverstein/minutes#14)
 - `MACOSX_DEPLOYMENT_TARGET=11.0` and `CMAKE_OSX_DEPLOYMENT_TARGET=11.0` — same root cause; `whisper-rs-sys` hardcodes 10.13 in CMake C/C++ flags, which is incompatible with `std::filesystem`
 - `GGML_CCACHE=OFF` — whisper.cpp's CMakeLists has `GGML_CCACHE=ON` by default; if a user has ccache installed (e.g. via Homebrew), `find_program()` locates it at cmake-configure time but the resulting `RULE_LAUNCH_COMPILE` fails at make-time inside Homebrew's sanitized superenv PATH (silverstein/minutes#89). `whisper-rs-sys` forwards any `GGML_*`, `WHISPER_*`, or `CMAKE_*` env var to cmake as `-D<KEY>=<VALUE>`, which is how this disable propagates.
-- Windows desktop release builds must set `GGML_NATIVE=OFF`, keep `GGML_AVX=ON` / `GGML_AVX2=ON`, and force all `GGML_AVX512*` flags `OFF` — otherwise the GitHub Windows runner can enable AVX-512 code paths in ggml/whisper.cpp that crash on normal consumer CPUs with `STATUS_ILLEGAL_INSTRUCTION` (silverstein/minutes#106)
+- Every shipped Windows build, including the standalone CLI and desktop app, must run `.github/scripts/export-windows-cpu-baseline.sh` before compiling. That shared contract sets `GGML_NATIVE=OFF`, keeps `GGML_AVX=ON` / `GGML_AVX2=ON`, and forces all `GGML_AVX512*` flags `OFF` — otherwise the GitHub Windows runner can enable AVX-512 code paths in ggml/whisper.cpp that crash on normal consumer CPUs with `STATUS_ILLEGAL_INSTRUCTION` (silverstein/minutes#106, silverstein/minutes#818).
 
 ### 9.3 crates.io: published again (revived in #79)
 

--- a/scripts/check_windows_cpu_baseline.test.mjs
+++ b/scripts/check_windows_cpu_baseline.test.mjs
@@ -1,0 +1,67 @@
+import { execFileSync } from "child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const exporter = join(repoRoot, ".github/scripts/export-windows-cpu-baseline.sh");
+const expected = [
+  "GGML_NATIVE=OFF",
+  "GGML_AVX=ON",
+  "GGML_AVX2=ON",
+  "GGML_AVX512=OFF",
+  "GGML_AVX512_VBMI=OFF",
+  "GGML_AVX512_VNNI=OFF",
+  "GGML_AVX512_BF16=OFF",
+];
+
+test("the shared exporter writes the portable Windows CPU contract", () => {
+  const dir = mkdtempSync(join(tmpdir(), "minutes-windows-cpu-"));
+  const githubEnv = join(dir, "github-env");
+  try {
+    writeFileSync(githubEnv, "");
+    execFileSync("bash", [exporter], {
+      cwd: repoRoot,
+      env: { ...process.env, GITHUB_ENV: githubEnv },
+      stdio: "pipe",
+    });
+    const actual = readFileSync(githubEnv, "utf8").trim().split("\n");
+    assert.deepEqual(actual, expected);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+for (const [workflow, buildNeedle] of [
+  ["release-cli.yml", "cargo build --release -p minutes-cli"],
+  ["release-windows-desktop.yml", "cargo tauri build --features parakeet"],
+  ["ci.yml", "cargo tauri build --ci --bundles nsis"],
+]) {
+  test(`${workflow} exports the baseline before its shipped Windows build`, () => {
+    const contents = readFileSync(join(repoRoot, ".github/workflows", workflow), "utf8");
+    const exportAt = contents.indexOf(".github/scripts/export-windows-cpu-baseline.sh");
+    const buildAt = contents.indexOf(buildNeedle);
+    assert.notEqual(exportAt, -1, `${workflow} must invoke the shared exporter`);
+    assert.notEqual(buildAt, -1, `${workflow} build command changed; update this guard deliberately`);
+    assert.ok(exportAt < buildAt, `${workflow} must export the CPU ceiling before building`);
+  });
+}
+
+test("the standalone release applies the baseline only to Windows", () => {
+  const contents = readFileSync(
+    join(repoRoot, ".github/workflows/release-cli.yml"),
+    "utf8"
+  );
+  assert.match(
+    contents,
+    /name: Configure portable Windows CPU baseline\n\s+if: runner\.os == 'Windows'\n\s+shell: bash\n\s+run: \.github\/scripts\/export-windows-cpu-baseline\.sh/
+  );
+});
+
+test("changing the shared baseline triggers the Windows CI artifact", () => {
+  const contents = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  assert.match(contents, /- '\.github\/scripts\/export-windows-cpu-baseline\.sh'/);
+});


### PR DESCRIPTION
Part of #818.

## What changed

- applies the existing AVX2-maximum Windows CPU contract to the standalone `minutes-windows-x64.exe` release, not only the desktop installer
- centralizes the GGML native/AVX settings in one shared exporter used by standalone release, desktop release, and Windows CI
- makes changes to that shared contract trigger the full Windows artifact build
- adds a regression guard so the three Windows build paths cannot silently drift again

## Why

The v0.25.2 standalone CLI crashes with `STATUS_ILLEGAL_INSTRUCTION` on an Intel Arrow Lake system, while v0.25.1 succeeds. The standalone release workflow was the only shipped Windows build path that did not explicitly disable host-native and AVX-512 ggml compilation.

This closes that confirmed packaging gap. The draft remains open until the exact candidate artifact is tested on the reporter's Arrow Lake hardware; the crash address was not available, so workflow correction alone is not treated as end-to-end proof.

## Verification

- `node --test scripts/check_windows_cpu_baseline.test.mjs` — 6 passed
- `node --test scripts/check_ci_rust_filter.test.mjs scripts/check_windows_cpu_baseline.test.mjs` — 14 passed
- `actionlint .github/workflows/ci.yml .github/workflows/release-cli.yml .github/workflows/release-windows-desktop.yml`
- `git diff --check`
