### PR TITLE
Explain when the Minutes engine is too old

### DIFF
--- a/crates/mcp/src/index.test.ts
+++ b/crates/mcp/src/index.test.ts
@@ -5428,6 +5428,59 @@ describe("agent trust readiness bridge", () => {
     ).rejects.toThrow(/run minutes qmd cleanup/i);
   });
 
+  it("turns an old engine missing agent-readiness into actionable upgrade guidance", async () => {
+    const calls: string[][] = [];
+    const error = await readAgentTrustReadiness(async (args) => {
+      calls.push(args);
+      if (args[0] === "--version") {
+        return { stdout: "minutes 0.24.0", stderr: "" };
+      }
+      const failure = new Error(
+        "error: unrecognized subcommand 'agent-readiness'\nPRIVATE-PATH-CANARY"
+      );
+      (failure as any).stderr = failure.message;
+      throw failure;
+    }, "win32").catch((failure: unknown) => failure);
+
+    expect(calls).toEqual([
+      ["agent-readiness", "--json"],
+      ["--version"],
+    ]);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("found v0.24.0");
+    expect((error as Error).message).toContain("needs v0.25.0 or newer");
+    expect((error as Error).message).toContain("Minutes desktop app");
+    expect((error as Error).message).not.toContain("PRIVATE");
+  });
+
+  it("keeps unexpected readiness failures opaque even when version probing would be possible", async () => {
+    const calls: string[][] = [];
+    const error = await readAgentTrustReadiness(async (args) => {
+      calls.push(args);
+      throw new Error("PRIVATE-CONFIG-CANARY");
+    }).catch((failure: unknown) => failure);
+
+    expect(calls).toEqual([["agent-readiness", "--json"]]);
+    expect((error as Error).message).toBe(
+      "Minutes agent readiness could not be verified safely."
+    );
+  });
+
+  it("does not mislabel a current custom engine as old", async () => {
+    const error = await readAgentTrustReadiness(async (args) => {
+      if (args[0] === "--version") {
+        return { stdout: "minutes 0.25.0", stderr: "" };
+      }
+      const failure = new Error("error: unknown subcommand 'agent-readiness'");
+      (failure as any).stderr = failure.message;
+      throw failure;
+    }).catch((failure: unknown) => failure);
+
+    expect((error as Error).message).toBe(
+      "Minutes agent readiness could not be verified safely."
+    );
+  });
+
   it("fails closed on malformed or inconsistent readiness responses", async () => {
     for (const stdout of [
       "",

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -84,7 +84,7 @@ import {
   validatePathInDirectories,
   validatePathInDirectory,
 } from "./paths.js";
-import { isCliCompatible } from "./version.js";
+import { isCliCompatible, parseVersion } from "./version.js";
 import {
   hasFeature,
   probeCapabilitiesSync,
@@ -3388,8 +3388,62 @@ export type AgentTrustReadiness = {
   remediation?: string;
 };
 
+const AGENT_READINESS_MIN_CLI_VERSION = "0.25.0";
+
+function isOlderVersion(installed: string, minimum: string): boolean {
+  const found = parseVersion(installed);
+  const required = parseVersion(minimum);
+  if (!found || !required) return false;
+  if (found.major !== required.major) return found.major < required.major;
+  if (found.minor !== required.minor) return found.minor < required.minor;
+  return found.patch < required.patch;
+}
+
+function rejectedUnknownSubcommand(error: any, subcommand: string): boolean {
+  const diagnostic = [error?.stderr, error?.message]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n")
+    .toLowerCase();
+  return (
+    diagnostic.includes(subcommand.toLowerCase()) &&
+    /(?:unrecognized|unknown|invalid) subcommand/.test(diagnostic)
+  );
+}
+
+export function cliTooOldGuidance(
+  installedVersion: string,
+  minimumVersion: string = AGENT_READINESS_MIN_CLI_VERSION,
+  platform: NodeJS.Platform = process.platform
+): string {
+  const update =
+    platform === "darwin" || platform === "win32"
+      ? "Install the latest free Minutes desktop app from https://useminutes.app"
+      : "Update the Minutes CLI from https://useminutes.app, or run `cargo install minutes-cli`";
+  return (
+    `The Minutes engine is too old for this extension (found v${installedVersion}; ` +
+    `needs v${minimumVersion} or newer). ${update}, then restart this app.`
+  );
+}
+
+async function oldCliReadinessGuidance(
+  runner: MinutesRunner,
+  platform: NodeJS.Platform
+): Promise<string | null> {
+  try {
+    const { stdout } = await runner(["--version"], 5000);
+    const match = stdout.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/);
+    if (!match || !isOlderVersion(match[0], AGENT_READINESS_MIN_CLI_VERSION)) {
+      return null;
+    }
+    return cliTooOldGuidance(match[0], AGENT_READINESS_MIN_CLI_VERSION, platform);
+  } catch {
+    return null;
+  }
+}
+
 export async function readAgentTrustReadiness(
-  runner: MinutesRunner = runMinutes
+  runner: MinutesRunner = runMinutes,
+  platform: NodeJS.Platform = process.platform
 ): Promise<AgentTrustReadiness> {
   let stdout: string;
   try {
@@ -3401,6 +3455,10 @@ export async function readAgentTrustReadiness(
     // the capture tools, and withholding it leaves a Claude Desktop user with
     // "could not be verified safely" and nothing to do about it (#774).
     if (error?.cliMissing) throw error;
+    if (rejectedUnknownSubcommand(error, "agent-readiness")) {
+      const guidance = await oldCliReadinessGuidance(runner, platform);
+      if (guidance) throw new Error(guidance);
+    }
     throw new Error("Minutes agent readiness could not be verified safely.");
   }
   let result: any;


### PR DESCRIPTION
## What changed

When an installed CLI does not recognize `agent-readiness`, Minutes now performs one path-free version check. A verified pre-0.25.0 engine gets an actionable update message with the found and required versions. All other readiness failures remain deliberately opaque and fail closed.

## User-visible result

Instead of:

> Minutes agent readiness could not be verified safely.

A Windows user with v0.24.0 now gets:

> The Minutes engine is too old for this extension (found v0.24.0; needs v0.25.0 or newer). Install the latest free Minutes desktop app from https://useminutes.app, then restart this app.

## Verification

- focused readiness suite: 19 passed
- full MCP unit suite: 319 passed, 3 skipped
- TypeScript check and production build: passed
- MCPB static check and startup handshake: passed
- privacy controls cover arbitrary errors, current custom engines, and path-bearing stderr

Fixes a minor first-run observation from #818. Tracks `minutes-uwvb`.
