### PR TITLE
docs(site): refresh v0.25.3 release copy

### DIFF
--- a/site/app/compare/hyprnote-vs-minutes/page.tsx
+++ b/site/app/compare/hyprnote-vs-minutes/page.tsx
@@ -4,7 +4,7 @@ import { ComparePage } from "@/components/compare-page";
 export const metadata: Metadata = {
   title: "Minutes vs Hyprnote",
   description:
-    "A fit-based comparison of Minutes and Hyprnote (Anarlog) for local-first meeting notes, agent workflows, consent provenance, and inspectable markdown output.",
+    "A fit-based comparison of Minutes and Hyprnote for local-first meeting notes, agent workflows, consent provenance, and inspectable markdown output.",
   alternates: {
     canonical: "/compare/hyprnote-vs-minutes",
   },
@@ -18,7 +18,7 @@ const comparisonRows = [
   },
   {
     label: "Open source",
-    competitor: "Yes, MIT",
+    competitor: "Yes, GPL-3.0",
     minutes: "Yes, MIT",
   },
   {
@@ -54,7 +54,7 @@ const comparisonRows = [
 ] as const;
 
 const sources = [
-  { label: "Hyprnote / Anarlog repository", href: "https://github.com/fastrepl/anarlog" },
+  { label: "Hyprnote repository", href: "https://github.com/bahodirr/hyprnote" },
   { label: "Minutes for agents", href: "https://useminutes.app/for-agents" },
   { label: "Minutes MCP reference", href: "https://useminutes.app/docs/mcp/tools" },
 ] as const;
@@ -63,9 +63,9 @@ export default function HyprnoteVsMinutesPage() {
   return (
     <ComparePage
       competitorName="Hyprnote"
-      competitorLabel="Hyprnote (Anarlog)"
+      competitorLabel="Hyprnote"
       markdownHref="/compare/hyprnote-vs-minutes.md"
-      lastReviewed="2026-07-29"
+      lastReviewed="2026-08-24"
       heroSummary="Hyprnote and Minutes are friendly neighbors: both are open source, local-first, and serious about privacy. The practical difference is the job. Hyprnote is a notepad you write in during meetings, with AI that enhances what you wrote. Minutes is a memory layer: it turns everything you record into structured markdown you own, then exposes policy-authorized normal sources to Claude, Codex, and MCP clients while excluding restricted meetings by default, with consent provenance in every file."
       quickVerdictCompetitor="you want a polished local notepad for taking and enhancing your own meeting notes, and the app itself is where you want to live."
       quickVerdictMinutes="you want a durable, agent-readable corpus: files on your disk, MCP tools, a CLI, and consent and provenance metadata your tools can rely on."
@@ -94,7 +94,7 @@ export default function HyprnoteVsMinutesPage() {
         "It is also more tool than you need if you have no interest in MCP, CLIs, or giving your AI assistants a memory of your conversations.",
       ]}
       evaluatedSection={[
-        "This page is based on public repository and product information, reviewed on 2026-06-10. It is a fit-based comparison between two open-source projects, not a teardown; we genuinely like that Hyprnote exists.",
+        "This page is based on public repository and product information, reviewed on 2026-08-24. It is a fit-based comparison between two open-source projects, not a teardown; we genuinely like that Hyprnote exists.",
         "The Minutes side is grounded in the public agent-facing docs surface and generated MCP reference, not hand-maintained marketing copy.",
       ]}
       sources={sources as any}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -40,7 +40,7 @@ const featureGrid = [
     label: "For daily work",
     title: "Dictation that stays useful",
     description:
-      "Hold the hotkey, speak, release. Minutes sends the text to the clipboard and your daily note without changing tools.",
+      "Hold the hotkey, speak, release. Minutes inserts the text where you are working, keeps a clipboard copy, and saves it to your daily note.",
   },
   {
     label: "For recall",
@@ -119,7 +119,7 @@ const capabilityColumns = [
 // Competitor cells reflect public docs spot-checked in August 2026. Refresh quarterly.
 const comparisons = [
   ["Local transcription", "No (cloud)", "No (cloud)", "Yes", "Yes"],
-  ["Open source", "No", "No", "MIT", "MIT"],
+  ["Open source", "No", "No", "GPL-3.0", "MIT"],
   ["Free", "Freemium", "Freemium", "Free", "Free"],
   ["Agent surface", "Hosted MCP", "Hosted integrations", "Local app", `Files + ${MINUTES_MCP_TOOL_COUNT} MCP tools`],
   ["Cross-meeting intelligence", "Cloud chat", "Cloud chat", "No", "Policy-safe search"],
@@ -383,9 +383,9 @@ export default function Home() {
         <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
           <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
           adds{" "}
-          reliable dual-source capture across mismatched mixer buffers and late
-          shutdown samples, prevents the desktop from stopping a separate CLI
-          recording, and surfaces source-dropout and mostly-zero-stem warnings.{" "}
+          a Windows setup path for modern Intel CPUs, dictation that reaches
+          terminal prompts while keeping a clipboard copy, and Claude
+          subscription sign-in before Recall reads meeting context.{" "}
           <a
             href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
             className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"

--- a/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
+++ b/site/app/resources/open-source-alternatives-to-granola-ai/page.tsx
@@ -21,10 +21,10 @@ const alternatives = [
       "Best if you want local conversation memory, inspectable markdown, MCP, CLI, desktop, and plugin workflows.",
   },
   {
-    name: "Hyprnote (now Char)",
+    name: "Hyprnote",
     bestFor: "Open-source private AI notepad",
     summary:
-      "Best if you want a local-first AI notepad experience oriented around private meetings and hosted/open-source hybrid options.",
+      "Best if you want a local-first AI notepad for private meetings, with offline models and optional approved third-party APIs.",
   },
   {
     name: "Meetily",
@@ -40,14 +40,14 @@ const sources = [
   { label: "Minutes for agents", href: "https://useminutes.app/for-agents" },
   { label: "Minutes MCP reference", href: "https://useminutes.app/docs/mcp/tools" },
   { label: "Hyprnote open source", href: "https://hyprnote.com/opensource" },
-  { label: "Hyprnote GitHub", href: "https://github.com/fastrepl/hyprnote" },
+  { label: "Hyprnote GitHub", href: "https://github.com/bahodirr/hyprnote" },
   { label: "Hyprnote docs", href: "https://hyprnote.com/docs/about/what-is-hyprnote/" },
-  { label: "Meetily website", href: "https://meetily.ai/de/" },
-  { label: "Meetily GitHub", href: "https://github.com/Zackriya-Solutions/meeting-minutes" },
+  { label: "Meetily website", href: "https://meetily.ai/" },
+  { label: "Meetily GitHub", href: "https://github.com/Zackriya-Solutions/meetily" },
 ] as const;
 
 
-const LAST_REVIEWED = "2026-04-09";
+const LAST_REVIEWED = "2026-08-24";
 
 export default function OpenSourceAlternativesToGranolaPage() {
   return (
@@ -108,7 +108,7 @@ export default function OpenSourceAlternativesToGranolaPage() {
           </p>
           <p>
             If you want an open-source private AI notepad that feels closer to the “AI notepad”
-            concept, <span className="font-medium text-[var(--text)]">Hyprnote (now Char)</span>{" "}
+            concept, <span className="font-medium text-[var(--text)]">Hyprnote</span>{" "}
             is a closer conceptual match. If you want a privacy-first open-source meeting assistant
             centered on local transcription and summary workflows,{" "}
             <span className="font-medium text-[var(--text)]">Meetily</span> is also worth a look.
@@ -145,7 +145,7 @@ export default function OpenSourceAlternativesToGranolaPage() {
             workflows.
           </p>
           <p>
-            Pick <span className="font-medium text-[var(--text)]">Hyprnote (now Char)</span> if you
+            Pick <span className="font-medium text-[var(--text)]">Hyprnote</span> if you
             want a more classic “private AI notepad” shape but still care about open-source and
             local-first principles.
           </p>

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -2,9 +2,9 @@
 // step 15) from the GitHub and npm APIs. Coarse on purpose: better slightly
 // stale and reliable than a flaky build-time fetch.
 // Contributors excludes anonymous entries and dependency automation.
-// Last refreshed: 2026-08-21.
+// Last refreshed: 2026-08-24.
 
-export const GITHUB_STARS = "1,441";
+export const GITHUB_STARS = "1,446";
 export const GITHUB_FORKS = "156";
 export const GITHUB_CONTRIBUTORS = "29";
-export const NPM_MONTHLY_DOWNLOADS = "4,400";
+export const NPM_MONTHLY_DOWNLOADS = "4,300";


### PR DESCRIPTION
Refreshes the public site for v0.25.3 after the release is published.

- highlights the Windows, dictation, and Recall improvements
- refreshes GitHub and npm proof figures from the public APIs
- corrects Hyprnote from MIT to GPL-3.0 and replaces its stale Anarlog/Char references
- updates the current Hyprnote and Meetily source links

Verification:
- production site build: 44/44 pages
- generated agent docs check passed
- design-token baseline passed
- release constants passed
- diff check passed

Hold merge until v0.25.3 is public.