### PR TITLE
docs: OpenClaw and Hermes-agent integration guides; minutes-mcp-recall routing skill

### DIFF
--- a/.agents/skills/minutes/minutes-mcp-recall/SKILL.md
+++ b/.agents/skills/minutes/minutes-mcp-recall/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: minutes-mcp-recall
+description: Route meeting-recall questions to the right Minutes MCP tool.
+---
+
+## Skill Path
+
+Before running helper scripts or opening bundled references, set:
+
+```bash
+export MINUTES_SKILLS_ROOT="$(git rev-parse --show-toplevel)/.agents/skills/minutes"
+export MINUTES_SKILL_ROOT="$MINUTES_SKILLS_ROOT/minutes-mcp-recall"
+```
+
+# /minutes-mcp-recall
+
+Route a meeting-memory question to the smallest useful Minutes MCP tool. This
+skill is tool-name-oriented for MCP hosts such as OpenClaw, Hermes-agent, and
+other MCP clients. Use `minutes-search` instead when the host only has CLI or
+shell access.
+
+Read [the complete tool map](references/tool-map.md) only when the decision
+table does not cover the request.
+
+## Decision table
+
+| User is asking... | Call |
+|---|---|
+| "What did we say about X?" or "Find that meeting about Y." | `search_meetings` |
+| "What is the full transcript of this specific meeting?" | `get_meeting` after finding its id or date with `list_meetings` or `search_meetings` |
+| About what is happening right now, mid-call | `read_live_transcript` with a cursor or time window |
+| "What do I still owe?" or "Who owes me?" | `track_commitments` |
+| "What is my history with this person?" | `get_person_profile` or `relationship_map` |
+| "Have I contradicted myself?" or "Which decisions are stale?" | `consistency_report` |
+| Broad research across many meetings | `research_topic` |
+
+## Tool-name prefix by host
+
+- OpenClaw and generic MCP clients use bare tool names such as
+  `search_meetings`.
+- Hermes-agent prefixes each tool with `mcp_minutes_`, so
+  `search_meetings` becomes `mcp_minutes_search_meetings`.
+
+Apply the same prefix rule to every tool in the decision table and tool map.
+
+## Anti-patterns
+
+- Do not call `get_meeting` speculatively to browse. It returns a full
+  transcript. Use `search_meetings` or `list_meetings` first to find the right
+  id or date and preserve context budget.
+- Do not call `read_live_transcript` without a cursor after one is available.
+  Replaying the whole transcript wastes tokens and duplicates content already
+  in context.
+- Do not use capture, dictation, processing, annotation, or speaker-mutation
+  tools for a recall question.
+

--- a/.agents/skills/minutes/minutes-mcp-recall/agents/openai.yaml
+++ b/.agents/skills/minutes/minutes-mcp-recall/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Minutes MCP Recall"
+  short_description: "Route meeting-recall questions to the right Minutes MCP tool."
+  default_prompt: "Use Minutes MCP Recall to choose the smallest read-only Minutes MCP tool for this question."

--- a/.agents/skills/minutes/minutes-mcp-recall/references/tool-map.md
+++ b/.agents/skills/minutes/minutes-mcp-recall/references/tool-map.md
@@ -1,0 +1,43 @@
+# Minutes MCP tool map
+
+> Generated from `manifest.json` by `node scripts/generate_llms_txt.mjs`.
+> Do not edit by hand.
+
+This manifest contains 34 MCP tools.
+
+| Tool | Description |
+|---|---|
+| `start_recording` | Start recording audio from the default input device |
+| `stop_recording` | Stop the current recording and process it |
+| `get_status` | Check if a recording is currently in progress |
+| `list_processing_jobs` | List background processing jobs for recent recordings |
+| `list_meetings` | List recent normal meetings and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `search_meetings` | Search normal meeting transcripts and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `get_meeting` | Get a normal meeting transcript; restricted meetings return a content-free stub unless an explicit logged override is enabled and requested |
+| `activity_summary` | Summarize desktop context bound to one exact normal meeting source |
+| `search_context` | Search desktop-context events bound to one exact normal meeting source |
+| `get_moment` | Show the local desktop-context rewind bound to one exact normal meeting source |
+| `get_screen_context` | Retrieve bounded, verified screenshots bound to one exact normal meeting source |
+| `process_audio` | On macOS and Linux, process bounded inbox or Downloads WAV audio; compressed/private containers and Windows fail closed without reading audio; retained library recordings are unavailable |
+| `add_note` | Add a timestamped note to the current active recording; existing meeting files are not mutable from this assistant tool |
+| `consistency_report` | Flag conflicting decisions and stale commitments |
+| `get_person_profile` | Build a profile from policy-authorized meetings within supported corpus bounds |
+| `research_topic` | Research a topic across policy-authorized meetings within supported corpus bounds |
+| `start_dictation` | Start dictation mode — speech to clipboard and daily notes |
+| `stop_dictation` | Stop dictation mode |
+| `track_commitments` | List open and stale commitments, optionally filtered by person |
+| `relationship_map` | Rank relationships from the bounded process-private policy-safe graph projection |
+| `list_voices` | List enrolled voice profiles for speaker identification |
+| `confirm_speaker` | Compatibility name only: agent-controlled speaker mutation is unavailable; use the Minutes app or human CLI |
+| `get_meeting_insights` | Query decisions, commitments, and questions extracted from meetings; each insight records a path to its source meeting, that path is resolved to a meeting in the live corpus and the resolved meeting is re-verified against live sensitivity policy before release, and withheld records are reported as a partial view |
+| `start_live_transcript` | Start a live transcript session for real-time meeting transcription |
+| `read_live_transcript` | Read utterances from the active live transcript with optional cursor or time window |
+| `start_copilot` | Start the independent real-time copilot for a goal and observe its CLI nudge stream |
+| `stop_copilot` | Stop the active real-time copilot without changing recording or live transcription |
+| `copilot_status` | Read current copilot session and provider health from the CLI status surface |
+| `read_copilot_nudges` | Read observed copilot nudges incrementally by cursor or time window |
+| `ingest_meeting` | Extract facts from a meeting and update the knowledge base (person profiles, log, index) |
+| `resummarize_meeting` | Re-run the AI pass on an edited meeting or memo, previewing by default and preserving user edits |
+| `knowledge_status` | Show the current state of the knowledge base — configuration, adapter, people count, log entries |
+| `add_agent_annotation` | Append attributed agent commentary as an agent.annotation event, never editing meeting markdown or frontmatter (allowlist-gated by ~/.minutes/agents.allow) |
+| `get_agent_annotations` | Compatibility name only: unavailable because an annotation's source pointer and body are both author-supplied, so revalidating the pointer cannot bound what the body discloses |

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "minutes",
       "source": "./.claude/plugins/minutes",
-      "description": "22 skills + 1 agent + 2 hooks for the full meeting lifecycle: brief, prep, record, Coach, live sidekick, tag, debrief, mirror, weekly synthesis, entity graph, video review, release notes, and cross-device voice memo recall",
+      "description": "23 skills + 1 agent + 2 hooks for the full meeting lifecycle: brief, prep, record, Coach, live sidekick, tag, debrief, mirror, weekly synthesis, entity graph, video review, release notes, and cross-device voice memo recall",
       "version": "0.21.0",
       "author": {
         "name": "Mat Silverstein"

--- a/.claude/plugins/minutes/.claude-plugin/plugin.json
+++ b/.claude/plugins/minutes/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "minutes",
   "version": "0.21.0",
-  "description": "Conversation memory for AI assistants — record, transcribe, search meetings and voice memos. 22 skills + 1 agent + 2 hooks.",
+  "description": "Conversation memory for AI assistants — record, transcribe, search meetings and voice memos. 23 skills + 1 agent + 2 hooks.",
   "author": {
     "name": "Mat Silverstein"
   },

--- a/.claude/plugins/minutes/plugin.json
+++ b/.claude/plugins/minutes/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "minutes",
   "version": "0.21.0",
-  "description": "Conversation memory for AI assistants — record, transcribe, search meetings and voice memos. 22 skills for the full meeting lifecycle: brief → prep → record → Coach → live sidekick → tag → debrief → mirror → weekly → graph → video-review.",
+  "description": "Conversation memory for AI assistants — record, transcribe, search meetings and voice memos. 23 skills for the full meeting lifecycle: brief → prep → record → Coach → live sidekick → tag → debrief → mirror → weekly → graph → video-review.",
   "skills": [
     { "name": "minutes-record", "path": "skills/minutes-record/SKILL.md" },
     { "name": "minutes-search", "path": "skills/minutes-search/SKILL.md" },

--- a/.claude/plugins/minutes/plugin.json
+++ b/.claude/plugins/minutes/plugin.json
@@ -24,7 +24,8 @@
     { "name": "minutes-video-review", "path": "skills/minutes-video-review/SKILL.md" },
     { "name": "minutes-copilot", "path": "skills/minutes-copilot/SKILL.md" },
     { "name": "minutes-live-sidekick", "path": "skills/minutes-live-sidekick/SKILL.md" },
-    { "name": "minutes-release-notes", "path": "skills/minutes-release-notes/SKILL.md" }
+    { "name": "minutes-release-notes", "path": "skills/minutes-release-notes/SKILL.md" },
+    { "name": "minutes-mcp-recall", "path": "skills/minutes-mcp-recall/SKILL.md" }
   ],
   "agents": [
     { "name": "meeting-analyst", "path": "agents/meeting-analyst.md" }

--- a/.claude/plugins/minutes/skills/minutes-mcp-recall/SKILL.md
+++ b/.claude/plugins/minutes/skills/minutes-mcp-recall/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: minutes-mcp-recall
+description: Route meeting-recall questions to the right Minutes MCP tool.
+user_invocable: true
+---
+
+# /minutes-mcp-recall
+
+Route a meeting-memory question to the smallest useful Minutes MCP tool. This
+skill is tool-name-oriented for MCP hosts such as OpenClaw, Hermes-agent, and
+other MCP clients. Use `minutes-search` instead when the host only has CLI or
+shell access.
+
+Read [the complete tool map](references/tool-map.md) only when the decision
+table does not cover the request.
+
+## Decision table
+
+| User is asking... | Call |
+|---|---|
+| "What did we say about X?" or "Find that meeting about Y." | `search_meetings` |
+| "What is the full transcript of this specific meeting?" | `get_meeting` after finding its id or date with `list_meetings` or `search_meetings` |
+| About what is happening right now, mid-call | `read_live_transcript` with a cursor or time window |
+| "What do I still owe?" or "Who owes me?" | `track_commitments` |
+| "What is my history with this person?" | `get_person_profile` or `relationship_map` |
+| "Have I contradicted myself?" or "Which decisions are stale?" | `consistency_report` |
+| Broad research across many meetings | `research_topic` |
+
+## Tool-name prefix by host
+
+- OpenClaw and generic MCP clients use bare tool names such as
+  `search_meetings`.
+- Hermes-agent prefixes each tool with `mcp_minutes_`, so
+  `search_meetings` becomes `mcp_minutes_search_meetings`.
+
+Apply the same prefix rule to every tool in the decision table and tool map.
+
+## Anti-patterns
+
+- Do not call `get_meeting` speculatively to browse. It returns a full
+  transcript. Use `search_meetings` or `list_meetings` first to find the right
+  id or date and preserve context budget.
+- Do not call `read_live_transcript` without a cursor after one is available.
+  Replaying the whole transcript wastes tokens and duplicates content already
+  in context.
+- Do not use capture, dictation, processing, annotation, or speaker-mutation
+  tools for a recall question.
+

--- a/.claude/plugins/minutes/skills/minutes-mcp-recall/references/tool-map.md
+++ b/.claude/plugins/minutes/skills/minutes-mcp-recall/references/tool-map.md
@@ -1,0 +1,43 @@
+# Minutes MCP tool map
+
+> Generated from `manifest.json` by `node scripts/generate_llms_txt.mjs`.
+> Do not edit by hand.
+
+This manifest contains 34 MCP tools.
+
+| Tool | Description |
+|---|---|
+| `start_recording` | Start recording audio from the default input device |
+| `stop_recording` | Stop the current recording and process it |
+| `get_status` | Check if a recording is currently in progress |
+| `list_processing_jobs` | List background processing jobs for recent recordings |
+| `list_meetings` | List recent normal meetings and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `search_meetings` | Search normal meeting transcripts and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `get_meeting` | Get a normal meeting transcript; restricted meetings return a content-free stub unless an explicit logged override is enabled and requested |
+| `activity_summary` | Summarize desktop context bound to one exact normal meeting source |
+| `search_context` | Search desktop-context events bound to one exact normal meeting source |
+| `get_moment` | Show the local desktop-context rewind bound to one exact normal meeting source |
+| `get_screen_context` | Retrieve bounded, verified screenshots bound to one exact normal meeting source |
+| `process_audio` | On macOS and Linux, process bounded inbox or Downloads WAV audio; compressed/private containers and Windows fail closed without reading audio; retained library recordings are unavailable |
+| `add_note` | Add a timestamped note to the current active recording; existing meeting files are not mutable from this assistant tool |
+| `consistency_report` | Flag conflicting decisions and stale commitments |
+| `get_person_profile` | Build a profile from policy-authorized meetings within supported corpus bounds |
+| `research_topic` | Research a topic across policy-authorized meetings within supported corpus bounds |
+| `start_dictation` | Start dictation mode — speech to clipboard and daily notes |
+| `stop_dictation` | Stop dictation mode |
+| `track_commitments` | List open and stale commitments, optionally filtered by person |
+| `relationship_map` | Rank relationships from the bounded process-private policy-safe graph projection |
+| `list_voices` | List enrolled voice profiles for speaker identification |
+| `confirm_speaker` | Compatibility name only: agent-controlled speaker mutation is unavailable; use the Minutes app or human CLI |
+| `get_meeting_insights` | Query decisions, commitments, and questions extracted from meetings; each insight records a path to its source meeting, that path is resolved to a meeting in the live corpus and the resolved meeting is re-verified against live sensitivity policy before release, and withheld records are reported as a partial view |
+| `start_live_transcript` | Start a live transcript session for real-time meeting transcription |
+| `read_live_transcript` | Read utterances from the active live transcript with optional cursor or time window |
+| `start_copilot` | Start the independent real-time copilot for a goal and observe its CLI nudge stream |
+| `stop_copilot` | Stop the active real-time copilot without changing recording or live transcription |
+| `copilot_status` | Read current copilot session and provider health from the CLI status surface |
+| `read_copilot_nudges` | Read observed copilot nudges incrementally by cursor or time window |
+| `ingest_meeting` | Extract facts from a meeting and update the knowledge base (person profiles, log, index) |
+| `resummarize_meeting` | Re-run the AI pass on an edited meeting or memo, previewing by default and preserving user edits |
+| `knowledge_status` | Show the current state of the knowledge base — configuration, adapter, people count, log entries |
+| `add_agent_annotation` | Append attributed agent commentary as an agent.annotation event, never editing meeting markdown or frontmatter (allowlist-gated by ~/.minutes/agents.allow) |
+| `get_agent_annotations` | Compatibility name only: unavailable because an annotation's source pointer and body are both author-supplied, so revalidating the pointer cannot bound what the body discloses |

--- a/.opencode/commands/minutes-mcp-recall.md
+++ b/.opencode/commands/minutes-mcp-recall.md
@@ -1,0 +1,9 @@
+---
+description: Route meeting-recall questions to the right Minutes MCP tool.
+---
+
+Load the `minutes-mcp-recall` skill and follow it exactly for this request.
+
+User arguments: $ARGUMENTS
+
+If no arguments were provided, use the skill's normal no-argument/default flow instead of stopping to ask for input.

--- a/.opencode/skills/minutes-mcp-recall/SKILL.md
+++ b/.opencode/skills/minutes-mcp-recall/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: minutes-mcp-recall
+description: Route meeting-recall questions to the right Minutes MCP tool.
+compatibility: opencode
+---
+
+## Skill Path
+
+Before running helper scripts or opening bundled references, set:
+
+```bash
+export MINUTES_SKILLS_ROOT="$(git rev-parse --show-toplevel)/.opencode/skills"
+export MINUTES_SKILL_ROOT="$MINUTES_SKILLS_ROOT/minutes-mcp-recall"
+```
+
+# /minutes-mcp-recall
+
+Route a meeting-memory question to the smallest useful Minutes MCP tool. This
+skill is tool-name-oriented for MCP hosts such as OpenClaw, Hermes-agent, and
+other MCP clients. Use `minutes-search` instead when the host only has CLI or
+shell access.
+
+Read [the complete tool map](references/tool-map.md) only when the decision
+table does not cover the request.
+
+## Decision table
+
+| User is asking... | Call |
+|---|---|
+| "What did we say about X?" or "Find that meeting about Y." | `search_meetings` |
+| "What is the full transcript of this specific meeting?" | `get_meeting` after finding its id or date with `list_meetings` or `search_meetings` |
+| About what is happening right now, mid-call | `read_live_transcript` with a cursor or time window |
+| "What do I still owe?" or "Who owes me?" | `track_commitments` |
+| "What is my history with this person?" | `get_person_profile` or `relationship_map` |
+| "Have I contradicted myself?" or "Which decisions are stale?" | `consistency_report` |
+| Broad research across many meetings | `research_topic` |
+
+## Tool-name prefix by host
+
+- OpenClaw and generic MCP clients use bare tool names such as
+  `search_meetings`.
+- Hermes-agent prefixes each tool with `mcp_minutes_`, so
+  `search_meetings` becomes `mcp_minutes_search_meetings`.
+
+Apply the same prefix rule to every tool in the decision table and tool map.
+
+## Anti-patterns
+
+- Do not call `get_meeting` speculatively to browse. It returns a full
+  transcript. Use `search_meetings` or `list_meetings` first to find the right
+  id or date and preserve context budget.
+- Do not call `read_live_transcript` without a cursor after one is available.
+  Replaying the whole transcript wastes tokens and duplicates content already
+  in context.
+- Do not use capture, dictation, processing, annotation, or speaker-mutation
+  tools for a recall question.
+

--- a/.opencode/skills/minutes-mcp-recall/references/tool-map.md
+++ b/.opencode/skills/minutes-mcp-recall/references/tool-map.md
@@ -1,0 +1,43 @@
+# Minutes MCP tool map
+
+> Generated from `manifest.json` by `node scripts/generate_llms_txt.mjs`.
+> Do not edit by hand.
+
+This manifest contains 34 MCP tools.
+
+| Tool | Description |
+|---|---|
+| `start_recording` | Start recording audio from the default input device |
+| `stop_recording` | Stop the current recording and process it |
+| `get_status` | Check if a recording is currently in progress |
+| `list_processing_jobs` | List background processing jobs for recent recordings |
+| `list_meetings` | List recent normal meetings and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `search_meetings` | Search normal meeting transcripts and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `get_meeting` | Get a normal meeting transcript; restricted meetings return a content-free stub unless an explicit logged override is enabled and requested |
+| `activity_summary` | Summarize desktop context bound to one exact normal meeting source |
+| `search_context` | Search desktop-context events bound to one exact normal meeting source |
+| `get_moment` | Show the local desktop-context rewind bound to one exact normal meeting source |
+| `get_screen_context` | Retrieve bounded, verified screenshots bound to one exact normal meeting source |
+| `process_audio` | On macOS and Linux, process bounded inbox or Downloads WAV audio; compressed/private containers and Windows fail closed without reading audio; retained library recordings are unavailable |
+| `add_note` | Add a timestamped note to the current active recording; existing meeting files are not mutable from this assistant tool |
+| `consistency_report` | Flag conflicting decisions and stale commitments |
+| `get_person_profile` | Build a profile from policy-authorized meetings within supported corpus bounds |
+| `research_topic` | Research a topic across policy-authorized meetings within supported corpus bounds |
+| `start_dictation` | Start dictation mode — speech to clipboard and daily notes |
+| `stop_dictation` | Stop dictation mode |
+| `track_commitments` | List open and stale commitments, optionally filtered by person |
+| `relationship_map` | Rank relationships from the bounded process-private policy-safe graph projection |
+| `list_voices` | List enrolled voice profiles for speaker identification |
+| `confirm_speaker` | Compatibility name only: agent-controlled speaker mutation is unavailable; use the Minutes app or human CLI |
+| `get_meeting_insights` | Query decisions, commitments, and questions extracted from meetings; each insight records a path to its source meeting, that path is resolved to a meeting in the live corpus and the resolved meeting is re-verified against live sensitivity policy before release, and withheld records are reported as a partial view |
+| `start_live_transcript` | Start a live transcript session for real-time meeting transcription |
+| `read_live_transcript` | Read utterances from the active live transcript with optional cursor or time window |
+| `start_copilot` | Start the independent real-time copilot for a goal and observe its CLI nudge stream |
+| `stop_copilot` | Stop the active real-time copilot without changing recording or live transcription |
+| `copilot_status` | Read current copilot session and provider health from the CLI status surface |
+| `read_copilot_nudges` | Read observed copilot nudges incrementally by cursor or time window |
+| `ingest_meeting` | Extract facts from a meeting and update the knowledge base (person profiles, log, index) |
+| `resummarize_meeting` | Re-run the AI pass on an edited meeting or memo, previewing by default and preserving user edits |
+| `knowledge_status` | Show the current state of the knowledge base — configuration, adapter, people count, log entries |
+| `add_agent_annotation` | Append attributed agent commentary as an agent.annotation event, never editing meeting markdown or frontmatter (allowlist-gated by ~/.minutes/agents.allow) |
+| `get_agent_annotations` | Compatibility name only: unavailable because an annotation's source pointer and body are both author-supplied, so revalidating the pointer cannot bound what the body discloses |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ quality. See the full [persona notes](docs/personas.md).
 | Desktop app | Menu bar capture, Recall, documents, and Coach. | [Install](docs/install.md#desktop-app) |
 | CLI (58 commands) | Local recording, processing, search, import, and automation. | [Commands](docs/features.md) |
 | MCP server (34 tools) | Local meeting tools and resources for any MCP client. | [MCP reference](docs/integration/agent-integrations.md) |
-| Claude Code plugin (22 skills) | Prep, capture, live help, debrief, and memory workflows. | [Client setup](docs/integration/clients.md#claude-code-plugin) |
+| Claude Code plugin (23 skills) | Prep, capture, live help, debrief, and memory workflows. | [Client setup](docs/integration/clients.md#claude-code-plugin) |
 | SDK | TypeScript access to meeting files without MCP. | [Agent architecture](docs/architecture/README.md#building-your-own-agent-on-minutes) |
 
 ## Output format

--- a/docs/integration/agent-integrations.md
+++ b/docs/integration/agent-integrations.md
@@ -9,8 +9,8 @@ actually supports.
 | Surface | Use when | Examples |
 |---|---|---|
 | Raw files | The agent can read `~/meetings/` directly. | Cursor, any local coding agent |
-| MCP server | The host supports MCP tools/resources/prompts. | Claude Desktop, Codex, Gemini CLI |
-| Portable skills | The host discovers Agent Skills-style `.agents/skills` folders. | Codex, Gemini CLI, Pi |
+| MCP server | The host supports MCP tools/resources/prompts. | Claude Desktop, Codex, Gemini CLI, OpenClaw, Hermes-agent |
+| Portable skills | The host discovers Agent Skills-style `.agents/skills` folders. | Codex, Gemini CLI, Pi, OpenClaw, Hermes-agent |
 | Host-specific skills | The host needs a different generated shape. | Claude Code plugin, OpenCode commands |
 | `agent_command` backend | Minutes should call the agent CLI for summaries. | `claude`, `codex`, `opencode`, `pi`, `agent` (Cursor Agent CLI) |
 | OpenAI-compatible model backend | Minutes should call a model API directly, not an agent CLI. | OpenRouter, Vercel AI Gateway, Cloudflare AI Gateway, llama.cpp, vLLM |

--- a/docs/integration/hermes-agent.md
+++ b/docs/integration/hermes-agent.md
@@ -1,0 +1,67 @@
+# Hermes-agent support
+
+Minutes works with [Hermes-agent](https://github.com/NousResearch/hermes-agent)
+as a local MCP server and through the portable `.agents/skills/minutes/` skill
+tree that Hermes-agent reads natively.
+
+## What is wired
+
+- `minutes-mcp` runs as a local stdio MCP server.
+- Hermes-agent exposes Minutes tools with an `mcp_minutes_` prefix.
+- Minutes' portable skills use the same Agent Skills format Hermes-agent
+  supports.
+
+## MCP server
+
+Add Minutes to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  minutes:
+    command: "npx"
+    args: ["-y", "minutes-mcp"]
+    enabled: true
+    timeout: 20000
+```
+
+Inside an active Hermes-agent session, reload MCP servers without restarting:
+
+```text
+/reload-mcp
+```
+
+Hermes-agent prefixes MCP tool names to avoid collisions. Minutes'
+`search_meetings` tool therefore appears as
+`mcp_minutes_search_meetings`. Skills and prompts written specifically for
+Hermes-agent should use the prefixed names.
+
+## Skills
+
+Hermes-agent discovers `.agents/skills/` at a project root. Running it from a
+Minutes checkout therefore makes `.agents/skills/minutes/*` available without
+another generated skill tree.
+
+To reuse the skills from another project, add the Minutes skill directory to
+`~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  external_dirs:
+    - /path/to/minutes/.agents/skills/minutes
+```
+
+Hermes-agent also supports installing skills from external sources. Check the
+installed CLI's syntax before using a repository path:
+
+```bash
+hermes skills install --help
+```
+
+Use `minutes-mcp-recall` for guidance on choosing a read or recall tool. Apply
+Hermes-agent's `mcp_minutes_` prefix to the tool name selected by the skill.
+
+## Memory-provider plugin
+
+Minutes does not currently ship a Hermes-agent memory-provider plugin. MCP
+registration does not replace the single provider selected under
+`memory.provider`, so Minutes recall can coexist with that provider.

--- a/docs/integration/openclaw.md
+++ b/docs/integration/openclaw.md
@@ -1,0 +1,91 @@
+# OpenClaw support
+
+Minutes works with [OpenClaw](https://github.com/openclaw/openclaw) in two
+ways: as an MCP server, which is the recommended path and works today, and
+through the portable `.agents/skills/minutes/` skill tree that OpenClaw reads
+natively.
+
+## What is wired
+
+- `minutes-mcp` runs as a local stdio MCP server.
+- OpenClaw can expose only the read and recall tools useful to a headless agent.
+- Minutes' portable skills use the same Agent Skills format OpenClaw supports.
+
+## MCP server
+
+Register Minutes from the command line:
+
+```bash
+openclaw mcp add minutes \
+  --command npx \
+  --arg -y --arg minutes-mcp \
+  --cwd ~
+openclaw mcp doctor minutes --probe
+```
+
+Or add a filtered server directly to `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  mcp: {
+    servers: {
+      minutes: {
+        command: "npx",
+        args: ["-y", "minutes-mcp"],
+        transport: "stdio",
+        enabled: true,
+        connectionTimeoutMs: 5000,
+        requestTimeoutMs: 20000,
+        toolFilter: {
+          include: [
+            "search_meetings",
+            "get_meeting",
+            "list_meetings",
+            "read_live_transcript",
+            "track_commitments",
+            "get_person_profile",
+            "consistency_report",
+            "research_topic",
+            "relationship_map",
+          ],
+        },
+      },
+    },
+  },
+}
+```
+
+The filter keeps capture, dictation, processing, annotation, and speaker tools
+away from a headless agent. Those tools only make sense on the machine and in
+the workflow where Minutes is actively capturing audio.
+
+## Skills
+
+Point OpenClaw at the existing skill tree instead of copying it:
+
+```json5
+{
+  skills: {
+    load: {
+      extraDirs: ["/path/to/minutes/.agents/skills/minutes"],
+    },
+  },
+}
+```
+
+Alternatively, link that directory at `~/.agents/skills/minutes`. OpenClaw also
+discovers `.agents/skills` within a workspace automatically.
+
+If an agent has an explicit skill allowlist in `agents.defaults.skills` or
+`agents.entries.<id>.skills`, add the Minutes skills there. An explicit list
+replaces the defaults rather than extending them.
+
+Use `minutes-mcp-recall` for guidance on choosing a read or recall tool. It uses
+bare MCP names such as `search_meetings` for OpenClaw.
+
+## Memory-provider plugin
+
+Minutes does not currently ship an OpenClaw memory-provider plugin. The MCP
+server remains available as ordinary agent tools and can coexist with the
+memory provider already selected in OpenClaw. OpenClaw's Active Memory lane
+does not automatically call arbitrary MCP servers.

--- a/scripts/generate_llms_txt.mjs
+++ b/scripts/generate_llms_txt.mjs
@@ -12,6 +12,15 @@ const llmsPath = join(repoRoot, "site", "public", "llms.txt");
 const llmsFullPath = join(repoRoot, "site", "public", "llms-full.txt");
 const productSurfacesPath = join(repoRoot, "site", "lib", "product-surfaces.json");
 const skillsCatalogPath = join(repoRoot, "site", "lib", "skills-catalog.json");
+const mcpRecallToolMapPath = join(
+  repoRoot,
+  "tooling",
+  "skills",
+  "sources",
+  "minutes-mcp-recall",
+  "references",
+  "tool-map.md"
+);
 const forAgentsBaseUrl = "https://useminutes.app/for-agents";
 const mcpToolsMarkdownPath = join(repoRoot, "site", "public", "docs", "mcp", "tools.md");
 const mcpToolsDataPath = join(repoRoot, "site", "app", "docs", "mcp", "tools", "data.json");
@@ -698,6 +707,27 @@ function buildMcpToolsData({ manifest, resources }) {
   );
 }
 
+function buildMcpRecallToolMap({ manifest }) {
+  const rows = manifest.tools
+    .map(
+      (tool) =>
+        `| \`${tool.name}\` | ${tool.description.replaceAll("|", "\\|")} |`
+    )
+    .join("\n");
+
+  return `# Minutes MCP tool map
+
+> Generated from \`manifest.json\` by \`node scripts/generate_llms_txt.mjs\`.
+> Do not edit by hand.
+
+This manifest contains ${manifest.tools.length} MCP tools.
+
+| Tool | Description |
+|---|---|
+${rows}
+`;
+}
+
 async function main() {
   const checkMode = process.argv.includes("--check");
 
@@ -759,6 +789,7 @@ async function main() {
   const nextFull = buildLlmsFull({ manifest, resources, surfaces, skillsCatalog });
   const nextMcpToolsMarkdown = buildMcpToolsMarkdown({ manifest, resources });
   const nextMcpToolsData = buildMcpToolsData({ manifest, resources });
+  const nextMcpRecallToolMap = buildMcpRecallToolMap({ manifest });
   const nextErrorsMarkdown = buildErrorsMarkdown(errorEntries);
   const nextErrorsData = buildErrorsData(errorEntries);
 
@@ -783,6 +814,8 @@ async function main() {
       staleFiles.push(mcpToolsMarkdownPath);
     if (await compare(mcpToolsDataPath, nextMcpToolsData))
       staleFiles.push(mcpToolsDataPath);
+    if (await compare(mcpRecallToolMapPath, nextMcpRecallToolMap))
+      staleFiles.push(mcpRecallToolMapPath);
     if (await compare(errorsMarkdownPath, nextErrorsMarkdown))
       staleFiles.push(errorsMarkdownPath);
     if (await compare(errorsDataPath, nextErrorsData))
@@ -804,6 +837,7 @@ async function main() {
   await mkdir(dirname(llmsFullPath), { recursive: true });
   await mkdir(dirname(mcpToolsMarkdownPath), { recursive: true });
   await mkdir(dirname(mcpToolsDataPath), { recursive: true });
+  await mkdir(dirname(mcpRecallToolMapPath), { recursive: true });
   await mkdir(dirname(errorsMarkdownPath), { recursive: true });
   await mkdir(dirname(errorsDataPath), { recursive: true });
 
@@ -811,6 +845,7 @@ async function main() {
   await writeFile(llmsFullPath, nextFull, "utf8");
   await writeFile(mcpToolsMarkdownPath, nextMcpToolsMarkdown, "utf8");
   await writeFile(mcpToolsDataPath, nextMcpToolsData, "utf8");
+  await writeFile(mcpRecallToolMapPath, nextMcpRecallToolMap, "utf8");
   await writeFile(errorsMarkdownPath, nextErrorsMarkdown, "utf8");
   await writeFile(errorsDataPath, nextErrorsData, "utf8");
   console.log(`Updated ${llmsPath}`);

--- a/site/lib/release.ts
+++ b/site/lib/release.ts
@@ -9,7 +9,7 @@ export const MINUTES_MCP_TOOL_COUNT = 34;
 export const MINUTES_MCP_RESOURCE_COUNT = 11;
 export const MINUTES_MCP_PROMPT_COUNT = 6;
 export const MINUTES_CLI_COMMAND_COUNT = 58;
-export const MINUTES_TEST_COUNT = 2984;
+export const MINUTES_TEST_COUNT = 2987;
 
 export const APPLE_SILICON_DMG =
   `https://github.com/silverstein/minutes/releases/download/${MINUTES_RELEASE_TAG}/Minutes_${MINUTES_RELEASE_VERSION}_aarch64.dmg`;

--- a/site/lib/skills-catalog.json
+++ b/site/lib/skills-catalog.json
@@ -343,6 +343,26 @@
     "userInvocable": true
   },
   {
+    "name": "minutes-mcp-recall",
+    "displayName": "Minutes MCP Recall",
+    "category": "Search",
+    "shortDescription": "Route meeting-recall questions to the right Minutes MCP tool.",
+    "description": "Route meeting-recall questions to the right Minutes MCP tool.",
+    "bestFor": "Route a meeting-memory question to the smallest useful read-only MCP tool.",
+    "example": "/minutes-mcp-recall what did we discuss about pricing?",
+    "triggers": [
+      "what did we say about",
+      "find that meeting about",
+      "get the full transcript",
+      "what do I still owe",
+      "who owes me",
+      "what is my history with",
+      "research across my meetings"
+    ],
+    "phase": null,
+    "userInvocable": true
+  },
+  {
     "name": "minutes-search",
     "displayName": "Minutes Search",
     "category": "Search",

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -212,6 +212,10 @@ Workflow-level skills that wrap MCP tools into operator motions. Install in Clau
 
 ### Search
 
+- `/minutes-mcp-recall` — Route a meeting-memory question to the smallest useful read-only MCP tool.
+  - Description: Route meeting-recall questions to the right Minutes MCP tool.
+  - Example: `/minutes-mcp-recall what did we discuss about pricing?`
+  - Docs: https://useminutes.app/for-agents#minutes-mcp-recall
 - `/minutes-search` — Find a topic, quote, person, or decision across past transcripts.
   - Description: Search past meeting transcripts and voice memos for specific topics, people, decisions, or ideas. Use this whenever the user asks "what did we discuss about X", "find that meeting where we talked about Y", "what did Alex say", "did we decide on", "what was that idea about", or any question that could be answered by searching their meeting history. Also use for "do I have any notes about" or "check my meetings for".
   - Example: `/minutes-search pricing strategy`

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -123,6 +123,7 @@ Workflow-level skills that wrap MCP tools into operator motions. Install in Clau
 - `/minutes-debrief` — Turn the latest meeting into decisions, follow-ups, and what changed from prep. Category: Lifecycle. Example: `/minutes-debrief`. Docs: https://useminutes.app/for-agents#minutes-debrief
 - `/minutes-prep` — Do a deeper relationship brief and talking-point prep before an important call. Category: Lifecycle. Example: `/minutes-prep Alex`. Docs: https://useminutes.app/for-agents#minutes-prep
 - `/minutes-weekly` — See weekly themes, stale commitments, and what deserves attention next. Category: Lifecycle. Example: `/minutes-weekly`. Docs: https://useminutes.app/for-agents#minutes-weekly
+- `/minutes-mcp-recall` — Route a meeting-memory question to the smallest useful read-only MCP tool. Category: Search. Example: `/minutes-mcp-recall what did we discuss about pricing?`. Docs: https://useminutes.app/for-agents#minutes-mcp-recall
 - `/minutes-search` — Find a topic, quote, person, or decision across past transcripts. Category: Search. Example: `/minutes-search pricing strategy`. Docs: https://useminutes.app/for-agents#minutes-search
 
 ## Output Format

--- a/tooling/skills/compiler/routing.fixtures.ts
+++ b/tooling/skills/compiler/routing.fixtures.ts
@@ -57,6 +57,10 @@ export const ROUTING_FIXTURES: RoutingFixture[] = [
     expectedSkill: "minutes-list",
   },
   {
+    utterance: "What did we say about pricing?",
+    expectedSkill: "minutes-mcp-recall",
+  },
+  {
     utterance: "How did I do in my last meeting?",
     expectedSkill: "minutes-mirror",
   },

--- a/tooling/skills/compiler/routing.test.ts
+++ b/tooling/skills/compiler/routing.test.ts
@@ -136,6 +136,7 @@ test("evaluateRoutingFixtures passes on the real Minutes skill corpus shape", ()
     makeSkill("minutes-ingest", ["backfill knowledge"]),
     makeSkill("minutes-lint", ["check for stale action items"]),
     makeSkill("minutes-list", ["show my recent recordings"]),
+    makeSkill("minutes-mcp-recall", ["what did we say about X"]),
     makeSkill("minutes-mirror", ["how did I do"]),
     makeSkill("minutes-note", ["note that"]),
     makeSkill("minutes-prep", ["prep me for my call with"]),

--- a/tooling/skills/goldens/claude/minutes-mcp-recall/SKILL.md
+++ b/tooling/skills/goldens/claude/minutes-mcp-recall/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: minutes-mcp-recall
+description: Route meeting-recall questions to the right Minutes MCP tool.
+user_invocable: true
+---
+
+# /minutes-mcp-recall
+
+Route a meeting-memory question to the smallest useful Minutes MCP tool. This
+skill is tool-name-oriented for MCP hosts such as OpenClaw, Hermes-agent, and
+other MCP clients. Use `minutes-search` instead when the host only has CLI or
+shell access.
+
+Read [the complete tool map](references/tool-map.md) only when the decision
+table does not cover the request.
+
+## Decision table
+
+| User is asking... | Call |
+|---|---|
+| "What did we say about X?" or "Find that meeting about Y." | `search_meetings` |
+| "What is the full transcript of this specific meeting?" | `get_meeting` after finding its id or date with `list_meetings` or `search_meetings` |
+| About what is happening right now, mid-call | `read_live_transcript` with a cursor or time window |
+| "What do I still owe?" or "Who owes me?" | `track_commitments` |
+| "What is my history with this person?" | `get_person_profile` or `relationship_map` |
+| "Have I contradicted myself?" or "Which decisions are stale?" | `consistency_report` |
+| Broad research across many meetings | `research_topic` |
+
+## Tool-name prefix by host
+
+- OpenClaw and generic MCP clients use bare tool names such as
+  `search_meetings`.
+- Hermes-agent prefixes each tool with `mcp_minutes_`, so
+  `search_meetings` becomes `mcp_minutes_search_meetings`.
+
+Apply the same prefix rule to every tool in the decision table and tool map.
+
+## Anti-patterns
+
+- Do not call `get_meeting` speculatively to browse. It returns a full
+  transcript. Use `search_meetings` or `list_meetings` first to find the right
+  id or date and preserve context budget.
+- Do not call `read_live_transcript` without a cursor after one is available.
+  Replaying the whole transcript wastes tokens and duplicates content already
+  in context.
+- Do not use capture, dictation, processing, annotation, or speaker-mutation
+  tools for a recall question.
+

--- a/tooling/skills/goldens/codex/minutes-mcp-recall/SKILL.md
+++ b/tooling/skills/goldens/codex/minutes-mcp-recall/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: minutes-mcp-recall
+description: Route meeting-recall questions to the right Minutes MCP tool.
+---
+
+## Skill Path
+
+Before running helper scripts or opening bundled references, set:
+
+```bash
+export MINUTES_SKILLS_ROOT="$(git rev-parse --show-toplevel)/.agents/skills/minutes"
+export MINUTES_SKILL_ROOT="$MINUTES_SKILLS_ROOT/minutes-mcp-recall"
+```
+
+# /minutes-mcp-recall
+
+Route a meeting-memory question to the smallest useful Minutes MCP tool. This
+skill is tool-name-oriented for MCP hosts such as OpenClaw, Hermes-agent, and
+other MCP clients. Use `minutes-search` instead when the host only has CLI or
+shell access.
+
+Read [the complete tool map](references/tool-map.md) only when the decision
+table does not cover the request.
+
+## Decision table
+
+| User is asking... | Call |
+|---|---|
+| "What did we say about X?" or "Find that meeting about Y." | `search_meetings` |
+| "What is the full transcript of this specific meeting?" | `get_meeting` after finding its id or date with `list_meetings` or `search_meetings` |
+| About what is happening right now, mid-call | `read_live_transcript` with a cursor or time window |
+| "What do I still owe?" or "Who owes me?" | `track_commitments` |
+| "What is my history with this person?" | `get_person_profile` or `relationship_map` |
+| "Have I contradicted myself?" or "Which decisions are stale?" | `consistency_report` |
+| Broad research across many meetings | `research_topic` |
+
+## Tool-name prefix by host
+
+- OpenClaw and generic MCP clients use bare tool names such as
+  `search_meetings`.
+- Hermes-agent prefixes each tool with `mcp_minutes_`, so
+  `search_meetings` becomes `mcp_minutes_search_meetings`.
+
+Apply the same prefix rule to every tool in the decision table and tool map.
+
+## Anti-patterns
+
+- Do not call `get_meeting` speculatively to browse. It returns a full
+  transcript. Use `search_meetings` or `list_meetings` first to find the right
+  id or date and preserve context budget.
+- Do not call `read_live_transcript` without a cursor after one is available.
+  Replaying the whole transcript wastes tokens and duplicates content already
+  in context.
+- Do not use capture, dictation, processing, annotation, or speaker-mutation
+  tools for a recall question.
+

--- a/tooling/skills/goldens/codex/minutes-mcp-recall/agents/openai.yaml
+++ b/tooling/skills/goldens/codex/minutes-mcp-recall/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Minutes MCP Recall"
+  short_description: "Route meeting-recall questions to the right Minutes MCP tool."
+  default_prompt: "Use Minutes MCP Recall to choose the smallest read-only Minutes MCP tool for this question."

--- a/tooling/skills/goldens/commands/minutes-mcp-recall.md
+++ b/tooling/skills/goldens/commands/minutes-mcp-recall.md
@@ -1,0 +1,9 @@
+---
+description: Route meeting-recall questions to the right Minutes MCP tool.
+---
+
+Load the `minutes-mcp-recall` skill and follow it exactly for this request.
+
+User arguments: $ARGUMENTS
+
+If no arguments were provided, use the skill's normal no-argument/default flow instead of stopping to ask for input.

--- a/tooling/skills/goldens/opencode/minutes-mcp-recall/SKILL.md
+++ b/tooling/skills/goldens/opencode/minutes-mcp-recall/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: minutes-mcp-recall
+description: Route meeting-recall questions to the right Minutes MCP tool.
+compatibility: opencode
+---
+
+## Skill Path
+
+Before running helper scripts or opening bundled references, set:
+
+```bash
+export MINUTES_SKILLS_ROOT="$(git rev-parse --show-toplevel)/.opencode/skills"
+export MINUTES_SKILL_ROOT="$MINUTES_SKILLS_ROOT/minutes-mcp-recall"
+```
+
+# /minutes-mcp-recall
+
+Route a meeting-memory question to the smallest useful Minutes MCP tool. This
+skill is tool-name-oriented for MCP hosts such as OpenClaw, Hermes-agent, and
+other MCP clients. Use `minutes-search` instead when the host only has CLI or
+shell access.
+
+Read [the complete tool map](references/tool-map.md) only when the decision
+table does not cover the request.
+
+## Decision table
+
+| User is asking... | Call |
+|---|---|
+| "What did we say about X?" or "Find that meeting about Y." | `search_meetings` |
+| "What is the full transcript of this specific meeting?" | `get_meeting` after finding its id or date with `list_meetings` or `search_meetings` |
+| About what is happening right now, mid-call | `read_live_transcript` with a cursor or time window |
+| "What do I still owe?" or "Who owes me?" | `track_commitments` |
+| "What is my history with this person?" | `get_person_profile` or `relationship_map` |
+| "Have I contradicted myself?" or "Which decisions are stale?" | `consistency_report` |
+| Broad research across many meetings | `research_topic` |
+
+## Tool-name prefix by host
+
+- OpenClaw and generic MCP clients use bare tool names such as
+  `search_meetings`.
+- Hermes-agent prefixes each tool with `mcp_minutes_`, so
+  `search_meetings` becomes `mcp_minutes_search_meetings`.
+
+Apply the same prefix rule to every tool in the decision table and tool map.
+
+## Anti-patterns
+
+- Do not call `get_meeting` speculatively to browse. It returns a full
+  transcript. Use `search_meetings` or `list_meetings` first to find the right
+  id or date and preserve context budget.
+- Do not call `read_live_transcript` without a cursor after one is available.
+  Replaying the whole transcript wastes tokens and duplicates content already
+  in context.
+- Do not use capture, dictation, processing, annotation, or speaker-mutation
+  tools for a recall question.
+

--- a/tooling/skills/sources/minutes-mcp-recall/references/tool-map.md
+++ b/tooling/skills/sources/minutes-mcp-recall/references/tool-map.md
@@ -1,0 +1,43 @@
+# Minutes MCP tool map
+
+> Generated from `manifest.json` by `node scripts/generate_llms_txt.mjs`.
+> Do not edit by hand.
+
+This manifest contains 34 MCP tools.
+
+| Tool | Description |
+|---|---|
+| `start_recording` | Start recording audio from the default input device |
+| `stop_recording` | Stop the current recording and process it |
+| `get_status` | Check if a recording is currently in progress |
+| `list_processing_jobs` | List background processing jobs for recent recordings |
+| `list_meetings` | List recent normal meetings and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `search_meetings` | Search normal meeting transcripts and voice memos; restricted items are excluded unless an explicit logged override is enabled and requested |
+| `get_meeting` | Get a normal meeting transcript; restricted meetings return a content-free stub unless an explicit logged override is enabled and requested |
+| `activity_summary` | Summarize desktop context bound to one exact normal meeting source |
+| `search_context` | Search desktop-context events bound to one exact normal meeting source |
+| `get_moment` | Show the local desktop-context rewind bound to one exact normal meeting source |
+| `get_screen_context` | Retrieve bounded, verified screenshots bound to one exact normal meeting source |
+| `process_audio` | On macOS and Linux, process bounded inbox or Downloads WAV audio; compressed/private containers and Windows fail closed without reading audio; retained library recordings are unavailable |
+| `add_note` | Add a timestamped note to the current active recording; existing meeting files are not mutable from this assistant tool |
+| `consistency_report` | Flag conflicting decisions and stale commitments |
+| `get_person_profile` | Build a profile from policy-authorized meetings within supported corpus bounds |
+| `research_topic` | Research a topic across policy-authorized meetings within supported corpus bounds |
+| `start_dictation` | Start dictation mode — speech to clipboard and daily notes |
+| `stop_dictation` | Stop dictation mode |
+| `track_commitments` | List open and stale commitments, optionally filtered by person |
+| `relationship_map` | Rank relationships from the bounded process-private policy-safe graph projection |
+| `list_voices` | List enrolled voice profiles for speaker identification |
+| `confirm_speaker` | Compatibility name only: agent-controlled speaker mutation is unavailable; use the Minutes app or human CLI |
+| `get_meeting_insights` | Query decisions, commitments, and questions extracted from meetings; each insight records a path to its source meeting, that path is resolved to a meeting in the live corpus and the resolved meeting is re-verified against live sensitivity policy before release, and withheld records are reported as a partial view |
+| `start_live_transcript` | Start a live transcript session for real-time meeting transcription |
+| `read_live_transcript` | Read utterances from the active live transcript with optional cursor or time window |
+| `start_copilot` | Start the independent real-time copilot for a goal and observe its CLI nudge stream |
+| `stop_copilot` | Stop the active real-time copilot without changing recording or live transcription |
+| `copilot_status` | Read current copilot session and provider health from the CLI status surface |
+| `read_copilot_nudges` | Read observed copilot nudges incrementally by cursor or time window |
+| `ingest_meeting` | Extract facts from a meeting and update the knowledge base (person profiles, log, index) |
+| `resummarize_meeting` | Re-run the AI pass on an edited meeting or memo, previewing by default and preserving user edits |
+| `knowledge_status` | Show the current state of the knowledge base — configuration, adapter, people count, log entries |
+| `add_agent_annotation` | Append attributed agent commentary as an agent.annotation event, never editing meeting markdown or frontmatter (allowlist-gated by ~/.minutes/agents.allow) |
+| `get_agent_annotations` | Compatibility name only: unavailable because an annotation's source pointer and body are both author-supplied, so revalidating the pointer cannot bound what the body discloses |

--- a/tooling/skills/sources/minutes-mcp-recall/skill.md
+++ b/tooling/skills/sources/minutes-mcp-recall/skill.md
@@ -1,0 +1,75 @@
+---
+name: minutes-mcp-recall
+description: Route meeting-recall questions to the right Minutes MCP tool.
+triggers:
+  - what did we say about
+  - find that meeting about
+  - get the full transcript
+  - what do I still owe
+  - who owes me
+  - what is my history with
+  - research across my meetings
+user_invocable: true
+metadata:
+  display_name: Minutes MCP Recall
+  short_description: Route meeting-recall questions to the right Minutes MCP tool.
+  default_prompt: Use Minutes MCP Recall to choose the smallest read-only Minutes MCP tool for this question.
+  site_category: Search
+  site_example: /minutes-mcp-recall what did we discuss about pricing?
+  site_best_for: Route a meeting-memory question to the smallest useful read-only MCP tool.
+assets:
+  scripts: []
+  templates: []
+  references:
+    - references/tool-map.md
+output:
+  claude:
+    path: .claude/plugins/minutes/skills/minutes-mcp-recall/SKILL.md
+  codex:
+    path: .agents/skills/minutes/minutes-mcp-recall/SKILL.md
+tests:
+  golden: true
+  lint_commands: true
+---
+
+# /minutes-mcp-recall
+
+Route a meeting-memory question to the smallest useful Minutes MCP tool. This
+skill is tool-name-oriented for MCP hosts such as OpenClaw, Hermes-agent, and
+other MCP clients. Use `minutes-search` instead when the host only has CLI or
+shell access.
+
+Read [the complete tool map](references/tool-map.md) only when the decision
+table does not cover the request.
+
+## Decision table
+
+| User is asking... | Call |
+|---|---|
+| "What did we say about X?" or "Find that meeting about Y." | `search_meetings` |
+| "What is the full transcript of this specific meeting?" | `get_meeting` after finding its id or date with `list_meetings` or `search_meetings` |
+| About what is happening right now, mid-call | `read_live_transcript` with a cursor or time window |
+| "What do I still owe?" or "Who owes me?" | `track_commitments` |
+| "What is my history with this person?" | `get_person_profile` or `relationship_map` |
+| "Have I contradicted myself?" or "Which decisions are stale?" | `consistency_report` |
+| Broad research across many meetings | `research_topic` |
+
+## Tool-name prefix by host
+
+- OpenClaw and generic MCP clients use bare tool names such as
+  `search_meetings`.
+- Hermes-agent prefixes each tool with `mcp_minutes_`, so
+  `search_meetings` becomes `mcp_minutes_search_meetings`.
+
+Apply the same prefix rule to every tool in the decision table and tool map.
+
+## Anti-patterns
+
+- Do not call `get_meeting` speculatively to browse. It returns a full
+  transcript. Use `search_meetings` or `list_meetings` first to find the right
+  id or date and preserve context budget.
+- Do not call `read_live_transcript` without a cursor after one is available.
+  Replaying the whole transcript wastes tokens and duplicates content already
+  in context.
+- Do not use capture, dictation, processing, annotation, or speaker-mutation
+  tools for a recall question.


### PR DESCRIPTION
OpenClaw and Hermes-agent both read the agentskills.io skill format Minutes already ships and both take a stdio MCP server with one config block, so this is docs plus one skill:

- `docs/integration/openclaw.md`: `openclaw mcp add minutes …`, the `openclaw.json` block with a `toolFilter.include` list of the nine recall tools (a headless agent on another machine should not see capture/dictation tools), and how to point OpenClaw at the existing skill tree.
- `docs/integration/hermes-agent.md`: the `~/.hermes/config.yaml` block, the `mcp_minutes_` tool-name prefix Hermes applies, and skill discovery.
- New skill `minutes-mcp-recall` (compiled to all four targets by the skills compiler): a decision table for when to call `search_meetings` vs `get_meeting` vs `read_live_transcript` vs `track_commitments`, with a per-host tool-name map. Skill count goes to 23; README, marketplace description, and the site catalog updated.

No registry submissions in this PR (ClawHub publish is a follow-up once this is on main).