### PR TITLE
Fix Recall Terminal input gate desynchronization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,6 +734,9 @@ jobs:
       - name: Verify Recall chat chunk contract
         run: node scripts/check_recall_chunk_contract.mjs
 
+      - name: Verify Recall terminal input privacy contract
+        run: node --test scripts/check_recall_terminal_input_contract.test.mjs
+
       - name: Test design-token checker
         run: node --test scripts/check_design_tokens.test.mjs
 

--- a/scripts/check_recall_terminal_input_contract.test.mjs
+++ b/scripts/check_recall_terminal_input_contract.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const PANEL = "tauri/src/index.html";
+const panel = readFileSync(PANEL, "utf8");
+const xterm = readFileSync("tauri/src/vendor/xterm/xterm.js", "utf8");
+
+function extractFunction(name) {
+  const asyncStart = panel.indexOf(`async function ${name}(`);
+  const start = asyncStart !== -1 ? asyncStart : panel.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `missing ${name} in ${PANEL}`);
+  const bodyStart = panel.indexOf("{", start);
+  let depth = 0;
+  for (let index = bodyStart; index < panel.length; index += 1) {
+    if (panel[index] === "{") depth += 1;
+    if (panel[index] === "}") depth -= 1;
+    if (depth === 0) return panel.slice(start, index + 1);
+  }
+  throw new Error(`unterminated ${name} in ${PANEL}`);
+}
+
+function createHarness() {
+  const source = `
+    (() => {
+      let pendingRecallTerminalMeetingPath = '/meetings/private.md';
+      let recallTerminalInputDraft = '';
+      let recallTerminalInputReliable = true;
+      const SESSION_ID = 'recall';
+      const calls = [];
+      const notices = [];
+      let prepareError = null;
+
+      async function invoke(command, args) {
+        calls.push({ command, args });
+        if (command === 'cmd_prepare_recall_terminal_meeting' && prepareError) {
+          throw new Error(prepareError);
+        }
+      }
+
+      function setRecallProviderNotice(message, level = 'info') {
+        notices.push({ message, level });
+      }
+
+      ${extractFunction("forwardRecallTerminalData")}
+      ${extractFunction("updateRecallTerminalInputDraft")}
+      ${extractFunction("forwardRecallTerminalInput")}
+
+      return {
+        send: forwardRecallTerminalData,
+        state: () => ({
+          pending: pendingRecallTerminalMeetingPath,
+          draft: recallTerminalInputDraft,
+          reliable: recallTerminalInputReliable,
+          calls: structuredClone(calls),
+          notices: structuredClone(notices),
+        }),
+        setPrepareError: (message) => { prepareError = message; },
+      };
+    })()
+  `;
+  return vm.runInNewContext(source, { structuredClone });
+}
+
+function commands(harness, command) {
+  return harness.state().calls.filter((call) => call.command === command);
+}
+
+test("xterm capability replies bypass the human-input shadow line", async () => {
+  const harness = createHarness();
+  await harness.send("\x1b[12;34R", false);
+
+  const state = harness.state();
+  assert.equal(state.draft, "");
+  assert.equal(state.reliable, true);
+  assert.equal(state.notices.length, 0);
+  assert.deepEqual(state.calls, [
+    {
+      command: "cmd_pty_input",
+      args: { sessionId: "recall", data: "\x1b[12;34R" },
+    },
+  ]);
+});
+
+test("the first plain question prepares the meeting before Return", async () => {
+  const harness = createHarness();
+  await harness.send("What did we decide?\r", true);
+
+  const state = harness.state();
+  assert.equal(state.pending, null);
+  assert.equal(state.draft, "");
+  assert.equal(state.reliable, true);
+  assert.deepEqual(
+    state.calls.map((call) => call.command),
+    ["cmd_pty_input", "cmd_prepare_recall_terminal_meeting", "cmd_pty_input"],
+  );
+  assert.equal(state.calls[2].args.data, "\r");
+});
+
+test("startup terminal replies do not poison the first real question", async () => {
+  const harness = createHarness();
+  await harness.send("\x1b[?1;2c", false);
+  await harness.send("Summarize the risks", true);
+  await harness.send("\r", true);
+
+  assert.equal(commands(harness, "cmd_prepare_recall_terminal_meeting").length, 1);
+  assert.equal(harness.state().pending, null);
+});
+
+test("slash commands pass through without reading the meeting", async () => {
+  const harness = createHarness();
+  await harness.send("/login\r", true);
+
+  const state = harness.state();
+  assert.equal(state.pending, "/meetings/private.md");
+  assert.equal(commands(harness, "cmd_prepare_recall_terminal_meeting").length, 0);
+  assert.equal(state.calls.at(-1).args.data, "\r");
+});
+
+test("Ctrl-U then Ctrl-Y cannot submit an untracked question", async () => {
+  const harness = createHarness();
+  await harness.send("secret question", true);
+  await harness.send("\x15", true);
+  await harness.send("\x19", true);
+  await harness.send("\r", true);
+
+  const state = harness.state();
+  assert.equal(state.pending, "/meetings/private.md");
+  assert.equal(commands(harness, "cmd_prepare_recall_terminal_meeting").length, 0);
+  assert.notEqual(state.calls.at(-1).args.data, "\r");
+  assert.match(state.notices.at(-1).message, /No meeting context was read/);
+});
+
+test("cursor editing holds Return until the line is cleanly retyped", async () => {
+  const harness = createHarness();
+  await harness.send("question", true);
+  await harness.send("\x1b[D", true);
+  await harness.send("\r", true);
+
+  const state = harness.state();
+  assert.equal(state.pending, "/meetings/private.md");
+  assert.equal(commands(harness, "cmd_prepare_recall_terminal_meeting").length, 0);
+  assert.notEqual(state.calls.at(-1).args.data, "\r");
+});
+
+test("an empty Return cannot bypass pending meeting preparation", async () => {
+  const harness = createHarness();
+  await harness.send("\r", true);
+
+  const state = harness.state();
+  assert.equal(state.pending, "/meetings/private.md");
+  assert.equal(state.calls.length, 0);
+  assert.match(state.notices.at(-1).message, /complete question or command/);
+});
+
+test("a preparation failure keeps both the meeting and Return pending", async () => {
+  const harness = createHarness();
+  harness.setPrepareError("not signed in");
+  await harness.send("Question", true);
+  await harness.send("\r", true);
+
+  const state = harness.state();
+  assert.equal(state.pending, "/meetings/private.md");
+  assert.equal(commands(harness, "cmd_prepare_recall_terminal_meeting").length, 1);
+  assert.notEqual(state.calls.at(-1).args?.data, "\r");
+  assert.match(state.notices.at(-1).message, /not signed in/);
+});
+
+test("the panel wires xterm's user-input signal with a fail-closed fallback", () => {
+  assert.ok(
+    xterm.includes("onUserInput=this._onUserInput.event") &&
+      xterm.includes("this.coreService=") &&
+      xterm.includes("this._core=this.register"),
+    "the vendored xterm internals used to distinguish human input changed",
+  );
+  assert.match(panel, /_core\?\.coreService\?\.onUserInput/);
+  assert.match(
+    panel,
+    /const isUserInput = !recallTerminalHasUserInputSignal \|\| recallTerminalNextDataIsUserInput/,
+  );
+});

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -13975,9 +13975,9 @@ mod tests {
         assert!(html.contains("let recallTerminalInputReliable = true;"));
         assert!(html.contains("recallTerminalInputReliable = false;"));
         assert!(html.contains(
-            "pendingRecallTerminalMeetingPath && question && !recallTerminalInputReliable"
+            "pendingRecallTerminalMeetingPath && (!question || !recallTerminalInputReliable)"
         ));
-        assert!(html.contains("no meeting context was read"));
+        assert!(html.contains("No meeting context was read"));
     }
 
     #[test]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -14338,6 +14338,8 @@
     let recallTerminalInputDraft = '';
     let recallTerminalInputReliable = true;
     let recallTerminalInputQueue = Promise.resolve();
+    let recallTerminalHasUserInputSignal = false;
+    let recallTerminalNextDataIsUserInput = false;
 
     // An informational notice ("Codex is open in Terminal. Ask your question
     // here...") earns its space exactly once: it tells you what the panel is
@@ -14806,6 +14808,19 @@
       recallFitAddon = new FitAddon.FitAddon();
       recallTerminal.loadAddon(recallFitAddon);
       recallTerminal.open(recallTerminalContainer);
+      // xterm's public onData event mixes real keyboard/paste input with
+      // automatic terminal replies generated for cursor and capability
+      // queries. Its internal user-input signal fires synchronously just
+      // before onData for keyboard, paste, and mouse input, which lets us keep
+      // those replies out of the privacy-sensitive shadow line. If a future
+      // xterm removes the signal, retain the older fail-closed behavior.
+      const onRecallTerminalUserInput = recallTerminal?._core?.coreService?.onUserInput;
+      if (typeof onRecallTerminalUserInput === 'function') {
+        recallTerminalHasUserInputSignal = true;
+        onRecallTerminalUserInput(() => {
+          recallTerminalNextDataIsUserInput = true;
+        });
+      }
       window.MINUTES_XTERM_THEME_QUERY.addEventListener('change', recallThemeHandler);
       document.addEventListener('uizoomchange', () => {
         recallTerminal.options.fontSize = getTerminalFontSize();
@@ -14847,19 +14862,30 @@
 
       recallTerminal.onData((data) => {
         if (!recallPtyAlive) return;
+        const isUserInput = !recallTerminalHasUserInputSignal || recallTerminalNextDataIsUserInput;
+        recallTerminalNextDataIsUserInput = false;
         // Typing into the terminal is the moment the "ask your question here"
-        // notice stops being useful.
-        dismissRecallProviderNotice();
+        // notice stops being useful. Automatic terminal replies are invisible
+        // plumbing and should not dismiss it.
+        if (isUserInput) dismissRecallProviderNotice();
         // Serialize PTY writes so the context-preparation command completes
         // before the Enter that submits the first real question. Normal typing
         // still follows the same one-invoke-per-input path as before.
         recallTerminalInputQueue = recallTerminalInputQueue
-          .then(() => forwardRecallTerminalInput(data))
+          .then(() => forwardRecallTerminalData(data, isUserInput))
           .catch((error) => {
             console.error('Recall terminal input:', error);
             setRecallProviderNotice(String(error), 'error');
           });
       });
+    }
+
+    async function forwardRecallTerminalData(data, isUserInput) {
+      if (!isUserInput) {
+        await invoke('cmd_pty_input', { sessionId: SESSION_ID, data });
+        return;
+      }
+      await forwardRecallTerminalInput(data);
     }
 
     function updateRecallTerminalInputDraft(data) {
@@ -14909,9 +14935,9 @@
         }
 
         const question = recallTerminalInputDraft.trim();
-        if (pendingRecallTerminalMeetingPath && question && !recallTerminalInputReliable) {
+        if (pendingRecallTerminalMeetingPath && (!question || !recallTerminalInputReliable)) {
           setRecallProviderNotice(
-            'For privacy, Minutes could not verify the edited input line. Press Ctrl-U, retype the command or question, and submit again; no meeting context was read.',
+            'For privacy, Minutes could not verify a complete question or command. Press Ctrl-U, retype it without cursor editing, and submit again. No meeting context was read.',
             'error'
           );
           return;


### PR DESCRIPTION
Fixes #910.

## What changed

- Separates real keyboard, paste, and mouse input from xterm's automatic terminal capability replies before updating the privacy-sensitive shadow line.
- Holds Return whenever a selected meeting is pending and the submitted line is empty or uncertain.
- Keeps slash commands such as `/login` and `/status` available without reading the selected meeting.
- Adds a CI contract suite covering startup terminal replies, the first real question, slash commands, Ctrl-U plus Ctrl-Y, cursor editing, empty Return, and preparation failures.

## Why

xterm's `onData` event includes both user input and automatic replies to terminal queries. Minutes treated both as user edits, which falsely blocked the first question. Separately, Ctrl-U plus Ctrl-Y could leave the assistant with a real question while Minutes believed the line was empty, allowing Return through without loading the meeting. The new contract distinguishes those paths and fails closed when the line cannot be proven.

## Verification

- `node --test scripts/check_recall_terminal_input_contract.test.mjs` (9 passed)
- `node scripts/check_recall_chunk_contract.mjs`
- inline JavaScript syntax check
- design-token baseline check
- `cargo fmt --all -- --check`
- `cargo test -p minutes-app --no-default-features` (367 passed)
- signed `Minutes Dev.app` build, valid Developer Team signature and strict bundle seal
- signed-app UI acceptance with a selected meeting and Terminal Recall; production Minutes and the active Live recording were untouched
