### PR TITLE
Add reproducible Nemotron streaming evaluation

### DIFF
--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -72,7 +72,10 @@ jobs:
           $runtimeLib = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib"
           $model = "$env:GITHUB_WORKSPACE\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
           $audio = "$env:GITHUB_WORKSPACE\tests\eval\fixtures\audio\apple-speech-meeting.wav"
-          $env:PATH = "$runtimeBin;$runtimeLib;$env:PATH"
+          # The release archive also places an older ONNX Runtime in bin for
+          # some bundled tools. The current C API requires the matching DLL in
+          # lib, so lib must win Windows DLL resolution.
+          $env:PATH = "$runtimeLib;$runtimeBin;$env:PATH"
           & .\benchmark_sherpa_streaming.exe $model $audio 120 2 --content-free |
             Tee-Object -FilePath nemotron-windows-metrics.json
           if ($LASTEXITCODE -ne 0) { throw "Paced benchmark exited with $LASTEXITCODE" }

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -57,17 +57,27 @@ jobs:
           if (-not (Test-Path $vcvars)) { throw "vcvars64.bat was not found" }
           "VCVARS64=$vcvars" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Compile and run at speaking speed
+      - name: Compile paced benchmark
         shell: cmd
         run: |
           call "%VCVARS64%"
-          if errorlevel 1 exit /b %errorlevel%
+          if errorlevel 1 exit /b 1
           cl /nologo /std:c++17 /O2 /EHsc /I"%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\include" scripts\benchmark_sherpa_streaming.cpp /link /LIBPATH:"%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib" sherpa-onnx-cxx-api.lib sherpa-onnx-c-api.lib
-          if errorlevel 1 exit /b %errorlevel%
-          set "PATH=%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin;%PATH%"
-          benchmark_sherpa_streaming.exe "%GITHUB_WORKSPACE%\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25" "%GITHUB_WORKSPACE%\tests\eval\fixtures\audio\apple-speech-meeting.wav" 120 2 --content-free > nemotron-windows-metrics.json
-          if errorlevel 1 exit /b %errorlevel%
-          type nemotron-windows-metrics.json
+          if errorlevel 1 exit /b 1
+
+      - name: Run at speaking speed
+        shell: pwsh
+        run: |
+          $runtimeBin = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin"
+          $model = "$env:GITHUB_WORKSPACE\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
+          $audio = "$env:GITHUB_WORKSPACE\tests\eval\fixtures\audio\apple-speech-meeting.wav"
+          $env:PATH = "$runtimeBin;$env:PATH"
+          & .\benchmark_sherpa_streaming.exe $model $audio 120 2 --content-free |
+            Tee-Object -FilePath nemotron-windows-metrics.json
+          if ($LASTEXITCODE -ne 0) { throw "Paced benchmark exited with $LASTEXITCODE" }
+          if ((Get-Item nemotron-windows-metrics.json).Length -eq 0) {
+            throw "Paced benchmark emitted no metrics"
+          }
 
       - name: Enforce live-draft viability bounds
         shell: pwsh

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -69,9 +69,10 @@ jobs:
         shell: pwsh
         run: |
           $runtimeBin = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin"
+          $runtimeLib = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib"
           $model = "$env:GITHUB_WORKSPACE\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
           $audio = "$env:GITHUB_WORKSPACE\tests\eval\fixtures\audio\apple-speech-meeting.wav"
-          $env:PATH = "$runtimeBin;$env:PATH"
+          $env:PATH = "$runtimeBin;$runtimeLib;$env:PATH"
           & .\benchmark_sherpa_streaming.exe $model $audio 120 2 --content-free |
             Tee-Object -FilePath nemotron-windows-metrics.json
           if ($LASTEXITCODE -ne 0) { throw "Paced benchmark exited with $LASTEXITCODE" }

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -47,13 +47,26 @@ jobs:
           tar -xjf $env:RUNTIME_ARCHIVE
           tar -xjf $env:MODEL_ARCHIVE
 
+      - name: Locate Visual Studio C++ tools
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installation = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $installation) { throw "Visual Studio C++ tools were not found" }
+          $vcvars = Join-Path $installation "VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat was not found" }
+          "VCVARS64=$vcvars" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Compile and run at speaking speed
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "%VCVARS64%"
+          if errorlevel 1 exit /b %errorlevel%
           cl /nologo /std:c++17 /O2 /EHsc /I"%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\include" scripts\benchmark_sherpa_streaming.cpp /link /LIBPATH:"%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib" sherpa-onnx-cxx-api.lib sherpa-onnx-c-api.lib
+          if errorlevel 1 exit /b %errorlevel%
           set "PATH=%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin;%PATH%"
           benchmark_sherpa_streaming.exe "%GITHUB_WORKSPACE%\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25" "%GITHUB_WORKSPACE%\tests\eval\fixtures\audio\apple-speech-meeting.wav" 120 2 --content-free > nemotron-windows-metrics.json
+          if errorlevel 1 exit /b %errorlevel%
           type nemotron-windows-metrics.json
 
       - name: Enforce live-draft viability bounds

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -75,14 +75,15 @@ jobs:
         shell: pwsh
         run: |
           $runtimeBin = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin"
-          $runtimeLib = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib"
-          $ortLib = "$env:GITHUB_WORKSPACE\onnxruntime-win-x64-1.27.1\lib"
+          $ortDll = "$env:GITHUB_WORKSPACE\onnxruntime-win-x64-1.27.1\lib\onnxruntime.dll"
           $model = "$env:GITHUB_WORKSPACE\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
           $audio = "$env:GITHUB_WORKSPACE\tests\eval\fixtures\audio\apple-speech-meeting.wav"
           # The Sherpa Windows archive bundles ONNX Runtime 1.17.1 even though
-          # its current C API requests API 27. Use the checksummed official
-          # 1.27.1 DLL that matches the macOS release runtime.
-          $env:PATH = "$ortLib;$runtimeLib;$runtimeBin;$env:PATH"
+          # its current C API requests API 27. Windows resolves a DLL dependency
+          # beside the Sherpa DLL before consulting PATH, so replace that stale
+          # bundled DLL with the checksummed official 1.27.1 runtime used on Mac.
+          Copy-Item -Force $ortDll (Join-Path $runtimeBin "onnxruntime.dll")
+          $env:PATH = "$runtimeBin;$env:PATH"
           & .\benchmark_sherpa_streaming.exe $model $audio 120 2 --content-free |
             Tee-Object -FilePath nemotron-windows-metrics.json
           if ($LASTEXITCODE -ne 0) { throw "Paced benchmark exited with $LASTEXITCODE" }

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -82,8 +82,14 @@ jobs:
           # its current C API requests API 27. Windows resolves a DLL dependency
           # beside the Sherpa DLL before consulting PATH, so replace that stale
           # bundled DLL with the checksummed official 1.27.1 runtime used on Mac.
-          Copy-Item -Force $ortDll (Join-Path $runtimeBin "onnxruntime.dll")
-          $env:PATH = "$runtimeBin;$env:PATH"
+          # Stage every Sherpa DLL beside the executable so its transitive DLLs
+          # resolve through Windows' deterministic application-directory rule.
+          Copy-Item -Force (Join-Path $runtimeBin "*.dll") .
+          Copy-Item -Force $ortDll .\onnxruntime.dll
+          $requiredDlls = @("sherpa-onnx-c-api.dll", "sherpa-onnx-cxx-api.dll", "onnxruntime.dll")
+          foreach ($dll in $requiredDlls) {
+            if (-not (Test-Path $dll)) { throw "Required runtime DLL was not staged: $dll" }
+          }
           & .\benchmark_sherpa_streaming.exe $model $audio 120 2 --content-free |
             Tee-Object -FilePath nemotron-windows-metrics.json
           if ($LASTEXITCODE -ne 0) { throw "Paced benchmark exited with $LASTEXITCODE" }

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -20,6 +20,8 @@ jobs:
     env:
       RUNTIME_ARCHIVE: sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts.tar.bz2
       RUNTIME_SHA256: 071d6641efd737a1f60de48c9c4cd596f78d5b0980815e8ad3798c95785d2b26
+      ORT_ARCHIVE: onnxruntime-win-x64-1.27.1.zip
+      ORT_SHA256: 2e00414a63fdef0914cd5a5ede6c707844878e0c08e1b6693842f0451b2df2a1
       MODEL_ARCHIVE: sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25.tar.bz2
       MODEL_SHA256: 78e2b79fcf7271553a74402a76b771b09ea40117a39566a79f52235b23db6358
     steps:
@@ -39,12 +41,16 @@ jobs:
         shell: pwsh
         run: |
           curl.exe -L --fail --retry 3 --output $env:RUNTIME_ARCHIVE "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/$env:RUNTIME_ARCHIVE"
+          curl.exe -L --fail --retry 3 --output $env:ORT_ARCHIVE "https://github.com/microsoft/onnxruntime/releases/download/v1.27.1/$env:ORT_ARCHIVE"
           curl.exe -L --fail --retry 3 --output $env:MODEL_ARCHIVE "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/$env:MODEL_ARCHIVE"
           $runtimeHash = (Get-FileHash $env:RUNTIME_ARCHIVE -Algorithm SHA256).Hash.ToLowerInvariant()
+          $ortHash = (Get-FileHash $env:ORT_ARCHIVE -Algorithm SHA256).Hash.ToLowerInvariant()
           $modelHash = (Get-FileHash $env:MODEL_ARCHIVE -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($runtimeHash -ne $env:RUNTIME_SHA256) { throw "Sherpa runtime checksum mismatch" }
+          if ($ortHash -ne $env:ORT_SHA256) { throw "ONNX Runtime checksum mismatch" }
           if ($modelHash -ne $env:MODEL_SHA256) { throw "Nemotron model checksum mismatch" }
           tar -xjf $env:RUNTIME_ARCHIVE
+          Expand-Archive -Path $env:ORT_ARCHIVE -DestinationPath .
           tar -xjf $env:MODEL_ARCHIVE
 
       - name: Locate Visual Studio C++ tools
@@ -70,12 +76,13 @@ jobs:
         run: |
           $runtimeBin = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin"
           $runtimeLib = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib"
+          $ortLib = "$env:GITHUB_WORKSPACE\onnxruntime-win-x64-1.27.1\lib"
           $model = "$env:GITHUB_WORKSPACE\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
           $audio = "$env:GITHUB_WORKSPACE\tests\eval\fixtures\audio\apple-speech-meeting.wav"
-          # The release archive also places an older ONNX Runtime in bin for
-          # some bundled tools. The current C API requires the matching DLL in
-          # lib, so lib must win Windows DLL resolution.
-          $env:PATH = "$runtimeLib;$runtimeBin;$env:PATH"
+          # The Sherpa Windows archive bundles ONNX Runtime 1.17.1 even though
+          # its current C API requests API 27. Use the checksummed official
+          # 1.27.1 DLL that matches the macOS release runtime.
+          $env:PATH = "$ortLib;$runtimeLib;$runtimeBin;$env:PATH"
           & .\benchmark_sherpa_streaming.exe $model $audio 120 2 --content-free |
             Tee-Object -FilePath nemotron-windows-metrics.json
           if ($LASTEXITCODE -ne 0) { throw "Paced benchmark exited with $LASTEXITCODE" }

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -75,6 +75,7 @@ jobs:
         shell: pwsh
         run: |
           $runtimeBin = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin"
+          $runtimeLib = "$env:GITHUB_WORKSPACE\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib"
           $ortDll = "$env:GITHUB_WORKSPACE\onnxruntime-win-x64-1.27.1\lib\onnxruntime.dll"
           $model = "$env:GITHUB_WORKSPACE\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
           $audio = "$env:GITHUB_WORKSPACE\tests\eval\fixtures\audio\apple-speech-meeting.wav"
@@ -85,6 +86,7 @@ jobs:
           # Stage every Sherpa DLL beside the executable so its transitive DLLs
           # resolve through Windows' deterministic application-directory rule.
           Copy-Item -Force (Join-Path $runtimeBin "*.dll") .
+          Copy-Item -Force (Join-Path $runtimeLib "*.dll") .
           Copy-Item -Force $ortDll .\onnxruntime.dll
           $requiredDlls = @("sherpa-onnx-c-api.dll", "sherpa-onnx-cxx-api.dll", "onnxruntime.dll")
           foreach ($dll in $requiredDlls) {

--- a/.github/workflows/nemotron-streaming-eval.yml
+++ b/.github/workflows/nemotron-streaming-eval.yml
@@ -1,0 +1,71 @@
+name: Nemotron Streaming Evaluation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - eval/nemotron-streaming-live
+    paths:
+      - .github/workflows/nemotron-streaming-eval.yml
+      - scripts/benchmark_sherpa_streaming.cpp
+      - tests/eval/fixtures/audio/apple-speech-meeting.wav
+
+permissions:
+  contents: read
+
+jobs:
+  windows-paced-stream:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      RUNTIME_ARCHIVE: sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts.tar.bz2
+      RUNTIME_SHA256: 071d6641efd737a1f60de48c9c4cd596f78d5b0980815e8ad3798c95785d2b26
+      MODEL_ARCHIVE: sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25.tar.bz2
+      MODEL_SHA256: 78e2b79fcf7271553a74402a76b771b09ea40117a39566a79f52235b23db6358
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Record representative Windows hardware
+        shell: pwsh
+        run: |
+          Get-CimInstance Win32_Processor |
+            Select-Object Name, NumberOfCores, NumberOfLogicalProcessors |
+            ConvertTo-Json -Compress
+          Get-CimInstance Win32_ComputerSystem |
+            Select-Object TotalPhysicalMemory |
+            ConvertTo-Json -Compress
+
+      - name: Download checksummed runtime and model
+        shell: pwsh
+        run: |
+          curl.exe -L --fail --retry 3 --output $env:RUNTIME_ARCHIVE "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/$env:RUNTIME_ARCHIVE"
+          curl.exe -L --fail --retry 3 --output $env:MODEL_ARCHIVE "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/$env:MODEL_ARCHIVE"
+          $runtimeHash = (Get-FileHash $env:RUNTIME_ARCHIVE -Algorithm SHA256).Hash.ToLowerInvariant()
+          $modelHash = (Get-FileHash $env:MODEL_ARCHIVE -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($runtimeHash -ne $env:RUNTIME_SHA256) { throw "Sherpa runtime checksum mismatch" }
+          if ($modelHash -ne $env:MODEL_SHA256) { throw "Nemotron model checksum mismatch" }
+          tar -xjf $env:RUNTIME_ARCHIVE
+          tar -xjf $env:MODEL_ARCHIVE
+
+      - name: Compile and run at speaking speed
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cl /nologo /std:c++17 /O2 /EHsc /I"%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\include" scripts\benchmark_sherpa_streaming.cpp /link /LIBPATH:"%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\lib" sherpa-onnx-cxx-api.lib sherpa-onnx-c-api.lib
+          set "PATH=%GITHUB_WORKSPACE%\sherpa-onnx-v1.13.6-win-x64-shared-MD-Release-no-tts\bin;%PATH%"
+          benchmark_sherpa_streaming.exe "%GITHUB_WORKSPACE%\sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25" "%GITHUB_WORKSPACE%\tests\eval\fixtures\audio\apple-speech-meeting.wav" 120 2 --content-free > nemotron-windows-metrics.json
+          type nemotron-windows-metrics.json
+
+      - name: Enforce live-draft viability bounds
+        shell: pwsh
+        run: |
+          $metrics = Get-Content nemotron-windows-metrics.json | ConvertFrom-Json
+          if ($metrics.firstUpdateMs -lt 0 -or $metrics.firstUpdateMs -gt 2000) {
+            throw "First live draft exceeded the 2 second product target"
+          }
+          if ($metrics.completionLagMs -gt 1500) {
+            throw "End-of-input completion lag exceeded 1.5 seconds"
+          }
+          if ($metrics.updates -lt 2) {
+            throw "The model did not produce revisable streaming updates"
+          }

--- a/docs/investigations/nemotron-streaming-live-evaluation-2026-08-25.md
+++ b/docs/investigations/nemotron-streaming-live-evaluation-2026-08-25.md
@@ -1,0 +1,163 @@
+# Nemotron streaming live-transcript evaluation
+
+Date: 2026-08-25
+
+Status: evidence complete, defer product integration
+
+## Decision
+
+Keep Nemotron as a reproducible research path, but do not package it or make it
+a Minutes live-transcript engine in this release.
+
+The model is genuinely streaming and meets the controlled latency target on
+both Apple Silicon and a native Windows runner. It does not yet beat the whole
+product tradeoff:
+
+- the extracted English model is about 663 MB and used about 1.2 GB peak memory
+  on the tested Mac;
+- the Windows run used about 788 MB peak memory and more than one CPU-second per
+  second of audio on a two-core GitHub runner;
+- the official Windows Sherpa 1.13.6 package contains ONNX Runtime 1.17.1 even
+  though the Sherpa API in that package requests ONNX Runtime API 27. The test
+  worked only after replacing the bundled runtime with checksummed ONNX Runtime
+  1.27.1 and staging the dependent DLLs beside the executable;
+- Minutes currently uses `sherpa-rs` 0.6.8 and sherpa-onnx 1.12.9, which predates
+  support for this model;
+- the tested English model made a proper-name error on the public meeting
+  fixture and disagreed slightly more with an existing final transcript than
+  Apple progressive speech did on the private sample;
+- the cross-platform Whisper draft path already supplies the product contract
+  without a second large model download or a runtime migration.
+
+Apple progressive speech is the better accelerator to continue validating on
+macOS because it uses the operating system's speech stack and avoids the model,
+memory, installer, and runtime-upgrade costs. Whisper remains the common fallback
+until another common streaming engine proves enough user benefit to justify its
+distribution cost.
+
+## Candidate
+
+The evaluated candidate was the 560 ms int8 English export:
+
+`sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25`
+
+NVIDIA describes the source model as a 600M-parameter cache-aware
+FastConformer-RNNT model with native punctuation and capitalization. It supports
+80, 160, 560, and 1120 ms chunks and is governed by the NVIDIA Open Model
+License Agreement. Sherpa publishes pre-exported int8 ONNX packages for those
+four chunk sizes.
+
+Primary references:
+
+- [NVIDIA model card](https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b)
+- [Sherpa Nemotron streaming documentation](https://k2-fsa.github.io/sherpa/onnx/nemo/nemotron-streaming.html)
+
+The downloaded artifacts were pinned by checksum in the evaluation workflow:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| Sherpa 1.13.6 Windows x64 shared runtime | `071d6641efd737a1f60de48c9c4cd596f78d5b0980815e8ad3798c95785d2b26` |
+| ONNX Runtime 1.27.1 Windows x64 | `2e00414a63fdef0914cd5a5ede6c707844878e0c08e1b6693842f0451b2df2a1` |
+| Nemotron English 560 ms int8 model | `78e2b79fcf7271553a74402a76b771b09ea40117a39566a79f52235b23db6358` |
+
+The model archive was 463,945,051 bytes compressed and its extracted model
+directory was 647,228 KiB on the test Mac.
+
+## Method
+
+The harness feeds 16 kHz mono PCM at actual speaking speed, polls the recognizer
+after each 120 ms input slice, records every changed hypothesis, and adds 800 ms
+of silence before the final drain. A 500 ms silent pre-roll was necessary to
+avoid dropping the first spoken word. Product telemetry output is content-free.
+Transcript text was emitted only for local quality scoring.
+
+The measured fields are:
+
+- model initialization time;
+- speech start to first non-empty draft;
+- count and maximum gap of changed draft revisions;
+- end-of-input completion lag;
+- process CPU time and peak resident memory.
+
+Private audio and transcript text stayed on the Mac. GitHub Actions received
+only the repository's public fixture and content-free metrics.
+
+## Results
+
+### Apple Silicon Mac
+
+| Measure | Result |
+| --- | --- |
+| First non-empty draft | about 1.07 s on public fixtures |
+| Draft cadence | about every 0.5 to 0.6 s |
+| Completion lag | about 0.38 to 0.90 s |
+| Peak resident memory | about 1.2 GB |
+| CPU | roughly one full core |
+| Clean dictation | exact against the fixture reference |
+| Public meeting fixture | transcribed `Matt` as `Mad` |
+
+A private 32.8-second sample produced its first update after 1.545 seconds, 37
+changed hypotheses, and 36 revisions. Its final text had 7.04 percent word
+disagreement against the existing 71-word Minutes final. Apple progressive
+speech measured 5.63 percent on that same local comparison. These disagreement
+figures are directional, not a general accuracy benchmark.
+
+### Windows
+
+The successful native run was GitHub Actions run
+[32899579370](https://github.com/silverstein/minutes/actions/runs/32899579370)
+at evaluation commit `46849615f082fa8cb219a1b0457f1b88a1068df6`.
+
+Runner hardware:
+
+- AMD EPYC 7763;
+- 2 cores, 4 logical processors;
+- 17,178,693,632 bytes of physical memory.
+
+| Measure | Result |
+| --- | ---: |
+| Audio duration | 10,625.8 ms |
+| Initialization | 3,121.6 ms |
+| First non-empty draft | 991.7 ms |
+| Changed drafts | 19 |
+| Revisions | 18 |
+| Maximum update gap | 617.1 ms |
+| Completion lag | 328.4 ms |
+| Process CPU time | 13,578.1 ms |
+| Peak resident memory | 788,336,640 bytes |
+
+The run passed the controlled product bounds of a first draft within two seconds,
+completion within 1.5 seconds, and more than one revisable update.
+
+## Packaging finding
+
+The Windows result required a runtime repair that would be inappropriate to
+hide inside product packaging. The official Sherpa 1.13.6 shared archive loaded
+its bundled ONNX Runtime 1.17.1, then requested API 27. Merely placing ONNX
+Runtime 1.27.1 earlier in `PATH` did not work because Windows resolved the DLL
+beside the Sherpa module. The reproducible harness therefore stages the Sherpa
+DLLs beside the executable and replaces the stale `onnxruntime.dll` with the
+checksummed 1.27.1 DLL.
+
+Any future integration must upgrade Minutes' Sherpa dependency as one reviewed
+runtime unit and verify its native packages on macOS, Windows, and Linux. Minutes
+must not silently splice runtime DLLs from separate release archives in the
+shipping app.
+
+## Revisit threshold
+
+Reconsider a common streaming engine when a candidate can demonstrate all of
+the following together:
+
+- a materially better current-speech experience than the shipped Whisper draft
+  path on representative meetings, names, accents, microphones, and long speech;
+- a model and peak-memory cost appropriate for an optional local component;
+- one supported runtime package per platform without manual library surgery;
+- native macOS, Windows, and Linux acceptance, including capture-isolation and
+  final-transcript preservation;
+- a reviewed license, download, update, removal, offline, and fallback story.
+
+Those conditions are tracked in beads `minutes-3zm3.10` and
+`minutes-3zm3.11`. This evaluation satisfies `minutes-3zm3.9` with a defer
+decision; it does not authorize a product dependency upgrade or a default
+change.

--- a/scripts/benchmark_sherpa_streaming.cpp
+++ b/scripts/benchmark_sherpa_streaming.cpp
@@ -1,0 +1,265 @@
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <psapi.h>
+#pragma comment(lib, "Psapi.lib")
+#elif defined(__APPLE__) || defined(__linux__)
+#include <sys/resource.h>
+#endif
+
+#include "sherpa-onnx/c-api/cxx-api.h"
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+double elapsed_ms(Clock::time_point start) {
+  return std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+}
+
+std::string json_escape(const std::string &value) {
+  std::string escaped;
+  escaped.reserve(value.size() + 16);
+  for (const unsigned char ch : value) {
+    switch (ch) {
+      case '\\':
+        escaped += "\\\\";
+        break;
+      case '"':
+        escaped += "\\\"";
+        break;
+      case '\n':
+        escaped += "\\n";
+        break;
+      case '\r':
+        escaped += "\\r";
+        break;
+      case '\t':
+        escaped += "\\t";
+        break;
+      default:
+        if (ch < 0x20) {
+          escaped += "?";
+        } else {
+          escaped += static_cast<char>(ch);
+        }
+    }
+  }
+  return escaped;
+}
+
+int64_t peak_rss_bytes() {
+#if defined(_WIN32)
+  PROCESS_MEMORY_COUNTERS counters {};
+  if (!GetProcessMemoryInfo(GetCurrentProcess(), &counters, sizeof(counters))) {
+    return -1;
+  }
+  return static_cast<int64_t>(counters.PeakWorkingSetSize);
+#elif defined(__APPLE__) || defined(__linux__)
+  struct rusage usage {};
+  if (getrusage(RUSAGE_SELF, &usage) != 0) {
+    return -1;
+  }
+#if defined(__APPLE__)
+  return usage.ru_maxrss;
+#else
+  return static_cast<int64_t>(usage.ru_maxrss) * 1024;
+#endif
+#else
+  return -1;
+#endif
+}
+
+double process_cpu_ms() {
+#if defined(_WIN32)
+  FILETIME created {};
+  FILETIME exited {};
+  FILETIME kernel {};
+  FILETIME user {};
+  if (!GetProcessTimes(GetCurrentProcess(), &created, &exited, &kernel, &user)) {
+    return -1;
+  }
+  ULARGE_INTEGER kernel_ticks {};
+  kernel_ticks.LowPart = kernel.dwLowDateTime;
+  kernel_ticks.HighPart = kernel.dwHighDateTime;
+  ULARGE_INTEGER user_ticks {};
+  user_ticks.LowPart = user.dwLowDateTime;
+  user_ticks.HighPart = user.dwHighDateTime;
+  return static_cast<double>(kernel_ticks.QuadPart + user_ticks.QuadPart) / 10000.0;
+#elif defined(__APPLE__) || defined(__linux__)
+  struct rusage usage {};
+  if (getrusage(RUSAGE_SELF, &usage) != 0) {
+    return -1;
+  }
+  const double user_ms = usage.ru_utime.tv_sec * 1000.0 + usage.ru_utime.tv_usec / 1000.0;
+  const double system_ms =
+      usage.ru_stime.tv_sec * 1000.0 + usage.ru_stime.tv_usec / 1000.0;
+  return user_ms + system_ms;
+#else
+  return -1;
+#endif
+}
+
+void usage(const char *program) {
+  std::cerr << "usage: " << program
+            << " <runtime-model-dir> <audio.wav> [chunk-ms] [num-threads]"
+               " [--content-free]\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 3 || argc > 6) {
+    usage(argv[0]);
+    return 2;
+  }
+
+  const std::string model_dir = argv[1];
+  const std::string audio_path = argv[2];
+  const int chunk_ms = argc >= 4 ? std::atoi(argv[3]) : 120;
+  const int num_threads = argc >= 5 ? std::atoi(argv[4]) : 2;
+  const bool content_free = argc == 6 && std::string(argv[5]) == "--content-free";
+  if (chunk_ms <= 0 || num_threads <= 0 || (argc == 6 && !content_free)) {
+    usage(argv[0]);
+    return 2;
+  }
+
+  const auto wave = sherpa_onnx::cxx::ReadWave(audio_path);
+  if (wave.samples.empty() || wave.sample_rate <= 0) {
+    std::cerr << "failed to read mono PCM WAVE input\n";
+    return 3;
+  }
+
+  sherpa_onnx::cxx::OnlineRecognizerConfig config;
+  config.model_config.transducer.encoder = model_dir + "/encoder.int8.onnx";
+  config.model_config.transducer.decoder = model_dir + "/decoder.int8.onnx";
+  config.model_config.transducer.joiner = model_dir + "/joiner.int8.onnx";
+  config.model_config.tokens = model_dir + "/tokens.txt";
+  config.model_config.num_threads = num_threads;
+  config.model_config.provider = "cpu";
+  config.decoding_method = "greedy_search";
+  config.enable_endpoint = false;
+
+  const auto init_start = Clock::now();
+  auto recognizer = sherpa_onnx::cxx::OnlineRecognizer::Create(config);
+  if (recognizer.Get() == nullptr) {
+    std::cerr << "failed to create online recognizer\n";
+    return 4;
+  }
+  const double initialization_ms = elapsed_ms(init_start);
+  auto stream = recognizer.CreateStream();
+  if (stream.Get() == nullptr) {
+    std::cerr << "failed to create online stream\n";
+    return 5;
+  }
+
+  // sherpa-onnx's reference file decoder supplies 500 ms of left padding.
+  // Pre-roll the cache before starting the wall-clock measurement so a live
+  // stream does not lose speech that begins immediately.
+  std::vector<float> left_padding(wave.sample_rate / 2, 0.0f);
+  stream.AcceptWaveform(wave.sample_rate, left_padding.data(),
+                        static_cast<int32_t>(left_padding.size()));
+  while (recognizer.IsReady(&stream)) {
+    recognizer.Decode(&stream);
+  }
+
+  const int64_t chunk_samples = std::max<int64_t>(
+      1, static_cast<int64_t>(wave.sample_rate) * chunk_ms / 1000);
+  const auto stream_start = Clock::now();
+  std::string last_text;
+  double first_update_ms = -1;
+  double last_update_ms = -1;
+  double max_update_gap_ms = 0;
+  int updates = 0;
+  int revisions = 0;
+
+  auto collect_result = [&]() {
+    const auto result = recognizer.GetResult(&stream);
+    if (result.text.empty() || result.text == last_text) {
+      return;
+    }
+    const double now_ms = elapsed_ms(stream_start);
+    if (first_update_ms < 0) {
+      first_update_ms = now_ms;
+    }
+    if (last_update_ms >= 0) {
+      max_update_gap_ms = std::max(max_update_gap_ms, now_ms - last_update_ms);
+      ++revisions;
+    }
+    last_update_ms = now_ms;
+    ++updates;
+    last_text = result.text;
+    if (!content_free) {
+      std::cerr << std::fixed << std::setprecision(1) << "update_ms=" << now_ms
+                << " text=" << result.text << '\n';
+    }
+  };
+
+  int64_t offset = 0;
+  while (offset < static_cast<int64_t>(wave.samples.size())) {
+    const int64_t count = std::min<int64_t>(
+        chunk_samples, static_cast<int64_t>(wave.samples.size()) - offset);
+    const double target_ms =
+        1000.0 * static_cast<double>(offset + count) / wave.sample_rate;
+    std::this_thread::sleep_until(
+        stream_start + std::chrono::duration_cast<Clock::duration>(
+                           std::chrono::duration<double, std::milli>(target_ms)));
+    stream.AcceptWaveform(wave.sample_rate, wave.samples.data() + offset,
+                          static_cast<int32_t>(count));
+    while (recognizer.IsReady(&stream)) {
+      recognizer.Decode(&stream);
+      collect_result();
+    }
+    offset += count;
+  }
+
+  const std::string text_at_audio_end = last_text;
+  // Match sherpa-onnx's file decoder: give the streaming encoder 800 ms of
+  // right context at end-of-input. Feed it immediately because this is stop
+  // finalization, not additional recorded time.
+  const int32_t right_padding_samples = wave.sample_rate * 8 / 10;
+  std::vector<float> right_padding(right_padding_samples, 0.0f);
+  stream.AcceptWaveform(wave.sample_rate, right_padding.data(),
+                        right_padding_samples);
+  stream.InputFinished();
+  while (recognizer.IsReady(&stream)) {
+    recognizer.Decode(&stream);
+    collect_result();
+  }
+  collect_result();
+
+  const double completion_ms = elapsed_ms(stream_start);
+  const double audio_ms =
+      1000.0 * static_cast<double>(wave.samples.size()) / wave.sample_rate;
+
+  std::cout << std::fixed << std::setprecision(1)
+            << "{\"engine\":\"sherpa-nemotron-streaming\","
+            << "\"chunkMs\":" << chunk_ms << ","
+            << "\"threads\":" << num_threads << ","
+            << "\"audioMs\":" << audio_ms << ","
+            << "\"initializationMs\":" << initialization_ms << ","
+            << "\"firstUpdateMs\":" << first_update_ms << ","
+            << "\"updates\":" << updates << ","
+            << "\"revisions\":" << revisions << ","
+            << "\"maxUpdateGapMs\":" << max_update_gap_ms << ","
+            << "\"completionMs\":" << completion_ms << ","
+            << "\"completionLagMs\":" << completion_ms - audio_ms << ","
+            << "\"processCpuMs\":" << process_cpu_ms() << ","
+            << "\"peakRssBytes\":" << peak_rss_bytes();
+  if (!content_free) {
+    std::cout << ",\"textAtAudioEnd\":\"" << json_escape(text_at_audio_end)
+              << "\",\"finalText\":\"" << json_escape(last_text) << "\"";
+  }
+  std::cout << "}\n";
+  return last_text.empty() ? 6 : 0;
+}

--- a/scripts/benchmark_sherpa_streaming.cpp
+++ b/scripts/benchmark_sherpa_streaming.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #if defined(_WIN32)
+#define NOMINMAX
 #include <windows.h>
 #include <psapi.h>
 #pragma comment(lib, "Psapi.lib")

--- a/scripts/run_sherpa_streaming_benchmark.sh
+++ b/scripts/run_sherpa_streaming_benchmark.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 || $# -gt 6 ]]; then
+  echo "usage: $0 <sherpa-runtime-root> <model-root> <audio.wav> [chunk-ms] [num-threads] [--content-free]" >&2
+  exit 2
+fi
+
+runtime_root="$1"
+model_root="$2"
+audio_path="$3"
+chunk_ms="${4:-120}"
+num_threads="${5:-2}"
+content_flag="${6:-}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+compiler="${CXX:-c++}"
+binary="${TMPDIR:-/tmp}/minutes-sherpa-streaming-benchmark"
+
+"$compiler" -std=c++17 -O2 \
+  -I"$runtime_root/include" \
+  "$script_dir/benchmark_sherpa_streaming.cpp" \
+  -L"$runtime_root/lib" -lsherpa-onnx-cxx-api -lsherpa-onnx-c-api \
+  -Wl,-rpath,"$runtime_root/lib" \
+  -o "$binary"
+
+args=("$model_root" "$audio_path" "$chunk_ms" "$num_threads")
+if [[ -n "$content_flag" ]]; then
+  if [[ "$content_flag" != "--content-free" ]]; then
+    echo "the only supported sixth argument is --content-free" >&2
+    exit 2
+  fi
+  args+=("$content_flag")
+fi
+
+exec "$binary" "${args[@]}"

--- a/scripts/score_sherpa_streaming.py
+++ b/scripts/score_sherpa_streaming.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Run the paced Sherpa benchmark and emit content-free quality metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def normalized_words(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+(?:'[a-z0-9]+)?", text.casefold())
+
+
+def edit_distance(reference: list[str], hypothesis: list[str]) -> int:
+    previous = list(range(len(hypothesis) + 1))
+    for row, reference_word in enumerate(reference, start=1):
+        current = [row]
+        for column, hypothesis_word in enumerate(hypothesis, start=1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[column] + 1,
+                    previous[column - 1]
+                    + (0 if reference_word == hypothesis_word else 1),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def read_reference(path: Path) -> str:
+    lines: list[str] = []
+    with path.open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            try:
+                value = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            text = value.get("text") if isinstance(value, dict) else None
+            if isinstance(text, str) and text.strip():
+                lines.append(text.strip())
+    return " ".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("runner", type=Path)
+    parser.add_argument("runtime_root", type=Path)
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("audio", type=Path)
+    parser.add_argument("reference_jsonl", type=Path)
+    parser.add_argument("--chunk-ms", default="120")
+    parser.add_argument("--threads", default="2")
+    args = parser.parse_args()
+
+    completed = subprocess.run(
+        [
+            str(args.runner),
+            str(args.runtime_root),
+            str(args.model_root),
+            str(args.audio),
+            args.chunk_ms,
+            args.threads,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        print("paced Sherpa benchmark failed; transcript output was suppressed", file=sys.stderr)
+        return completed.returncode
+
+    try:
+        metrics = json.loads(completed.stdout.strip().splitlines()[-1])
+        hypothesis = metrics.pop("finalText")
+        metrics.pop("textAtAudioEnd", None)
+    except (IndexError, KeyError, json.JSONDecodeError, TypeError):
+        print("paced Sherpa benchmark returned invalid metrics", file=sys.stderr)
+        return 7
+
+    reference_words = normalized_words(read_reference(args.reference_jsonl))
+    hypothesis_words = normalized_words(hypothesis)
+    if not reference_words:
+        print("reference transcript contained no words", file=sys.stderr)
+        return 8
+    edits = edit_distance(reference_words, hypothesis_words)
+    metrics.update(
+        {
+            "referenceWords": len(reference_words),
+            "hypothesisWords": len(hypothesis_words),
+            "wordErrors": edits,
+            "wordErrorRatePct": round(100.0 * edits / len(reference_words), 2),
+        }
+    )
+    print(json.dumps(metrics, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Measure the current 560 ms Nemotron streaming model at actual speaking speed before deciding whether Minutes should adopt it as a common Mac, Windows, and Linux live-draft engine.

## Result

The evaluation is complete. Nemotron is genuinely streaming and passed the controlled latency bounds on Apple Silicon and native Windows:

- Mac first text: about 1.07 seconds
- Windows first text: 991.7 ms
- Windows completion lag: 328.4 ms
- frequent replaceable revisions on both platforms

The product decision is **defer integration**.

The model is about 663 MB extracted, used about 1.2 GB peak memory on Mac and 788 MB on Windows, consumed roughly one full CPU core or more, and requires a Sherpa runtime upgrade. The official Windows Sherpa package also bundled an ONNX Runtime too old for its own API request, so the successful test required an explicit checksummed runtime repair. Minutes should not hide that kind of library surgery in a shipping app.

Apple progressive speech remains the more promising Mac accelerator. The shipped common path should remain the bounded Whisper draft worker until another engine produces enough user benefit to justify its model, memory, installer, and support costs.

## What this adds

- a paced, revisable C++ streaming harness
- content-free CPU, memory, latency, cadence, and completion metrics
- local-only word-disagreement scoring for private samples
- checksummed official runtime and model downloads
- a fail-closed native Windows evaluation lane
- the complete evidence and product decision in `docs/investigations/nemotron-streaming-live-evaluation-2026-08-25.md`

This PR does not change the app, package the model, upgrade Minutes' runtime, or change any default.
