### PR TITLE
fix(voice): make every voice list use active enrollments

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17002,8 +17002,10 @@ fn cmd_voices(delete: bool, json: bool) -> Result<()> {
         anyhow::bail!("voice deletion is unavailable under the active assistant policy");
     }
     let conn = voice::open_db().map_err(|e| anyhow::anyhow!("{}", e))?;
+    voice::migrate_legacy_profiles(&conn).map_err(|e| anyhow::anyhow!("{}", e))?;
     if delete {
-        let profiles = voice::list_profiles(&conn).map_err(|e| anyhow::anyhow!("{}", e))?;
+        let profiles =
+            voice::list_profiles_for_display(&conn).map_err(|e| anyhow::anyhow!("{}", e))?;
         if profiles.is_empty() {
             eprintln!("No voice profiles enrolled.");
             return Ok(());
@@ -17014,7 +17016,7 @@ fn cmd_voices(delete: bool, json: bool) -> Result<()> {
         }
         return Ok(());
     }
-    let profiles = voice::list_profiles(&conn).map_err(|e| anyhow::anyhow!("{}", e))?;
+    let profiles = voice::list_profiles_for_display(&conn).map_err(|e| anyhow::anyhow!("{}", e))?;
     if json {
         println!("{}", serde_json::to_string_pretty(&profiles)?);
         return Ok(());

--- a/crates/core/src/voice.rs
+++ b/crates/core/src/voice.rs
@@ -1006,6 +1006,57 @@ pub fn list_voice_enrollments(
     Ok(summaries)
 }
 
+/// List active model-scoped enrollments using the legacy `VoiceProfile` JSON shape.
+///
+/// `minutes voices --json` predates immutable voice samples, and the MCP
+/// `list_voices` tool consumes its field names. Keep that public shape while
+/// sourcing the rows from `voice_active_profiles`, which is the same canonical
+/// store used by `minutes voice status`, matching, and new enrollment.
+pub fn list_profiles_for_display(conn: &Connection) -> Result<Vec<VoiceProfile>, VoiceError> {
+    let mut stmt = conn.prepare(
+        "SELECT active.person_slug,
+                active.name,
+                COALESCE(
+                    (SELECT MIN(samples.created_at) FROM voice_samples samples
+                     WHERE samples.person_slug = active.person_slug
+                       AND samples.model_id = active.model_id
+                       AND samples.revoked_at IS NULL),
+                    active.updated_at),
+                active.updated_at,
+                active.sample_count,
+                COALESCE(
+                    (SELECT NULLIF(samples.capture_source, '') FROM voice_samples samples
+                     WHERE samples.person_slug = active.person_slug
+                       AND samples.model_id = active.model_id
+                       AND samples.revoked_at IS NULL
+                       AND samples.capture_source IS NOT NULL
+                     ORDER BY samples.created_at DESC, samples.id DESC LIMIT 1),
+                    (SELECT samples.trust_class FROM voice_samples samples
+                     WHERE samples.person_slug = active.person_slug
+                       AND samples.model_id = active.model_id
+                       AND samples.revoked_at IS NULL
+                     ORDER BY samples.created_at DESC, samples.id DESC LIMIT 1),
+                    'local-enrollment'),
+                active.model_id
+         FROM voice_active_profiles active
+         ORDER BY active.updated_at DESC, lower(active.name), active.model_id",
+    )?;
+    let profiles = stmt
+        .query_map([], |row| {
+            Ok(VoiceProfile {
+                person_slug: row.get(0)?,
+                name: row.get(1)?,
+                enrolled_at: row.get(2)?,
+                updated_at: row.get(3)?,
+                sample_count: row.get(4)?,
+                source: row.get(5)?,
+                model_version: row.get(6)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(profiles)
+}
+
 /// Compare a probe only with profiles produced by the same embedding model.
 pub fn match_active_profiles(
     embedding: &[f32],
@@ -1606,6 +1657,30 @@ mod tests {
     }
 
     #[test]
+    fn voice_samples_listing_uses_canonical_active_profiles() {
+        let (conn, _tmp) = test_db();
+        insert_voice_sample(
+            &conn,
+            &voice_sample_input("mat", "Mat", &[1.0, 0.0], "model-a", "2026-01-01T00:00:00Z"),
+        )
+        .unwrap();
+        insert_voice_sample(
+            &conn,
+            &voice_sample_input("mat", "Mat", &[0.8, 0.2], "model-a", "2026-01-02T00:00:00Z"),
+        )
+        .unwrap();
+
+        let profiles = list_profiles_for_display(&conn).unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].person_slug, "mat");
+        assert_eq!(profiles[0].sample_count, 2);
+        assert_eq!(profiles[0].model_version, "model-a");
+        assert_eq!(profiles[0].source, "test");
+        assert_eq!(profiles[0].enrolled_at, "2026-01-01T00:00:00Z");
+        assert!(!profiles[0].updated_at.is_empty());
+    }
+
+    #[test]
     fn voice_samples_different_models_are_isolated() {
         let (conn, _tmp) = test_db();
         insert_voice_sample(
@@ -1729,6 +1804,12 @@ mod tests {
         assert_eq!(sample_count, 2);
         assert!(active_profile(&conn, "mat", "model-a").unwrap().is_some());
         assert!(active_profile(&conn, "alex", "model-b").unwrap().is_some());
+        let displayed = list_profiles_for_display(&conn).unwrap();
+        assert_eq!(displayed.len(), 2);
+        assert!(displayed.iter().any(|profile| profile.person_slug == "mat"));
+        assert!(displayed
+            .iter()
+            .any(|profile| profile.person_slug == "alex"));
     }
 
     #[test]
@@ -2088,6 +2169,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(revoked, 1);
+        assert!(list_profiles_for_display(&conn).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -7474,7 +7474,7 @@ registerTool(
 
 registerTool(
   "list_voices",
-  "List enrolled voice profiles for speaker identification. Shows who has been enrolled, sample count, and model version.",
+  "List active voice enrollments for speaker identification. Shows who has been enrolled, sample count, and model version.",
   {},
   { title: "Voice Profiles", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   async () => {
@@ -7487,7 +7487,7 @@ registerTool(
 
     if (!Array.isArray(profiles) || profiles.length === 0) {
       return {
-        content: [{ type: "text" as const, text: "No voice profiles enrolled. The user can enroll with: minutes enroll" }],
+        content: [{ type: "text" as const, text: "No voice profiles enrolled. The user can enroll with: minutes voice enroll" }],
       };
     }
 


### PR DESCRIPTION
Fixes the voice-enrollment visibility part of #818.

Minutes had two voice stores. The modern minutes voice enroll command wrote immutable samples and an active profile, while the older minutes voices command and the MCP list_voices tool read only the legacy mutable table. A successful enrollment could therefore appear in voice status but disappear in Claude Desktop.

This change keeps the existing voices --json shape for compatibility, but sources it from the same active enrollments used by status and matching. Legacy profiles are migrated before listing, and deletion works for profiles created through either path. The empty-state guidance now points to minutes voice enroll.

Validation at b8ffb853a2a855ac408c0f5d06af5fb615775884:
- voice core suite passes, 30 of 30
- CLI voice parsing suite passes, 2 of 2
- strict focused Rust clippy passes with the existing no-default dead-code allowance
- MCP TypeScript build passes
- MCPB pack, bundle validation, and packaged handshake pass
- end-to-end temporary-profile check passes: an active enrollment appears in minutes voices --json with the compatibility fields, then minutes voices --delete revokes it and clears the active profile

This stays draft until exact-head CI, including Windows, is green.