### PR TITLE
Make setup save the selected speech model safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,6 +4062,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "toml 1.0.7+spec-1.1.0",
+ "toml_edit 0.25.5+spec-1.1.0",
  "tracing",
  "ureq",
  "walkdir",
@@ -7884,6 +7885,7 @@ dependencies = [
  "indexmap 2.13.0",
  "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 toml = "1.0"
+toml_edit = "0.25"
 
 # Audio
 cpal = { version = "0.18.1", default-features = false, features = ["pipewire", "realtime"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{Local, TimeZone};
 use clap::{Parser, Subcommand};
 use minutes_core::apple_speech::{
@@ -7316,7 +7316,7 @@ fn cmd_setup(model: &str, list: bool, diarization: bool) -> Result<()> {
         );
     }
 
-    let config = Config::default();
+    let config = Config::load_strict().map_err(anyhow::Error::msg)?;
     let model_dir = &config.transcription.model_path;
     std::fs::create_dir_all(model_dir)?;
 
@@ -7385,12 +7385,22 @@ fn cmd_setup(model: &str, list: bool, diarization: bool) -> Result<()> {
                 );
             }
         }
-
-        // Update config hint
-        eprintln!("\nTo use this model, add to ~/.config/minutes/config.toml:");
-        eprintln!("  [transcription]");
-        eprintln!("  model = \"{}\"", model);
     }
+
+    let config_path = Config::config_path();
+    Config::upsert_string_setting_at(&config_path, "transcription", "model", model).with_context(
+        || {
+            format!(
+                "failed to save the selected model in {}",
+                config_path.display()
+            )
+        },
+    )?;
+    eprintln!(
+        "Configured transcription.model = \"{}\" in {}",
+        model,
+        config_path.display()
+    );
 
     // Auto-download Silero VAD model (prevents transcription loops on non-English audio)
     let vad_dest = model_dir.join("ggml-silero-v6.2.0.bin");

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -52,6 +52,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1766,6 +1766,62 @@ impl Config {
         Ok(())
     }
 
+    /// Create or update one string setting without rewriting the rest of the
+    /// user's TOML. Setup commands use this instead of serializing the full
+    /// [`Config`], which would discard comments and unknown forward-compatible
+    /// keys from a hand-edited file.
+    ///
+    /// An existing config must first pass the same strict parse used by the
+    /// privacy-sensitive bridges. A malformed file is left byte-for-byte
+    /// untouched rather than being replaced with defaults.
+    pub fn upsert_string_setting_at(
+        path: &Path,
+        section: &str,
+        key: &str,
+        value: &str,
+    ) -> std::io::Result<()> {
+        let mut document = if path.exists() {
+            let raw = std::fs::read_to_string(path)?;
+            Self::load_strict_from(path)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+            raw.parse::<toml_edit::DocumentMut>().map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Minutes config could not be edited safely: {error}"),
+                )
+            })?
+        } else {
+            toml_edit::DocumentMut::new()
+        };
+
+        let item = document
+            .entry(section)
+            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+        let table = item.as_table_mut().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Minutes config [{section}] value is not a table."),
+            )
+        })?;
+        let existing_decor = table
+            .get(key)
+            .and_then(toml_edit::Item::as_value)
+            .map(|value| value.decor().clone());
+        let mut replacement = toml_edit::value(value);
+        if let (Some(decor), Some(replacement_value)) = (existing_decor, replacement.as_value_mut())
+        {
+            *replacement_value.decor_mut() = decor;
+        }
+        table.insert(key, replacement);
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, document.to_string())?;
+        tracing::info!(path = %path.display(), section, key, "config setting saved");
+        Ok(())
+    }
+
     /// Ensure required directories exist.
     pub fn ensure_dirs(&self) -> std::io::Result<()> {
         std::fs::create_dir_all(&self.output_dir)?;
@@ -2229,6 +2285,68 @@ mod tests {
         assert!(error.contains("malformed"));
         assert!(!error.contains("PRIVATE-CONFIG-CANARY"));
         assert!(!Config::load_from(&path).knowledge.enabled);
+    }
+
+    #[test]
+    fn string_setting_upsert_creates_a_fresh_minimal_config() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let path = directory.path().join("nested/minutes/config.toml");
+
+        Config::upsert_string_setting_at(&path, "transcription", "model", "base").unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("[transcription]"));
+        assert!(raw.contains("model = \"base\""));
+        assert_eq!(
+            Config::load_strict_from(&path).unwrap().transcription.model,
+            "base"
+        );
+    }
+
+    #[test]
+    fn string_setting_upsert_preserves_comments_and_unknown_sections() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let path = directory.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"# Keep this founder note.
+[transcription]
+model = "tiny" # Keep this model note.
+language = "es"
+
+[future_product]
+launch_mode = "careful"
+"#,
+        )
+        .unwrap();
+
+        Config::upsert_string_setting_at(&path, "transcription", "model", "small").unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("# Keep this founder note."));
+        assert!(raw.contains("# Keep this model note."));
+        assert!(raw.contains("language = \"es\""));
+        assert!(raw.contains("[future_product]"));
+        assert!(raw.contains("launch_mode = \"careful\""));
+        assert_eq!(
+            Config::load_strict_from(&path).unwrap().transcription.model,
+            "small"
+        );
+    }
+
+    #[test]
+    fn string_setting_upsert_leaves_a_malformed_config_untouched() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let path = directory.path().join("config.toml");
+        let original = b"[transcription\nPRIVATE-CONFIG-CANARY";
+        std::fs::write(&path, original).unwrap();
+
+        let error =
+            Config::upsert_string_setting_at(&path, "transcription", "model", "small").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(!error.to_string().contains("PRIVATE-CONFIG-CANARY"));
+        assert_eq!(std::fs::read(&path).unwrap(), original);
     }
 
     #[test]

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2911;
+export const MINUTES_TEST_COUNT = 2914;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;


### PR DESCRIPTION
## What changed

- `minutes setup --model ...` now saves the selected model instead of printing TOML for the user to hand-copy
- a fresh machine gets a minimal valid `config.toml`
- an existing config is edited surgically so comments, unrelated settings, and unknown forward-compatible sections survive
- malformed config files are left byte-for-byte untouched and produce an honest error
- setup now respects an existing custom model directory by loading config strictly before downloading

## Verification

- config suite: 60 passed
- new create/update/fail-closed tests: 3 passed
- CLI no-default-features suite: 115 unit tests plus 5 integration tests passed
- CLI no-default-features compile: passed
- focused strict clippy: passed with the documented baseline dead-code allowance
- rustfmt, diff check, and generated site count: passed
- Windows will run the same cross-platform config tests in exact-head CI

Fixes a minor clean-install observation from #818. Tracks `minutes-zn39`.
