### PR TITLE
Fix release MCPB builds with checkout SDK changes

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -308,11 +308,12 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install MCP dependencies from this exact checkout
+        run: node scripts/install_mcp_dependencies.mjs
+
       - name: Build the MCP server
         working-directory: crates/mcp
-        run: |
-          npm ci
-          npm run build
+        run: npm run build
 
       - name: Pack the bundle
         run: |

--- a/scripts/install_mcp_dependencies.test.mjs
+++ b/scripts/install_mcp_dependencies.test.mjs
@@ -6,9 +6,11 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-const sourceScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "install_mcp_dependencies.mjs");
+const scriptsDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptsDirectory, "..");
+const sourceScript = path.join(scriptsDirectory, "install_mcp_dependencies.mjs");
 const permissionsScript = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
+  scriptsDirectory,
   "normalize_npm_pack_permissions.mjs",
 );
 
@@ -107,4 +109,12 @@ test("refuses a local SDK whose tarball differs from the committed lock", async 
   assert.match(result.stderr, /integrity does not match the MCP lockfile/);
   const log = await readFile(fixture.log, "utf8");
   assert.doesNotMatch(log, /ci --cache .*crates\/mcp/);
+});
+
+test("release bundle installs the SDK from the exact checkout", async () => {
+  const workflow = await readFile(path.join(repoRoot, ".github", "workflows", "release-cli.yml"), "utf8");
+  const bundleJob = workflow.match(/\n  mcpb:\n[\s\S]*?\n  checksums:/)?.[0];
+  assert.ok(bundleJob, "release workflow must contain the mcpb job");
+  assert.match(bundleJob, /node scripts\/install_mcp_dependencies\.mjs/);
+  assert.doesNotMatch(bundleJob, /working-directory: crates\/mcp\n\s+run: \|\n\s+npm ci/);
 });


### PR DESCRIPTION
## What changed

- make the release MCPB job use the same exact-checkout SDK installer as CI
- build the MCP server only after that installer has selected the published SDK or packed the current checkout safely
- add a workflow contract test so the release job cannot silently return to a direct registry-only install

## Why

The combined Windows acceptance build for #818 included an unreleased same-version SDK repair. The release job fetched the older registry tarball and failed its integrity check instead of packaging the reviewed checkout. The normal MCP CI path already handled this case correctly.

## Verification

- `node --test scripts/install_mcp_dependencies.test.mjs` — 4/4 passed
- `actionlint .github/workflows/release-cli.yml` — passed
- exact-checkout install, MCP build, MCPB static check, and handshake — passed on the combined #818 acceptance branch
- fresh release workflow run: https://github.com/silverstein/minutes/actions/runs/32654641438

Tracks `minutes-hgot`, discovered while preparing #818 reporter acceptance.
