### PR TITLE
fix(dictation): restore clipboard and terminal delivery

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -243,12 +243,13 @@ retention, nothing is deleted automatically unless `auto_cleanup` is enabled.
 | key | default | meaning |
 |---|---|---|
 | `backend` | `"whisper"` | Final transcription backend. Retained `"apple-speech"` and `"parakeet"` values resolve to sealed Whisper while their secure private-audio release gates remain closed. |
-| `destination` | `"clipboard"` | `"clipboard"`, `"file"`, or `"command"` |
+| `destination` | `"insert"` | `"insert"` puts the final text in the active app and on the clipboard; `"clipboard"`, `"file"`, and `"command"` remain available for explicit delivery workflows |
 | `destination_file` | unset | Target file when `destination = "file"` |
 | `destination_command` | unset | Shell command when `destination = "command"` |
 | `accumulate` | `true` | Append successive utterances rather than replacing |
 | `daily_note_log` | `true` | Append every dictation to the daily note |
 | `auto_paste` | `false` | Paste the result immediately after dictation ends when the platform can do that honestly |
+| `auto_paste_restore` | `true` | Preserve the previous clipboard during explicit re-paste and reprocess actions. Routine insert-mode dictation always leaves the final transcript on the clipboard. |
 | `silence_timeout_ms` | `2000` | Silence threshold that ends a dictation session |
 | `max_utterance_secs` | `120` | Force-finalize an utterance at this length |
 | `model` | `"base"` | Whisper model for dictation |

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -21095,7 +21095,12 @@ fn start_dictation_session(
                         crate::text_insertion::TextInsertionRequest {
                             text: result.text.clone(),
                             mode: crate::text_insertion::TextInsertionMode::BestEffortVerified,
-                            restore_clipboard: config_for_results.dictation.auto_paste_restore,
+                            // Routine dictation has one predictable delivery
+                            // contract: the final text stays in both the target
+                            // app and the clipboard. Explicit re-paste and
+                            // reprocess actions may still preserve the previous
+                            // clipboard through auto_paste_restore.
+                            restore_clipboard: false,
                             clipboard_snapshot: None,
                             expected_target: dictation_target_context_for_results.clone(),
                         },

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -12585,6 +12585,18 @@ mod tests {
         assert_eq!(duration_between_ms(None, Some(later)), None);
     }
 
+    #[test]
+    fn routine_dictation_keeps_the_final_text_on_the_clipboard() {
+        let request = routine_dictation_insertion_request("dictated text".into(), None);
+
+        assert_eq!(
+            request.mode,
+            crate::text_insertion::TextInsertionMode::BestEffortVerified
+        );
+        assert!(!request.restore_clipboard);
+        assert!(request.clipboard_snapshot.is_none());
+    }
+
     /// Loopback enforcement must judge the destination, not the spelling.
     ///
     /// Both Recall chat guards previously accepted the literal string
@@ -20859,6 +20871,23 @@ pub fn start_dictation_session_public(
     start_dictation_session(app, capture_style).map(|_| ())
 }
 
+fn routine_dictation_insertion_request(
+    text: String,
+    expected_target: Option<crate::text_insertion::ActiveTargetContext>,
+) -> crate::text_insertion::TextInsertionRequest {
+    crate::text_insertion::TextInsertionRequest {
+        text,
+        mode: crate::text_insertion::TextInsertionMode::BestEffortVerified,
+        // Routine dictation has one predictable delivery contract: the final
+        // text stays in both the target app and the clipboard. Explicit
+        // re-paste and reprocess actions may still preserve the previous
+        // clipboard through auto_paste_restore.
+        restore_clipboard: false,
+        clipboard_snapshot: None,
+        expected_target,
+    }
+}
+
 fn start_dictation_session(
     app: &tauri::AppHandle,
     capture_style: Option<HotkeyCaptureStyle>,
@@ -21091,20 +21120,11 @@ fn start_dictation_session(
                         &app_for_results,
                         &dictation_target_context_for_results,
                     );
-                    let insertion = crate::text_insertion::insert_text(
-                        crate::text_insertion::TextInsertionRequest {
-                            text: result.text.clone(),
-                            mode: crate::text_insertion::TextInsertionMode::BestEffortVerified,
-                            // Routine dictation has one predictable delivery
-                            // contract: the final text stays in both the target
-                            // app and the clipboard. Explicit re-paste and
-                            // reprocess actions may still preserve the previous
-                            // clipboard through auto_paste_restore.
-                            restore_clipboard: false,
-                            clipboard_snapshot: None,
-                            expected_target: dictation_target_context_for_results.clone(),
-                        },
-                    );
+                    let insertion =
+                        crate::text_insertion::insert_text(routine_dictation_insertion_request(
+                            result.text.clone(),
+                            dictation_target_context_for_results.clone(),
+                        ));
                     app_for_results.emit("dictation:insertion", &insertion).ok();
                     publish_dictation_overlay_state(&app_for_results, insertion.overlay_state());
                     log_dictation_insert(

--- a/tauri/src-tauri/src/text_insertion.rs
+++ b/tauri/src-tauri/src/text_insertion.rs
@@ -300,6 +300,85 @@ fn copy_only(text: &str, target_context: Option<ActiveTargetContext>) -> TextIns
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
+fn target_prefers_clipboard_paste(target: Option<&ActiveTargetContext>) -> bool {
+    let bundle_id = target
+        .and_then(|context| context.bundle_id.as_deref())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let app_name = target
+        .and_then(|context| context.app_name.as_deref())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    [
+        "ghostty",
+        "terminal",
+        "iterm",
+        "wezterm",
+        "alacritty",
+        "kitty",
+        "warp",
+    ]
+    .iter()
+    .any(|marker| bundle_id.contains(marker) || app_name.contains(marker))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn native_ax_delivery_verified(
+    before: Option<&str>,
+    after: Option<&str>,
+    inserted_text: &str,
+) -> bool {
+    matches!((before, after), (Some(before), Some(after)) if before != after && after.contains(inserted_text))
+}
+
+#[cfg(target_os = "macos")]
+fn copy_after_unverified_native_insert(
+    request: TextInsertionRequest,
+    target_context: Option<ActiveTargetContext>,
+    operation_started: std::time::Instant,
+    visible_ms: u64,
+    verification_ms: u64,
+) -> TextInsertionResult {
+    let diagnostic = "native_ax: macOS accepted the write but delivery was not verified";
+    tracing::warn!(diagnostic, "dictation native insertion was not verified");
+
+    match write_clipboard(&request.text) {
+        Ok(()) => TextInsertionResult {
+            outcome: InsertOutcome::Copied,
+            method: InsertMethod::ClipboardOnly,
+            verified: true,
+            clipboard_restored: false,
+            target_context,
+            message: "Could not verify typing into the active app. Copied dictation instead."
+                .into(),
+            timing: TextInsertionTiming {
+                visible_ms: Some(visible_ms),
+                clipboard_restore_ms: None,
+                verification_ms: Some(verification_ms),
+                total_ms: operation_started.elapsed().as_millis() as u64,
+                diagnostic: Some(diagnostic.into()),
+            },
+        },
+        Err(error) => TextInsertionResult {
+            outcome: InsertOutcome::Failed,
+            method: InsertMethod::ClipboardOnly,
+            verified: false,
+            clipboard_restored: false,
+            target_context,
+            message: error.clone(),
+            timing: TextInsertionTiming {
+                visible_ms: Some(visible_ms),
+                clipboard_restore_ms: None,
+                verification_ms: Some(verification_ms),
+                total_ms: operation_started.elapsed().as_millis() as u64,
+                diagnostic: Some(format!("{diagnostic}; clipboard_copy: {error}")),
+            },
+        },
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn best_effort_verified(
     request: TextInsertionRequest,
@@ -314,35 +393,68 @@ fn best_effort_verified(
 
     let before_value = focused_ax_value().ok();
 
-    // Prefer the focused control's selected-text range. This commits directly
-    // at the caret without touching the clipboard or launching a subprocess.
-    // Many native controls support it; browsers, terminals, and custom editors
-    // may not, so failure falls through to the proven clipboard paste path.
-    let native_ax_error = match macos_ax::insert_selected_text(&request.text) {
-        Ok(()) => {
-            let visible_ms = operation_started.elapsed().as_millis() as u64;
-            let verification_started = std::time::Instant::now();
-            let verified = focused_ax_value().ok().is_some_and(|after| {
-                before_value.as_ref() != Some(&after) && after.contains(&request.text)
-            });
-            let verification_ms = verification_started.elapsed().as_millis() as u64;
-            return TextInsertionResult {
-                outcome: InsertOutcome::Typed,
-                method: InsertMethod::NativeAx,
-                verified,
-                clipboard_restored: false,
-                target_context,
-                message: "Typed dictation into the active app.".into(),
-                timing: TextInsertionTiming {
-                    visible_ms: Some(visible_ms),
-                    clipboard_restore_ms: None,
-                    verification_ms: Some(verification_ms),
-                    total_ms: operation_started.elapsed().as_millis() as u64,
-                    diagnostic: None,
-                },
-            };
+    // Terminal accessibility trees can report a successful AXSelectedText
+    // write without delivering anything to the live prompt. Route known
+    // terminals through the proven clipboard-paste path instead. Other native
+    // controls may use the faster direct path, but only a verified change is
+    // allowed to claim `Typed`.
+    let native_ax_error = if target_prefers_clipboard_paste(target_context.as_ref()) {
+        "skipped for terminal target".to_string()
+    } else {
+        match macos_ax::insert_selected_text(&request.text) {
+            Ok(()) => {
+                let visible_ms = operation_started.elapsed().as_millis() as u64;
+                let verification_started = std::time::Instant::now();
+                let after_value = focused_ax_value().ok();
+                let verified = native_ax_delivery_verified(
+                    before_value.as_deref(),
+                    after_value.as_deref(),
+                    &request.text,
+                );
+                let verification_ms = verification_started.elapsed().as_millis() as u64;
+                if !verified {
+                    return copy_after_unverified_native_insert(
+                        request,
+                        target_context,
+                        operation_started,
+                        visible_ms,
+                        verification_ms,
+                    );
+                }
+
+                let clipboard_error = if request.restore_clipboard {
+                    None
+                } else {
+                    write_clipboard(&request.text).err()
+                };
+                if let Some(error) = clipboard_error.as_deref() {
+                    tracing::warn!(error, "dictation typed but clipboard copy failed");
+                    minutes_core::logging::log_error("dictation_clipboard", "", error);
+                }
+
+                return TextInsertionResult {
+                    outcome: InsertOutcome::Typed,
+                    method: InsertMethod::NativeAx,
+                    verified: true,
+                    clipboard_restored: false,
+                    target_context,
+                    message: if clipboard_error.is_some() {
+                        "Typed dictation into the active app, but could not copy it to the clipboard."
+                            .into()
+                    } else {
+                        "Typed dictation into the active app and copied it to the clipboard.".into()
+                    },
+                    timing: TextInsertionTiming {
+                        visible_ms: Some(visible_ms),
+                        clipboard_restore_ms: None,
+                        verification_ms: Some(verification_ms),
+                        total_ms: operation_started.elapsed().as_millis() as u64,
+                        diagnostic: clipboard_error.map(|error| format!("clipboard_copy: {error}")),
+                    },
+                };
+            }
+            Err(error) => error,
         }
-        Err(error) => error,
     };
 
     let paste_started_ms = operation_started.elapsed().as_millis() as u64;
@@ -1635,6 +1747,82 @@ mod tests {
             operations.into_inner(),
             vec!["write:dictated text", "paste"]
         );
+    }
+
+    #[test]
+    fn clipboard_paste_without_restore_leaves_dictation_on_clipboard() {
+        let operations = std::cell::RefCell::new(Vec::new());
+        let restored = clipboard_paste_restore_with(
+            "dictated text",
+            false,
+            Some("previous clipboard"),
+            |text| {
+                operations.borrow_mut().push(format!("write:{text}"));
+                Ok(())
+            },
+            || {
+                operations.borrow_mut().push("paste".into());
+                Ok(())
+            },
+            || operations.borrow_mut().push("wait".into()),
+        )
+        .expect("clipboard flow should succeed");
+
+        assert!(!restored);
+        assert_eq!(
+            operations.into_inner(),
+            vec!["write:dictated text", "paste"]
+        );
+    }
+
+    #[test]
+    fn terminal_targets_use_clipboard_paste_instead_of_native_ax() {
+        for (app_name, bundle_id) in [
+            ("Ghostty", "com.mitchellh.ghostty"),
+            ("Terminal", "com.apple.Terminal"),
+            ("iTerm2", "com.googlecode.iterm2"),
+            ("Warp", "dev.warp.Warp-Stable"),
+        ] {
+            let target = ActiveTargetContext {
+                platform: "macos".into(),
+                app_name: Some(app_name.into()),
+                bundle_id: Some(bundle_id.into()),
+                process_id: Some(42),
+            };
+            assert!(target_prefers_clipboard_paste(Some(&target)), "{app_name}");
+        }
+
+        let notes = ActiveTargetContext {
+            platform: "macos".into(),
+            app_name: Some("Notes".into()),
+            bundle_id: Some("com.apple.Notes".into()),
+            process_id: Some(42),
+        };
+        assert!(!target_prefers_clipboard_paste(Some(&notes)));
+    }
+
+    #[test]
+    fn native_ax_delivery_requires_observed_text_change() {
+        assert!(native_ax_delivery_verified(
+            Some("before"),
+            Some("before dictated text"),
+            "dictated text"
+        ));
+        assert!(!native_ax_delivery_verified(
+            Some("before"),
+            Some("before"),
+            "dictated text"
+        ));
+        assert!(!native_ax_delivery_verified(
+            None,
+            Some("dictated text"),
+            "dictated text"
+        ));
+        assert!(!native_ax_delivery_verified(
+            Some("before"),
+            None,
+            "dictated text"
+        ));
     }
 
     #[cfg(target_os = "macos")]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -11794,7 +11794,7 @@
           const insertionCapability = s.dictation.insert_capability || 'unavailable';
           if (insertionCapability === 'macos_native_or_paste') {
             insertOption.textContent = "Type at cursor — inserts into the app you're in";
-            destinationDetail.textContent = 'Minutes prefers native text insertion, with a verified paste fallback. If the target changes or macOS blocks insertion, your transcript stays on the clipboard.';
+            destinationDetail.textContent = 'Minutes inserts into the active app and keeps the final transcript on your clipboard. Terminal prompts use the reliable paste path; if direct typing cannot be verified, the transcript stays safely copied.';
           } else if (insertionCapability === 'linux_x11_paste') {
             insertOption.textContent = "Type at cursor — inserts into the app you're in";
             destinationDetail.textContent = 'On X11, Minutes uses the clipboard and xdotool after verifying the target. If insertion is unavailable, your transcript stays on the clipboard.';


### PR DESCRIPTION
## What changed

- Keep routine dictation on the clipboard after inserting it into the active app.
- Route known terminal apps through the reliable paste path instead of trusting an accessibility write that can report success without delivering text.
- Only claim direct insertion when Minutes can verify the text changed; otherwise keep the transcript safely copied.
- Clarify the behavior in Settings and the configuration reference.

## Why

Dictation could appear correctly in Apple Notes but disappear from the clipboard, while Ghostty prompts received nothing even though Minutes believed insertion had succeeded.

## Verification at f004bd8bd1959bb05f7520926ef1188c098d8116

- Signed `Minutes Dev.app` installed with the stable development identity; production `Minutes.app` untouched.
- Apple Notes insertion: pass.
- Final dictated text remains on clipboard: pass.
- Codex in Ghostty: pass.
- Claude Code in Ghostty: pass.
- Full local desktop suite: 338 passed, 0 failed.
- Strict focused lint, formatting, inline JavaScript syntax, design tokens, and sealed worker packaging checks passed.
- Fresh exact-SHA GitHub CI passed on macOS, Windows, and Linux, including the Windows installer.

Ready for exact-SHA landing approval; no release is included.