### PR TITLE
site: name both ways people use Minutes

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -604,7 +604,37 @@ export default function Home() {
         <p className="mt-3 font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--text-secondary)]">
           From meetings to memos to agents
         </p>
-        <div className="mt-8 grid gap-px bg-[var(--border)] sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-8 grid gap-px bg-[var(--border)] sm:grid-cols-2">
+          <div className="bg-[var(--bg)] px-6 py-6">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--accent)]">
+              If your agent is the interface
+            </p>
+            <h3 className="mt-3 font-serif text-[20px] leading-6 text-[var(--text)]">
+              Minutes is the capture layer of a memory you own
+            </h3>
+            <p className="mt-3 text-[14px] leading-6 text-[var(--text-secondary)]">
+              Wait for the call banner, record, and never open the app again.
+              Claude Code, Cursor, Codex, or OpenCode call{" "}
+              <span className="font-mono text-[13px]">search_meetings</span> over
+              MCP, and the markdown folds into your own vault or wiki. The recap
+              is optional; the agent is the reader.
+            </p>
+          </div>
+          <div className="bg-[var(--bg)] px-6 py-6">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--accent)]">
+              If you read the results yourself
+            </p>
+            <h3 className="mt-3 font-serif text-[20px] leading-6 text-[var(--text)]">
+              Minutes is a complete local notetaker
+            </h3>
+            <p className="mt-3 text-[14px] leading-6 text-[var(--text-secondary)]">
+              Transcript, speakers, summary, and action items in one inspectable
+              file, with Recall to ask about the meeting afterwards. No account,
+              no server, and no agent required.
+            </p>
+          </div>
+        </div>
+        <div className="mt-px grid gap-px bg-[var(--border)] sm:grid-cols-2 lg:grid-cols-3">
           {featureGrid.map((item) => (
             <div key={item.title} className="bg-[var(--bg)] px-6 py-6">
               <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--accent)]">


### PR DESCRIPTION
Companion to #881. Adds two cards at the top of the Audience section — *If your agent is the interface* (capture layer, MCP `search_meetings`, your own vault; recap optional) and *If you read the results yourself* (complete local notetaker) — above the existing feature grid. Copy only, existing tokens and layout primitives; no new colors, fonts, or radii.

**Held for a look before merge** — this is the homepage. Preview by building `site/`; `npm --prefix site run build` passes (44/44).