### PR TITLE
fix: restore live Recall transcript contract

### DIFF
--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -2999,6 +2999,7 @@ fn run_sidecar_inner_mpsc(
         .as_ref()
         .map(|_| RecordingDraftGate::new(config));
     let mut last_draft_text = String::new();
+    let mut input_disconnected_unexpectedly = false;
 
     tracing::info!(
         current_speech_drafts = partial_publisher.is_some(),
@@ -3059,6 +3060,7 @@ fn run_sidecar_inner_mpsc(
             Ok(s) => s,
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                input_disconnected_unexpectedly = !stop_flag.load(Ordering::Relaxed);
                 draft_jobs.clear();
                 if let (Some(gate), Some(publisher)) =
                     (draft_gate.as_mut(), partial_publisher.as_mut())
@@ -3117,8 +3119,6 @@ fn run_sidecar_inner_mpsc(
         Some(w) => w.finalize(),
         None => (0, 0.0, PathBuf::new()),
     };
-    // Clean up status file so session_status() doesn't report stale data
-    clear_status_file();
     tracing::info!(
         vad_mode = vad.mode_name(),
         samples_fed = gating_stats.samples_fed,
@@ -3144,6 +3144,19 @@ fn run_sidecar_inner_mpsc(
         draft_results_replaced = draft_results.replaced.load(Ordering::Relaxed),
         "live sidecar ended (recording mode)"
     );
+
+    if input_disconnected_unexpectedly {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "live transcript audio feeder disconnected while recording was still active",
+        )
+        .into());
+    }
+
+    // A normal recording stop should not leave stale sidecar state. Unexpected
+    // disconnects return an error above so the outer boundary can persist a
+    // Failed status and diagnostic instead of erasing the evidence.
+    clear_status_file();
 
     Ok(())
 }
@@ -4790,6 +4803,42 @@ mod tests {
         assert!(!status.active);
         assert_eq!(status.source, None);
         assert_eq!(status.diagnostic.as_deref(), Some("sidecar failed"));
+    }
+
+    #[cfg(feature = "whisper")]
+    #[test]
+    fn unexpected_sidecar_input_disconnect_preserves_failure_diagnostic() {
+        with_temp_home(|| {
+            let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(1);
+            drop(tx);
+            let stop = Arc::new(AtomicBool::new(false));
+
+            run_sidecar_mpsc(rx, stop, &Config::default(), None);
+
+            let status = read_live_status(&pid::live_transcript_status_path())
+                .expect("unexpected disconnect should leave a status file");
+            assert_eq!(status.state, LiveStatusState::Failed);
+            assert!(status.diagnostic.as_deref().is_some_and(|message| {
+                message.contains("audio feeder disconnected while recording was still active")
+            }));
+        });
+    }
+
+    #[cfg(feature = "whisper")]
+    #[test]
+    fn expected_sidecar_stop_clears_status_file() {
+        with_temp_home(|| {
+            let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(1);
+            drop(tx);
+            let stop = Arc::new(AtomicBool::new(true));
+
+            run_sidecar_mpsc(rx, stop, &Config::default(), None);
+
+            assert!(
+                !pid::live_transcript_status_path().exists(),
+                "a normal recording stop must not leave stale sidecar state"
+            );
+        });
     }
 
     #[cfg(all(feature = "whisper", feature = "streaming"))]

--- a/crates/core/src/stem_tail.rs
+++ b/crates/core/src/stem_tail.rs
@@ -234,6 +234,24 @@ const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250)
 /// so this only has to outlast process startup.
 const HEADER_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Give the sibling stem a brief chance to publish its header after the first
+/// source becomes usable. The native helper normally creates both together,
+/// but their first writes can race. After this grace period, start with the
+/// usable source instead of sacrificing the entire live transcript.
+const SIBLING_STEM_GRACE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// If one opened stem stops producing frames while its sibling advances, do
+/// not let the stalled source block the healthy source forever. This also
+/// covers a header-only microphone stem when macOS grants capture but delivers
+/// no microphone frames.
+const STEM_STALL_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StalledSource {
+    Voice,
+    System,
+}
+
 /// Feed the live-transcription sidecar from native call-capture stems.
 ///
 /// Native capture writes audio to WAV stems rather than handing samples to the
@@ -279,38 +297,103 @@ pub fn spawn_live_transcription_from_stems(
     }
 }
 
-/// Open both stems, then forward mixed audio until asked to stop.
+/// Open whichever stems are usable, then forward audio until asked to stop.
 fn feed_from_stems(
     voice_stem: PathBuf,
     system_stem: Option<PathBuf>,
     live_tx: &std::sync::mpsc::SyncSender<Vec<f32>>,
     stop_flag: &Arc<AtomicBool>,
 ) {
-    let Some(mut voice) = wait_for_stem(&voice_stem, stop_flag) else {
+    let Some((mut voice, mut system)) = wait_for_stems(
+        &voice_stem,
+        system_stem.as_deref(),
+        stop_flag,
+        SIBLING_STEM_GRACE,
+    ) else {
         return;
     };
-    let mut system = system_stem
-        .as_deref()
-        .and_then(|path| wait_for_stem(path, stop_flag));
+    let mut has_voice = voice.is_some();
+    let mut has_system = system.is_some();
+
+    if !has_voice {
+        tracing::warn!(
+            stem = %voice_stem.display(),
+            "voice stem unavailable; live transcript is using system audio only"
+        );
+    }
+    if let Some(system_stem) = system_stem.as_deref().filter(|_| !has_system) {
+        tracing::warn!(
+            stem = %system_stem.display(),
+            "system stem unavailable; live transcript is using voice audio only"
+        );
+    }
 
     // Per-stem residue: the stems advance independently, so each round mixes the
     // overlapping prefix and keeps the rest for the next one.
     let mut voice_pending: Vec<f32> = Vec::new();
     let mut system_pending: Vec<f32> = Vec::new();
+    let started_at = std::time::Instant::now();
+    let mut voice_last_progress = started_at;
+    let mut system_last_progress = started_at;
 
     while !stop_flag.load(Ordering::Relaxed) {
-        match voice.poll() {
-            Ok(samples) => voice_pending.extend_from_slice(&samples),
-            Err(error) => tracing::debug!(%error, "voice stem poll failed; continuing"),
+        if let Some(voice) = voice.as_mut() {
+            match voice.poll() {
+                Ok(samples) => {
+                    if !samples.is_empty() {
+                        voice_last_progress = std::time::Instant::now();
+                        voice_pending.extend_from_slice(&samples);
+                    }
+                }
+                Err(error) => tracing::debug!(%error, "voice stem poll failed; continuing"),
+            }
         }
         if let Some(system) = system.as_mut() {
             match system.poll() {
-                Ok(samples) => system_pending.extend_from_slice(&samples),
+                Ok(samples) => {
+                    if !samples.is_empty() {
+                        system_last_progress = std::time::Instant::now();
+                        system_pending.extend_from_slice(&samples);
+                    }
+                }
                 Err(error) => tracing::debug!(%error, "system stem poll failed; continuing"),
             }
         }
 
-        let chunk = take_mixed(&mut voice_pending, &mut system_pending, system.is_some());
+        let now = std::time::Instant::now();
+        match stalled_source_to_drop(
+            has_voice,
+            has_system,
+            voice_pending.len(),
+            system_pending.len(),
+            now.duration_since(voice_last_progress),
+            now.duration_since(system_last_progress),
+        ) {
+            Some(StalledSource::Voice) => {
+                has_voice = false;
+                voice = None;
+                voice_pending.clear();
+                tracing::warn!(
+                    "voice stem stopped producing frames; live transcript is continuing with system audio only"
+                );
+            }
+            Some(StalledSource::System) => {
+                has_system = false;
+                system = None;
+                system_pending.clear();
+                tracing::warn!(
+                    "system stem stopped producing frames; live transcript is continuing with voice audio only"
+                );
+            }
+            None => {}
+        }
+
+        let chunk = take_audio(
+            &mut voice_pending,
+            &mut system_pending,
+            has_voice,
+            has_system,
+        );
         if !chunk.is_empty() && live_tx.send(chunk).is_err() {
             // The sidecar is gone; nothing left to feed.
             return;
@@ -320,27 +403,49 @@ fn feed_from_stems(
     }
 
     // Final sweep so the tail of the call is not lost to the stop race.
-    if let Ok(samples) = voice.poll() {
-        voice_pending.extend_from_slice(&samples);
+    if let Some(voice) = voice.as_mut() {
+        if let Ok(samples) = voice.poll() {
+            voice_pending.extend_from_slice(&samples);
+        }
     }
     if let Some(system) = system.as_mut() {
         if let Ok(samples) = system.poll() {
             system_pending.extend_from_slice(&samples);
         }
     }
-    let tail = take_mixed(&mut voice_pending, &mut system_pending, system.is_some());
+    let mut tail = take_audio(
+        &mut voice_pending,
+        &mut system_pending,
+        has_voice,
+        has_system,
+    );
+    // At stop there will be no later sibling frames to align with, so preserve
+    // the longer stem's remaining suffix instead of silently discarding it.
+    // One of these buffers is empty after `take_audio` mixes the overlap.
+    tail.extend(std::mem::take(&mut voice_pending));
+    tail.extend(std::mem::take(&mut system_pending));
     if !tail.is_empty() {
         let _ = live_tx.send(tail);
     }
 }
 
-/// Mix the overlapping prefix of both stems, leaving any surplus buffered.
+/// Return audio for the selected source plan.
 ///
-/// With no system stem the voice audio passes through untouched. Sums are
-/// clamped rather than scaled so a quiet side is not attenuated by a loud one.
-fn take_mixed(voice: &mut Vec<f32>, system: &mut Vec<f32>, has_system: bool) -> Vec<f32> {
-    if !has_system {
-        return std::mem::take(voice);
+/// A single usable stem passes through untouched. With both stems, mix only
+/// their overlapping prefix and buffer any surplus so the sources stay
+/// aligned. Sums are clamped rather than scaled so a quiet side is not
+/// attenuated by a loud one.
+fn take_audio(
+    voice: &mut Vec<f32>,
+    system: &mut Vec<f32>,
+    has_voice: bool,
+    has_system: bool,
+) -> Vec<f32> {
+    match (has_voice, has_system) {
+        (true, false) => return std::mem::take(voice),
+        (false, true) => return std::mem::take(system),
+        (false, false) => return Vec::new(),
+        (true, true) => {}
     }
     let n = voice.len().min(system.len());
     if n == 0 {
@@ -354,21 +459,75 @@ fn take_mixed(voice: &mut Vec<f32>, system: &mut Vec<f32>, has_system: bool) -> 
     mixed
 }
 
-/// Wait for a stem to exist and carry a parseable header.
-fn wait_for_stem(path: &Path, stop_flag: &Arc<AtomicBool>) -> Option<StemTail> {
+fn stalled_source_to_drop(
+    has_voice: bool,
+    has_system: bool,
+    voice_pending: usize,
+    system_pending: usize,
+    voice_idle: std::time::Duration,
+    system_idle: std::time::Duration,
+) -> Option<StalledSource> {
+    if !(has_voice && has_system) {
+        return None;
+    }
+    if voice_pending == 0 && system_pending > 0 && voice_idle >= STEM_STALL_GRACE {
+        return Some(StalledSource::Voice);
+    }
+    if system_pending == 0 && voice_pending > 0 && system_idle >= STEM_STALL_GRACE {
+        return Some(StalledSource::System);
+    }
+    None
+}
+
+/// Wait for at least one stem to exist and carry a parseable header.
+///
+/// Voice and system are probed in parallel. Once either is ready, the sibling
+/// gets a short grace period to avoid dropping one side because of a startup
+/// race. A missing voice stem must not suppress healthy system audio.
+fn wait_for_stems(
+    voice_path: &Path,
+    system_path: Option<&Path>,
+    stop_flag: &Arc<AtomicBool>,
+    sibling_grace: std::time::Duration,
+) -> Option<(Option<StemTail>, Option<StemTail>)> {
     let deadline = std::time::Instant::now() + HEADER_WAIT;
+    let mut voice = None;
+    let mut system = None;
+    let mut first_ready_at = None;
+
     while std::time::Instant::now() < deadline {
         if stop_flag.load(Ordering::Relaxed) {
             return None;
         }
-        match StemTail::open(path) {
-            Ok(tail) => return Some(tail),
-            Err(_) => std::thread::sleep(POLL_INTERVAL),
+
+        if voice.is_none() {
+            voice = StemTail::open(voice_path).ok();
         }
+        if system.is_none() {
+            system = system_path.and_then(|path| StemTail::open(path).ok());
+        }
+
+        let any_ready = voice.is_some() || system.is_some();
+        let all_expected_ready = voice.is_some() && (system_path.is_none() || system.is_some());
+        if all_expected_ready {
+            return Some((voice, system));
+        }
+        if any_ready {
+            let ready_at = first_ready_at.get_or_insert_with(std::time::Instant::now);
+            if ready_at.elapsed() >= sibling_grace {
+                return Some((voice, system));
+            }
+        }
+
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    if voice.is_some() || system.is_some() {
+        return Some((voice, system));
     }
     tracing::warn!(
-        stem = %path.display(),
-        "stem header never appeared; live transcript will not run for this capture"
+        voice_stem = %voice_path.display(),
+        system_stem = system_path.map(|path| path.display().to_string()),
+        "no usable stem header appeared; live transcript will not run for this capture"
     );
     None
 }
@@ -516,7 +675,7 @@ mod tests {
         let mut voice = vec![0.1, 0.2, 0.3];
         let mut system = vec![0.4];
 
-        let mixed = take_mixed(&mut voice, &mut system, true);
+        let mixed = take_audio(&mut voice, &mut system, true, true);
         assert_eq!(mixed.len(), 1, "only the overlapping prefix is emitted");
         assert!((mixed[0] - 0.5).abs() < 1e-6);
         assert_eq!(voice.len(), 2, "unmatched voice audio stays buffered");
@@ -527,9 +686,18 @@ mod tests {
     fn mixing_passes_voice_through_when_there_is_no_system_stem() {
         let mut voice = vec![0.1, 0.2];
         let mut system = Vec::new();
-        let out = take_mixed(&mut voice, &mut system, false);
+        let out = take_audio(&mut voice, &mut system, true, false);
         assert_eq!(out, vec![0.1, 0.2]);
         assert!(voice.is_empty(), "everything is consumed");
+    }
+
+    #[test]
+    fn mixing_passes_system_through_when_voice_is_unavailable() {
+        let mut voice = Vec::new();
+        let mut system = vec![0.3, 0.4];
+        let out = take_audio(&mut voice, &mut system, false, true);
+        assert_eq!(out, vec![0.3, 0.4]);
+        assert!(system.is_empty(), "everything is consumed");
     }
 
     #[test]
@@ -537,12 +705,90 @@ mod tests {
         // Two loud sides must not produce out-of-range samples.
         let mut voice = vec![0.9];
         let mut system = vec![0.9];
-        let out = take_mixed(&mut voice, &mut system, true);
+        let out = take_audio(&mut voice, &mut system, true, true);
         assert_eq!(out, vec![1.0]);
     }
 
     #[test]
-    fn waiting_for_a_stem_gives_up_when_asked_to_stop() {
+    fn final_mix_can_preserve_the_longer_stem_suffix() {
+        let mut voice = vec![0.1, 0.2, 0.3];
+        let mut system = vec![0.4];
+
+        let mut tail = take_audio(&mut voice, &mut system, true, true);
+        tail.extend(std::mem::take(&mut voice));
+        tail.extend(std::mem::take(&mut system));
+
+        assert_eq!(tail, vec![0.5, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn header_only_voice_does_not_block_advancing_system_audio() {
+        assert_eq!(
+            stalled_source_to_drop(
+                true,
+                true,
+                0,
+                16_000,
+                STEM_STALL_GRACE,
+                std::time::Duration::ZERO,
+            ),
+            Some(StalledSource::Voice)
+        );
+    }
+
+    #[test]
+    fn header_only_system_does_not_block_advancing_voice_audio() {
+        assert_eq!(
+            stalled_source_to_drop(
+                true,
+                true,
+                16_000,
+                0,
+                std::time::Duration::ZERO,
+                STEM_STALL_GRACE,
+            ),
+            Some(StalledSource::System)
+        );
+    }
+
+    #[test]
+    fn sibling_startup_grace_prevents_premature_source_drop() {
+        assert_eq!(
+            stalled_source_to_drop(
+                true,
+                true,
+                0,
+                16_000,
+                STEM_STALL_GRACE - std::time::Duration::from_millis(1),
+                std::time::Duration::ZERO,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn waiting_for_stems_accepts_system_only_audio() {
+        let dir = tempfile::tempdir().unwrap();
+        let voice = dir.path().join("missing-voice.wav");
+        let system = dir.path().join("system.wav");
+        write_growing_stem(&system, 2, 48_000, Encoding::F32);
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let start = std::time::Instant::now();
+        let (voice_tail, system_tail) =
+            wait_for_stems(&voice, Some(&system), &stop, std::time::Duration::ZERO)
+                .expect("the healthy system stem should be sufficient");
+
+        assert!(voice_tail.is_none());
+        assert!(system_tail.is_some());
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "system-only startup should not wait for the missing voice stem"
+        );
+    }
+
+    #[test]
+    fn waiting_for_stems_gives_up_when_asked_to_stop() {
         // Failure isolation: a capture that stops before the helper writes a
         // header must not leave this thread parked for the full timeout.
         let dir = tempfile::tempdir().unwrap();
@@ -550,7 +796,7 @@ mod tests {
         let stop = Arc::new(AtomicBool::new(true));
 
         let start = std::time::Instant::now();
-        let result = wait_for_stem(&missing, &stop);
+        let result = wait_for_stems(&missing, None, &stop, std::time::Duration::ZERO);
         assert!(result.is_none());
         assert!(
             start.elapsed() < std::time::Duration::from_secs(2),

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -1934,12 +1934,12 @@ fn is_assistant_instruction_file(path: &Path) -> bool {
 /// upcoming meeting as "prepped"; the Documents list did not, so a brief the
 /// assistant had just written was invisible in the sidebar -- and no restart
 /// would surface it, because the folder was never a scan root.
-fn append_prep_documents(
+fn append_prep_documents_from(
     documents: &mut Vec<DocumentView>,
     seen: &mut std::collections::HashSet<PathBuf>,
+    preps_dir: &Path,
 ) {
-    let preps_dir = Config::minutes_dir().join("preps");
-    let Ok(entries) = std::fs::read_dir(&preps_dir) else {
+    let Ok(entries) = std::fs::read_dir(preps_dir) else {
         return;
     };
     for entry in entries.flatten() {
@@ -2088,6 +2088,23 @@ fn list_documents_for_roots_with_recent_state(
     limit: usize,
     recent_state_path: &Path,
 ) -> Vec<DocumentView> {
+    let preps_dir = Config::minutes_dir().join("preps");
+    list_documents_for_roots_with_recent_state_and_preps(
+        config,
+        assistant_dir,
+        limit,
+        recent_state_path,
+        &preps_dir,
+    )
+}
+
+fn list_documents_for_roots_with_recent_state_and_preps(
+    config: &Config,
+    assistant_dir: &Path,
+    limit: usize,
+    recent_state_path: &Path,
+    preps_dir: &Path,
+) -> Vec<DocumentView> {
     let mut documents = Vec::new();
     let mut seen = std::collections::HashSet::new();
 
@@ -2105,7 +2122,7 @@ fn list_documents_for_roots_with_recent_state(
     }
 
     append_assistant_documents(&mut documents, &mut seen, assistant_dir);
-    append_prep_documents(&mut documents, &mut seen);
+    append_prep_documents_from(&mut documents, &mut seen, preps_dir);
     documents.sort_by(|a, b| {
         b.mtime
             .cmp(&a.mtime)
@@ -3448,6 +3465,37 @@ impl Drop for LiveTranscriptStopGuard {
     }
 }
 
+/// Keep Recall's live-transcript instructions aligned with a native call
+/// recording. The generic microphone recording path already updates this
+/// context, but native ScreenCaptureKit capture returns through a separate
+/// function and previously skipped the marker entirely.
+#[cfg(target_os = "macos")]
+struct AssistantLiveContextGuard(Option<PathBuf>);
+
+#[cfg(target_os = "macos")]
+impl AssistantLiveContextGuard {
+    fn start(config: &Config, live_transcript_started: bool) -> Self {
+        if !live_transcript_started {
+            return Self(None);
+        }
+
+        let workspace = crate::context::create_workspace(config).ok();
+        if let Some(workspace) = workspace.as_deref() {
+            update_assistant_live_context(workspace, true);
+        }
+        Self(workspace)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for AssistantLiveContextGuard {
+    fn drop(&mut self) {
+        if let Some(workspace) = self.0.as_deref() {
+            update_assistant_live_context(workspace, false);
+        }
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 fn start_native_call_recording(
@@ -3594,6 +3642,8 @@ fn start_native_call_recording(
             _ => false,
         }
     };
+    let _assistant_live_context_guard =
+        AssistantLiveContextGuard::start(config, live_transcript_started);
 
     let mut capabilities = vec![
         "native-call.capture".to_string(),
@@ -15337,8 +15387,7 @@ mod tests {
     fn update_assistant_live_context_updates_both_instruction_files() {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path();
-        std::fs::write(workspace.join("CLAUDE.md"), "# Minutes Assistant\n").unwrap();
-        std::fs::write(workspace.join("AGENTS.md"), "# Minutes Assistant\n").unwrap();
+        crate::context::write_deferred_assistant_context(workspace).unwrap();
 
         update_assistant_live_context(workspace, true);
 
@@ -15346,6 +15395,14 @@ mod tests {
         let agents = std::fs::read_to_string(workspace.join("AGENTS.md")).unwrap();
         assert!(claude.contains("## Live Transcript Active"));
         assert!(agents.contains("## Live Transcript Active"));
+        assert!(claude.contains("gates stored meeting context, not an active live transcript"));
+        assert!(agents.contains("gates stored meeting context, not an active live transcript"));
+        assert!(
+            claude.contains("read this live transcript even when `CURRENT_MEETING.md` is absent")
+        );
+        assert!(
+            agents.contains("read this live transcript even when `CURRENT_MEETING.md` is absent")
+        );
 
         update_assistant_live_context(workspace, false);
 
@@ -15353,6 +15410,8 @@ mod tests {
         let agents = std::fs::read_to_string(workspace.join("AGENTS.md")).unwrap();
         assert!(!claude.contains("## Live Transcript Active"));
         assert!(!agents.contains("## Live Transcript Active"));
+        assert!(claude.contains("## Deferred meeting context"));
+        assert!(agents.contains("## Deferred meeting context"));
     }
 
     /// Arms that have no current caller but are deliberately kept pending a
@@ -18126,9 +18185,11 @@ mod tests {
         let assistant = temp.path().join("assistant");
         let assistant_artifacts = assistant.join("artifacts");
         let meetings = temp.path().join("meetings");
+        let preps = temp.path().join("preps");
         let state_path = temp.path().join("recent-artifacts.json");
         std::fs::create_dir_all(&assistant_artifacts).unwrap();
         std::fs::create_dir_all(&meetings).unwrap();
+        std::fs::create_dir_all(&preps).unwrap();
 
         let older = assistant.join("prep.md");
         std::fs::write(&older, "# Prep").unwrap();
@@ -18155,8 +18216,13 @@ mod tests {
         };
         record_recent_artifact_canonical_with_limit(&meeting, 8, &state_path);
 
-        let docs =
-            list_documents_for_roots_with_recent_state(&config, &assistant, 200, &state_path);
+        let docs = list_documents_for_roots_with_recent_state_and_preps(
+            &config,
+            &assistant,
+            200,
+            &state_path,
+            &preps,
+        );
         let names: Vec<_> = docs.iter().map(|doc| doc.filename.as_str()).collect();
 
         assert_eq!(names.len(), 3);
@@ -18167,8 +18233,13 @@ mod tests {
         assert!(!names.contains(&"outside-secret.md"));
         assert!(!names.contains(&"linked-secret.md"));
 
-        let capped =
-            list_documents_for_roots_with_recent_state(&config, &assistant, 2, &state_path);
+        let capped = list_documents_for_roots_with_recent_state_and_preps(
+            &config,
+            &assistant,
+            2,
+            &state_path,
+            &preps,
+        );
         let capped_names: Vec<_> = capped.iter().map(|doc| doc.filename.as_str()).collect();
         assert_eq!(
             capped_names,
@@ -18198,11 +18269,12 @@ mod tests {
             let non_utf8_path = assistant.join(non_utf8_name);
             match std::fs::write(&non_utf8_path, "# Non UTF-8") {
                 Ok(()) => {
-                    let docs = list_documents_for_roots_with_recent_state(
+                    let docs = list_documents_for_roots_with_recent_state_and_preps(
                         &config,
                         &assistant,
                         200,
                         &state_path,
+                        &preps,
                     );
                     assert!(docs
                         .iter()
@@ -21307,6 +21379,11 @@ fn update_assistant_live_context_file(path: &std::path::Path, live_active: bool)
             ## Live Transcript Active\n\
             \n\
             A live meeting transcript is being recorded right now.\n\
+            \n\
+            This section is exact-session live evidence. When the user explicitly asks about the \
+            current call, read this live transcript even when `CURRENT_MEETING.md` is absent. The \
+            missing file means stored meeting metadata and verified speaker identities are \
+            unavailable; it does not block bounded live-transcript coaching.\n\
             \n\
             **JSONL file:** `{path}`\n\
             \n\

--- a/tauri/src-tauri/src/context.rs
+++ b/tauri/src-tauri/src/context.rs
@@ -513,41 +513,38 @@ fn write_atomic(path: &Path, content: &str) -> Result<(), String> {
     })
 }
 
+fn merge_live_transcript_section(base: &str, existing: &str, live_active: bool) -> String {
+    if !live_active {
+        return base.to_string();
+    }
+
+    let marker_start = "<!-- LIVE_TRANSCRIPT_START -->";
+    let marker_end = "<!-- LIVE_TRANSCRIPT_END -->";
+    let live_section = if let (Some(start), Some(end)) =
+        (existing.find(marker_start), existing.find(marker_end))
+    {
+        (start < end).then(|| existing[start..end + marker_end.len()].to_string())
+    } else {
+        None
+    };
+
+    match live_section {
+        Some(section) => format!("{}\n{}\n", base.trim_end(), section),
+        None => base.to_string(),
+    }
+}
+
+fn live_transcript_active() -> bool {
+    // Covers standalone Live and a recording-owned sidecar. PID-only checks
+    // miss the latter and can strip valid instructions during a recording.
+    minutes_core::live_transcript::session_status().active
+}
+
 pub fn write_assistant_context(workspace: &Path, config: &Config) -> Result<(), String> {
     let claude_md_path = workspace.join("CLAUDE.md");
     let assistant_md = generate_assistant_context(config)?;
-
-    // Preserve live transcript markers only if a session is actually active (V3).
-    // Don't trust stale markers in the file — verify via PID. `inspect_pid_file`
-    // so a session holding the PID under a mandatory Windows lock isn't misread as
-    // inactive (which would strip the live markers mid-session). See #258.
-    let lt_pid = minutes_core::pid::live_transcript_pid_path();
-    let live_actually_active = minutes_core::pid::inspect_pid_file(&lt_pid).is_active();
-
-    let content = if live_actually_active {
-        let marker_start = "<!-- LIVE_TRANSCRIPT_START -->";
-        let marker_end = "<!-- LIVE_TRANSCRIPT_END -->";
-        let existing = std::fs::read_to_string(&claude_md_path).unwrap_or_default();
-        let live_section = if let (Some(start), Some(end)) =
-            (existing.find(marker_start), existing.find(marker_end))
-        {
-            if start < end {
-                Some(existing[start..end + marker_end.len()].to_string())
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        if let Some(section) = live_section {
-            format!("{}\n{}\n", assistant_md.trim_end(), section)
-        } else {
-            assistant_md.clone()
-        }
-    } else {
-        assistant_md
-    };
+    let existing = std::fs::read_to_string(&claude_md_path).unwrap_or_default();
+    let content = merge_live_transcript_section(&assistant_md, &existing, live_transcript_active());
 
     for file_name in ASSISTANT_INSTRUCTION_FILES {
         write_atomic(&workspace.join(file_name), &content)?;
@@ -564,17 +561,25 @@ pub fn write_assistant_context(workspace: &Path, config: &Config) -> Result<(), 
 /// meeting is materialized into `CURRENT_MEETING.md` only after the user sends
 /// a non-slash question and the provider's authentication has been verified.
 pub fn write_deferred_assistant_context(workspace: &Path) -> Result<(), String> {
-    let content = format!(
+    let deferred = format!(
         "# Minutes Assistant\n\n\
 You are running inside Minutes Recall. No meeting context has been loaded yet.\n\n\
 ## Deferred meeting context\n\n\
 Before answering every user question, check whether `{ACTIVE_MEETING_FILE}` exists in this directory. \
-If it exists, read it first and treat it as the current meeting focus. If it does not exist, explain \
-that Minutes has not shared a meeting with this session yet.\n\n\
+If it exists, read it first and treat it as the current stored meeting focus. If it does not exist and \
+there is no `Live Transcript Active` section below, explain that Minutes has not shared stored meeting \
+context with this session yet.\n\n\
+`{ACTIVE_MEETING_FILE}` gates stored meeting context, not an active live transcript. If a \
+`Live Transcript Active` section exists and the user explicitly asks about the current call, use one \
+bounded read from the exact transcript path or supported CLI named in that section even when \
+`{ACTIVE_MEETING_FILE}` is absent. In that case, the missing file means stored metadata and verified \
+speaker identities are unavailable; it does not mean the live transcript is unavailable.\n\n\
 Slash commands such as `/login` are account controls, not meeting questions. Never claim a meeting \
 was loaded merely because an account command succeeded.\n\n\
 Do not attribute a statement to a named person unless the meeting context verifies that identity.\n"
     );
+    let existing = std::fs::read_to_string(workspace.join("CLAUDE.md")).unwrap_or_default();
+    let content = merge_live_transcript_section(&deferred, &existing, live_transcript_active());
 
     for file_name in ASSISTANT_INSTRUCTION_FILES {
         write_atomic(&workspace.join(file_name), &content)?;
@@ -689,10 +694,38 @@ mod tests {
             let content = std::fs::read_to_string(workspace.path().join(file_name)).unwrap();
             assert!(content.contains(ACTIVE_MEETING_FILE));
             assert!(content.contains("No meeting context has been loaded yet"));
+            assert!(content.contains("gates stored meeting context, not an active live transcript"));
+            assert!(content.contains("it does not mean the live transcript is unavailable"));
             assert!(content.contains("/login"));
             assert!(!content.contains("## Recent Meetings"));
             assert!(!content.contains("## Open Action Items"));
         }
+    }
+
+    #[test]
+    fn active_live_section_survives_context_rewrites() {
+        let existing = "# Old context\n<!-- LIVE_TRANSCRIPT_START -->\n## Live Transcript Active\nexact session\n<!-- LIVE_TRANSCRIPT_END -->\n";
+        let merged = merge_live_transcript_section("# New context\n", existing, true);
+
+        assert!(merged.starts_with("# New context"));
+        assert!(merged.contains("## Live Transcript Active"));
+        assert!(merged.contains("exact session"));
+        assert_eq!(merged.matches("LIVE_TRANSCRIPT_START").count(), 1);
+    }
+
+    #[test]
+    fn inactive_or_malformed_live_sections_are_not_preserved() {
+        let valid = "<!-- LIVE_TRANSCRIPT_START -->live<!-- LIVE_TRANSCRIPT_END -->";
+        let malformed = "<!-- LIVE_TRANSCRIPT_END -->live<!-- LIVE_TRANSCRIPT_START -->";
+
+        assert_eq!(
+            merge_live_transcript_section("# Base\n", valid, false),
+            "# Base\n"
+        );
+        assert_eq!(
+            merge_live_transcript_section("# Base\n", malformed, true),
+            "# Base\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the active live-transcript lane when Recall rewrites deferred assistant context
- attach native ScreenCaptureKit recordings to the same assistant live-context contract
- allow live transcription to continue with one healthy stem when the sibling is absent or stalls
- persist unexpected sidecar disconnect diagnostics and preserve the longer final stem tail
- isolate the document-list test from user prep files

## Root cause

Recall's deferred context rewrite treated CURRENT_MEETING.md as the only meeting gate and could erase the live-transcript marker. A meeting could be transcribed live while the assistant was instructed not to read it.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all --no-default-features -- -D warnings
- cargo test -p minutes-app: 378 passed
- stem-tail regression tests: 16 passed
- recording-sidecar disconnect and normal-stop tests passed with streaming,whisper
- signed Minutes Dev.app installed with bundle id com.useminutes.desktop.dev
- strict bundle seal passed and installed bytes matched the repaired build
- post-launch native hotkey diagnostic passed
- installed runtime wrote the corrected deferred Recall contract

The production app was not replaced.