### PR TITLE
ci: install the MCP against a branch-local SDK instead of refusing it

### DIFF
--- a/scripts/install_mcp_dependencies.mjs
+++ b/scripts/install_mcp_dependencies.mjs
@@ -77,7 +77,13 @@ try {
   const [packed] = JSON.parse(packOutput);
   if (!packed?.filename || !packed?.integrity) throw new Error("npm pack returned no filename or integrity");
   const hasCanonicalIntegrity = packed.integrity === lockedSdk.integrity;
-  if (!hasCanonicalIntegrity && process.platform !== "win32") {
+  // The committed lock pins the *published* SDK tarball. A branch that changes
+  // anything under crates/sdk (source, package.json) packs to a different
+  // integrity, which is expected between releases, not drift: the release
+  // workflow packs, publishes, and re-pins independently (#888). Only refuse the
+  // mismatch when a caller explicitly asks for the published tarball.
+  const requirePublishedSdk = process.env.MINUTES_MCP_REQUIRE_PUBLISHED_SDK === "1";
+  if (!hasCanonicalIntegrity && requirePublishedSdk) {
     throw new Error(
       `local minutes-sdk ${sdkPackage.version} integrity does not match the MCP lockfile\n` +
         `  lockfile: ${lockedSdk.integrity}\n  local:    ${packed.integrity}`,
@@ -88,14 +94,17 @@ try {
   const cacheDirectory = path.join(temporaryDirectory, "npm-cache");
   try {
     if (!hasCanonicalIntegrity) {
-      // npm's Windows tar writer emits different archive metadata even after
-      // payload file modes are normalized. The trusted release workflow packs
-      // and publishes on Ubuntu, so the committed lock retains that canonical
-      // registry integrity. Patch only the disposable checkout lock long enough
-      // to prove the same local SDK source installs and builds on Windows.
+      // Two reasons the local tarball can differ from the committed pin: npm's
+      // Windows tar writer emits different archive metadata, and a branch that
+      // changes crates/sdk packs new bytes. Either way the committed lock keeps
+      // the canonical registry integrity; patch only the disposable checkout
+      // lock long enough to prove this SDK source installs and builds.
       mcpLock.packages["node_modules/minutes-sdk"].integrity = packed.integrity;
       await writeFile(mcpLockFile, `${JSON.stringify(mcpLock, null, 2)}\n`, "utf8");
-      console.log("Using Windows-local SDK archive integrity for this CI install only.");
+      console.log(
+        `Local minutes-sdk ${sdkPackage.version} differs from the published pin; ` +
+          "using its archive integrity for this install only (lock restored afterwards).",
+      );
     }
     runNpm(["cache", "add", tarball, "--cache", cacheDirectory], root);
     runNpm(["ci", "--cache", cacheDirectory], mcpDirectory);


### PR DESCRIPTION
Fixes #888.

`install_mcp_dependencies.mjs` (the `Agent Corpus + MCP Lockfile` job) required the locally packed `minutes-sdk` to match the *published* tarball pinned in the MCP lock byte-for-byte — so any change under `crates/sdk` (source or `package.json`) failed the job until the next release (#778 then, the corpus-lease fix #889 now).

The release workflow packs, publishes, waits for the exact integrity, and re-pins on its own (`release-publish.yml`, `check_version_sync --release`), so the CI install can tolerate a branch-local SDK the same way the Windows path already did: patch only the disposable checkout lock for the install, restore it afterwards, and say so in the log. `MINUTES_MCP_REQUIRE_PUBLISHED_SDK=1` restores the strict refusal for any caller that wants it.

Verified locally on a branch with SDK source changes: install succeeds, lock restored, mirror and version checks unaffected.