### PR TITLE
release: pin minutes-sdk 0.25.5 for mcp

### DIFF
--- a/crates/mcp/package-lock.json
+++ b/crates/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "minutes-sdk": "0.25.4",
+        "minutes-sdk": "0.25.5",
         "yaml": "^2.8.3",
         "zod": "^3.25 || ^4.0"
       },
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/minutes-sdk": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.4.tgz",
-      "integrity": "sha512-NzbX/nlwONdAofr7afy7zxZXmJ+Zph9GcE+hRz8tYPlLDawNY4sJlDQH4iptCa9TraLsmRwl6cAsZbbYSbT1rw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/minutes-sdk/-/minutes-sdk-0.25.5.tgz",
+      "integrity": "sha512-vkkR8nYTTl/kIms9h3ox25iGwO/vZ2IzhS2oLccWK2dnVG1yFFDWKLKYl/Wsv8NNA1mJYvjbO0Mnz/xfXD1F1g==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "minutes-sdk": "0.25.4",
+    "minutes-sdk": "0.25.5",
     "yaml": "^2.8.3",
     "zod": "^3.25 || ^4.0"
   },


### PR DESCRIPTION
Phase 2 of `docs/release/procedure.md` for v0.25.5: `crates/mcp/package.json` pinned to the exact `minutes-sdk` 0.25.5 with the MCP lockfile regenerated, created by `scripts/release.mjs phase2 0.25.5` after a clean phase-1 preflight on `main` at `4180f924`. Same shape as #875 / #829.