### PR TITLE
fix(desktop): collapsing the list with a document open frees its space

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -331,6 +331,16 @@
       flex: 0 0 var(--list-width, 22%);
     }
 
+    /* Collapsed must beat doc-open. Both selectors have equal specificity and
+       this block comes later, so with a document open the list kept its 22%
+       while every child was visibility:hidden — a blank column where the
+       list used to be, and chat never reclaimed the space. */
+    body.sidebar-collapsed.doc-open .app-left {
+      flex: 0 0 0;
+      width: 0;
+      min-width: 0;
+    }
+
     body.doc-open .recall-panel.expanded {
       width: auto;
       flex: 1 1 auto;


### PR DESCRIPTION
With a document open, collapsing the list left a blank 22% column: `body.doc-open .app-left` (later, equal specificity) overrode `body.sidebar-collapsed .app-left`, so the pane kept its width while its children were `visibility:hidden`. A `body.sidebar-collapsed.doc-open .app-left` rule restores the zero-width collapse and chat reclaims the space. Introduced by the pane move in #833/#834.