### PR TITLE
feat: MCP registry server.json with release publish job; Claude plugin marketplace

### DIFF
--- a/.claude/plugins/minutes/.claude-plugin/plugin.json
+++ b/.claude/plugins/minutes/.claude-plugin/plugin.json
@@ -16,5 +16,11 @@
     "whisper",
     "conversation"
   ],
-  "category": "productivity"
+  "category": "productivity",
+  "mcpServers": {
+    "minutes": {
+      "command": "npx",
+      "args": ["-y", "minutes-mcp"]
+    }
+  }
 }

--- a/.claude/plugins/minutes/plugin.json
+++ b/.claude/plugins/minutes/plugin.json
@@ -29,6 +29,15 @@
   "agents": [
     { "name": "meeting-analyst", "path": "agents/meeting-analyst.md" }
   ],
+  "mcpServers": {
+      "minutes": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "minutes-mcp"
+        ]
+      }
+    },
   "hooks": {
       "SessionStart": [
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,6 +669,9 @@ jobs:
       - name: Verify version policy
         run: node scripts/check_version_sync.mjs
 
+      - name: Validate MCP Registry server metadata
+        run: node scripts/validate_server_json.mjs
+
       - name: Verify corpus lease mirror
         run: node scripts/check_corpus_lease_mirror.mjs
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -342,9 +342,54 @@ jobs:
           publish_crate minutes-cli
           poll_crate minutes-cli
 
+  publish_mcp_registry:
+    name: Publish MCP Registry metadata
+    needs: publish_npm
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install mcp-publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_log="$(mktemp)"
+          set +e
+          ./mcp-publisher publish 2>&1 | tee "$publish_log"
+          publish_status="${PIPESTATUS[0]}"
+          set -e
+
+          if [ "$publish_status" -eq 0 ]; then
+            rm -f "$publish_log"
+            exit 0
+          fi
+          if grep -Fqi "invalid version: cannot publish duplicate version" "$publish_log"; then
+            echo "MCP Registry already contains this server version; treating this rerun as successful."
+            rm -f "$publish_log"
+            exit 0
+          fi
+          rm -f "$publish_log"
+          exit "$publish_status"
+
   summary:
     name: Registry publish summary
-    needs: [publish_npm, publish_crates, release_readiness]
+    needs: [publish_npm, publish_crates, publish_mcp_registry, release_readiness]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -361,4 +406,5 @@ jobs:
             echo "- npm: \`minutes-mcp@$VERSION\`"
             echo "- crates.io: \`minutes-core@$VERSION\`"
             echo "- crates.io: \`minutes-cli@$VERSION\`"
+            echo "- MCP Registry: \`io.github.silverstein/minutes@$VERSION\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "minutes": {
+      "command": "npx",
+      "args": ["-y", "minutes-mcp"]
+    }
+  }
+}

--- a/crates/mcp/package.json
+++ b/crates/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "minutes-mcp",
   "version": "0.25.6",
+  "mcpName": "io.github.silverstein/minutes",
   "description": "MCP server for minutes \u2014 conversation memory for AI assistants. Works with Claude Desktop, Mistral Vibe, Cursor, Windsurf, and any MCP client.",
   "main": "dist/index.js",
   "type": "module",

--- a/docs/integration/agent-integrations.md
+++ b/docs/integration/agent-integrations.md
@@ -4,6 +4,19 @@ Minutes has several agent surfaces. Do not add a new agent by copying an existin
 integration wholesale. Pick the smallest surface that matches what the host
 actually supports.
 
+## Install the Claude Code plugin
+
+The repository is a Claude Code plugin marketplace. Add it, then install the
+Minutes plugin:
+
+```bash
+claude plugin marketplace add silverstein/minutes
+claude plugin install minutes@minutes
+```
+
+The plugin starts `npx -y minutes-mcp` automatically, so its Minutes tools are
+available without a separate MCP configuration.
+
 ## Surfaces
 
 | Surface | Use when | Examples |

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -26,6 +26,7 @@ const domainOneFiles = [
   "crates/sdk/package.json",
   "manifest.json",
   "manifest.mcpb.json",
+  "server.json",
   "crates/mcp/src/index.ts",
   "crates/mcp/package-lock.json",
   "crates/sdk/package-lock.json",
@@ -149,6 +150,21 @@ async function updateJsonVersion(root, file, readCurrent, version) {
     throw new Error(`${file} must contain exactly one live JSON version declaration`);
   }
   await writeText(root, file, text.replace(pattern, `$1${version}$2`));
+}
+
+async function updateServerJsonVersions(root, version) {
+  const file = "server.json";
+  const text = await readText(root, file);
+  const value = JSON.parse(text);
+  if (typeof value.version !== "string") {
+    throw new Error(`${file} is missing its top-level version field`);
+  }
+  if (typeof value.packages?.[0]?.version !== "string") {
+    throw new Error(`${file} is missing packages[0].version`);
+  }
+  value.version = version;
+  value.packages[0].version = version;
+  await writeText(root, file, `${JSON.stringify(value, null, 2)}\n`);
 }
 
 function workspaceVersion(text) {
@@ -291,6 +307,7 @@ async function applyDomainOneWrites(root, version) {
   ]) {
     await updateJsonVersion(root, file, (value) => value.version, version);
   }
+  await updateServerJsonVersions(root, version);
 
   await writeText(
     root,
@@ -478,6 +495,9 @@ async function main() {
       console.log(`Dry run: ${mode} version ${existingVersion} -> ${options.version}`);
       console.log("Files that would change:");
       for (const file of changedFiles) console.log(`  ${file}`);
+      if (!options.plugin) {
+        console.log(`Domain 2 verified unchanged: ${pluginFiles[0]}`);
+      }
       console.log("\nUnified diff:");
       process.stdout.write(patch);
     } else {

--- a/scripts/bump_version.test.mjs
+++ b/scripts/bump_version.test.mjs
@@ -155,6 +155,10 @@ async function makeRepo(t) {
   });
   await writeJson(root, "manifest.json", { version: initialVersion, tools: [] });
   await writeJson(root, "manifest.mcpb.json", { version: initialVersion });
+  await writeJson(root, "server.json", {
+    version: initialVersion,
+    packages: [{ version: initialVersion }],
+  });
   await writeFixture(
     root,
     "crates/mcp/src/index.ts",
@@ -268,6 +272,8 @@ test("dry-run prints its file plan and diff without touching the real tree", asy
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /Dry run: main version 1\.2\.3 -> 1\.3\.0-beta\.1/);
   assert.match(result.stdout, /Files that would change:/);
+  assert.match(result.stdout, /server\.json/);
+  assert.match(result.stdout, /Domain 2 verified unchanged: \.claude-plugin\/marketplace\.json/);
   assert.match(result.stdout, /diff --git a\/Cargo\.toml b\/Cargo\.toml/);
   assert.equal(status(root), "");
   await assertSnapshot(root, before);
@@ -287,6 +293,7 @@ test("real run updates every Domain-1 source and passes the checker", async (t) 
     "crates/sdk/package.json",
     "manifest.json",
     "manifest.mcpb.json",
+    "server.json",
     "crates/mcp/src/index.ts",
     "crates/mcp/package-lock.json",
     "crates/sdk/package-lock.json",
@@ -295,6 +302,9 @@ test("real run updates every Domain-1 source and passes the checker", async (t) 
   ]) {
     assert.equal(await readVersion(root, file), nextVersion, `${file} contains the new version`);
   }
+  const server = JSON.parse(await readFile(path.join(root, "server.json"), "utf8"));
+  assert.equal(server.version, nextVersion);
+  assert.equal(server.packages[0].version, nextVersion);
   const check = runChecker(root);
   assert.equal(check.status, 0, check.stderr || check.stdout);
   for (const pluginFile of [

--- a/scripts/check_version_sync.mjs
+++ b/scripts/check_version_sync.mjs
@@ -191,6 +191,12 @@ function collectDomains(root) {
     source("manifest.mcpb.json", ".version", () =>
       requireVersion(readJson(root, "manifest.mcpb.json").version, ".version"),
     ),
+    source("server.json", ".version", () =>
+      requireVersion(readJson(root, "server.json").version, ".version"),
+    ),
+    source("server.json", ".packages[0].version", () =>
+      requireVersion(readJson(root, "server.json").packages?.[0]?.version, ".packages[0].version"),
+    ),
     source("crates/mcp/src/index.ts", "MCP_SERVER_VERSION", () =>
       mcpServerVersion(readText(root, "crates/mcp/src/index.ts")),
     ),

--- a/scripts/check_version_sync.test.mjs
+++ b/scripts/check_version_sync.test.mjs
@@ -43,6 +43,10 @@ async function makeRepo(t) {
   await writeJson(root, "crates/sdk/package.json", { name: "minutes-sdk", version: mainVersion });
   await writeJson(root, "manifest.json", { version: mainVersion });
   await writeJson(root, "manifest.mcpb.json", { version: mainVersion });
+  await writeJson(root, "server.json", {
+    version: mainVersion,
+    packages: [{ version: mainVersion }],
+  });
   await writeFixture(
     root,
     "crates/mcp/src/index.ts",
@@ -125,7 +129,7 @@ test("matching miniature repo passes with independent plugin and ignored version
   assert.equal(report.ok, true);
   assert.equal(report.domain1.expected, mainVersion);
   assert.equal(report.domain2.expected, pluginVersion);
-  assert.equal(report.domain1.sources.length, 15);
+  assert.equal(report.domain1.sources.length, 17);
   assert.equal(report.domain2.sources.length, 3);
 });
 
@@ -161,6 +165,19 @@ const domain1Mutations = [
     key: ".version",
     mutate: (root) => mutateJson(root, file, (value) => (value.version = changedVersion)),
   })),
+  {
+    name: "server.json top-level version",
+    file: "server.json",
+    key: ".version",
+    mutate: (root) => mutateJson(root, "server.json", (value) => (value.version = changedVersion)),
+  },
+  {
+    name: "server.json package version",
+    file: "server.json",
+    key: ".packages[0].version",
+    mutate: (root) =>
+      mutateJson(root, "server.json", (value) => (value.packages[0].version = changedVersion)),
+  },
   {
     name: "MCP server constant",
     file: "crates/mcp/src/index.ts",

--- a/scripts/setup_hooks.test.mjs
+++ b/scripts/setup_hooks.test.mjs
@@ -124,6 +124,10 @@ async function makeVersionRepo(t) {
     version: mainVersion,
   });
   await writeJson(root, "manifest.json", { version: mainVersion });
+  await writeJson(root, "server.json", {
+    version: mainVersion,
+    packages: [{ registryType: "npm", identifier: "minutes-mcp", version: mainVersion }],
+  });
   await writeJson(root, "manifest.mcpb.json", { version: mainVersion });
   await writeFixture(
     root,

--- a/scripts/validate_server_json.mjs
+++ b/scripts/validate_server_json.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const serverPath = path.join(root, "server.json");
+
+function describe(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function matchesType(value, type) {
+  switch (type) {
+    case "array":
+      return Array.isArray(value);
+    case "integer":
+      return Number.isInteger(value);
+    case "null":
+      return value === null;
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "object":
+      return value !== null && typeof value === "object" && !Array.isArray(value);
+    default:
+      return typeof value === type;
+  }
+}
+
+function sameJson(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function resolveReference(schemaRoot, reference) {
+  if (!reference.startsWith("#/")) {
+    throw new Error(`unsupported external schema reference ${JSON.stringify(reference)}`);
+  }
+  return reference
+    .slice(2)
+    .split("/")
+    .map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"))
+    .reduce((value, part) => value?.[part], schemaRoot);
+}
+
+function validate(schema, value, instancePath, schemaRoot) {
+  if (schema === true) return [];
+  if (schema === false) return [`${instancePath}: rejected by schema`];
+  if (!schema || typeof schema !== "object") {
+    return [`${instancePath}: invalid schema node`];
+  }
+
+  if (schema.$ref) {
+    const referenced = resolveReference(schemaRoot, schema.$ref);
+    if (referenced === undefined) {
+      return [`${instancePath}: unresolved schema reference ${schema.$ref}`];
+    }
+    return validate(referenced, value, instancePath, schemaRoot);
+  }
+
+  const errors = [];
+  if (schema.allOf) {
+    for (const child of schema.allOf) {
+      errors.push(...validate(child, value, instancePath, schemaRoot));
+    }
+  }
+  if (schema.anyOf) {
+    const alternatives = schema.anyOf.map((child) =>
+      validate(child, value, instancePath, schemaRoot),
+    );
+    if (!alternatives.some((candidate) => candidate.length === 0)) {
+      errors.push(`${instancePath}: does not match any allowed schema`);
+    }
+  }
+  if (schema.not && validate(schema.not, value, instancePath, schemaRoot).length === 0) {
+    errors.push(`${instancePath}: matches a forbidden schema`);
+  }
+
+  if (schema.type && !matchesType(value, schema.type)) {
+    errors.push(`${instancePath}: expected ${schema.type}, found ${describe(value)}`);
+    return errors;
+  }
+  if (schema.const !== undefined && !sameJson(value, schema.const)) {
+    errors.push(`${instancePath}: expected ${JSON.stringify(schema.const)}`);
+  }
+  if (schema.enum && !schema.enum.some((candidate) => sameJson(value, candidate))) {
+    errors.push(`${instancePath}: must be one of ${schema.enum.map(JSON.stringify).join(", ")}`);
+  }
+
+  if (typeof value === "string") {
+    if (schema.minLength !== undefined && value.length < schema.minLength) {
+      errors.push(`${instancePath}: must contain at least ${schema.minLength} characters`);
+    }
+    if (schema.maxLength !== undefined && value.length > schema.maxLength) {
+      errors.push(`${instancePath}: must contain at most ${schema.maxLength} characters`);
+    }
+    if (schema.pattern && !new RegExp(schema.pattern, "u").test(value)) {
+      errors.push(`${instancePath}: does not match ${schema.pattern}`);
+    }
+    if (schema.format === "uri") {
+      try {
+        const uri = new URL(value);
+        if (!uri.protocol) throw new Error("missing scheme");
+      } catch {
+        errors.push(`${instancePath}: must be an absolute URI`);
+      }
+    }
+  }
+
+  if (Array.isArray(value) && schema.items) {
+    value.forEach((item, index) => {
+      errors.push(...validate(schema.items, item, `${instancePath}[${index}]`, schemaRoot));
+    });
+  }
+
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    for (const required of schema.required ?? []) {
+      if (!Object.hasOwn(value, required)) {
+        errors.push(`${instancePath}.${required}: required property is missing`);
+      }
+    }
+    for (const [key, child] of Object.entries(schema.properties ?? {})) {
+      if (Object.hasOwn(value, key)) {
+        errors.push(...validate(child, value[key], `${instancePath}.${key}`, schemaRoot));
+      }
+    }
+    for (const [key, child] of Object.entries(value)) {
+      if (Object.hasOwn(schema.properties ?? {}, key)) continue;
+      if (schema.additionalProperties === false) {
+        errors.push(`${instancePath}.${key}: additional property is not allowed`);
+      } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+        errors.push(
+          ...validate(schema.additionalProperties, child, `${instancePath}.${key}`, schemaRoot),
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+try {
+  const server = JSON.parse(await readFile(serverPath, "utf8"));
+  const schemaUrl = server.$schema;
+  if (
+    typeof schemaUrl !== "string" ||
+    !/^https:\/\/static\.modelcontextprotocol\.io\/schemas\/\d{4}-\d{2}-\d{2}\/server\.schema\.json$/.test(
+      schemaUrl,
+    )
+  ) {
+    throw new Error("server.json must reference a dated official MCP Registry schema URL");
+  }
+
+  const response = await fetch(schemaUrl);
+  if (!response.ok) {
+    throw new Error(`failed to fetch ${schemaUrl}: HTTP ${response.status}`);
+  }
+  const schema = await response.json();
+  if (schema.$id !== schemaUrl) {
+    throw new Error(`schema $id ${JSON.stringify(schema.$id)} does not match ${schemaUrl}`);
+  }
+
+  const errors = validate(schema, server, "$", schema);
+  if (errors.length > 0) {
+    throw new Error(`server.json does not match ${schemaUrl}:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+  console.log(`server.json is valid against ${schemaUrl}`);
+} catch (error) {
+  console.error(`validate_server_json: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.silverstein/minutes",
+  "description": "The private, owned conversation-memory layer for AI. Record, transcribe, and search every meeting.",
+  "repository": {
+    "url": "https://github.com/silverstein/minutes",
+    "source": "github"
+  },
+  "version": "0.25.6",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "minutes-mcp",
+      "version": "0.25.6",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "npx"
+    }
+  ]
+}

--- a/tooling/skills/compiler/compile.test.ts
+++ b/tooling/skills/compiler/compile.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -65,6 +65,12 @@ output:
         version: "0.0.0",
         description: "Compiler drift fixture",
         skills: [],
+        mcpServers: {
+          minutes: {
+            command: "npx",
+            args: ["-y", "minutes-mcp"],
+          },
+        },
       },
       null,
       2,
@@ -82,6 +88,12 @@ test("compile:dry passes clean generated skills and rejects drift", async (t) =>
   const generated = runCompile(repoRoot, false);
   assert.equal(generated.status, 0, generated.stderr);
   assert.match(generated.stdout, /"status":"written"/);
+  const generatedManifest = JSON.parse(
+    await readFile(path.join(repoRoot, ".claude", "plugins", "minutes", "plugin.json"), "utf8"),
+  );
+  assert.deepEqual(generatedManifest.mcpServers, {
+    minutes: { command: "npx", args: ["-y", "minutes-mcp"] },
+  });
 
   const clean = runCompile(repoRoot, true);
   assert.equal(clean.status, 0, clean.stderr);

--- a/tooling/skills/compiler/plugin.ts
+++ b/tooling/skills/compiler/plugin.ts
@@ -8,6 +8,7 @@ interface ClaudePluginManifest {
   description: string;
   skills: Array<{ name: string; path: string }>;
   agents?: Array<{ name: string; path: string }>;
+  mcpServers?: Record<string, unknown>;
   hooks?: Record<string, unknown>;
 }
 
@@ -63,6 +64,13 @@ function renderClaudePluginManifestText(manifest: ClaudePluginManifest): string 
     lines.push("  \"agents\": [");
     lines.push(manifest.agents.map((agent) => `    ${renderObjectInline(agent)}`).join(",\n"));
     lines.push("  ],");
+  }
+
+  if (manifest.mcpServers) {
+    const renderedMcpServers = renderUnknown(manifest.mcpServers, 2).split("\n");
+    lines.push(`  "mcpServers": ${renderedMcpServers[0]}`);
+    lines.push(...renderedMcpServers.slice(1).map((line) => `  ${line}`));
+    lines[lines.length - 1] += ",";
   }
 
   if (manifest.hooks) {


### PR DESCRIPTION
Makes Minutes discoverable where agents and directories look.

- `server.json` for the official MCP registry (`io.github.silverstein/minutes`, npm package `minutes-mcp`, stdio, `npx` runtime hint), validated against the registry schema in CI by a new `scripts/validate_server_json.mjs`.
- `mcpName` added to `crates/mcp/package.json` (the registry's npm ownership check).
- Release workflow: a `publish_mcp_registry` job after the npm publish, GitHub OIDC login, idempotent on the registry's duplicate-version error, reported in the release summary.
- `bump-version.mjs` rewrites `server.json`; `check_version_sync.mjs` enforces it (tests added).
- Claude plugin: `plugin.json` now declares the MCP server (`npx -y minutes-mcp`) via the skills compiler, so installing the plugin from the marketplace also installs the server. `docs/integration/agent-integrations.md` documents `claude plugin marketplace add silverstein/minutes`.
- Root `.mcp.json` so directories that auto-detect it (cursor.directory) pick the server up.

Nothing is published by this PR; the registry job runs on the next tag. PulseMCP ingests from the official registry, so that listing follows automatically.