### PR TITLE
docs(site): refresh v0.25.5 release copy

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -383,9 +383,9 @@ export default function Home() {
         <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
           <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
           adds{" "}
-          live transcripts that survive Recall rewrites and stalled audio
-          sources, an MCP server that no longer resets your speech model, and a
-          three-pane Recall workspace with an editable document pane.{" "}
+          Bluetooth headsets that record real audio on native calls, a call
+          banner that shows up while the last recording is still summarizing,
+          and a VAD-only model download for drives that keep models off C:.{" "}
           <a
             href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
             className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -2,7 +2,7 @@
 // step 15) from the GitHub and npm APIs. Coarse on purpose: better slightly
 // stale and reliable than a flaky build-time fetch.
 // Contributors excludes anonymous entries and dependency automation.
-// Last refreshed: 2026-08-28.
+// Last refreshed: 2026-08-29.
 
 export const GITHUB_STARS = "1,455";
 export const GITHUB_FORKS = "157";


### PR DESCRIPTION
Post-release site refresh (procedure step 15): the headline blurb now names the Bluetooth HFP call fix, the call banner during summarization, and `setup --vad`. Proof numbers unchanged since yesterday's refresh (stars/forks moved by single digits; left as-is). Build 44/44.