### PR TITLE
fix(desktop): first launch opens wide enough for three panes

### DIFF
--- a/scripts/check_apple_speech_worker_packaging.mjs
+++ b/scripts/check_apple_speech_worker_packaging.mjs
@@ -10,7 +10,7 @@ const EXPECTED_SOURCE_SHA256 = {
   worker: "b1cc9e5dd780d0fc116ba325155324783bef012b288a4c7e11381a110f3a613c",
   xpc: "bfe9dfc1f015e6825adc02212305af52efe0f2faeff0d79c736cdce4e4c4d2aa",
   swift: "77310730cfa46ac8301c1a65622681005ebf00f0c699f24fdca757e2e02fcef4",
-  main: "c74c729e2fca0cdba421c196229a0268a8bbe9b08dec003a1b25b8dcd9428aab",
+  main: "8bbe7aa5fd3510cb61944e1df35f4b2ff2a2da8497fce3784f1ab0cdddbe254a",
   acceptanceWorkflow:
     "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   acceptanceHarness:

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -302,7 +302,12 @@ pub(crate) fn show_main_window(app: &tauri::AppHandle) {
         // Empty title hides the centered "Minutes" text in any native chrome.
         // The in-app brand mark (italic m + recording dot) carries the identity.
         .title("")
-        .inner_size(560.0, 700.0)
+        // 560px was sized for a single list pane. Chat expands to half the
+        // window and a document opens beside it; three panes need ~820px just
+        // to reach their minimums and stop fighting near 1000. First launch
+        // now opens wide enough for the layout the app actually has. Returning
+        // users keep their saved size (tauri_plugin_window_state).
+        .inner_size(1120.0, 720.0)
         .min_inner_size(460.0, 520.0)
         // The main window is hidden, shown, and resized while the app lives in
         // the tray. On macOS 26, keeping that long-lived WebView transparent


### PR DESCRIPTION
The default window (`inner_size(560, 700)`) predates chat and the document pane. Three panes need ~820px minimum and are comfortable near 1000; a first launch at 560 put every pane at its floor. New installs open at 1120×720. Returning users are unaffected — `tauri_plugin_window_state` restores their saved size. Minimum size unchanged.
