### PR TITLE
ci: diff dependency PRs from the merge base

### DIFF
--- a/.github/workflows/dependency-pr-scope.yml
+++ b/.github/workflows/dependency-pr-scope.yml
@@ -60,7 +60,11 @@ jobs:
           echo "Branch: $HEAD_REF"
           echo
 
-          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          # Diff from the merge base, not the base branch tip. A dependabot
+          # branch that is behind main would otherwise "change" every file
+          # main gained since the branch was cut and fail its own check.
+          merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          changed=$(git diff --name-only "$merge_base" "$HEAD_SHA")
           if [ -z "$changed" ]; then
             echo "No changed files."
             exit 0


### PR DESCRIPTION
## What

`dependency-pr-scope.yml` compared `base.sha` to `head.sha` with a two-dot `git diff`. When a dependabot branch is behind `main`, every file `main` gained since the branch was cut shows up as a change and the PR fails its own scope check — #826 tripped on `docs/investigations/nemotron-streaming-live-evaluation-2026-08-25.md` and `scripts/benchmark_sherpa_streaming.cpp` from #852.

Diff from `git merge-base` instead, which is what the check meant.

## Verification

- The failure on #826 (run 33040423768) lists only files from `main`, none from the branch.
- After this lands, `@dependabot rebase` on #826 re-runs the check against the merge base.