### PR TITLE
ci: treat 'already exists on crates.io index' as an idempotent publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -270,8 +270,13 @@ jobs:
               rm -f "$publish_log"
               return 0
             fi
-            if grep -Fqi "already uploaded" "$publish_log"; then
-              echo "$crate@$VERSION is already uploaded; treating this rerun as successful."
+            # cargo reports a previously published version two ways depending
+            # on where it notices: "already uploaded" from the registry, or
+            # "already exists on crates.io index" from the index refresh
+            # (seen on the v0.25.5 rerun, which then never reached minutes-cli).
+            if grep -Fqi "already uploaded" "$publish_log" \
+              || grep -Fqi "already exists on crates.io index" "$publish_log"; then
+              echo "$crate@$VERSION is already published; treating this rerun as successful."
               rm -f "$publish_log"
               return 0
             fi


### PR DESCRIPTION
The v0.25.5 `Release Registry Packages` run timed out waiting for `minutes-core@0.25.5` to appear in the crates.io index (propagation lag), so `minutes-cli` was never published. Rerunning the job then failed on `minutes-core` with cargo's *other* already-published wording — `crate minutes-core@0.25.5 already exists on crates.io index` — which the guard (`already uploaded` only) didn't recognize, so it still never reached `minutes-cli`.

Accept both phrasings. After this lands I'll `workflow_dispatch` the registry workflow for `v0.25.5` (its npm job is already rerun-safe via the `already=true` checks) to publish `minutes-cli@0.25.5`. `actionlint` clean.