### PR TITLE
fix: detach the DMG mount from the cleanup trap and make Finder layout best-effort for installs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -148,10 +148,18 @@ from pathlib import Path
 print(json.loads(Path("tauri/src-tauri/tauri.conf.json").read_text())["version"])
 PY
 )"
+# Local installs treat the DMG window cosmetics as best-effort: a Finder
+# AppleEvent failure must not block installing the app that was just built.
+# The ${arr[@]+...} guard keeps set -u happy on the bash 3.2 macOS ships.
+DMG_LAYOUT_ARGS=()
+if [[ " $* " == *" --install "* ]]; then
+    DMG_LAYOUT_ARGS=(--layout-best-effort)
+fi
 ./scripts/create-branded-dmg.sh \
     --app target/release/bundle/macos/Minutes.app \
     --version "$APP_VERSION" \
-    --output "target/release/bundle/dmg/Minutes_${APP_VERSION}_aarch64.dmg"
+    --output "target/release/bundle/dmg/Minutes_${APP_VERSION}_aarch64.dmg" \
+    ${DMG_LAYOUT_ARGS[@]+"${DMG_LAYOUT_ARGS[@]}"}
 
 echo "=== Signing + Installing CLI ==="
 mkdir -p ~/.local/bin

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -9,7 +9,7 @@ import { existsSync, readFileSync } from "node:fs";
 const EXPECTED_SOURCE_SHA256 = {
   release: "3a71697445c183e033afeaa9fc097de990870d934933a2cbba35c2e0289d677a",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
-  build: "24fca291f683c7c6cc0599e7e88514f4f3374e357983298b857b4fef0acada9f",
+  build: "cbc8570be555a3d5c5679166150cdfaebaa1d15b7eaaea8cda88dc135e77e405",
   dev: "4b8cacb078a06320c9718c6f4d35801125bfa8629e71962caa841a36dcf600b4",
   packageXpc: "450e1cf9d62dc938be45af5f84206fb9d7199f4f865d4f8af37c05f20863573a",
   tauri: "f127e92a1a2a635326d13dd766b3e6cc841655bce30ea2d01d67d9f12c15502c",

--- a/scripts/create-branded-dmg.sh
+++ b/scripts/create-branded-dmg.sh
@@ -89,10 +89,40 @@ STAGING_DIR="$WORK_DIR/staging"
 MOUNT_DIR="$WORK_DIR/mount"
 RW_DMG="$WORK_DIR/Minutes-${VERSION}.rw.dmg"
 
-cleanup() {
-  if mount | grep -Fq "$MOUNT_DIR"; then
-    hdiutil detach "$MOUNT_DIR" -force -quiet || true
+# Detach whatever is mounted at $1, retrying with force while Finder settles.
+# Resolves the physical path first: macOS TMPDIR lives under /var, a symlink
+# to /private/var, and `mount` prints resolved paths, so an unresolved
+# comparison never matches (#859). Returns 0 when nothing is mounted there or
+# the detach succeeded; the not-mounted early exit keeps the EXIT trap cheap
+# on successful runs and on failures before the attach.
+detach_mount_dir() {
+  local mount_dir="$1"
+  local real_dir
+  real_dir="$(cd "$mount_dir" 2>/dev/null && pwd -P)" || return 0
+  if ! mount | grep -Fq " on $real_dir ("; then
+    return 0
   fi
+
+  osascript -e 'tell application "Finder" to quit' >/dev/null 2>&1 || true
+
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if hdiutil detach "$real_dir" -quiet; then
+      return 0
+    fi
+
+    echo "DMG detach attempt ${attempt} failed; retrying with force after Finder settles..." >&2
+    diskutil unmount force "$real_dir" >/dev/null 2>&1 || true
+    if hdiutil detach "$real_dir" -force -quiet; then
+      return 0
+    fi
+    sleep "$((attempt * 2))"
+  done
+  return 1
+}
+
+cleanup() {
+  detach_mount_dir "$MOUNT_DIR" || true
   rm -rf "$WORK_DIR" || true
 }
 trap cleanup EXIT
@@ -170,25 +200,7 @@ sync
 sleep 2
 
 echo "Detaching DMG..."
-osascript -e 'tell application "Finder" to quit' >/dev/null 2>&1 || true
-
-DETACHED=0
-for attempt in 1 2 3 4 5; do
-  if hdiutil detach "$MOUNT_DIR" -quiet; then
-    DETACHED=1
-    break
-  fi
-
-  echo "DMG detach attempt ${attempt} failed; retrying with force after Finder settles..." >&2
-  diskutil unmount force "$MOUNT_DIR" >/dev/null 2>&1 || true
-  if hdiutil detach "$MOUNT_DIR" -force -quiet; then
-    DETACHED=1
-    break
-  fi
-  sleep "$((attempt * 2))"
-done
-
-if [[ "$DETACHED" -ne 1 ]]; then
+if ! detach_mount_dir "$MOUNT_DIR"; then
   echo "Failed to detach DMG mount after retries: $MOUNT_DIR" >&2
   exit 1
 fi

--- a/scripts/create-branded-dmg.sh
+++ b/scripts/create-branded-dmg.sh
@@ -8,18 +8,23 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/create-branded-dmg.sh --app <application.app> --version <x.y.z> --output <path.dmg>
+Usage: scripts/create-branded-dmg.sh --app <application.app> --version <x.y.z> --output <path.dmg> [--layout-best-effort]
 
 Creates a signed-app installer DMG with:
   - the supplied application on the left
   - /Applications symlink on the right
   - the generated Minutes DMG background
+
+With --layout-best-effort, a failure in the Finder window-layout step is a
+warning instead of an error: the DMG is still produced, just without the
+arranged window. Local installs pass this; release packaging does not.
 EOF
 }
 
 APP_PATH=""
 VERSION=""
 OUTPUT_PATH=""
+LAYOUT_BEST_EFFORT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +39,10 @@ while [[ $# -gt 0 ]]; do
     --output)
       OUTPUT_PATH="$2"
       shift 2
+      ;;
+    --layout-best-effort)
+      LAYOUT_BEST_EFFORT=1
+      shift
       ;;
     -h|--help)
       usage
@@ -165,7 +174,7 @@ if command -v SetFile >/dev/null 2>&1; then
 fi
 chflags hidden "$MOUNT_DIR/.background" "$MOUNT_DIR/.VolumeIcon.icns" || true
 
-osascript - "$MOUNT_DIR" "$APP_NAME" <<'APPLESCRIPT'
+if ! osascript - "$MOUNT_DIR" "$APP_NAME" <<'APPLESCRIPT'
 on run argv
   set mountPath to item 1 of argv
   set appName to item 2 of argv
@@ -194,6 +203,14 @@ on run argv
   end tell
 end run
 APPLESCRIPT
+then
+  if [[ "$LAYOUT_BEST_EFFORT" -eq 1 ]]; then
+    echo "Finder window layout failed; continuing without DMG cosmetics (--layout-best-effort)." >&2
+  else
+    echo "Finder window layout failed." >&2
+    exit 1
+  fi
+fi
 
 echo "Flushing Finder metadata..."
 sync


### PR DESCRIPTION
## Summary

Implements the direction from #859 (options 2 + 3, plus the `--install` question), one commit per point:

- **Cleanup trap** (`create-branded-dmg.sh`): the retry-then-force detach loop moved into a shared `detach_mount_dir()`, used by both the main path and the EXIT trap in place of the broken `mount | grep` gate. The function resolves the physical path once (`pwd -P`), which fixes the `/var` → `/private/var` symlink mismatch, and exits early when nothing is mounted (the trap also fires on successful exits and on failures before the attach, so calling the full retry loop unconditionally would add ~30s of no-op retries there)
- **Best-effort layout** (`create-branded-dmg.sh` + `build.sh`): new `--layout-best-effort` flag turns a Finder window-layout failure into a warning (DMG still produced, window not arranged); `build.sh` passes it only when `--install` was requested, so release packaging keeps the step fatal
- The `${arr[@]+...}` expansion guard in `build.sh` is for the bash 3.2 macOS ships, where an empty array trips `set -u`

Closes #859

## Test plan

- [x] `bash -n` on both scripts
- [x] Full success path: DMG created, no leftover mounts, workdir removed
- [x] Simulated Finder failure (osascript stub on PATH returning the -1712 error) without the flag: script exits 1, the trap detaches the volume and removes the workdir; the #859 leak is gone
- [x] Same simulated failure with `--layout-best-effort`: warning on stderr, DMG still produced, exit 0, no leftover mounts
- [x] Flag plumbing in bash 3.2 with `set -u`: `--install` present and absent both expand correctly
- [x] `./scripts/build.sh --install` end to end on macOS 26: build, DMG, CLI and app installed, exit 0, no leftover mounts

shellcheck did not run (not installed on this machine); happy to address any findings if CI has it.
