### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# One live run per PR: a new push supersedes the previous run's results, so
+# cancel it instead of letting it hold runners for 30+ minutes. Pushes to
+# main keep every run (each merge commit is worth a full result).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## What

Adds a `concurrency` block to `ci.yml`: one live run per PR, cancelled when a new push supersedes it. Pushes to `main` are grouped by sha, so `cancel-in-progress` never applies there.

## Why

Every rebase or force-push left the previous run going. During today's merge batch the queue carried several 30-minute Windows/macOS runs whose results were already obsolete, which delayed the runs that mattered.

## Notes

- `cancel-in-progress` is an expression so it evaluates `true` only for `pull_request` events.
- Other workflows already use concurrency groups (archive/homebrew/acceptance); this brings `CI` in line.
- `actionlint` clean.