### PR TITLE
fix(recall): keep the terminal viewport at the tail across resizes

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -14279,9 +14279,24 @@
         if (!recallExpanded) return;
         clearTimeout(fitTimeout);
         fitTimeout = setTimeout(() => {
-          if (!recallFitAddon) return;
+          if (!recallFitAddon || !recallTerminal) return;
+          // Resizing reflows the buffer, and a TUI answering the SIGWINCH
+          // redraws from scratch — both of which used to leave the viewport
+          // parked at the top of scrollback. Every window drag, pane open,
+          // or list collapse threw the reader back up to the beginning of a
+          // long answer. Remember whether they were following the tail and
+          // put them back there.
+          const buf = recallTerminal.buffer.active;
+          const wasAtBottom = buf.viewportY >= buf.baseY;
+          const prevCols = recallTerminal.cols;
+          const prevRows = recallTerminal.rows;
           recallFitAddon.fit();
-          if (recallPtyAlive && recallTerminal) {
+          if (wasAtBottom) recallTerminal.scrollToBottom();
+          // Only tell the child when the grid actually changed. A width jitter
+          // that rounds to the same cell grid still fired SIGWINCH and forced a
+          // full TUI redraw for nothing.
+          const gridChanged = recallTerminal.cols !== prevCols || recallTerminal.rows !== prevRows;
+          if (recallPtyAlive && gridChanged) {
             invoke('cmd_pty_resize', {
               sessionId: SESSION_ID,
               cols: recallTerminal.cols,


### PR DESCRIPTION
Every resize (window drag, document pane open/close, list collapse) ran `fit()` + `cmd_pty_resize`; the reflow and the TUI's SIGWINCH redraw left the xterm viewport at the top of scrollback, throwing the reader back to the start of a long answer. Now: remember whether the viewport was at the tail before `fit()`, restore it after; and skip the PTY resize when cols/rows didn't actually change.

Needs a click-test: resize the window / open a document while a long Codex answer is on screen — the view should stay where it was.