### PR TITLE
docs(site): refresh v0.25.4 release copy

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -383,9 +383,9 @@ export default function Home() {
         <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
           <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
           adds{" "}
-          a Windows setup path for modern Intel CPUs, dictation that reaches
-          terminal prompts while keeping a clipboard copy, and Claude
-          subscription sign-in before Recall reads meeting context.{" "}
+          live transcripts that survive Recall rewrites and stalled audio
+          sources, an MCP server that no longer resets your speech model, and a
+          three-pane Recall workspace with an editable document pane.{" "}
           <a
             href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
             className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -2,9 +2,9 @@
 // step 15) from the GitHub and npm APIs. Coarse on purpose: better slightly
 // stale and reliable than a flaky build-time fetch.
 // Contributors excludes anonymous entries and dependency automation.
-// Last refreshed: 2026-08-24.
+// Last refreshed: 2026-08-28.
 
-export const GITHUB_STARS = "1,446";
-export const GITHUB_FORKS = "156";
-export const GITHUB_CONTRIBUTORS = "29";
-export const NPM_MONTHLY_DOWNLOADS = "4,300";
+export const GITHUB_STARS = "1,455";
+export const GITHUB_FORKS = "157";
+export const GITHUB_CONTRIBUTORS = "30";
+export const NPM_MONTHLY_DOWNLOADS = "3,200";


### PR DESCRIPTION
Refreshes the public site for v0.25.4 after the release is published (procedure step 15).

- headline blurb: live transcripts that survive Recall rewrites and stalled sources, MCP server no longer resets the speech model, three-pane Recall workspace with an editable document pane
- social proof refreshed 2026-08-28 from the public APIs: stars 1,455, forks 157, contributors 30 (users only, bots excluded)
- npm monthly downloads set to 3,200 = `minutes-mcp` last-month from `api.npmjs.org`. The previous figure's basis wasn't recorded; `minutes-sdk` alone is 3,993 and the two combined 7,167 — adjust if the intended basis differs.

Verification:
- `npm --prefix site ci`, `npm --prefix site run check:llms` (generated agent docs up to date), `npm --prefix site run build`: 44/44 pages
- `sync_site_release_version.mjs --check`: constants already match v0.25.4

**Hold merge until v0.25.4 is public** (draft still pending macOS/Windows desktop assets).