### PR TITLE
fix(mcp): run Node helpers under Electron on Windows

### DIFF
--- a/crates/mcp/package-lock.json
+++ b/crates/mcp/package-lock.json
@@ -1945,7 +1945,7 @@
     "node_modules/minutes-sdk": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.2.tgz",
-      "integrity": "sha512-3uVt1StFrqBykNZm+MgUgG3rGuSVtRMP/ktbNaxMu0M65BWD6kvcvis53MV3gC+tRll4rd1GH/O5ye3qn83svA==",
+      "integrity": "sha512-Vzntst0FmFoi2nSYIpL+bCDbyExXalCRK+rsIQRmsXEbWFxBowvlIqHAvQPu87e5WEUB+DMEYPgdBb95pghgug==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -25,6 +25,7 @@ import {
   type BoundFileRevision,
   writeOperatorDiagnostic,
 } from "./secure-read.js";
+import { nodeChildEnvironment } from "./node-child.js";
 
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
 const DEFAULT_FENCE_TIMEOUT_MS = 5_000;
@@ -1943,7 +1944,7 @@ async function dispatchStableCorpusLease<T>(
     detached: process.platform !== "win32",
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
-    env: { ...process.env },
+    env: nodeChildEnvironment(),
   });
   child.stderr?.resume();
   let resolveTermination!: () => void;

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -85,6 +85,7 @@ import {
   validatePathInDirectory,
 } from "./paths.js";
 import { isCliCompatible } from "./version.js";
+import { nodeChildEnvironment } from "./node-child.js";
 import {
   hasFeature,
   probeCapabilitiesSync,
@@ -6456,7 +6457,7 @@ export async function runIsolatedMcpProcessAudio(
         child = spawn(helper.binary, helper.args, {
           detached: true,
           stdio: ["pipe", "pipe", "pipe", "pipe"],
-          env: mcpCliChildEnv(),
+          env: nodeChildEnvironment(mcpCliChildEnv()),
         });
       } catch {
         rejectRun(new Error("process_audio helper could not be started safely"));

--- a/crates/mcp/src/node-child.test.ts
+++ b/crates/mcp/src/node-child.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { nodeChildEnvironment } from "./node-child.js";
+
+describe("Node helper environment", () => {
+  it("forces Electron hosts into Node mode", () => {
+    const environment = nodeChildEnvironment(
+      { PATH: "synthetic", ELECTRON_RUN_AS_NODE: "0" },
+      "42.9.2"
+    );
+    expect(environment).toEqual({
+      PATH: "synthetic",
+      ELECTRON_RUN_AS_NODE: "1",
+    });
+  });
+
+  it("does not invent Electron mode for an ordinary Node host", () => {
+    expect(nodeChildEnvironment({ PATH: "synthetic" }, undefined)).toEqual({
+      PATH: "synthetic",
+    });
+  });
+
+  it("does not mutate the caller's environment object", () => {
+    const base = { ELECTRON_RUN_AS_NODE: "0" };
+    nodeChildEnvironment(base, "42.9.2");
+    expect(base.ELECTRON_RUN_AS_NODE).toBe("0");
+  });
+});

--- a/crates/mcp/src/node-child.ts
+++ b/crates/mcp/src/node-child.ts
@@ -1,0 +1,19 @@
+/**
+ * Environment for a helper that must run as Node through process.execPath.
+ *
+ * Electron hosts such as Claude Desktop expose their app executable as
+ * process.execPath. Spawning that executable with a JavaScript file does not
+ * start Node unless ELECTRON_RUN_AS_NODE is set for the child. Keep the switch
+ * scoped to helpers whose argv is a Node program; ordinary Minutes CLI children
+ * must continue to receive their existing policy environment unchanged.
+ */
+export function nodeChildEnvironment(
+  base: NodeJS.ProcessEnv = process.env,
+  electronVersion: string | undefined = process.versions.electron
+): NodeJS.ProcessEnv {
+  const environment = { ...base };
+  if (electronVersion) {
+    environment.ELECTRON_RUN_AS_NODE = "1";
+  }
+  return environment;
+}

--- a/crates/mcp/src/secure-read.ts
+++ b/crates/mcp/src/secure-read.ts
@@ -9,6 +9,8 @@ import {
 import { basename, dirname } from "path";
 import { TextDecoder } from "node:util";
 
+import { nodeChildEnvironment } from "./node-child.js";
+
 /**
  * Decode security-policy-bearing text without Unicode replacement.
  *
@@ -430,7 +432,7 @@ class BoundParentReader {
     });
     this.child = spawn(process.execPath, ["-e", BOUND_READER_SOURCE], {
       cwd: parent,
-      env: { ...process.env, MINUTES_BOUND_PARENT: parent },
+      env: nodeChildEnvironment({ ...process.env, MINUTES_BOUND_PARENT: parent }),
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
     });

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -25,6 +25,7 @@ import {
   type BoundFileRevision,
   writeOperatorDiagnostic,
 } from "./secure-read.js";
+import { nodeChildEnvironment } from "./node-child.js";
 
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
 const DEFAULT_FENCE_TIMEOUT_MS = 5_000;
@@ -1943,7 +1944,7 @@ async function dispatchStableCorpusLease<T>(
     detached: process.platform !== "win32",
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
-    env: { ...process.env },
+    env: nodeChildEnvironment(),
   });
   child.stderr?.resume();
   let resolveTermination!: () => void;

--- a/crates/sdk/src/node-child.test.ts
+++ b/crates/sdk/src/node-child.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { nodeChildEnvironment } from "./node-child.js";
+
+describe("Node helper environment", () => {
+  it("forces Electron hosts into Node mode", () => {
+    const environment = nodeChildEnvironment(
+      { PATH: "synthetic", ELECTRON_RUN_AS_NODE: "0" },
+      "42.9.2"
+    );
+    expect(environment).toEqual({
+      PATH: "synthetic",
+      ELECTRON_RUN_AS_NODE: "1",
+    });
+  });
+
+  it("does not invent Electron mode for an ordinary Node host", () => {
+    expect(nodeChildEnvironment({ PATH: "synthetic" }, undefined)).toEqual({
+      PATH: "synthetic",
+    });
+  });
+
+  it("does not mutate the caller's environment object", () => {
+    const base = { ELECTRON_RUN_AS_NODE: "0" };
+    nodeChildEnvironment(base, "42.9.2");
+    expect(base.ELECTRON_RUN_AS_NODE).toBe("0");
+  });
+});

--- a/crates/sdk/src/node-child.ts
+++ b/crates/sdk/src/node-child.ts
@@ -1,0 +1,19 @@
+/**
+ * Environment for a helper that must run as Node through process.execPath.
+ *
+ * Electron hosts such as Claude Desktop expose their app executable as
+ * process.execPath. Spawning that executable with a JavaScript file does not
+ * start Node unless ELECTRON_RUN_AS_NODE is set for the child. Keep the switch
+ * scoped to helpers whose argv is a Node program; ordinary Minutes CLI children
+ * must continue to receive their existing policy environment unchanged.
+ */
+export function nodeChildEnvironment(
+  base: NodeJS.ProcessEnv = process.env,
+  electronVersion: string | undefined = process.versions.electron
+): NodeJS.ProcessEnv {
+  const environment = { ...base };
+  if (electronVersion) {
+    environment.ELECTRON_RUN_AS_NODE = "1";
+  }
+  return environment;
+}

--- a/crates/sdk/src/secure-read.ts
+++ b/crates/sdk/src/secure-read.ts
@@ -9,6 +9,8 @@ import {
 import { basename, dirname } from "path";
 import { TextDecoder } from "node:util";
 
+import { nodeChildEnvironment } from "./node-child.js";
+
 /**
  * Decode security-policy-bearing text without Unicode replacement.
  *
@@ -430,7 +432,7 @@ class BoundParentReader {
     });
     this.child = spawn(process.execPath, ["-e", BOUND_READER_SOURCE], {
       cwd: parent,
-      env: { ...process.env, MINUTES_BOUND_PARENT: parent },
+      env: nodeChildEnvironment({ ...process.env, MINUTES_BOUND_PARENT: parent }),
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
     });

--- a/scripts/check_corpus_lease_mirror.mjs
+++ b/scripts/check_corpus_lease_mirror.mjs
@@ -33,6 +33,8 @@ const MIRRORED_FILES = [
   "corpus-lease-refusal.test.ts",
   "corpus-lease-poisoning.test.ts",
   "corpus-lease-worker.ts",
+  "node-child.ts",
+  "node-child.test.ts",
   "secure-read.ts",
 ];
 


### PR DESCRIPTION
Fixes the Claude Desktop worker-launch part of #818.

On Windows, Claude Desktop is an Electron app, so process.execPath points to Claude.exe rather than node.exe. Minutes was using that executable for isolated JavaScript helpers without enabling Electron Node mode. The helpers therefore failed before corpus-gated MCP tools could do useful work.

This change adds one shared Node-helper environment policy and applies it only to JavaScript helpers: corpus leases, secure bound reads, and isolated process-audio. Normal Minutes CLI children keep their existing environment. The MCP and SDK copies are kept byte-identical by the mirror guard.

Validation at 882dd6c995ef57735b24e00e9e624f05a0392fa5:
- exact local SDK packaging and MCP lockfile integrity pass
- MCP and SDK TypeScript builds pass
- MCP and SDK unit suites pass
- focused Electron environment tests pass, 3 of 3 in each package
- MCP and SDK mirror guard passes, 8 files identical
- MCP tool integration passes, 13 of 13
- copilot and surface-parity contracts pass
- MCPB pack, bundle validation, and packaged handshake pass

One existing HTTP concurrency check fails 12 of 13 because list_meetings responses differ between calls. I reproduced the same failure on an untouched worktree, so it is not caused by this patch and is tracked separately.

This stays draft until exact-head CI is green and the packaged MCPB is exercised in Claude Desktop on Windows.