### PR TITLE
site: 0.25.6 release blurb

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -382,10 +382,10 @@ export default function Home() {
 
         <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
           <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
-          adds{" "}
-          Bluetooth headsets that record real audio on native calls, a call
-          banner that shows up while the last recording is still summarizing,
-          and a VAD-only model download for drives that keep models off C:.{" "}
+          fixes{" "}
+          the launch that briefly claimed you had no meetings: the list now says
+          it is loading, and it loads about 25× faster (1.8 s to 0.07 s on a
+          977-meeting library).{" "}
           <a
             href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
             className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"


### PR DESCRIPTION
The homepage version chip renders `MINUTES_RELEASE_VERSION` (now 0.25.6) next to prose that still described 0.25.5's Bluetooth/banner/VAD changes. Replaces it with what 0.25.6 actually shipped: the meeting-list loading state and the ~25× faster list.

Copy only — no logic, no constants (`site/lib/release.ts` was regenerated by the bump).