### PR TITLE
Prove Apple Speech through the signed worker

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -40,6 +40,7 @@ jobs:
           python3 scripts/seal_graph_worker_hash.py --self-test
           node scripts/check_apple_speech_worker_packaging.mjs
           node scripts/check_apple_speech_worker_packaging.mjs --self-test
+          python3 scripts/test_apple_speech_watcher.py
           python3 scripts/seal_apple_speech_worker_hash.py --self-test
 
       - name: Check sherpa archive packaging

--- a/crates/core/src/apple_speech_worker.rs
+++ b/crates/core/src/apple_speech_worker.rs
@@ -63,6 +63,18 @@ pub(crate) struct TransportAcceptanceReceipt {
     pub runtime_supported: bool,
 }
 
+/// Content-free evidence from the fixed public-fixture runtime acceptance.
+/// The transcript itself never leaves the parent process.
+#[derive(Debug)]
+#[cfg(target_os = "macos")]
+pub struct SignedRuntimeAcceptanceReceipt {
+    pub module_id: String,
+    pub word_count: usize,
+    pub segment_count: usize,
+    pub first_result_elapsed_ms: Option<u64>,
+    pub total_elapsed_ms: u64,
+}
+
 /// FNV-1a over the little-endian sample bytes. Proves content integrity, not
 /// just that the declared byte structure arrived, which parse already checks.
 #[cfg(any(test, target_os = "macos"))]
@@ -294,6 +306,86 @@ pub fn run_signed_transport_acceptance() -> Result<bool, String> {
         return Err("Apple Speech acceptance did not preserve the product Whisper fallback".into());
     }
     Ok(receipt.runtime_supported)
+}
+
+/// Exercise the exact signed parent -> authenticated XPC -> worker -> Apple
+/// Speech analyzer path on real macOS hardware. The caller cannot supply audio,
+/// a path, a locale, or any worker configuration: the input is the checked-in
+/// public fixture embedded into the parent at compile time. Only content-free
+/// metrics leave this function, and the normal product gate must remain closed.
+#[cfg(target_os = "macos")]
+pub fn run_signed_runtime_acceptance() -> Result<SignedRuntimeAcceptanceReceipt, String> {
+    if crate::pipeline::apple_speech_private_audio_transport_supported() {
+        return Err("Apple Speech product selection must remain closed during acceptance".into());
+    }
+    if !crate::macos_graph_xpc::current_process_is_trusted_distribution() {
+        return Err("Apple Speech runtime acceptance requires a trusted signed app".into());
+    }
+    println!("apple-speech-signed-parent-trusted=true");
+
+    let samples = runtime_acceptance_samples()?;
+    let result = transcribe_samples(
+        samples.as_slice(),
+        Some("en-US"),
+        AppleSpeechMode::Speech,
+        true,
+    )
+    .map_err(|error| format!("signed Apple Speech worker runtime failed: {error}"))?;
+    if result.kind != "transcription"
+        || result.schema_version != REQUEST_SCHEMA_VERSION
+        || result.module_id != "speech-transcriber"
+        || !result.runtime_supported
+        || result.error.is_some()
+        || result.transcript.trim().is_empty()
+        || result.word_count < 10
+        || result.segments.is_empty()
+        || result.first_result_elapsed_ms.is_none()
+    {
+        return Err("signed Apple Speech worker did not produce a valid bounded transcript".into());
+    }
+
+    let mut config = crate::config::Config::default();
+    config.live_transcript.backend = "apple-speech".to_string();
+    if crate::pipeline::resolved_apple_speech_backend(config.effective_live_transcript_backend())
+        != "whisper"
+    {
+        return Err("Apple Speech acceptance did not preserve the product Whisper fallback".into());
+    }
+
+    Ok(SignedRuntimeAcceptanceReceipt {
+        module_id: result.module_id,
+        word_count: result.word_count,
+        segment_count: result.segments.len(),
+        first_result_elapsed_ms: result.first_result_elapsed_ms,
+        total_elapsed_ms: result.total_elapsed_ms,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn runtime_acceptance_samples() -> Result<zeroize::Zeroizing<Vec<f32>>, String> {
+    const FIXTURE: &[u8] = include_bytes!("../../assets/demo.wav");
+    let mut reader = hound::WavReader::new(std::io::Cursor::new(FIXTURE))
+        .map_err(|_| "embedded Apple Speech runtime fixture was invalid".to_string())?;
+    let spec = reader.spec();
+    if spec.channels != 1
+        || spec.sample_rate != SAMPLE_RATE_HZ
+        || spec.bits_per_sample != 16
+        || spec.sample_format != hound::SampleFormat::Int
+    {
+        return Err("embedded Apple Speech runtime fixture had an unexpected format".into());
+    }
+    let samples = reader
+        .samples::<i16>()
+        .map(|sample| {
+            sample.map(|value| f32::from(value) / 32768.0).map_err(|_| {
+                "embedded Apple Speech runtime fixture could not be decoded".to_string()
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if samples.is_empty() || samples.len() > SAMPLE_RATE_HZ as usize * MAX_UTTERANCE_SECONDS {
+        return Err("embedded Apple Speech runtime fixture exceeded its sample budget".into());
+    }
+    Ok(zeroize::Zeroizing::new(samples))
 }
 
 #[cfg(target_os = "macos")]
@@ -661,6 +753,15 @@ mod tests {
             "a single changed sample must change the checksum"
         );
         assert_eq!(transport_acceptance_checksum(&a).len(), 16);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn signed_runtime_fixture_is_bounded_canonical_pcm() {
+        let samples = runtime_acceptance_samples().unwrap();
+        assert_eq!(samples.len(), 170_013);
+        assert!(samples.iter().all(|sample| sample.is_finite()));
+        assert!(samples.iter().any(|sample| sample.abs() > 0.01));
     }
 
     #[cfg(target_os = "macos")]

--- a/docs/architecture/apple-speech.md
+++ b/docs/architecture/apple-speech.md
@@ -41,6 +41,14 @@ route from the signed app while a same-UID process watches and holds newly
 created temporary files. The resulting content-free receipt is acceptance
 evidence only after that protected workflow actually runs for the exact SHA.
 
+On real macOS hardware, the separate fixed-input
+`--apple-speech-runtime-acceptance` route closes the analyzer confound without
+opening the product gate. It embeds the checked-in public speech fixture in the
+parent, sends its bounded PCM bytes through the authenticated XPC worker, and
+emits only content-free timing and count metrics. It accepts no caller audio,
+path, locale, or executable and runs under the same same-UID open-holder
+watcher.
+
 ## Fallback behavior
 
 Standalone live transcript and dictation currently resolve Apple Speech to:

--- a/scripts/check_apple_speech_worker_packaging.mjs
+++ b/scripts/check_apple_speech_worker_packaging.mjs
@@ -7,14 +7,14 @@ import { readFileSync } from "node:fs";
 // Structural matches below are necessary but these goldens ensure a copied
 // comment or dead duplicate cannot silently replace the active boundary.
 const EXPECTED_SOURCE_SHA256 = {
-  worker: "b1cc9e5dd780d0fc116ba325155324783bef012b288a4c7e11381a110f3a613c",
+  worker: "65e487ed419c22dab849c7017db222c430c9fceb86f85e6cf25001653f890f08",
   xpc: "bfe9dfc1f015e6825adc02212305af52efe0f2faeff0d79c736cdce4e4c4d2aa",
   swift: "77310730cfa46ac8301c1a65622681005ebf00f0c699f24fdca757e2e02fcef4",
-  main: "8bbe7aa5fd3510cb61944e1df35f4b2ff2a2da8497fce3784f1ab0cdddbe254a",
+  main: "6c931ff9bac4e041ed2bcb48024313632b8972708c53eee7471808c5a72edc9b",
   acceptanceWorkflow:
     "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   acceptanceHarness:
-    "dfbdf3e2f0290ee05063e44780a16a8af457ead00b6a687ed1dc2adffd3eeeba",
+    "034d8dd5a048b0d8abb6e8a7dfcd82295aa694a43367074b3c4a3a1babd117e0",
 };
 
 const files = {
@@ -208,6 +208,7 @@ function validate(candidate, checkGoldens = true) {
     "setitimer",
     "parse_private_audio_request",
     "run_signed_transport_acceptance",
+    "run_signed_runtime_acceptance",
     "private_audio_parser_accepts_only_exact_finite_pcm_cardinality",
     "private_audio_parser_rejects_magic_metadata_schema_and_budget_attacks",
   ]) {
@@ -402,6 +403,8 @@ function validate(candidate, checkGoldens = true) {
   for (const value of [
     "--apple-speech-transport-acceptance",
     "run_signed_transport_acceptance()",
+    "--apple-speech-runtime-acceptance",
+    "run_signed_runtime_acceptance()",
     "acceptance accepts no caller-supplied input",
   ]) {
     requireText(
@@ -428,6 +431,9 @@ function validate(candidate, checkGoldens = true) {
     "os.O_NOFOLLOW",
     "raw_f32",
     "pcm_i16",
+    "runtime_fixture_patterns",
+    "apple-speech-signed-runtime=accepted",
+    "signedWorkerRuntime",
     "namedAudioCanaryObserved",
     "productGateExpectedClosed",
   ]) {

--- a/scripts/check_apple_speech_worker_packaging.mjs
+++ b/scripts/check_apple_speech_worker_packaging.mjs
@@ -14,7 +14,7 @@ const EXPECTED_SOURCE_SHA256 = {
   acceptanceWorkflow:
     "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   acceptanceHarness:
-    "034d8dd5a048b0d8abb6e8a7dfcd82295aa694a43367074b3c4a3a1babd117e0",
+    "454e9eab87dba92a492f8e85d84db81b1f6bf6e6c38b330e8592fa16cf95dc9c",
 };
 
 const files = {

--- a/scripts/test_apple_speech_signed_transport.py
+++ b/scripts/test_apple_speech_signed_transport.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import threading
 import time
+import wave
 
 
 MAX_HELD_FILE_BYTES = 64 * 1024 * 1024
@@ -48,6 +49,11 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--app", required=True, type=pathlib.Path)
     parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument(
+        "--runtime",
+        action="store_true",
+        help="run the fixed public-fixture analyzer path instead of the transport-only canary",
+    )
     return parser.parse_args()
 
 
@@ -224,6 +230,23 @@ def canary_patterns() -> tuple[bytes, bytes]:
         for value in bits
     )
     return raw_f32, pcm_i16
+
+
+def runtime_fixture_patterns() -> tuple[bytes, bytes]:
+    fixture = pathlib.Path(__file__).resolve().parent.parent / "crates/assets/demo.wav"
+    with wave.open(str(fixture)) as source:
+        if (
+            source.getnchannels() != 1
+            or source.getsampwidth() != 2
+            or source.getframerate() != 16000
+        ):
+            raise RuntimeError("fixed Apple Speech runtime fixture format changed")
+        pcm = source.readframes(source.getnframes())
+    values = struct.unpack(f"<{len(pcm) // 2}h", pcm)
+    raw_f32 = b"".join(struct.pack("<f", value / 32768.0) for value in values)
+    # A bounded interior slice detects a named WAV/PCM spool without requiring
+    # the watcher to retain or compare an entire file.
+    return raw_f32[16_384:32_768], pcm[8_192:24_576]
 
 
 def decode_stream(stream) -> str:
@@ -419,8 +442,9 @@ def emit_failure_diagnostics(
     Diagnostics must never reach stdout: the workflow tees stdout into
     ``signed-runtime-provenance.json``, so anything printed there would corrupt
     the receipt. This is safe to emit in full because the runtime job holds no
-    secrets and the only audio in the process is the synthetic canary, so no
-    signing material and no private utterance can appear here.
+    secrets and the only audio in the process is either the synthetic canary or
+    the checked-in public fixture, so no signing material and no private
+    utterance can appear here.
     """
     def write(line: str) -> None:
         print(line, file=sys.stderr)
@@ -482,8 +506,13 @@ def main() -> int:
         environment["TMPDIR"] = str(isolated_temp)
         started_at = time.time()
         try:
+            acceptance_argument = (
+                "--apple-speech-runtime-acceptance"
+                if args.runtime
+                else "--apple-speech-transport-acceptance"
+            )
             result = subprocess.run(
-                [str(executable), "--apple-speech-transport-acceptance"],
+                [str(executable), acceptance_argument],
                 env=environment,
                 capture_output=True,
                 text=True,
@@ -529,7 +558,12 @@ def main() -> int:
             "signed Apple Speech transport acceptance failed with "
             f"exit {result.returncode}: {result.stderr[-2000:]}"
         )
-    if "apple-speech-signed-byte-transport=accepted" not in result.stdout:
+    expected_marker = (
+        "apple-speech-signed-runtime=accepted"
+        if args.runtime
+        else "apple-speech-signed-byte-transport=accepted"
+    )
+    if expected_marker not in result.stdout:
         raise RuntimeError("signed app did not emit the content-free acceptance receipt")
     runtime_supported_match = re.search(
         r"^apple-speech-signed-runtime-supported=(true|false)$",
@@ -539,6 +573,8 @@ def main() -> int:
     if runtime_supported_match is None:
         raise RuntimeError("signed app did not report whether the Speech runtime was supported")
     runtime_supported = runtime_supported_match.group(1) == "true"
+    if args.runtime and not runtime_supported:
+        raise RuntimeError("signed Apple Speech worker did not run the analyzer")
     if "apple-speech-signed-parent-trusted=true" not in result.stdout:
         raise RuntimeError(
             "signed app did not confirm it evaluated its signing authority as trusted"
@@ -550,11 +586,13 @@ def main() -> int:
         f"apple-speech-signed-runtime-supported={str(runtime_supported).lower()}",
         file=sys.stderr,
     )
-    raw_f32, pcm_i16 = canary_patterns()
+    raw_f32, pcm_i16 = (
+        runtime_fixture_patterns() if args.runtime else canary_patterns()
+    )
     for contents in held_contents:
         if raw_f32 in contents or pcm_i16 in contents:
             raise RuntimeError(
-                "same-UID open holder recovered the synthetic utterance from a named file"
+                "same-UID open holder recovered acceptance audio from a named file"
             )
 
     receipt = {
@@ -569,20 +607,30 @@ def main() -> int:
         "namedAudioCanaryObserved": False,
         "productGateExpectedClosed": True,
         "signedByteTransport": "accepted",
-        # "accepted" attests that the exact authenticated canary bytes crossed
-        # the parent -> XPC -> worker transport and the worker returned a
-        # content receipt whose checksum matched. It does NOT attest that the
-        # Speech analyzer ran: a hosted runner has no Speech assets and cannot
-        # transcribe, and constructing the analyzer aborts the sandboxed XPC
-        # worker, so acceptance proves the transport and the analyzer is
-        # verified separately on real hardware. runtimeSupported is therefore
-        # false here; a transcript is proven by verify_apple_speech_hardware.sh.
+        "signedWorkerRuntime": "accepted" if args.runtime else "not-run",
+        # Transport-only acceptance intentionally leaves runtimeSupported
+        # false. Runtime mode is a real-hardware-only successor that sends the
+        # fixed public fixture through the same worker and requires true.
         "runtimeSupported": runtime_supported,
         # The worker derives its peer requirement from the same trusted-
         # distribution verdict, and fails closed when that evaluation cannot
         # complete, so a trusted parent means no identifier-only downgrade.
         "parentTrustedDistribution": True,
     }
+    if args.runtime:
+        for field, pattern in (
+            ("moduleId", r"^apple-speech-module=(.+)$"),
+            ("wordCount", r"^apple-speech-word-count=([0-9]+)$"),
+            ("segmentCount", r"^apple-speech-segment-count=([0-9]+)$"),
+            ("firstResultElapsedMs", r"^apple-speech-first-result-ms=([0-9]+)$"),
+            ("totalElapsedMs", r"^apple-speech-total-elapsed-ms=([0-9]+)$"),
+        ):
+            match = re.search(pattern, result.stdout, re.MULTILINE)
+            if match is None:
+                raise RuntimeError(f"signed runtime receipt omitted {field}")
+            receipt[field] = (
+                match.group(1) if field == "moduleId" else int(match.group(1))
+            )
     print(json.dumps(receipt, sort_keys=True))
     return 0
 

--- a/scripts/test_apple_speech_signed_transport.py
+++ b/scripts/test_apple_speech_signed_transport.py
@@ -198,7 +198,11 @@ class SameUidOpenHolder:
         while not self.stop.is_set():
             for root in self.roots:
                 for directory, _, names in os.walk(root, followlinks=False):
+                    if self.stop.is_set():
+                        return
                     for name in names:
+                        if self.stop.is_set():
+                            return
                         path = pathlib.Path(directory) / name
                         try:
                             info = path.lstat()
@@ -505,6 +509,7 @@ def main() -> int:
         environment = os.environ.copy()
         environment["TMPDIR"] = str(isolated_temp)
         started_at = time.time()
+        result = None
         try:
             acceptance_argument = (
                 "--apple-speech-runtime-acceptance"
@@ -548,7 +553,16 @@ def main() -> int:
             raise
         finally:
             time.sleep(0.1)
-            held_contents = watcher.close()
+            try:
+                held_contents = watcher.close()
+            except Exception:
+                # A failed observer cannot qualify acceptance, but must not
+                # hide the signed child's result behind its cleanup error.
+                if result is not None:
+                    emit_failure_diagnostics(
+                        started_at, result.returncode, result.stdout, result.stderr, worker
+                    )
+                raise
 
     if result.returncode != 0:
         emit_failure_diagnostics(

--- a/scripts/test_apple_speech_watcher.py
+++ b/scripts/test_apple_speech_watcher.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Local deterministic checks for acceptance-watcher cancellation."""
+
+import importlib.util
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "apple_speech_acceptance",
+    pathlib.Path(__file__).with_name("test_apple_speech_signed_transport.py"),
+)
+ACCEPTANCE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ACCEPTANCE)
+
+
+class WatcherCancellationTests(unittest.TestCase):
+    def test_stop_interrupts_the_current_directory_scan(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            watcher = ACCEPTANCE.SameUidOpenHolder([root])
+            for index in range(3):
+                (root / f"new-{index}").write_bytes(b"synthetic watcher fixture")
+            real_open = os.open
+
+            def stop_after_first_open(*args, **kwargs):
+                descriptor = real_open(*args, **kwargs)
+                watcher.stop.set()
+                return descriptor
+
+            try:
+                with mock.patch.object(ACCEPTANCE.os, "open", side_effect=stop_after_first_open):
+                    watcher._run()
+                self.assertEqual(len(watcher.held), 1)
+            finally:
+                for descriptor in watcher.held:
+                    os.close(descriptor)
+
+    def test_stopped_watcher_does_not_start_a_scan(self):
+        watcher = ACCEPTANCE.SameUidOpenHolder([])
+        watcher.stop.set()
+        with mock.patch.object(ACCEPTANCE.os, "walk") as walk:
+            watcher._run()
+        walk.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -37,6 +37,8 @@ const MAIN_WINDOW_TRANSPARENT: bool = false;
 const MAIN_WINDOW_APPLY_VIBRANCY: bool = false;
 #[cfg(target_os = "macos")]
 const APPLE_SPEECH_TRANSPORT_ACCEPTANCE_ARG: &str = "--apple-speech-transport-acceptance";
+#[cfg(target_os = "macos")]
+const APPLE_SPEECH_RUNTIME_ACCEPTANCE_ARG: &str = "--apple-speech-runtime-acceptance";
 
 static CLEAN_EXIT_STARTED: AtomicBool = AtomicBool::new(false);
 
@@ -64,6 +66,42 @@ fn maybe_run_apple_speech_transport_acceptance() -> Option<i32> {
         }
         Err(error) => {
             eprintln!("Apple Speech signed byte-transport acceptance failed: {error}");
+            Some(1)
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn maybe_run_apple_speech_runtime_acceptance() -> Option<i32> {
+    let mut arguments = std::env::args_os();
+    let _executable = arguments.next();
+    if arguments.next().as_deref()
+        != Some(std::ffi::OsStr::new(APPLE_SPEECH_RUNTIME_ACCEPTANCE_ARG))
+    {
+        return None;
+    }
+    if arguments.next().is_some() {
+        eprintln!("Apple Speech runtime acceptance accepts no caller-supplied input");
+        return Some(64);
+    }
+    match minutes_core::apple_speech_worker::run_signed_runtime_acceptance() {
+        Ok(receipt) => {
+            println!("apple-speech-signed-runtime=accepted");
+            println!("apple-speech-signed-runtime-supported=true");
+            println!("apple-speech-module={}", receipt.module_id);
+            println!("apple-speech-word-count={}", receipt.word_count);
+            println!("apple-speech-segment-count={}", receipt.segment_count);
+            println!(
+                "apple-speech-first-result-ms={}",
+                receipt
+                    .first_result_elapsed_ms
+                    .map_or_else(|| "null".to_string(), |value| value.to_string())
+            );
+            println!("apple-speech-total-elapsed-ms={}", receipt.total_elapsed_ms);
+            Some(0)
+        }
+        Err(error) => {
+            eprintln!("Apple Speech signed runtime acceptance failed: {error}");
             Some(1)
         }
     }
@@ -1639,6 +1677,10 @@ fn main() {
     }
     #[cfg(target_os = "macos")]
     if let Some(code) = maybe_run_apple_speech_transport_acceptance() {
+        std::process::exit(code);
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(code) = maybe_run_apple_speech_runtime_acceptance() {
         std::process::exit(code);
     }
     // Route whisper.cpp + ggml C-level logs through Rust `tracing` so they


### PR DESCRIPTION
The existing signed Apple Speech acceptance proves authenticated audio transport but deliberately never constructs the Speech analyzer. This adds a separate test mode that sends the checked-in public audio fixture through the signed parent, XPC worker, and real analyzer, returning only counts and timings.

The caller cannot supply audio, paths, locale, or worker settings. The test requires the normal Apple Speech product gate to remain closed and verifies the existing Whisper fallback. The same-UID temporary-file watcher checks for named audio spools. This does not enable Apple Speech for users or establish progressive live-transcript performance.

Candidate `95a12ce2356b3300c3c90d7ddba48694b5132ca0`, based on main `8736a3a3`:

- macOS 26.6 / arm64 on Silverbook, pinned Rust 1.95.0.
- Core no-default-feature suite: 1,817 passed, 0 failed, 1 ignored. The compiled harness ran with CI's `--test-threads=1` discipline and the same-candidate CLI beside it for compressed-audio worker tests.
- All six Apple worker tests passed, including fixed-fixture validation.
- `cargo clippy -p minutes-core --no-default-features -- -D warnings`, `cargo fmt --all -- --check`, Apple packaging guard, and packaging self-test passed.
- The canonical `install-dev-app.sh` completed release CLI and desktop compilation, app bundling, identity signing, and installation into `~/Applications/Minutes Dev.app`.
- Fixed a real acceptance-harness shutdown failure: the temporary-file watcher now observes cancellation inside directory/file scans, and its cleanup cannot hide a captured child result. Two deterministic regression tests pass and now run in CI.

Real signed analyzer acceptance passed on the final exact SHA `95a12ce2356b3300c3c90d7ddba48694b5132ca0`: trusted parent, authenticated worker, `speech-transcriber`, 28 words, 2 segments, runtime supported, first result 179 ms and total analyzer time 274 ms. This is a preloaded 10.63-second public fixture, not paced microphone input or live-draft latency evidence. The watcher held one newly created regular file and observed no acceptance audio in it; this observation is not exhaustive proof of the absence of transient files.

An earlier signed run at `92edd0fc` also passed with 28 words and 2 segments. The only difference to the final candidate is wiring the two Python tests into CI. The Rust sources are unchanged from the 1,817-test and strict-clippy run at `b5ed156e`.

Signing succeeds in a fresh Apple Terminal session with the existing Apple Development identity and Team `63TMLKT8HN`; the SSH `errSecInternalComponent` issue did not require any keychain or password changes. The original Dev app was backed up, restored, and verified by executable SHA-256 and strict seal. Production was untouched. Input Monitoring is unavailable to Dev, so Fn hotkey acceptance is not claimed and is not required for this fixed-input analyzer test.

Final exact-SHA signed acceptance is complete; fresh cross-platform CI remains the landing gate. Apple Speech remains disabled for product selection. Real microphone, AirPods, far-field, proper-name, long-speech, and failure/fallback evidence remain separate from this testing PR.

Content-free receipt on the test Mac: `apple-runtime-current-20260905/apple-runtime-evidence-95a12ce2/runtime.json`. Worker CDHash: `8615ab3c76b24eec220f3452579eba5c0c0943e6`. Original Dev restoration passed with strict seal and identical executable SHA-256.

Tracking: `minutes-k7yv` under the live-draft transcript program.
