### PR TITLE
fix(desktop): show the call banner while processing; stop job cards overflowing the column

### DIFF
--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -1624,6 +1624,10 @@
 
     .processing-jobs {
       display: grid;
+      /* minmax(0, 1fr): a grid track's implicit min-width is `auto`, so a
+         card with a nowrap title widened the track past the column and the
+         state pill was clipped by the pane edge ("SUMMARIZI…"). */
+      grid-template-columns: minmax(0, 1fr);
       gap: 8px;
       margin-top: 12px;
     }
@@ -1639,6 +1643,7 @@
     }
 
     .processing-job {
+      min-width: 0;
       border-radius: var(--radius);
       padding: 10px 12px;
       background: var(--bg-elevated);
@@ -8460,7 +8465,10 @@
           processingBar.classList.add('active');
           liveBar.classList.remove('active'); // T4
           isLiveTranscript = false;
-          callBanner.classList.remove('active');
+          // A background job does not preclude a new call recording, so keep
+          // the call banner visible while processing; only starting/recording
+          // hide it. Hiding it here made back-to-back calls invisible (#885).
+          callBanner.classList.toggle('active', !!(activeCallSession && !activeCallSession.dismissed));
           setFooterCaptureMode(false);
           processingStage.textContent =
             status.processingStageLabel


### PR DESCRIPTION
Closes #885.

**Call banner hidden while processing.** A second Zoom call started while the previous recording's summary was generating; the detector fired (`call_detect: detected` 17:03:02, `reminder` 17:03:25) but the banner never appeared. The status-poll handler's `isProcessing` branch removed the banner on every tick. It now keeps the banner when an undismissed call session exists — the same rule the idle branch already applies. Starting/recording still hide it (a recording is already in flight).

**Job card overflow.** In the same session the running job card read "…SHIR Microphone SU" with the SUMMARIZING pill clipped by the pane edge. `.processing-jobs` is a grid with no column sizing; the track's implicit `min-width: auto` let the nowrap title widen the card past the column, defeating the card's own ellipsis. `grid-template-columns: minmax(0, 1fr)` + `min-width: 0` on the card fixes it.

Both changes are in `tauri/src/index.html` only; design tokens unchanged. Render-verified on the dev build (see comment).