### PR TITLE
fix(mcp): stop startup auto-setup from resetting the configured transcription model

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9525,13 +9525,16 @@ life (qmd://life/)
     }
 
     #[test]
-    fn json_envelope_includes_schema_metadata() {
-        let envelope = json_envelope("minutes health", json!({ "engine": "parakeet" }));
+    fn health_json_envelope_includes_effective_transcription_metadata() {
+        let report = health_json_report(&Config::default(), &[]);
+        let envelope = json_envelope("minutes health", report);
         let value = serde_json::to_value(envelope).unwrap();
         assert_eq!(value["ok"], true);
         assert_eq!(value["command"], "minutes health");
         assert_eq!(value["meta"]["schemaVersion"], 1);
-        assert_eq!(value["data"]["engine"], "parakeet");
+        assert!(value["data"]["engine"].is_string());
+        assert!(value["data"]["effective_engine"].is_string());
+        assert!(value["data"]["model"].is_string());
         assert!(value["meta"]["generatedAt"].is_string());
     }
 
@@ -16526,16 +16529,7 @@ fn cmd_health(json: bool) -> Result<()> {
     let items = minutes_core::health::check_all(&config);
 
     if json {
-        let attention_count = items
-            .iter()
-            .filter(|item| item.state == "attention")
-            .count();
-        let report = serde_json::json!({
-            "engine": config.transcription.engine,
-            "all_ready": attention_count == 0,
-            "attention_count": attention_count,
-            "items": items,
-        });
+        let report = health_json_report(&config, &items);
         let envelope = json_envelope("minutes health", report);
         println!("{}", serde_json::to_string_pretty(&envelope)?);
     } else {
@@ -16563,6 +16557,24 @@ fn cmd_health(json: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn health_json_report(
+    config: &Config,
+    items: &[minutes_core::health::HealthItem],
+) -> serde_json::Value {
+    let attention_count = items
+        .iter()
+        .filter(|item| item.state == "attention")
+        .count();
+    serde_json::json!({
+        "engine": config.transcription.engine,
+        "effective_engine": minutes_core::transcribe::effective_transcription_engine(config),
+        "model": config.transcription.model,
+        "all_ready": attention_count == 0,
+        "attention_count": attention_count,
+        "items": items,
+    })
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -488,6 +488,12 @@ pub(crate) fn effective_batch_engine(config: &Config) -> &str {
     }
 }
 
+/// Return the transcription engine that batch/default transcription will
+/// actually use after resolving unavailable or unsupported configured engines.
+pub fn effective_transcription_engine(config: &Config) -> &str {
+    effective_batch_engine(config)
+}
+
 #[cfg(feature = "parakeet")]
 const PARAKEET_LONG_AUDIO_CHUNK_THRESHOLD_SECS: f64 = 60.0;
 #[cfg(feature = "parakeet")]
@@ -4335,6 +4341,21 @@ mod tests {
             ChunkTranscriptionStrategy::DispatchPerChunk
         };
         assert_eq!(chunk_transcription_strategy(&config), expected);
+    }
+
+    #[test]
+    #[cfg(not(feature = "parakeet"))]
+    fn effective_transcription_engine_reports_resolved_engine() {
+        let mut config = Config::default();
+
+        config.transcription.engine = "parakeet".into();
+        assert_eq!(effective_transcription_engine(&config), "whisper");
+
+        config.transcription.engine = "whisper".into();
+        assert_eq!(effective_transcription_engine(&config), "whisper");
+
+        config.transcription.engine = "WHISPER".into();
+        assert_eq!(effective_transcription_engine(&config), "WHISPER");
     }
 
     #[test]

--- a/crates/mcp/src/index.test.ts
+++ b/crates/mcp/src/index.test.ts
@@ -110,6 +110,8 @@ import {
   parseCopilotStatusOutput,
   parseKnowledgeConfig,
   parseDictationModelMissingError,
+  parseConfiguredTranscriptionModel,
+  parseHealthOutput,
   parseMeetingsRootSnapshot,
   parseLiveEventsResourceUri,
   parsePolicyVerifiedMeeting,
@@ -128,6 +130,7 @@ import {
   readVerifiedScreenImage,
   createCapabilityRepairCoordinator,
   repairCliCapabilities,
+  ensureWhisperModel,
   researchTopicProjection,
   runAgentToolPolicies,
   stopCopilotBeforeStatusRead,
@@ -194,6 +197,106 @@ describe("dictation model preflight errors", () => {
 
   it("ignores unrelated startup errors", () => {
     expect(parseDictationModelMissingError("microphone permission denied")).toBeNull();
+  });
+});
+
+describe("Whisper model auto-setup", () => {
+  const readyItem = { label: "Speech model", state: "ready", detail: "medium" };
+  const missingItem = { label: "Speech model", state: "attention", detail: "missing" };
+
+  async function runModelCheck(input: {
+    health: unknown;
+    configuredModel?: string | null;
+  }): Promise<{ setups: string[]; logs: string[] }> {
+    const setups: string[] = [];
+    const logs: string[] = [];
+    await ensureWhisperModel({
+      checkState: { done: false },
+      health: async () =>
+        typeof input.health === "string" ? input.health : JSON.stringify(input.health),
+      readConfiguredModel: async () => input.configuredModel ?? null,
+      setup: async (model) => {
+        setups.push(model);
+      },
+      log: (message) => logs.push(message),
+    });
+    return { setups, logs };
+  }
+
+  it("parses the current health envelope and skips setup when the model is ready", async () => {
+    const result = await runModelCheck({
+      health: { ok: true, data: { engine: "whisper", items: [readyItem] } },
+    });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs).toContain("[Minutes] Whisper model ready");
+  });
+
+  it("keeps accepting the legacy bare health-item array", async () => {
+    const result = await runModelCheck({ health: [readyItem] });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs).toContain("[Minutes] Whisper model ready");
+  });
+
+  it("skips Whisper setup for a non-Whisper transcription engine", async () => {
+    const result = await runModelCheck({
+      health: { ok: true, data: { engine: "parakeet", items: [missingItem] } },
+      configuredModel: "medium",
+    });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs).toContain(
+      "[Minutes] Transcription engine is parakeet — skipping Whisper auto-setup"
+    );
+  });
+
+  it("downloads the configured Whisper model without downgrading it", async () => {
+    const result = await runModelCheck({
+      health: { ok: true, data: { engine: "whisper", items: [missingItem] } },
+      configuredModel: "medium",
+    });
+
+    expect(result.setups).toEqual(["medium"]);
+  });
+
+  it("keeps the zero-touch tiny download when no Whisper model is configured", async () => {
+    const result = await runModelCheck({
+      health: { ok: true, data: { engine: "whisper", items: [missingItem] } },
+      configuredModel: null,
+    });
+
+    expect(result.setups).toEqual(["tiny"]);
+  });
+
+  it("fails safe without setup when health output is unparsable", async () => {
+    const result = await runModelCheck({ health: "not json" });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs).toContain(
+      "[Minutes] Unrecognized health --json output — skipping Whisper auto-setup"
+    );
+    expect(result.logs).toHaveLength(1);
+  });
+
+  it("extracts health items and engine from both supported JSON shapes", () => {
+    expect(parseHealthOutput(JSON.stringify([readyItem]))).toEqual({ items: [readyItem] });
+    expect(
+      parseHealthOutput(
+        JSON.stringify({ data: { engine: "whisper", items: [missingItem] } })
+      )
+    ).toEqual({ items: [missingItem], engine: "whisper" });
+    expect(parseHealthOutput(JSON.stringify({ data: { items: [missingItem] } }))).toEqual({
+      items: null,
+    });
+  });
+
+  it("reads only the model in the transcription TOML section", () => {
+    expect(
+      parseConfiguredTranscriptionModel(
+        '[dictation]\nmodel = "small"\n\n[transcription]\nmodel = "medium" # keep quality\n'
+      )
+    ).toBe("medium");
   });
 });
 

--- a/crates/mcp/src/index.test.ts
+++ b/crates/mcp/src/index.test.ts
@@ -110,7 +110,6 @@ import {
   parseCopilotStatusOutput,
   parseKnowledgeConfig,
   parseDictationModelMissingError,
-  parseConfiguredTranscriptionModel,
   parseHealthOutput,
   parseMeetingsRootSnapshot,
   parseLiveEventsResourceUri,
@@ -206,15 +205,19 @@ describe("Whisper model auto-setup", () => {
 
   async function runModelCheck(input: {
     health: unknown;
-    configuredModel?: string | null;
+    configExists?: boolean;
   }): Promise<{ setups: string[]; logs: string[] }> {
     const setups: string[] = [];
     const logs: string[] = [];
     await ensureWhisperModel({
       checkState: { done: false },
-      health: async () =>
-        typeof input.health === "string" ? input.health : JSON.stringify(input.health),
-      readConfiguredModel: async () => input.configuredModel ?? null,
+      health: async () => {
+        if (input.health instanceof Error) throw input.health;
+        return typeof input.health === "string"
+          ? input.health
+          : JSON.stringify(input.health);
+      },
+      configFileExists: async () => input.configExists ?? false,
       setup: async (model) => {
         setups.push(model);
       },
@@ -223,7 +226,56 @@ describe("Whisper model auto-setup", () => {
     return { setups, logs };
   }
 
-  it("parses the current health envelope and skips setup when the model is ready", async () => {
+  it("parses legacy and current health output shapes", () => {
+    expect(parseHealthOutput(JSON.stringify([readyItem]))).toEqual({
+      ok: true,
+      items: [readyItem],
+    });
+    expect(
+      parseHealthOutput(
+        JSON.stringify({
+          ok: true,
+          data: {
+            engine: "parakeet",
+            effective_engine: "whisper",
+            model: "small",
+            items: [missingItem],
+          },
+        })
+      )
+    ).toEqual({
+      ok: true,
+      items: [missingItem],
+      engine: "parakeet",
+      effectiveEngine: "whisper",
+      model: "small",
+    });
+  });
+
+  it.each([
+    ["a failed health command", new Error("health failed")],
+    ["an ok:false envelope", { ok: false, data: { items: [missingItem] } }],
+    ["invalid health items", { ok: true, data: { items: ["invalid"] } }],
+  ])("fails closed for %s", async (_label, health) => {
+    const result = await runModelCheck({ health });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs).toHaveLength(1);
+  });
+
+  it.each([
+    ["an empty legacy array", []],
+    ["an array without the speech model item", [{ label: "CLI", state: "ready" }]],
+  ])("fails closed for %s", async (_label, health) => {
+    const result = await runModelCheck({ health });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs).toContain(
+      "[Minutes] unrecognized health items — skipping Whisper auto-setup"
+    );
+  });
+
+  it("skips setup when the speech model is ready", async () => {
     const result = await runModelCheck({
       health: { ok: true, data: { engine: "whisper", items: [readyItem] } },
     });
@@ -239,64 +291,105 @@ describe("Whisper model auto-setup", () => {
     expect(result.logs).toContain("[Minutes] Whisper model ready");
   });
 
-  it("skips Whisper setup for a non-Whisper transcription engine", async () => {
+  it("fails closed for an unknown speech model state", async () => {
     const result = await runModelCheck({
-      health: { ok: true, data: { engine: "parakeet", items: [missingItem] } },
-      configuredModel: "medium",
+      health: {
+        ok: true,
+        data: { engine: "whisper", items: [{ ...missingItem, state: "unknown" }] },
+      },
     });
 
     expect(result.setups).toEqual([]);
     expect(result.logs).toContain(
-      "[Minutes] Transcription engine is parakeet — skipping Whisper auto-setup"
+      "[Minutes] Speech model health state is unknown — skipping Whisper auto-setup"
     );
   });
 
-  it("downloads the configured Whisper model without downgrading it", async () => {
+  it("uses the effective engine and reported model when configured parakeet resolves to Whisper", async () => {
     const result = await runModelCheck({
-      health: { ok: true, data: { engine: "whisper", items: [missingItem] } },
-      configuredModel: "medium",
+      health: {
+        ok: true,
+        data: {
+          engine: "parakeet",
+          effective_engine: "whisper",
+          model: "small",
+          items: [missingItem],
+        },
+      },
+    });
+
+    expect(result.setups).toEqual(["small"]);
+  });
+
+  it("skips setup when the effective engine is non-Whisper", async () => {
+    const result = await runModelCheck({
+      health: {
+        ok: true,
+        data: {
+          engine: "parakeet",
+          effective_engine: "parakeet",
+          items: [missingItem],
+        },
+      },
+    });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs.join("\n")).toContain("skipping Whisper auto-setup");
+  });
+
+  it("conservatively skips an old CLI non-Whisper engine with upgrade guidance", async () => {
+    const result = await runModelCheck({
+      health: { ok: true, data: { engine: "parakeet", items: [missingItem] } },
+    });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs.join("\n")).toContain(
+      "upgrade the CLI to let auto-setup resolve the effective engine"
+    );
+  });
+
+  it("treats a capitalized effective Whisper engine as Whisper", async () => {
+    const result = await runModelCheck({
+      health: {
+        ok: true,
+        data: { effective_engine: "Whisper", model: "medium", items: [missingItem] },
+      },
     });
 
     expect(result.setups).toEqual(["medium"]);
   });
 
-  it("keeps the zero-touch tiny download when no Whisper model is configured", async () => {
+  it("uses the reported model as the only mutation path for an existing config", async () => {
     const result = await runModelCheck({
-      health: { ok: true, data: { engine: "whisper", items: [missingItem] } },
-      configuredModel: null,
+      health: {
+        ok: true,
+        data: { effective_engine: "whisper", model: "large-v3", items: [missingItem] },
+      },
+      configExists: true,
     });
 
-    expect(result.setups).toEqual(["tiny"]);
+    expect(result.setups).toEqual(["large-v3"]);
   });
 
-  it("fails safe without setup when health output is unparsable", async () => {
-    const result = await runModelCheck({ health: "not json" });
+  it("does not mutate an existing config when an old CLI omits the model", async () => {
+    const result = await runModelCheck({
+      health: { ok: true, data: { engine: "whisper", items: [missingItem] } },
+      configExists: true,
+    });
 
     expect(result.setups).toEqual([]);
     expect(result.logs).toContain(
-      "[Minutes] Unrecognized health --json output — skipping Whisper auto-setup"
+      "[Minutes] config exists but this CLI does not report the configured model; run `minutes setup --model <your model>` or upgrade the CLI"
     );
-    expect(result.logs).toHaveLength(1);
   });
 
-  it("extracts health items and engine from both supported JSON shapes", () => {
-    expect(parseHealthOutput(JSON.stringify([readyItem]))).toEqual({ items: [readyItem] });
-    expect(
-      parseHealthOutput(
-        JSON.stringify({ data: { engine: "whisper", items: [missingItem] } })
-      )
-    ).toEqual({ items: [missingItem], engine: "whisper" });
-    expect(parseHealthOutput(JSON.stringify({ data: { items: [missingItem] } }))).toEqual({
-      items: null,
+  it("keeps zero-touch tiny setup for an old CLI on a fresh machine", async () => {
+    const result = await runModelCheck({
+      health: { ok: true, data: { engine: "whisper", items: [missingItem] } },
+      configExists: false,
     });
-  });
 
-  it("reads only the model in the transcription TOML section", () => {
-    expect(
-      parseConfiguredTranscriptionModel(
-        '[dictation]\nmodel = "small"\n\n[transcription]\nmodel = "medium" # keep quality\n'
-      )
-    ).toBe("medium");
+    expect(result.setups).toEqual(["tiny"]);
   });
 });
 

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -2444,41 +2444,181 @@ async function checkCliVersion(): Promise<void> {
   }
 }
 
-// ── Auto-setup: download whisper model if missing ───────────
-// Recording needs a whisper model (~75MB for tiny). If the CLI is
-// available but the model isn't downloaded, trigger setup automatically
-// in the background so the first "start recording" just works.
+// ── Auto-setup: download configured whisper model if missing ───────────
+// Whisper recording needs a model. If Whisper is configured but its model
+// isn't downloaded, trigger setup automatically in the background so the
+// first "start recording" just works without changing the user's choice.
 
 let modelCheckDone = false;
 
-async function ensureWhisperModel(): Promise<void> {
-  if (modelCheckDone) return;
-  modelCheckDone = true;
+export type HealthItem = {
+  label?: unknown;
+  state?: unknown;
+  [key: string]: unknown;
+};
 
+export type HealthOutput = {
+  items: HealthItem[] | null;
+  engine?: string;
+};
+
+function isHealthItem(value: unknown): value is HealthItem {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseHealthOutput(stdout: string): HealthOutput {
+  let parsed: unknown;
   try {
-    // health --json returns an array of { label, state, detail, optional } items.
-    // The "Speech model" item has state "ready" when downloaded.
-    const { stdout } = await execFileAsync(MINUTES_BIN, ["health", "--json"], { timeout: 10000, env: mcpCliChildEnv() });
-    const items = JSON.parse(stdout);
-    const modelItem = Array.isArray(items) && items.find((i: any) => i.label === "Speech model");
-    if (modelItem && modelItem.state === "ready") {
-      console.error("[Minutes] Whisper model ready");
-      return;
-    }
+    parsed = JSON.parse(stdout);
   } catch {
-    // health command may not exist in older CLI versions — fall through to setup
+    return { items: null };
   }
 
-  // Model not found — download tiny model in background
-  console.error("[Minutes] Whisper model not found — downloading tiny model (~75MB)...");
+  if (Array.isArray(parsed)) {
+    return parsed.every(isHealthItem) ? { items: parsed } : { items: null };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { items: null };
+  }
+
+  const data = (parsed as Record<string, unknown>).data;
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return { items: null };
+  }
+
+  const dataRecord = data as Record<string, unknown>;
+  const items = dataRecord.items;
+  if (
+    !Array.isArray(items) ||
+    !items.every(isHealthItem) ||
+    typeof dataRecord.engine !== "string"
+  ) {
+    return { items: null };
+  }
+
+  return {
+    items,
+    engine: dataRecord.engine,
+  };
+}
+
+export function parseConfiguredTranscriptionModel(configContent: string): string | null {
+  let inTranscriptionSection = false;
+  for (const line of configContent.split(/\r?\n/)) {
+    const section = line.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/);
+    if (section) {
+      inTranscriptionSection = section[1].trim() === "transcription";
+      continue;
+    }
+    if (!inTranscriptionSection) continue;
+
+    const model = line.match(
+      /^\s*model\s*=\s*["']([^"'\r\n]+)["']\s*(?:#.*)?$/
+    )?.[1].trim();
+    if (model) return model;
+  }
+  return null;
+}
+
+async function readConfiguredTranscriptionModel(): Promise<string | null> {
+  const configRoot = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
   try {
-    await execFileAsync(MINUTES_BIN, ["setup", "--model", "tiny"], { timeout: 300000, env: mcpCliChildEnv() });
-    console.error("[Minutes] ✓ Whisper tiny model downloaded — recording is ready");
-  } catch (e: any) {
-    console.error(
-      `[Minutes] Model download failed: ${e.message || e}. ` +
-      `Run manually: minutes setup --model tiny`
+    return parseConfiguredTranscriptionModel(
+      await readFile(join(configRoot, "minutes", "config.toml"), "utf8")
     );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+type WhisperModelCheckState = { done: boolean };
+
+export type EnsureWhisperModelOptions = {
+  checkState?: WhisperModelCheckState;
+  health?: () => Promise<string>;
+  readConfiguredModel?: () => Promise<string | null>;
+  setup?: (model: string) => Promise<void>;
+  log?: (message: string) => void;
+};
+
+export async function ensureWhisperModel(
+  options: EnsureWhisperModelOptions = {}
+): Promise<void> {
+  const checkState = options.checkState;
+  if (checkState ? checkState.done : modelCheckDone) return;
+  if (checkState) checkState.done = true;
+  else modelCheckDone = true;
+
+  const log = options.log ?? ((message: string) => console.error(message));
+  const health = options.health ?? (async () => {
+    const { stdout } = await execFileAsync(MINUTES_BIN, ["health", "--json"], {
+      timeout: 10000,
+      env: mcpCliChildEnv(),
+    });
+    return stdout;
+  });
+  const setup = options.setup ?? (async (model: string) => {
+    await execFileAsync(MINUTES_BIN, ["setup", "--model", model], {
+      timeout: 300000,
+      env: mcpCliChildEnv(),
+    });
+  });
+  const readConfiguredModel =
+    options.readConfiguredModel ?? readConfiguredTranscriptionModel;
+
+  let healthOutput: HealthOutput;
+  try {
+    healthOutput = parseHealthOutput(await health());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(
+      `[Minutes] Unable to check speech model status — skipping Whisper auto-setup: ${message}`
+    );
+    return;
+  }
+
+  if (healthOutput.items === null) {
+    log("[Minutes] Unrecognized health --json output — skipping Whisper auto-setup");
+    return;
+  }
+
+  const modelItem = healthOutput.items.find((item) => item.label === "Speech model");
+  if (modelItem?.state === "ready") {
+    log("[Minutes] Whisper model ready");
+    return;
+  }
+
+  if (healthOutput.engine !== undefined && healthOutput.engine !== "whisper") {
+    log(`[Minutes] Transcription engine is ${healthOutput.engine} — skipping Whisper auto-setup`);
+    return;
+  }
+
+  let configuredModel: string | null;
+  try {
+    configuredModel = await readConfiguredModel();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(
+      `[Minutes] Unable to read the configured transcription model — skipping Whisper auto-setup: ${message}`
+    );
+    return;
+  }
+
+  const model = configuredModel ?? "tiny";
+  if (configuredModel) {
+    log(`[Minutes] Whisper model ${model} is configured but not ready — downloading it...`);
+  } else {
+    log("[Minutes] No Whisper model is configured — downloading tiny model (~75MB)...");
+  }
+
+  try {
+    await setup(model);
+    log(`[Minutes] ✓ Whisper ${model} model downloaded — recording is ready`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`[Minutes] Model download failed: ${message}. Run manually: minutes setup --model ${model}`);
   }
 }
 

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -70,7 +70,7 @@ import {
   realpathSync,
   statSync,
 } from "fs";
-import { mkdir, readFile, rm, stat, writeFile } from "fs/promises";
+import { access, mkdir, readFile, rm, stat, writeFile } from "fs/promises";
 import { basename, delimiter, dirname, extname, isAbsolute, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
@@ -2458,8 +2458,11 @@ export type HealthItem = {
 };
 
 export type HealthOutput = {
+  ok: boolean;
   items: HealthItem[] | null;
   engine?: string;
+  effectiveEngine?: string;
+  model?: string;
 };
 
 function isHealthItem(value: unknown): value is HealthItem {
@@ -2471,64 +2474,53 @@ export function parseHealthOutput(stdout: string): HealthOutput {
   try {
     parsed = JSON.parse(stdout);
   } catch {
-    return { items: null };
+    return { ok: false, items: null };
   }
 
   if (Array.isArray(parsed)) {
-    return parsed.every(isHealthItem) ? { items: parsed } : { items: null };
+    return parsed.every(isHealthItem)
+      ? { ok: true, items: parsed }
+      : { ok: false, items: null };
   }
 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    return { items: null };
+    return { ok: false, items: null };
   }
 
-  const data = (parsed as Record<string, unknown>).data;
+  const envelope = parsed as Record<string, unknown>;
+  if (envelope.ok !== true) {
+    return { ok: false, items: null };
+  }
+
+  const data = envelope.data;
   if (typeof data !== "object" || data === null || Array.isArray(data)) {
-    return { items: null };
+    return { ok: false, items: null };
   }
 
   const dataRecord = data as Record<string, unknown>;
   const items = dataRecord.items;
-  if (
-    !Array.isArray(items) ||
-    !items.every(isHealthItem) ||
-    typeof dataRecord.engine !== "string"
-  ) {
-    return { items: null };
+  if (!Array.isArray(items) || !items.every(isHealthItem)) {
+    return { ok: false, items: null };
   }
 
   return {
+    ok: true,
     items,
-    engine: dataRecord.engine,
+    ...(typeof dataRecord.engine === "string" ? { engine: dataRecord.engine } : {}),
+    ...(typeof dataRecord.effective_engine === "string"
+      ? { effectiveEngine: dataRecord.effective_engine }
+      : {}),
+    ...(typeof dataRecord.model === "string" ? { model: dataRecord.model } : {}),
   };
 }
 
-export function parseConfiguredTranscriptionModel(configContent: string): string | null {
-  let inTranscriptionSection = false;
-  for (const line of configContent.split(/\r?\n/)) {
-    const section = line.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/);
-    if (section) {
-      inTranscriptionSection = section[1].trim() === "transcription";
-      continue;
-    }
-    if (!inTranscriptionSection) continue;
-
-    const model = line.match(
-      /^\s*model\s*=\s*["']([^"'\r\n]+)["']\s*(?:#.*)?$/
-    )?.[1].trim();
-    if (model) return model;
-  }
-  return null;
-}
-
-async function readConfiguredTranscriptionModel(): Promise<string | null> {
+async function configFileExists(): Promise<boolean> {
   const configRoot = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
   try {
-    return parseConfiguredTranscriptionModel(
-      await readFile(join(configRoot, "minutes", "config.toml"), "utf8")
-    );
+    await access(join(configRoot, "minutes", "config.toml"));
+    return true;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
     throw error;
   }
 }
@@ -2538,7 +2530,7 @@ type WhisperModelCheckState = { done: boolean };
 export type EnsureWhisperModelOptions = {
   checkState?: WhisperModelCheckState;
   health?: () => Promise<string>;
-  readConfiguredModel?: () => Promise<string | null>;
+  configFileExists?: () => Promise<boolean>;
   setup?: (model: string) => Promise<void>;
   log?: (message: string) => void;
 };
@@ -2565,8 +2557,7 @@ export async function ensureWhisperModel(
       env: mcpCliChildEnv(),
     });
   });
-  const readConfiguredModel =
-    options.readConfiguredModel ?? readConfiguredTranscriptionModel;
+  const doesConfigFileExist = options.configFileExists ?? configFileExists;
 
   let healthOutput: HealthOutput;
   try {
@@ -2579,37 +2570,61 @@ export async function ensureWhisperModel(
     return;
   }
 
-  if (healthOutput.items === null) {
+  if (!healthOutput.ok || healthOutput.items === null) {
     log("[Minutes] Unrecognized health --json output — skipping Whisper auto-setup");
     return;
   }
 
   const modelItem = healthOutput.items.find((item) => item.label === "Speech model");
-  if (modelItem?.state === "ready") {
+  if (!modelItem) {
+    log("[Minutes] unrecognized health items — skipping Whisper auto-setup");
+    return;
+  }
+
+  if (modelItem.state === "ready") {
     log("[Minutes] Whisper model ready");
     return;
   }
 
-  if (healthOutput.engine !== undefined && healthOutput.engine !== "whisper") {
-    log(`[Minutes] Transcription engine is ${healthOutput.engine} — skipping Whisper auto-setup`);
-    return;
-  }
-
-  let configuredModel: string | null;
-  try {
-    configuredModel = await readConfiguredModel();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+  if (modelItem.state !== "attention") {
     log(
-      `[Minutes] Unable to read the configured transcription model — skipping Whisper auto-setup: ${message}`
+      `[Minutes] Speech model health state is ${String(modelItem.state)} — skipping Whisper auto-setup`
     );
     return;
   }
 
-  const model = configuredModel ?? "tiny";
-  if (configuredModel) {
+  const engineForDecision = healthOutput.effectiveEngine ?? healthOutput.engine;
+  if (engineForDecision !== undefined && engineForDecision.toLowerCase() !== "whisper") {
+    const upgradeGuidance = healthOutput.effectiveEngine === undefined
+      ? "; upgrade the CLI to let auto-setup resolve the effective engine"
+      : "";
+    log(
+      `[Minutes] Transcription engine is ${engineForDecision} — skipping Whisper auto-setup${upgradeGuidance}`
+    );
+    return;
+  }
+
+  let model = healthOutput.model;
+  if (model !== undefined) {
     log(`[Minutes] Whisper model ${model} is configured but not ready — downloading it...`);
   } else {
+    let configExists: boolean;
+    try {
+      configExists = await doesConfigFileExist();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(
+        `[Minutes] Unable to check for an existing config — skipping Whisper auto-setup: ${message}`
+      );
+      return;
+    }
+    if (configExists) {
+      log(
+        "[Minutes] config exists but this CLI does not report the configured model; run `minutes setup --model <your model>` or upgrade the CLI"
+      );
+      return;
+    }
+    model = "tiny";
     log("[Minutes] No Whisper model is configured — downloading tiny model (~75MB)...");
   }
 


### PR DESCRIPTION
## What

Two-part fix for #868 (MCP startup auto-setup silently resetting the configured transcription model):

**CLI (additive, contract-preserving):** `minutes health --json` now reports `data.effective_engine` (via a new public `minutes_core::transcribe::effective_transcription_engine`, which is the existing resolver that turns a retained `parakeet` / `apple-speech` / unselectable `sherpa` into `whisper`) and `data.model` (the configured transcription model). Every existing field is unchanged; the envelope test now asserts the new fields are strings.

**MCP:** `ensureWhisperModel()` in `crates/mcp/src/index.ts` no longer parses TOML at all. It parses the `health --json` envelope (still accepting the legacy bare array) and **mutates config only on positive evidence**:

| evidence | result |
|---|---|
| health failed / `ok: false` / unrecognized shape | skip, log once |
| no `Speech model` item, or its state is not `attention` | skip |
| `Speech model` ready | nothing to do |
| effective engine (or, on an older CLI, configured engine) is not whisper | skip — never download a whisper model for a non-whisper user |
| whisper + CLI reports `model` | `minutes setup --model <that model>` — the only path that can touch an existing config, and it re-persists the same value |
| whisper, older CLI without `model`, config file exists | skip with "run `minutes setup --model <yours>` or upgrade the CLI" |
| whisper, older CLI without `model`, no config file | fresh machine → `setup --model tiny` (the original zero-touch flow) |

Each row is pinned by a test in `crates/mcp/src/index.test.ts`.

## Why

Since `ef2405b3` (Apr 13) `health --json` has printed an envelope, so the MCP's `Array.isArray(JSON.parse(stdout))` ready-check has been false for four months. That was harmless until #825 (Aug 23, shipped in 0.25.3) made `setup --model` persist its choice — after which every MCP spawn (every agent session) rewrote the user's configured model to `tiny`. Full trace in #868.

Rationale deliberately preserved: #825's persistence is untouched (the CLI's `setup` is not changed); the zero-touch first run from `67686e36` still works; the envelope is consumed as the stable contract `ef2405b3` introduced it to be.

## Adversarial review

An adversarial pass on the first revision found three real gaps, all closed here: an existing config *without* a `model` key (CLI default `small`) would still have been persisted to `tiny`; the hand-rolled TOML scanner missed valid TOML (dotted keys, inline tables); and `data.engine` is the *configured* engine, so a retained `parakeet` that actually resolves to whisper was wrongly skipped. The concurrent-spawn download race it also flagged predates this change and is tracked in #871.

One behavior change worth naming: on a fresh machine with the new CLI, auto-setup now downloads the CLI's reported default (`small`, the same default `minutes setup` uses) rather than `tiny`. That is the product default and avoids the quality trap the reporter hit; `tiny` remains the fallback only when an older CLI can't report a model.

## Verification

- `npx vitest run src/index.test.ts -t "Whisper model auto-setup"`: 16 passed; `npm run build` clean
- `cargo test -p minutes-core --no-default-features effective_transcription_engine`, `cargo test -p minutes-cli --no-default-features health_json_envelope`: green
- `cargo fmt --all -- --check`, `cargo clippy --all --no-default-features -- -D warnings`: clean
- Live: `minutes health --json` from this build reports `engine`, `effective_engine`, `model`

## Release

Users get the MCP via `npx`, so this needs a **minutes-mcp 0.25.4** npm release (and the CLI half rides the next CLI release; the MCP is safe against the older CLI in the meantime, per the table).

Closes #868
