### PR TITLE
Fix Recall calendar prep routing in Terminal mode

### DIFF
--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -13981,6 +13981,16 @@ mod tests {
     }
 
     #[test]
+    fn recall_prep_phase_opens_the_supported_assistant_conversation_mode() {
+        let html = include_str!("../../src/index.html");
+        assert!(html.contains(
+            "const conversationMode = mode === 'prep' || mode === 'debrief' ? 'assistant' : mode;"
+        ));
+        assert!(html.contains("openRecall(conversationMode);"));
+        assert!(html.contains("if (mode === 'prep') setRecallPhase('prep', context);"));
+    }
+
+    #[test]
     fn recall_ui_hides_unavailable_chat_and_uses_the_configured_assistant_name() {
         let html = include_str!("../../src/index.html");
         assert!(html.contains("modeToggleBtn.hidden = !nativeAvailable"));

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -15532,7 +15532,8 @@
         recallNudge.classList.add('active');
         return;
       }
-      openRecall(mode === 'debrief' ? 'assistant' : mode);
+      const conversationMode = mode === 'prep' || mode === 'debrief' ? 'assistant' : mode;
+      openRecall(conversationMode);
       if (mode === 'prep') setRecallPhase('prep', context);
       else if (mode === 'debrief') setRecallPhase('debrief', context);
     }


### PR DESCRIPTION
Fixes #909.

## What changed

- Maps the calendar prep phase to the supported assistant conversation mode before opening Recall.
- Keeps the prep phase and upcoming-meeting title intact for the prep experience.
- Adds a focused regression test for the calendar plus Terminal combination.

## Verification

- cargo fmt --all -- --check
- git diff --check
- design-token baseline check
- Recall chunk contract check
- cargo test -p minutes-app --no-default-features (368 passed)
- signed Minutes Dev.app build with a valid Developer Team signature and strict bundle seal
- signed-app UI click test: Recall closed and reopened cleanly into the configured Codex conversation

The Dev app has limited Calendar access, so the exact automatic calendar trigger was verified by the focused regression test. The click test covered the resulting Recall surface without sending meeting content to an assistant. Production Minutes remained running and untouched.