### PR TITLE
fix(desktop): show a loading state instead of a false "No meetings yet"

### DIFF
--- a/scripts/check_meeting_list_loading_state.mjs
+++ b/scripts/check_meeting_list_loading_state.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const PANEL = "tauri/src/index.html";
+const panel = readFileSync(PANEL, "utf8");
+
+function requireContract(condition, message) {
+  if (!condition) {
+    console.error(`meeting list loading state: ${message}`);
+    process.exit(1);
+  }
+}
+
+const listStart = panel.indexOf('<div class="meetings-scroll" id="meetings-scroll"');
+const listEnd = panel.indexOf("<!-- Footer -->", listStart);
+requireContract(listStart !== -1 && listEnd !== -1, "could not locate initial meeting list markup");
+
+const initialList = panel.slice(listStart, listEnd);
+requireContract(
+  initialList.includes('id="meeting-list-loading"') && initialList.includes("Loading meetings…"),
+  "initial meeting list must render the loading state",
+);
+requireContract(
+  (initialList.match(/data-meeting-skeleton/g) || []).length === 3,
+  "initial loading state must contain exactly three skeleton meeting cards",
+);
+requireContract(
+  !initialList.includes("No meetings yet"),
+  'initial meeting list must not claim "No meetings yet"',
+);
+
+const loadStart = panel.indexOf("async function loadMeetings(options = {})");
+const loadingStart = panel.indexOf("beginMeetingInventoryLoading();", loadStart);
+const inventoryStart = panel.indexOf("invoke('cmd_list_meetings'", loadStart);
+requireContract(
+  loadStart !== -1 && loadingStart > loadStart && inventoryStart > loadingStart,
+  "loadMeetings must enter loading before starting the inventory request",
+);
+requireContract(
+  panel.includes("if (meetingInventoryFingerprint !== null || documentsViewActive) return;"),
+  "loading must be gated to the unresolved meeting inventory",
+);
+requireContract(
+  panel.includes("meetingInventoryLoadingTemplate.cloneNode(true)"),
+  "a retry with no rendered inventory must restore the loading state",
+);
+requireContract(
+  panel.includes("Still loading your meetings… (${elapsedSeconds}s)") &&
+    panel.includes("Waiting for another Minutes task to finish…"),
+  "slow and busy inventory feedback must remain present",
+);
+requireContract(
+  panel.includes("<h2>Couldn't load your meetings</h2>"),
+  "the final failure state must describe a load failure",
+);
+
+console.log("meeting list loading state: ok");

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -3490,6 +3490,48 @@
       color: var(--text-secondary);
     }
 
+    .meeting-list-loading {
+      padding-top: 12px;
+    }
+
+    .meeting-list-skeletons {
+      display: grid;
+      gap: 6px;
+    }
+
+    .meeting-list-skeleton {
+      display: grid;
+      gap: 8px;
+      padding: 12px 16px 12px 28px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+
+    .meeting-list-skeleton-title,
+    .meeting-list-skeleton-meta {
+      display: block;
+      height: 8px;
+      background: var(--border);
+      border-radius: var(--radius);
+    }
+
+    .meeting-list-skeleton-title {
+      width: 58%;
+    }
+
+    .meeting-list-skeleton-meta {
+      width: 28%;
+    }
+
+    .meeting-list-loading .empty-state {
+      padding: 18px 20px;
+    }
+
+    .meeting-list-loading .sub {
+      font-variant-numeric: tabular-nums;
+    }
+
     /* ── About view ── */
     .about-overlay {
       position: fixed;
@@ -5988,10 +6030,25 @@
     <!-- Markdown viewer (replaces meeting list when a file is open) -->
 
     <!-- Meeting list -->
-    <div class="meetings-scroll" id="meetings-scroll">
-      <div class="empty-state">
-        <div class="title">No meetings yet</div>
-        <div class="sub">Record your first conversation to get started.</div>
+    <div class="meetings-scroll" id="meetings-scroll" aria-busy="true">
+      <div class="meeting-list-loading" id="meeting-list-loading" role="status" aria-live="polite">
+        <div class="meeting-list-skeletons" aria-hidden="true">
+          <div class="meeting-list-skeleton" data-meeting-skeleton>
+            <span class="meeting-list-skeleton-title"></span>
+            <span class="meeting-list-skeleton-meta"></span>
+          </div>
+          <div class="meeting-list-skeleton" data-meeting-skeleton>
+            <span class="meeting-list-skeleton-title"></span>
+            <span class="meeting-list-skeleton-meta"></span>
+          </div>
+          <div class="meeting-list-skeleton" data-meeting-skeleton>
+            <span class="meeting-list-skeleton-title"></span>
+            <span class="meeting-list-skeleton-meta"></span>
+          </div>
+        </div>
+        <div class="empty-state">
+          <div class="sub" id="meeting-list-loading-copy">Loading meetings…</div>
+        </div>
       </div>
     </div>
 
@@ -7421,6 +7478,7 @@
     const noteInput = document.getElementById('note-inline-input');
     const footer = document.getElementById('footer');
     const meetingsScroll = document.getElementById('meetings-scroll');
+    const meetingInventoryLoadingTemplate = document.getElementById('meeting-list-loading').cloneNode(true);
     const documentsToggle = document.getElementById('btn-documents-toggle');
     const sidebarCollapseButton = document.getElementById('btn-sidebar-collapse');
     const sidebarExpandRail = document.getElementById('btn-sidebar-expand');
@@ -11396,6 +11454,53 @@
     let meetingInventoryGeneration = 0;
     let meetingInventoryRetryTimer = null;
     let meetingInventoryFingerprint = null;
+    let meetingInventoryLoadingTimer = null;
+    let meetingInventoryLoadingStartedAt = null;
+    let meetingInventoryWaitingOnBusy = false;
+
+    function updateMeetingInventoryLoadingCopy() {
+      if (documentsViewActive || meetingInventoryFingerprint !== null) return;
+      const copy = document.getElementById('meeting-list-loading-copy');
+      if (!copy || meetingInventoryLoadingStartedAt === null) return;
+      const elapsedSeconds = Math.floor((Date.now() - meetingInventoryLoadingStartedAt) / 1000);
+      if (meetingInventoryWaitingOnBusy) {
+        copy.textContent = 'Waiting for another Minutes task to finish…';
+      } else if (elapsedSeconds >= 3) {
+        copy.textContent = `Still loading your meetings… (${elapsedSeconds}s)`;
+      } else {
+        copy.textContent = 'Loading meetings…';
+      }
+    }
+
+    function beginMeetingInventoryLoading() {
+      if (meetingInventoryFingerprint !== null || documentsViewActive) return;
+      if (meetingInventoryLoadingStartedAt === null) {
+        meetingInventoryLoadingStartedAt = Date.now();
+      }
+      if (!document.getElementById('meeting-list-loading')) {
+        meetingsScroll.replaceChildren(meetingInventoryLoadingTemplate.cloneNode(true));
+      }
+      meetingsScroll.setAttribute('aria-busy', 'true');
+      updateMeetingInventoryLoadingCopy();
+      if (!meetingInventoryLoadingTimer) {
+        meetingInventoryLoadingTimer = window.setInterval(updateMeetingInventoryLoadingCopy, 1000);
+      }
+    }
+
+    function setMeetingInventoryWaitingOnBusy(waiting) {
+      meetingInventoryWaitingOnBusy = waiting;
+      updateMeetingInventoryLoadingCopy();
+    }
+
+    function finishMeetingInventoryLoading() {
+      if (meetingInventoryLoadingTimer) {
+        clearInterval(meetingInventoryLoadingTimer);
+        meetingInventoryLoadingTimer = null;
+      }
+      meetingInventoryLoadingStartedAt = null;
+      meetingInventoryWaitingOnBusy = false;
+      meetingsScroll.setAttribute('aria-busy', 'false');
+    }
 
     function fingerprintMeetingInventory(meetings) {
       return JSON.stringify(meetings.map((meeting) => [
@@ -11427,10 +11532,15 @@
         return;
       }
       const generation = ++meetingInventoryGeneration;
+      beginMeetingInventoryLoading();
       let meetings = [];
       try {
         meetings = options.patient === true
-          ? await invokeInventoryPatiently(120000)
+          ? await invokeInventoryPatiently(120000, () => {
+              if (generation === meetingInventoryGeneration) {
+                setMeetingInventoryWaitingOnBusy(true);
+              }
+            })
           : await withUiDeadline(
               invoke('cmd_list_meetings', { limit: 30 }),
               'Meeting inventory'
@@ -11441,6 +11551,7 @@
           invalidateProactiveContextBundle();
         }
         meetingInventoryFingerprint = nextFingerprint;
+        finishMeetingInventoryLoading();
         setSearchError(null);
         renderMeetings(meetings);
       } catch (e) {
@@ -11479,6 +11590,7 @@
           return;
         }
         setSearchError(e);
+        finishMeetingInventoryLoading();
         // NOT renderMeetings([]) — an empty array means "this user has no
         // meetings" and renders the first-run card. A failed read tells us
         // nothing about what is on disk, so it must not make that claim.
@@ -11715,7 +11827,7 @@
       failed.className = 'empty-state';
       failed.innerHTML = `
         <div class="onboarding-content">
-          <h2>Couldn't read your meetings</h2>
+          <h2>Couldn't load your meetings</h2>
           <p class="onboarding-sub">Your notes on disk are untouched — this was a problem reading the list. A large library can take longer than the check allows.</p>
           <div class="onboarding-actions">
             <button class="btn btn-primary btn-sm" id="inventory-retry-btn">Try again</button>
@@ -11765,7 +11877,7 @@
     // finishes. The budget bounds how long we keep RETRYING; one already-running
     // scan can still exceed it, because the backend worker cannot be cancelled
     // and abandoning it would only waste the work.
-    async function invokeInventoryPatiently(budgetMs) {
+    async function invokeInventoryPatiently(budgetMs, onBusy) {
       const deadline = Date.now() + budgetMs;
       while (true) {
         try {
@@ -11774,6 +11886,7 @@
           const busy = String((e && e.message) || e || '').toLowerCase()
             .includes('still checking');
           if (!busy || Date.now() >= deadline) throw e;
+          if (onBusy) onBusy();
           await new Promise((resolve) => window.setTimeout(resolve, 1000));
         }
       }


### PR DESCRIPTION
Closes #895.

The sidebar's empty state was **static markup**, visible from first paint until the meeting inventory resolved — 1–3 s with ~1,000 meetings, and up to 120 s of patient retries when the single-flight inventory is busy. Every user with a large library read *"No meetings yet — Record your first conversation"* on every launch and assumed their data was gone. The error path already refused to render an empty list on failure; the initial markup defeated that intent.

## Behavior now

| state | what the sidebar shows |
|---|---|
| launch, inventory in flight | three skeleton cards + "Loading meetings…" (`aria-busy`, `aria-live=polite`) |
| still in flight after 3 s | "Still loading your meetings… (Ns)" with a live counter |
| inventory busy (single-flight) | "Waiting for another Minutes task to finish…" |
| success, 0 meetings | the existing onboarding empty state — **only** here |
| final failure | "Couldn't load your meetings" + retry (never the empty state) |
| background refresh | never flashes the loading state over a rendered list |

Existing tokens only (`--bg-elevated`, `--border`, `--radius`, `--text-*`); design-token baseline unchanged. New `scripts/check_meeting_list_loading_state.mjs` asserts the initial `#meetings-scroll` markup is the loading state and never contains the empty-state copy.

The perf half (each inventory re-reads and hashes every meeting file) is a separate PR.