### PR TITLE
release: pin minutes-sdk 0.25.3 for mcp

### DIFF
--- a/crates/mcp/package-lock.json
+++ b/crates/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "minutes-sdk": "0.25.2",
+        "minutes-sdk": "0.25.3",
         "yaml": "^2.8.3",
         "zod": "^3.25 || ^4.0"
       },
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/minutes-sdk": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.2.tgz",
-      "integrity": "sha512-3uVt1StFrqBykNZm+MgUgG3rGuSVtRMP/ktbNaxMu0M65BWD6kvcvis53MV3gC+tRll4rd1GH/O5ye3qn83svA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.3.tgz",
+      "integrity": "sha512-tnhJw+qx1AUjwEitemDxD2NM+WVoirTcffDJI9dj9pGs4+HO1DeIafCVBqey9vm4vOjNwlaLPQG+fDkwO4eRDg==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "minutes-sdk": "0.25.2",
+    "minutes-sdk": "0.25.3",
     "yaml": "^2.8.3",
     "zod": "^3.25 || ^4.0"
   },


### PR DESCRIPTION
Final package-lock step for v0.25.3.

This changes exactly the MCP package manifest and lockfile so minutes-mcp publishes against the exact minutes-sdk 0.25.3 package produced from this release.

Local verification:
- release version sync passed
- site release constants passed
- MCP build passed
- MCP unit suite: 324 passed, 1 skipped
- local SDK tarball install and integrity check passed
- installer contract tests: 4 passed