### PR TITLE
Make Live stop immediately and process in the background

### DIFF
--- a/crates/core/src/context_store.rs
+++ b/crates/core/src/context_store.rs
@@ -995,6 +995,59 @@ pub fn mark_capture_session_processing(
     Ok(())
 }
 
+/// Move a stopped Live Transcript session into durable background processing
+/// while retaining links to the archived real-time transcript and WAV.
+pub fn mark_live_transcript_processing(
+    session_id: &str,
+    job_id: &str,
+    job_audio_path: &Path,
+    jsonl_path: &Path,
+    archived_wav_path: &Path,
+    ended_at: Option<DateTime<Local>>,
+) -> Result<(), ContextStoreError> {
+    let mut conn = open_db()?;
+    let transaction = conn.transaction()?;
+    update_session_state_with_conn(
+        &transaction,
+        session_id,
+        ContextSessionState::Processing,
+        ended_at,
+        None,
+        Some(ContentType::Meeting),
+        json!({ "job_id": job_id, "background_processing": true }),
+    )?;
+    upsert_link_with_conn(
+        &transaction,
+        session_id,
+        ContextLinkKind::Job,
+        job_id,
+        json!({}),
+    )?;
+    upsert_link_with_conn(
+        &transaction,
+        session_id,
+        ContextLinkKind::AudioCapture,
+        &job_audio_path.display().to_string(),
+        json!({}),
+    )?;
+    upsert_link_with_conn(
+        &transaction,
+        session_id,
+        ContextLinkKind::LiveTranscriptJsonl,
+        &jsonl_path.display().to_string(),
+        json!({}),
+    )?;
+    upsert_link_with_conn(
+        &transaction,
+        session_id,
+        ContextLinkKind::LiveTranscriptWav,
+        &archived_wav_path.display().to_string(),
+        json!({}),
+    )?;
+    transaction.commit()?;
+    Ok(())
+}
+
 pub fn mark_capture_session_complete(
     session_id: &str,
     output_path: &Path,
@@ -1787,6 +1840,46 @@ mod tests {
             )
             .unwrap();
             assert_eq!(window_events.len(), 2);
+        });
+    }
+
+    #[test]
+    fn live_transcript_processing_retains_archived_pair_links() {
+        with_temp_home(|home| {
+            let started_at = Local::now();
+            let session = start_live_transcript_session(started_at).unwrap();
+            let job_audio = home.path().join(".minutes/jobs/job-live.wav");
+            let archived_wav = home
+                .path()
+                .join(".minutes/live-sessions/live-transcript-20260901.wav");
+            let archived_jsonl = archived_wav.with_extension("jsonl");
+
+            mark_live_transcript_processing(
+                &session.id,
+                "job-live",
+                &job_audio,
+                &archived_jsonl,
+                &archived_wav,
+                Some(started_at + Duration::seconds(30)),
+            )
+            .unwrap();
+
+            let reloaded = get_session(&session.id).unwrap().unwrap();
+            assert_eq!(reloaded.state, ContextSessionState::Processing);
+            assert_eq!(reloaded.capture_mode, Some(CaptureMode::LiveTranscript));
+            assert_eq!(reloaded.content_type, Some(ContentType::Meeting));
+            let links = list_links_for_session(&session.id).unwrap();
+            assert!(links
+                .iter()
+                .any(|link| { link.kind == ContextLinkKind::Job && link.target == "job-live" }));
+            assert!(links.iter().any(|link| {
+                link.kind == ContextLinkKind::LiveTranscriptJsonl
+                    && link.target == archived_jsonl.display().to_string()
+            }));
+            assert!(links.iter().any(|link| {
+                link.kind == ContextLinkKind::LiveTranscriptWav
+                    && link.target == archived_wav.display().to_string()
+            }));
         });
     }
 

--- a/crates/core/src/jobs.rs
+++ b/crates/core/src/jobs.rs
@@ -532,8 +532,109 @@ pub fn enqueue_capture_job(
     calendar_event: Option<CalendarEvent>,
     template_slug: Option<String>,
 ) -> std::io::Result<ProcessingJob> {
+    enqueue_capture_job_with_id(
+        next_job_id(),
+        mode,
+        title,
+        audio_path,
+        user_notes,
+        pre_context,
+        recording_started_at,
+        recording_finished_at,
+        context_session_id,
+        calendar_event,
+        template_slug,
+    )
+}
+
+/// Queue an already-preserved capture without transferring ownership of the
+/// source file to the processing worker.
+///
+/// Live Transcript archives its recoverable WAV/JSONL pair before returning
+/// control to the desktop. The worker normally moves its input alongside the
+/// finished Markdown, so pointing a job directly at that archived WAV would
+/// dismantle the recovery pair on success. Give the job its own hard link
+/// (copy fallback) instead; the archived source remains durable through
+/// success, failure, retry, and worker crashes.
+#[allow(clippy::too_many_arguments)]
+pub fn enqueue_preserved_capture_job(
+    mode: CaptureMode,
+    title: Option<String>,
+    preserved_audio_path: &Path,
+    user_notes: Option<String>,
+    pre_context: Option<String>,
+    recording_started_at: Option<DateTime<Local>>,
+    recording_finished_at: Option<DateTime<Local>>,
+    context_session_id: Option<String>,
+    calendar_event: Option<CalendarEvent>,
+    template_slug: Option<String>,
+) -> std::io::Result<ProcessingJob> {
+    let job_id = next_job_id();
+    let audio_path = link_preserved_capture_into_job(&job_id, preserved_audio_path)?;
+    let result = enqueue_capture_job_with_id(
+        job_id,
+        mode,
+        title,
+        audio_path.clone(),
+        user_notes,
+        pre_context,
+        recording_started_at,
+        recording_finished_at,
+        context_session_id,
+        calendar_event,
+        template_slug,
+    );
+    if result.is_err() {
+        fs::remove_file(audio_path).ok();
+    }
+    result
+}
+
+fn link_preserved_capture_into_job(
+    job_id: &str,
+    preserved_audio_path: &Path,
+) -> std::io::Result<PathBuf> {
+    let destination = job_capture_path_for_source(job_id, preserved_audio_path);
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if let Err(link_error) = fs::hard_link(preserved_audio_path, &destination) {
+        fs::copy(preserved_audio_path, &destination).map_err(|copy_error| {
+            std::io::Error::new(
+                copy_error.kind(),
+                format!(
+                    "could not prepare preserved capture for processing (hard link: {link_error}; copy: {copy_error})"
+                ),
+            )
+        })?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(error) = fs::set_permissions(&destination, fs::Permissions::from_mode(0o600)) {
+            fs::remove_file(&destination).ok();
+            return Err(error);
+        }
+    }
+    Ok(destination)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enqueue_capture_job_with_id(
+    job_id: String,
+    mode: CaptureMode,
+    title: Option<String>,
+    audio_path: PathBuf,
+    user_notes: Option<String>,
+    pre_context: Option<String>,
+    recording_started_at: Option<DateTime<Local>>,
+    recording_finished_at: Option<DateTime<Local>>,
+    context_session_id: Option<String>,
+    calendar_event: Option<CalendarEvent>,
+    template_slug: Option<String>,
+) -> std::io::Result<ProcessingJob> {
     let job = ProcessingJob {
-        id: next_job_id(),
+        id: job_id,
         mode,
         content_type: mode.content_type(),
         title,
@@ -1934,6 +2035,50 @@ mod tests {
             assert!(job_path(&job.id).exists());
             assert!(PathBuf::from(&job.audio_path).exists());
             assert!(crate::screen::screens_dir_for(Path::new(&job.audio_path)).exists());
+        });
+    }
+
+    #[test]
+    fn queue_preserved_capture_keeps_archive_through_output_preservation() {
+        with_temp_home(|tmp| {
+            let live_sessions = tmp.path().join(".minutes/live-sessions");
+            fs::create_dir_all(&live_sessions).unwrap();
+            let archived_wav = live_sessions.join("live-transcript-20260901-100005.wav");
+            let archived_jsonl = archived_wav.with_extension("jsonl");
+            fs::write(&archived_wav, b"recoverable-live-audio").unwrap();
+            fs::write(&archived_jsonl, b"{\"text\":\"hello\"}\n").unwrap();
+
+            let mut job = enqueue_preserved_capture_job(
+                CaptureMode::LiveTranscript,
+                None,
+                &archived_wav,
+                None,
+                None,
+                None,
+                Some(Local::now()),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+            let job_audio = PathBuf::from(&job.audio_path);
+            assert_ne!(job_audio, archived_wav);
+            assert_eq!(fs::read(&job_audio).unwrap(), b"recoverable-live-audio");
+            assert_eq!(fs::read(&archived_wav).unwrap(), b"recoverable-live-audio");
+            assert!(archived_jsonl.exists());
+            assert!(job_path(&job.id).exists());
+
+            let output_path = tmp.path().join("meetings/live-meeting.md");
+            fs::create_dir_all(output_path.parent().unwrap()).unwrap();
+            fs::write(&output_path, "# Live meeting\n").unwrap();
+            job.output_path = Some(output_path.display().to_string());
+            preserve_audio_alongside_output(&job, &Config::default());
+
+            assert!(output_path.with_extension("wav").exists());
+            assert!(!job_audio.exists());
+            assert_eq!(fs::read(&archived_wav).unwrap(), b"recoverable-live-audio");
+            assert!(archived_jsonl.exists());
         });
     }
 

--- a/crates/core/src/live_session.rs
+++ b/crates/core/src/live_session.rs
@@ -111,7 +111,7 @@ where
 /// The desktop uses this path so capture can visibly end as soon as its
 /// recoverable files are safe. It then hands a separate link to the durable
 /// processing queue. CLI callers retain the configured inline behavior above.
-#[cfg(any(feature = "whisper", test))]
+#[cfg(any(all(feature = "streaming", feature = "whisper"), test))]
 pub(crate) fn finalize_stopped_live_session_for_background_with_release<F>(
     config: &Config,
     wav_path: &Path,

--- a/crates/core/src/live_session.rs
+++ b/crates/core/src/live_session.rs
@@ -102,6 +102,32 @@ where
         jsonl_path,
         Local::now(),
         release_live_lock,
+        true,
+    )
+}
+
+/// Archive a stopped live session and return before the meeting pipeline.
+///
+/// The desktop uses this path so capture can visibly end as soon as its
+/// recoverable files are safe. It then hands a separate link to the durable
+/// processing queue. CLI callers retain the configured inline behavior above.
+#[cfg(any(feature = "whisper", test))]
+pub(crate) fn finalize_stopped_live_session_for_background_with_release<F>(
+    config: &Config,
+    wav_path: &Path,
+    jsonl_path: &Path,
+    release_live_lock: F,
+) -> Result<LiveSessionStopResult, MinutesError>
+where
+    F: FnOnce(),
+{
+    finalize_stopped_live_session_at(
+        config,
+        wav_path,
+        jsonl_path,
+        Local::now(),
+        release_live_lock,
+        false,
     )
 }
 
@@ -111,6 +137,7 @@ fn finalize_stopped_live_session_at<F>(
     jsonl_path: &Path,
     stopped_at: DateTime<Local>,
     release_live_lock: F,
+    process_inline: bool,
 ) -> Result<LiveSessionStopResult, MinutesError>
 where
     F: FnOnce(),
@@ -142,7 +169,9 @@ where
     let (preserved_wav, preserved_jsonl) = preserve_live_pair(wav_path, jsonl_path, stopped_at)?;
     release_live_lock();
 
-    if config.live_transcript.promote_on_stop == LiveTranscriptPromoteOnStop::Preserve {
+    if config.live_transcript.promote_on_stop == LiveTranscriptPromoteOnStop::Preserve
+        || !process_inline
+    {
         tracing::info!(
             wav = %preserved_wav.display(),
             jsonl = %preserved_jsonl.display(),
@@ -333,6 +362,37 @@ mod tests {
         );
         assert!(!wav.exists());
         assert!(!jsonl.exists());
+    }
+
+    #[test]
+    fn background_process_stop_archives_pair_without_running_pipeline() {
+        let (_temp, wav, jsonl, mut config) = stopped_session();
+        config.live_transcript.promote_on_stop = LiveTranscriptPromoteOnStop::Process;
+        let released = std::cell::Cell::new(false);
+
+        let result = finalize_stopped_live_session_for_background_with_release(
+            &config,
+            &wav,
+            &jsonl,
+            || {
+                assert!(!wav.exists(), "fixed WAV must be clear before unlock");
+                assert!(!jsonl.exists(), "fixed JSONL must be clear before unlock");
+                released.set(true);
+            },
+        )
+        .unwrap();
+
+        let LiveSessionStopResult::Preserved {
+            wav_path,
+            jsonl_path,
+        } = result
+        else {
+            panic!("desktop stop must return the archived pair before processing");
+        };
+        assert!(released.get());
+        assert!(wav_path.exists());
+        assert!(jsonl_path.exists());
+        assert!(!config.output_dir.exists());
     }
 
     #[test]

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -791,6 +791,42 @@ pub fn run_with_partials(
     existing_context_session_id: Option<String>,
     partial_publisher: Option<LivePartialPublisher>,
 ) -> Result<(usize, f64, PathBuf), MinutesError> {
+    run_with_partials_internal(
+        stop_flag,
+        config,
+        existing_context_session_id,
+        partial_publisher,
+        false,
+    )
+}
+
+/// Run the desktop Live session, archive its recoverable files on stop, and
+/// return before configured meeting processing begins. The desktop owns
+/// enqueueing that archived capture in the durable background worker.
+#[cfg(feature = "whisper")]
+pub fn run_with_partials_for_background(
+    stop_flag: Arc<AtomicBool>,
+    config: &Config,
+    existing_context_session_id: Option<String>,
+    partial_publisher: Option<LivePartialPublisher>,
+) -> Result<(usize, f64, PathBuf), MinutesError> {
+    run_with_partials_internal(
+        stop_flag,
+        config,
+        existing_context_session_id,
+        partial_publisher,
+        true,
+    )
+}
+
+#[cfg(feature = "whisper")]
+fn run_with_partials_internal(
+    stop_flag: Arc<AtomicBool>,
+    config: &Config,
+    existing_context_session_id: Option<String>,
+    partial_publisher: Option<LivePartialPublisher>,
+    defer_processing: bool,
+) -> Result<(usize, f64, PathBuf), MinutesError> {
     let mark_precreated_session_failed = |error: &MinutesError| {
         if let Some(session_id) = existing_context_session_id.as_deref() {
             crate::context_store::mark_live_transcript_failed(
@@ -857,12 +893,22 @@ pub fn run_with_partials(
             // The writer is closed now. Keep the liveness lock until the fixed
             // scratch files have moved so a new session cannot truncate them,
             // then release it before the potentially long meeting pipeline.
-            let finalization = match crate::live_session::finalize_stopped_live_session_with_release(
-                config,
-                &pid::live_transcript_wav_path(),
-                &path,
-                || drop(pid_guard),
-            ) {
+            let finalization_result = if defer_processing {
+                crate::live_session::finalize_stopped_live_session_for_background_with_release(
+                    config,
+                    &pid::live_transcript_wav_path(),
+                    &path,
+                    || drop(pid_guard),
+                )
+            } else {
+                crate::live_session::finalize_stopped_live_session_with_release(
+                    config,
+                    &pid::live_transcript_wav_path(),
+                    &path,
+                    || drop(pid_guard),
+                )
+            };
+            let finalization = match finalization_result {
                 Ok(finalization) => finalization,
                 Err(error) => {
                     if let Some(session_id) = context_session_id.as_deref() {
@@ -876,21 +922,27 @@ pub fn run_with_partials(
                     return Err(error);
                 }
             };
-            if let Some(session_id) = context_session_id.as_deref() {
-                crate::context_store::mark_live_transcript_complete(
-                    session_id,
-                    finalization.jsonl_path(),
-                    finalization.wav_path(),
-                    Some(Local::now()),
-                    json!({
-                        "line_count": lines,
-                        "duration_secs": duration,
-                        "meeting_path": finalization
-                            .meeting_path()
-                            .map(|path| path.display().to_string()),
-                    }),
-                )
-                .ok();
+            let awaiting_background_processing = defer_processing
+                && config.live_transcript.promote_on_stop
+                    == crate::config::LiveTranscriptPromoteOnStop::Process
+                && finalization.wav_path().is_some();
+            if !awaiting_background_processing {
+                if let Some(session_id) = context_session_id.as_deref() {
+                    crate::context_store::mark_live_transcript_complete(
+                        session_id,
+                        finalization.jsonl_path(),
+                        finalization.wav_path(),
+                        Some(Local::now()),
+                        json!({
+                            "line_count": lines,
+                            "duration_secs": duration,
+                            "meeting_path": finalization
+                                .meeting_path()
+                                .map(|path| path.display().to_string()),
+                        }),
+                    )
+                    .ok();
+                }
             }
             Ok((lines, duration, finalization.output_path().to_path_buf()))
         }

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -2568,14 +2568,33 @@ fn processing_job_title_fallback(mode: CaptureMode) -> &'static str {
         CaptureMode::Meeting => "Meeting recording",
         CaptureMode::QuickThought => "Quick thought",
         CaptureMode::Dictation => "Dictation",
-        CaptureMode::LiveTranscript => "Live transcript",
+        CaptureMode::LiveTranscript => "Live meeting",
     }
 }
 
 fn processing_job_view(job: minutes_core::jobs::ProcessingJob) -> ProcessingJobView {
     let mode = job.mode;
     let fallback_title = processing_job_title_fallback(mode);
-    let stage_label = pipeline_stage_label(job.stage.as_deref(), Some(mode)).map(String::from);
+    let stage_label = match job.state {
+        minutes_core::jobs::JobState::Transcribing => Some(stage_label(
+            minutes_core::pipeline::PipelineStage::Transcribing,
+            mode,
+        )),
+        minutes_core::jobs::JobState::Diarizing => Some(stage_label(
+            minutes_core::pipeline::PipelineStage::Diarizing,
+            mode,
+        )),
+        minutes_core::jobs::JobState::Summarizing => Some(stage_label(
+            minutes_core::pipeline::PipelineStage::Summarizing,
+            mode,
+        )),
+        minutes_core::jobs::JobState::Saving => Some(stage_label(
+            minutes_core::pipeline::PipelineStage::Saving,
+            mode,
+        )),
+        _ => None,
+    }
+    .map(String::from);
     ProcessingJobView {
         id: job.id,
         title: job.title.unwrap_or_else(|| fallback_title.into()),
@@ -4284,20 +4303,25 @@ fn arm_desktop_call_capture_route(
 
 fn stage_label(stage: minutes_core::pipeline::PipelineStage, mode: CaptureMode) -> &'static str {
     match (stage, mode) {
-        (minutes_core::pipeline::PipelineStage::Transcribing, CaptureMode::Meeting) => {
-            "Transcribing meeting"
-        }
+        (
+            minutes_core::pipeline::PipelineStage::Transcribing,
+            CaptureMode::Meeting | CaptureMode::LiveTranscript,
+        ) => "Transcribing meeting",
         (minutes_core::pipeline::PipelineStage::Transcribing, CaptureMode::QuickThought) => {
             "Transcribing quick thought"
         }
         (minutes_core::pipeline::PipelineStage::Diarizing, _) => "Separating speakers",
-        (minutes_core::pipeline::PipelineStage::Summarizing, CaptureMode::Meeting) => {
-            "Generating meeting summary"
-        }
+        (
+            minutes_core::pipeline::PipelineStage::Summarizing,
+            CaptureMode::Meeting | CaptureMode::LiveTranscript,
+        ) => "Generating meeting summary",
         (minutes_core::pipeline::PipelineStage::Summarizing, CaptureMode::QuickThought) => {
             "Generating memo summary"
         }
-        (minutes_core::pipeline::PipelineStage::Saving, CaptureMode::Meeting) => "Saving meeting",
+        (
+            minutes_core::pipeline::PipelineStage::Saving,
+            CaptureMode::Meeting | CaptureMode::LiveTranscript,
+        ) => "Saving meeting",
         (minutes_core::pipeline::PipelineStage::Saving, CaptureMode::QuickThought) => {
             "Saving quick thought"
         }
@@ -4310,7 +4334,6 @@ fn stage_label(stage: minutes_core::pipeline::PipelineStage, mode: CaptureMode) 
         (minutes_core::pipeline::PipelineStage::Saving, CaptureMode::Dictation) => {
             "Saving dictation"
         }
-        (_, CaptureMode::LiveTranscript) => "Processing live transcript",
     }
 }
 
@@ -17417,6 +17440,30 @@ mod tests {
             ),
             "Saving meeting"
         );
+        assert_eq!(
+            stage_label(
+                minutes_core::pipeline::PipelineStage::Transcribing,
+                CaptureMode::LiveTranscript
+            ),
+            "Transcribing meeting"
+        );
+        assert_eq!(
+            stage_label(
+                minutes_core::pipeline::PipelineStage::Summarizing,
+                CaptureMode::LiveTranscript
+            ),
+            "Generating meeting summary"
+        );
+    }
+
+    #[test]
+    fn live_stop_ui_hands_off_to_background_processing() {
+        let html = include_str!("../../src/index.html");
+        assert!(html.contains("Meeting saved, processing in background"));
+        assert!(html.contains("const processing = !!event.payload?.processing;"));
+        assert!(html.contains("processingBar.classList.add('active');"));
+        assert!(html.contains("startFastPoll();\n        checkStatus();"));
+        assert!(!html.contains("Processing live transcript"));
     }
 
     #[test]
@@ -17450,12 +17497,24 @@ mod tests {
             recording_health: None,
         };
 
+        let mut live_job = job.clone();
+        live_job.mode = CaptureMode::LiveTranscript;
+        live_job.title = None;
+
         let view = processing_job_view(job);
 
         assert_eq!(view.state, "summarizing");
         assert_eq!(view.stage.as_deref(), Some("summarizing"));
         assert_eq!(
             view.stage_label.as_deref(),
+            Some("Generating meeting summary")
+        );
+
+        let live_view = processing_job_view(live_job);
+        assert_eq!(live_view.title, "Live meeting");
+        assert_eq!(live_view.mode, "live-transcript");
+        assert_eq!(
+            live_view.stage_label.as_deref(),
             Some("Generating meeting summary")
         );
     }
@@ -20765,7 +20824,7 @@ impl Drop for LiveActiveGuard {
 /// Shared live transcript session runner. Spawned on a background thread by both
 /// cmd_start_live_transcript and handle_live_shortcut_event.
 fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: Arc<AtomicBool>) {
-    let _guard = LiveActiveGuard {
+    let guard = LiveActiveGuard {
         active,
         app: app.clone(),
     };
@@ -20785,7 +20844,7 @@ fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: A
             chrono::Local::now(),
         );
 
-    let _desktop_context_collector = live_context_session_id.as_ref().and_then(|session_id| {
+    let desktop_context_collector = live_context_session_id.as_ref().and_then(|session_id| {
         match minutes_core::desktop_context::DesktopContextCollector::start(
             session_id.clone(),
             minutes_core::desktop_context::DesktopContextSessionKind::LiveTranscript,
@@ -20809,7 +20868,7 @@ fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: A
         minutes_core::live_partials::DEFAULT_PARTIAL_CHANNEL_CAPACITY,
         "standalone",
     );
-    let _capture_relay = match minutes_core::copilot::CaptureRelayServer::start(
+    let capture_relay = match minutes_core::copilot::CaptureRelayServer::start(
         minutes_core::copilot::CopilotEvidenceMode::CaptureRelayPartials,
         Some(partial_subscriber),
     ) {
@@ -20849,12 +20908,23 @@ fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: A
             None
         }
     };
-    let result = minutes_core::live_transcript::run_with_partials(
-        stop_flag.clone(),
-        &config,
-        live_context_session_id.clone(),
-        Some(partial_publisher),
-    );
+    let process_in_background = config.live_transcript.promote_on_stop
+        == minutes_core::config::LiveTranscriptPromoteOnStop::Process;
+    let result = if process_in_background {
+        minutes_core::live_transcript::run_with_partials_for_background(
+            stop_flag.clone(),
+            &config,
+            live_context_session_id.clone(),
+            Some(partial_publisher),
+        )
+    } else {
+        minutes_core::live_transcript::run_with_partials(
+            stop_flag.clone(),
+            &config,
+            live_context_session_id.clone(),
+            Some(partial_publisher),
+        )
+    };
 
     stop_flag.store(false, Ordering::Relaxed);
 
@@ -20862,8 +20932,99 @@ fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: A
         update_assistant_live_context(&workspace, false);
     }
 
+    // End the capture-only consumers before advertising that a new Live
+    // session can start. The durable processing worker never owns them.
+    drop(capture_relay);
+    drop(desktop_context_collector);
+
     match result {
         Ok((lines, duration, path)) => {
+            let mut queued_job = None;
+            let mut processing_error = None;
+            if process_in_background && path.extension().is_some_and(|ext| ext == "wav") {
+                let finished_at = chrono::Local::now();
+                match minutes_core::jobs::enqueue_preserved_capture_job(
+                    CaptureMode::LiveTranscript,
+                    None,
+                    &path,
+                    None,
+                    None,
+                    None,
+                    Some(finished_at),
+                    live_context_session_id.clone(),
+                    None,
+                    None,
+                ) {
+                    Ok(job) => {
+                        let jsonl_path = path.with_extension("jsonl");
+                        if let Some(session_id) = live_context_session_id.as_deref() {
+                            if let Err(error) =
+                                minutes_core::context_store::mark_live_transcript_processing(
+                                    session_id,
+                                    &job.id,
+                                    Path::new(&job.audio_path),
+                                    &jsonl_path,
+                                    &path,
+                                    Some(finished_at),
+                                )
+                            {
+                                tracing::warn!(
+                                    session_id,
+                                    job_id = %job.id,
+                                    error = %error,
+                                    "failed to attach archived Live artifacts to processing context"
+                                );
+                            }
+                        }
+                        minutes_core::pid::set_processing_status(
+                            job.stage.as_deref(),
+                            Some(job.mode),
+                            job.title.as_deref(),
+                            Some(&job.id),
+                            minutes_core::jobs::active_job_count(),
+                        )
+                        .ok();
+                        queued_job = Some(job);
+                    }
+                    Err(error) => {
+                        let detail = format!(
+                            "Your audio and live transcript are safe, but background processing could not start: {error}"
+                        );
+                        if let Some(session_id) = live_context_session_id.as_deref() {
+                            minutes_core::context_store::mark_live_transcript_complete(
+                                session_id,
+                                &path.with_extension("jsonl"),
+                                Some(&path),
+                                Some(finished_at),
+                                serde_json::json!({
+                                    "line_count": lines,
+                                    "duration_secs": duration,
+                                    "processing_queue_error": error.to_string(),
+                                }),
+                            )
+                            .ok();
+                        }
+                        if let Some(state) = app.try_state::<AppState>() {
+                            set_latest_output(
+                                &state.latest_output,
+                                Some(OutputNotice {
+                                    kind: "preserved-capture".into(),
+                                    title: "Meeting saved, processing not started".into(),
+                                    path: path.display().to_string(),
+                                    detail: detail.clone(),
+                                    job_id: None,
+                                }),
+                            );
+                        }
+                        processing_error = Some(detail);
+                    }
+                }
+            }
+
+            // The archive and durable queue record are safe. Clear Live before
+            // the stopped event so the UI and shortcuts can start another
+            // session immediately while this meeting processes.
+            drop(guard);
             eprintln!(
                 "[live-transcript] ended: {} lines in {:.0}s; saved to {}",
                 lines,
@@ -20877,12 +21038,29 @@ fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: A
                         "lines": lines,
                         "duration_secs": duration,
                         "path": path.display().to_string(),
+                        "processing": queued_job.is_some(),
+                        "processing_job_id": queued_job.as_ref().map(|job| job.id.as_str()),
+                        "processing_error": processing_error,
                     }),
                 )
                 .ok();
             }
+            if queued_job.is_some() {
+                if let Some(state) = app.try_state::<AppState>() {
+                    sync_processing_indicator(&state.processing, &state.processing_stage);
+                    spawn_processing_worker(
+                        app.clone(),
+                        state.processing.clone(),
+                        state.processing_stage.clone(),
+                        state.latest_output.clone(),
+                        state.activation_progress.clone(),
+                        state.completion_notifications_enabled.clone(),
+                    );
+                }
+            }
         }
         Err(e) => {
+            drop(guard);
             eprintln!("[live-transcript] error: {}", e);
             if let Some(win) = app.get_webview_window("main") {
                 win.emit(
@@ -20894,10 +21072,8 @@ fn run_live_session(app: tauri::AppHandle, active: Arc<AtomicBool>, stop_flag: A
         }
     }
 
-    // Tray sync fires from `LiveActiveGuard`'s Drop once this function
-    // returns and the guard sets `live_transcript_active` to false. Calling
-    // sync_tray_state here would still see the flag as true and re-render
-    // the menu in Live mode.
+    // Every match arm drops `LiveActiveGuard` before its UI event so status
+    // polling observes the completed Live transition immediately.
 }
 
 /// Try to acquire the live transcript state. Returns Err with a message on conflict.

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -7997,7 +7997,9 @@
     }
 
     function currentProcessingTitle(mode) {
-      return mode === 'quick-thought' ? 'Processing quick thought' : 'Processing recording';
+      if (mode === 'quick-thought') return 'Processing quick thought';
+      if (mode === 'live-transcript') return 'Processing meeting';
+      return 'Processing recording';
     }
 
     function formatIsoElapsed(isoString) {
@@ -8056,7 +8058,11 @@
     }
 
     function processingJobMeta(job) {
-      const mode = job.mode === 'quick-thought' ? 'Quick thought' : 'Meeting';
+      const mode = job.mode === 'quick-thought'
+        ? 'Quick thought'
+        : job.mode === 'live-transcript'
+          ? 'Live meeting'
+          : 'Meeting';
       if (job.state === 'queued') {
         const elapsed = formatIsoElapsed(job.createdAt);
         return elapsed ? `${mode} · waiting ${elapsed}` : `${mode} · waiting`;
@@ -8084,7 +8090,7 @@
       switch (job?.mode) {
         case 'quick-thought': return 'Quick thought';
         case 'dictation': return 'Dictation';
-        case 'live-transcript': return 'Live transcript';
+        case 'live-transcript': return 'Live meeting';
         case 'meeting':
         default:
           return 'Meeting recording';
@@ -8104,21 +8110,22 @@
 
     function processingStatusTitle(status, mode) {
       const job = primaryProcessingJob(status);
+      const processingMode = job?.mode || mode;
       switch (job?.state) {
         case 'transcribing':
-          return mode === 'quick-thought' ? 'Transcribing quick thought' : 'Transcribing recording';
+          return processingMode === 'quick-thought' ? 'Transcribing quick thought' : 'Transcribing meeting';
         case 'transcript-only':
           return 'Transcript ready, summarizing';
         case 'diarizing':
           return 'Separating speakers';
         case 'summarizing':
-          return mode === 'quick-thought' ? 'Generating memo summary' : 'Generating meeting summary';
+          return processingMode === 'quick-thought' ? 'Generating memo summary' : 'Generating meeting summary';
         case 'saving':
-          return mode === 'quick-thought' ? 'Saving quick thought' : 'Saving recording';
+          return processingMode === 'quick-thought' ? 'Saving quick thought' : 'Saving meeting';
         default:
           return status.processingTitle
             ? `Processing ${status.processingTitle}`
-            : currentProcessingTitle(mode);
+            : currentProcessingTitle(processingMode);
       }
     }
 
@@ -16638,10 +16645,24 @@
       isLiveTranscript = false;
       liveBar.classList.remove('active');
       setFooterCaptureMode(false);
-      statusPill.className = 'status-pill';
-      statusPill.textContent = 'idle';
-      stopFastPoll();
-      loadMeetings();
+      const processing = !!event.payload?.processing;
+      if (processing) {
+        statusPill.className = 'status-pill processing';
+        statusPill.textContent = 'queued';
+        processingBar.classList.add('active');
+        processingTitle.textContent = 'Meeting saved, processing in background';
+        processingStage.textContent = 'Queued for processing';
+        processingElapsed.textContent = '';
+        startFastPoll();
+        checkStatus();
+      } else {
+        statusPill.className = 'status-pill';
+        statusPill.textContent = 'idle';
+        processingBar.classList.remove('active');
+        stopFastPoll();
+        loadMeetings();
+        if (event.payload?.processing_error) checkStatus();
+      }
       playCue('stop');
     });
 


### PR DESCRIPTION
## What changed

- Live now finishes as soon as its recoverable WAV and real-time transcript are safely archived.
- The saved meeting is handed to Minutes' durable background worker through a separate job-owned audio link, so processing cannot remove or damage the archived Live pair.
- A new Live session can start while the previous meeting is transcribing, separating speakers, or generating its summary.
- The desktop shows honest meeting-processing stages and a clear recovery notice if queue creation fails.
- CLI behavior and the Preserve/Off Live settings remain unchanged.

## Why

Stopping a Live meeting previously kept the Live UI in its stopping state while the entire meeting pipeline ran. A verified 44-minute meeting spent about 150 seconds there, which looked hung even though capture had already ended safely.

## Safety

- Recording safety remains the first boundary: the original archived WAV and JSONL stay intact.
- The background worker receives its own hard link, with a copy fallback across filesystems.
- Queue failure leaves the archived capture recoverable and tells the user processing did not start.
- Capture-only listeners are stopped before Live is released; the optional meeting processor never owns capture.

## Verification

- Signed Mac acceptance in `~/Applications/Minutes Dev.app`
  - bundle: `com.useminutes.desktop.dev`
  - authority: `Apple Development: Mathieu Silverstein (97C8UF8QVF)`
  - team: `63TMLKT8HN`
  - strict bundle seal valid
  - native hotkey diagnostic active
  - real Live recording stopped immediately, archived both WAV and JSONL, queued a separate job copy, and continued through transcription and summary generation in the background
- `cargo fmt --all -- --check`
- `cargo clippy --all --no-default-features -- -D warnings`
- `cargo check -p minutes-app`
- Focused Live archive, queue-preservation, context-link, desktop handoff, and stage-label tests
- Full `minutes-core --no-default-features --lib`: 1808 passed, 2 unrelated knowledge-layout isolation tests failed under the parallel full run and passed immediately when rerun individually; tracked locally as `minutes-lh6i`
- Design-token policy and checker suite
- Recall chunk contract
- Inline desktop JavaScript syntax
