### PR TITLE
feat(diarize): optional pyannote community-1 model set with measured comparison

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -931,7 +931,7 @@ enum Commands {
 
     /// Download whisper model and set up minutes
     Setup {
-        /// Model to download: tiny, base, small, medium, large-v3
+        /// Model to download: a Whisper model, or legacy/community-1 with --diarization
         #[arg(short, long, default_value = "small")]
         model: String,
 
@@ -7316,7 +7316,7 @@ fn cmd_setup(model: &str, list: bool, diarization: bool) -> Result<()> {
     }
 
     if diarization {
-        return cmd_setup_diarization();
+        return cmd_setup_diarization(model);
     }
 
     let valid_models = ["tiny", "base", "small", "medium", "large-v3"];
@@ -7533,23 +7533,37 @@ fn cmd_setup_demo() -> Result<()> {
     Ok(())
 }
 
-fn cmd_setup_diarization() -> Result<()> {
+fn cmd_setup_diarization(requested_model: &str) -> Result<()> {
     use minutes_core::diarize;
 
-    let config = Config::load();
+    let mut config = Config::load();
+    let selected_model = if requested_model == "small" {
+        config.diarization.model.clone()
+    } else {
+        requested_model.to_string()
+    };
+    let model_info = diarize::diarization_model_info(&selected_model).ok_or_else(|| {
+        anyhow::anyhow!(
+            "unknown diarization model: {}. Available: {}",
+            selected_model,
+            diarize::DIARIZATION_MODEL_NAMES.join(", ")
+        )
+    })?;
+    config.diarization.model = selected_model;
     let emb_info = diarize::embedding_model_for_config(&config);
     let model_dir = &config.diarization.model_path;
     std::fs::create_dir_all(model_dir)?;
 
+    eprintln!("Diarization model set: {}", model_info.name);
     eprintln!(
         "Embedding model: {} ({})",
-        config.diarization.embedding_model, emb_info.filename
+        emb_info.version, emb_info.filename
     );
 
     let models: [(&str, &str, &str); 2] = [
         (
-            diarize::SEGMENTATION_MODEL,
-            diarize::SEGMENTATION_MODEL_URL,
+            model_info.segmentation_filename,
+            model_info.segmentation_url,
             "segmentation",
         ),
         (emb_info.filename, emb_info.url, "speaker embedding"),
@@ -7581,7 +7595,10 @@ fn cmd_setup_diarization() -> Result<()> {
     eprintln!("\nTo enable speaker diarization, add to ~/.config/minutes/config.toml:");
     eprintln!("  [diarization]");
     eprintln!("  engine = \"pyannote-rs\"");
-    eprintln!("  # embedding_model = \"cam++-lm\"  # or \"cam++\" for the lighter original");
+    eprintln!("  model = \"{}\"", model_info.name);
+    if model_info.name == diarize::DIARIZATION_MODEL_LEGACY {
+        eprintln!("  # embedding_model = \"cam++-lm\"  # or \"cam++\" for the lighter original");
+    }
 
     Ok(())
 }

--- a/crates/core/examples/diarization_eval.rs
+++ b/crates/core/examples/diarization_eval.rs
@@ -1,0 +1,238 @@
+//! Small, reproducible diarization comparison over repository-owned audio.
+//!
+//! The fixtures contain one known speaker. They measure speech-boundary DER,
+//! speaker-count accuracy, and boundary error; they do not claim to measure
+//! multi-speaker confusion or reproduce pyannote's academic benchmark suite.
+
+use minutes_core::config::Config;
+use minutes_core::diarize::{self, SpeakerSegment};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+const FRAME_SECONDS: f64 = 0.01;
+
+#[derive(Debug, Deserialize)]
+struct EvalCase {
+    id: String,
+    audio: PathBuf,
+    duration: f64,
+    segments: Vec<ReferenceSegment>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceSegment {
+    speaker: String,
+    start: f64,
+    end: f64,
+}
+
+#[derive(Default)]
+struct Metrics {
+    reference_frames: usize,
+    missed_frames: usize,
+    false_alarm_frames: usize,
+    confusion_frames: usize,
+    boundary_error_sum: f64,
+    boundary_count: usize,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let mut model = None;
+    let mut models_dir = None;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--model" => model = args.next(),
+            "--models-dir" => models_dir = args.next().map(PathBuf::from),
+            _ => return Err(format!("unknown argument: {arg}").into()),
+        }
+    }
+    let model = model.ok_or("usage: diarization_eval --model legacy|community-1")?;
+    if !diarize::DIARIZATION_MODEL_NAMES.contains(&model.as_str()) {
+        return Err(format!("unknown diarization model: {model}").into());
+    }
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .ok_or("could not resolve repository root")?;
+    let reference_path = root.join("tests/eval/fixtures/diarization-reference.json");
+    let cases: Vec<EvalCase> = serde_json::from_str(&std::fs::read_to_string(reference_path)?)?;
+
+    let mut config = Config::default();
+    config.diarization.engine = "pyannote-rs".into();
+    config.diarization.model = model.clone();
+    if let Some(models_dir) = models_dir {
+        config.diarization.model_path = models_dir;
+    }
+
+    println!("diarization model: {model}");
+    println!(
+        "frame step: {:.0} ms; collar: 0 ms; overlap: scored",
+        FRAME_SECONDS * 1000.0
+    );
+    let mut totals = Metrics::default();
+    let mut exact_counts = 0usize;
+
+    for case in &cases {
+        let audio = root.join(&case.audio);
+        let result = diarize::diarize(&audio, &config).ok_or_else(|| {
+            format!(
+                "diarization failed for {} (install with `minutes setup --diarization --model {model}`)",
+                audio.display()
+            )
+        })?;
+        let metrics = score_case(case, &result.segments);
+        let reference_speakers: HashSet<_> = case
+            .segments
+            .iter()
+            .map(|segment| &segment.speaker)
+            .collect();
+        let predicted_speakers: HashSet<_> = result
+            .segments
+            .iter()
+            .filter(|segment| segment.end > segment.start)
+            .map(|segment| &segment.speaker)
+            .collect();
+        let count_exact = reference_speakers.len() == predicted_speakers.len();
+        exact_counts += usize::from(count_exact);
+
+        println!(
+            "case={} DER={:.2}% miss={:.2}% false_alarm={:.2}% confusion={:.2}% speakers={}/{} count_exact={} boundary_MAE={:.3}s",
+            case.id,
+            percent(
+                metrics.missed_frames + metrics.false_alarm_frames + metrics.confusion_frames,
+                metrics.reference_frames
+            ),
+            percent(metrics.missed_frames, metrics.reference_frames),
+            percent(metrics.false_alarm_frames, metrics.reference_frames),
+            percent(metrics.confusion_frames, metrics.reference_frames),
+            predicted_speakers.len(),
+            reference_speakers.len(),
+            count_exact,
+            boundary_mae(&metrics)
+        );
+        add_metrics(&mut totals, &metrics);
+    }
+
+    println!(
+        "TOTAL model={} DER={:.2}% miss={:.2}% false_alarm={:.2}% confusion={:.2}% speaker_count_accuracy={}/{} boundary_MAE={:.3}s",
+        model,
+        percent(
+            totals.missed_frames + totals.false_alarm_frames + totals.confusion_frames,
+            totals.reference_frames
+        ),
+        percent(totals.missed_frames, totals.reference_frames),
+        percent(totals.false_alarm_frames, totals.reference_frames),
+        percent(totals.confusion_frames, totals.reference_frames),
+        exact_counts,
+        cases.len(),
+        boundary_mae(&totals)
+    );
+    Ok(())
+}
+
+fn score_case(case: &EvalCase, predicted: &[SpeakerSegment]) -> Metrics {
+    let mut overlap: HashMap<(&str, &str), usize> = HashMap::new();
+    let frame_count = (case.duration / FRAME_SECONDS).ceil() as usize;
+    for frame in 0..frame_count {
+        let time = (frame as f64 + 0.5) * FRAME_SECONDS;
+        if let (Some(reference), Some(candidate)) = (
+            reference_at(&case.segments, time),
+            predicted_at(predicted, time),
+        ) {
+            *overlap.entry((candidate, reference)).or_default() += 1;
+        }
+    }
+
+    let mut pairs: Vec<_> = overlap.into_iter().collect();
+    pairs.sort_by_key(|(_, frames)| std::cmp::Reverse(*frames));
+    let mut used_predicted = HashSet::new();
+    let mut used_reference = HashSet::new();
+    let mut mapping = HashMap::new();
+    for ((candidate, reference), _) in pairs {
+        if used_predicted.insert(candidate) && used_reference.insert(reference) {
+            mapping.insert(candidate, reference);
+        }
+    }
+
+    let mut metrics = Metrics::default();
+    for frame in 0..frame_count {
+        let time = (frame as f64 + 0.5) * FRAME_SECONDS;
+        let reference = reference_at(&case.segments, time);
+        let candidate = predicted_at(predicted, time);
+        if reference.is_some() {
+            metrics.reference_frames += 1;
+        }
+        match (reference, candidate) {
+            (Some(_), None) => metrics.missed_frames += 1,
+            (None, Some(_)) => metrics.false_alarm_frames += 1,
+            (Some(reference), Some(candidate))
+                if mapping.get(candidate).copied() != Some(reference) =>
+            {
+                metrics.confusion_frames += 1;
+            }
+            _ => {}
+        }
+    }
+
+    let predicted_boundaries: Vec<f64> = predicted
+        .iter()
+        .flat_map(|segment| [segment.start, segment.end])
+        .collect();
+    for boundary in case
+        .segments
+        .iter()
+        .flat_map(|segment| [segment.start, segment.end])
+    {
+        if let Some(error) = predicted_boundaries
+            .iter()
+            .map(|candidate| (candidate - boundary).abs())
+            .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        {
+            metrics.boundary_error_sum += error;
+            metrics.boundary_count += 1;
+        }
+    }
+    metrics
+}
+
+fn reference_at(segments: &[ReferenceSegment], time: f64) -> Option<&str> {
+    segments
+        .iter()
+        .find(|segment| segment.start <= time && time < segment.end)
+        .map(|segment| segment.speaker.as_str())
+}
+
+fn predicted_at(segments: &[SpeakerSegment], time: f64) -> Option<&str> {
+    segments
+        .iter()
+        .find(|segment| segment.start <= time && time < segment.end)
+        .map(|segment| segment.speaker.as_str())
+}
+
+fn percent(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 * 100.0 / denominator as f64
+    }
+}
+
+fn boundary_mae(metrics: &Metrics) -> f64 {
+    if metrics.boundary_count == 0 {
+        0.0
+    } else {
+        metrics.boundary_error_sum / metrics.boundary_count as f64
+    }
+}
+
+fn add_metrics(total: &mut Metrics, case: &Metrics) {
+    total.reference_frames += case.reference_frames;
+    total.missed_frames += case.missed_frames;
+    total.false_alarm_frames += case.false_alarm_frames;
+    total.confusion_frames += case.confusion_frames;
+    total.boundary_error_sum += case.boundary_error_sum;
+    total.boundary_count += case.boundary_count;
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -388,6 +388,10 @@ pub const VALID_PARAKEET_MODELS: &[&str] = &["tdt-ctc-110m", "tdt-600m"];
 pub struct DiarizationConfig {
     pub engine: String,
     pub model_path: PathBuf,
+    /// Diarization model set: "legacy" (default) or "community-1".
+    /// Kept separate from `embedding_model` so opting into community-1
+    /// selects its compatible segmentation + embedding pair atomically.
+    pub model: String,
     /// Cosine similarity threshold for speaker matching (0.0–1.0).
     /// Lower values merge more aggressively; higher values create more speakers.
     pub threshold: f32,
@@ -1408,6 +1412,7 @@ impl Default for DiarizationConfig {
         Self {
             engine: "auto".into(),
             model_path: minutes_dir().join("models").join("diarization"),
+            model: "legacy".into(),
             threshold: 0.4,
             embedding_model: "cam++".into(),
             stem_correlation_threshold: 0.85,
@@ -2043,6 +2048,7 @@ mod tests {
             "tdt-600m.tokenizer.vocab"
         );
         assert_eq!(config.diarization.engine, "auto");
+        assert_eq!(config.diarization.model, "legacy");
         assert_eq!(config.summarization.engine, "none");
         assert!(!config.copilot.enabled);
         assert_eq!(config.copilot.surface, "tui");

--- a/crates/core/src/diarize.rs
+++ b/crates/core/src/diarize.rs
@@ -159,9 +159,9 @@ where
 //   "pyannote"    → Python pyannote.audio subprocess (legacy)
 //   "none"        → Skip diarization (default)
 //
-// The pyannote-rs engine uses ONNX models (~34 MB total):
-//   - segmentation-3.0.onnx (speech segmentation)
-//   - voxceleb_CAM++_LM.onnx (speaker embeddings, large-margin fine-tuned)
+// The pyannote-rs engine supports two ONNX model sets:
+//   - legacy (default): segmentation-3.0 + CAM++
+//   - community-1 (opt-in): community-1 segmentation + WeSpeaker ResNet34
 //
 // Download with: minutes setup --diarization
 // ──────────────────────────────────────────────────────────────
@@ -497,33 +497,108 @@ fn is_non_lexical_event_text(text: &str) -> bool {
     trimmed.starts_with('[') && trimmed.ends_with(']')
 }
 
-/// Model filenames expected by pyannote-rs.
+pub const DIARIZATION_MODEL_LEGACY: &str = "legacy";
+pub const DIARIZATION_MODEL_COMMUNITY_1: &str = "community-1";
+pub const DIARIZATION_MODEL_NAMES: &[&str] =
+    &[DIARIZATION_MODEL_LEGACY, DIARIZATION_MODEL_COMMUNITY_1];
+
+/// Legacy model filenames expected by pyannote-rs.
 pub const SEGMENTATION_MODEL: &str = "segmentation-3.0.onnx";
 
 pub const SEGMENTATION_MODEL_URL: &str =
     "https://github.com/thewh1teagle/pyannote-rs/releases/download/v0.1.0/segmentation-3.0.onnx";
 
+pub const COMMUNITY_1_SEGMENTATION_MODEL: &str = "segmentation-community-1.onnx";
+pub const COMMUNITY_1_SEGMENTATION_MODEL_URL: &str =
+    "https://huggingface.co/altunenes/speaker-diarization-community-1-onnx/resolve/main/segmentation-community-1.onnx";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmbeddingContract {
+    LegacyCamPlusPlus,
+    Community1ResNet34,
+}
+
 /// Descriptor for a speaker embedding ONNX model.
+#[cfg_attr(not(feature = "diarize"), allow(dead_code))]
 pub struct EmbeddingModelInfo {
     pub filename: &'static str,
     pub url: &'static str,
     pub version: &'static str,
+    input_name: &'static str,
+    output_name: &'static str,
+    contract: EmbeddingContract,
+}
+
+static CAM_PP: EmbeddingModelInfo = EmbeddingModelInfo {
+    filename: "wespeaker_en_voxceleb_CAM++.onnx",
+    url: "https://github.com/thewh1teagle/pyannote-rs/releases/download/v0.1.0/wespeaker_en_voxceleb_CAM++.onnx",
+    version: "wespeaker_en_voxceleb_CAM++_v0.3",
+    input_name: "feats",
+    output_name: "embs",
+    contract: EmbeddingContract::LegacyCamPlusPlus,
+};
+
+static CAM_PP_LM: EmbeddingModelInfo = EmbeddingModelInfo {
+    filename: "voxceleb_CAM++_LM.onnx",
+    url: "https://huggingface.co/Wespeaker/wespeaker-voxceleb-campplus-LM/resolve/main/voxceleb_CAM%2B%2B_LM.onnx",
+    version: "wespeaker_voxceleb_CAM++_LM_v0.3",
+    input_name: "feats",
+    output_name: "embs",
+    contract: EmbeddingContract::LegacyCamPlusPlus,
+};
+
+static COMMUNITY_1_RESNET34: EmbeddingModelInfo = EmbeddingModelInfo {
+    filename: "embedding-community-1.onnx",
+    url: "https://huggingface.co/altunenes/speaker-diarization-community-1-onnx/resolve/main/embedding_model.onnx",
+    version: "pyannote_community-1_wespeaker_resnet34_v1",
+    input_name: "fbank_features",
+    output_name: "embeddings",
+    contract: EmbeddingContract::Community1ResNet34,
+};
+
+/// Segmentation-side contract for one selectable diarization model set.
+#[cfg_attr(not(feature = "diarize"), allow(dead_code))]
+pub struct DiarizationModelInfo {
+    pub name: &'static str,
+    pub segmentation_filename: &'static str,
+    pub segmentation_url: &'static str,
+    segmentation_input_name: &'static str,
+    segmentation_output_name: &'static str,
+}
+
+static LEGACY_MODEL_SET: DiarizationModelInfo = DiarizationModelInfo {
+    name: DIARIZATION_MODEL_LEGACY,
+    segmentation_filename: SEGMENTATION_MODEL,
+    segmentation_url: SEGMENTATION_MODEL_URL,
+    segmentation_input_name: "input",
+    segmentation_output_name: "output",
+};
+
+static COMMUNITY_1_MODEL_SET: DiarizationModelInfo = DiarizationModelInfo {
+    name: DIARIZATION_MODEL_COMMUNITY_1,
+    segmentation_filename: COMMUNITY_1_SEGMENTATION_MODEL,
+    segmentation_url: COMMUNITY_1_SEGMENTATION_MODEL_URL,
+    segmentation_input_name: "input_values",
+    segmentation_output_name: "logits",
+};
+
+pub fn diarization_model_info(name: &str) -> Option<&'static DiarizationModelInfo> {
+    match name {
+        DIARIZATION_MODEL_LEGACY => Some(&LEGACY_MODEL_SET),
+        DIARIZATION_MODEL_COMMUNITY_1 => Some(&COMMUNITY_1_MODEL_SET),
+        _ => None,
+    }
+}
+
+/// Resolve config while preserving the historical model set for absent or
+/// unrecognized values.
+pub fn diarization_model_for_config(config: &Config) -> &'static DiarizationModelInfo {
+    diarization_model_info(&config.diarization.model).unwrap_or(&LEGACY_MODEL_SET)
 }
 
 /// Resolve the configured embedding model name to its ONNX file, download URL,
 /// and version tag stored alongside voice profiles.
 pub fn embedding_model_info(name: &str) -> Option<&'static EmbeddingModelInfo> {
-    static CAM_PP: EmbeddingModelInfo = EmbeddingModelInfo {
-        filename: "wespeaker_en_voxceleb_CAM++.onnx",
-        url: "https://github.com/thewh1teagle/pyannote-rs/releases/download/v0.1.0/wespeaker_en_voxceleb_CAM++.onnx",
-        version: "wespeaker_en_voxceleb_CAM++_v0.3",
-    };
-    static CAM_PP_LM: EmbeddingModelInfo = EmbeddingModelInfo {
-        filename: "voxceleb_CAM++_LM.onnx",
-        url: "https://huggingface.co/Wespeaker/wespeaker-voxceleb-campplus-LM/resolve/main/voxceleb_CAM%2B%2B_LM.onnx",
-        version: "wespeaker_voxceleb_CAM++_LM_v0.3",
-    };
-
     match name {
         "cam++" => Some(&CAM_PP),
         "cam++-lm" => Some(&CAM_PP_LM),
@@ -536,8 +611,25 @@ pub const EMBEDDING_MODEL_NAMES: &[&str] = &["cam++", "cam++-lm"];
 
 /// Resolve from config, falling back to the default (cam++).
 pub fn embedding_model_for_config(config: &Config) -> &'static EmbeddingModelInfo {
+    if diarization_model_for_config(config).name == DIARIZATION_MODEL_COMMUNITY_1 {
+        return &COMMUNITY_1_RESNET34;
+    }
     embedding_model_info(&config.diarization.embedding_model)
         .unwrap_or_else(|| embedding_model_info("cam++").unwrap())
+}
+
+#[cfg(feature = "diarize")]
+fn community_embedding_features(
+    samples: &[i16],
+) -> Result<ndarray::Array3<f32>, Box<dyn std::error::Error>> {
+    use ndarray::Axis;
+
+    let mut samples_f32 = zeroize::Zeroizing::new(vec![0.0; samples.len()]);
+    knf_rs::convert_integer_to_float_audio(samples, &mut samples_f32);
+    for sample in samples_f32.iter_mut() {
+        *sample *= 32768.0;
+    }
+    Ok(knf_rs::compute_fbank(&samples_f32)?.insert_axis(Axis(0)))
 }
 
 /// Compute raw speaker embeddings for pre-normalized 16 kHz PCM windows.
@@ -550,8 +642,6 @@ pub fn extract_speaker_embeddings(
     windows: &[Vec<i16>],
     config: &Config,
 ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error>> {
-    use pyannote_rs::EmbeddingExtractor;
-
     let info = embedding_model_for_config(config);
     let model_path = config.diarization.model_path.join(info.filename);
     if !model_path.exists() {
@@ -561,18 +651,47 @@ pub fn extract_speaker_embeddings(
         )
         .into());
     }
-    let mut extractor = EmbeddingExtractor::new(&model_path)?;
-    windows
-        .iter()
-        .map(|window| Ok(extractor.compute(window)?.collect()))
-        .collect()
+    match info.contract {
+        EmbeddingContract::LegacyCamPlusPlus => {
+            use pyannote_rs::EmbeddingExtractor;
+            let mut extractor = EmbeddingExtractor::new(&model_path)?;
+            windows
+                .iter()
+                .map(|window| Ok(extractor.compute(window)?.collect()))
+                .collect()
+        }
+        EmbeddingContract::Community1ResNet34 => {
+            use ort::session::builder::GraphOptimizationLevel;
+            use ort::value::Tensor;
+
+            let mut session = ort::session::Session::builder()?
+                .with_optimization_level(GraphOptimizationLevel::Level3)?
+                .with_intra_threads(1)?
+                .with_inter_threads(1)?
+                .commit_from_file(&model_path)?;
+            validate_embedding_contract(&session, info)?;
+            windows
+                .iter()
+                .map(|window| {
+                    let features = community_embedding_features(window)?;
+                    let outputs = session.run(ort::inputs![Tensor::from_array(features)?])?;
+                    let embedding = outputs
+                        .get(info.output_name)
+                        .ok_or("embedding model output is missing")?
+                        .try_extract_tensor::<f32>()?;
+                    Ok(embedding.1.to_vec())
+                })
+                .collect()
+        }
+    }
 }
 
 /// Check if diarization models are installed.
 pub fn models_installed(config: &Config) -> bool {
     let dir = &config.diarization.model_path;
+    let model = diarization_model_for_config(config);
     let emb = embedding_model_for_config(config);
-    dir.join(SEGMENTATION_MODEL).exists() && dir.join(emb.filename).exists()
+    dir.join(model.segmentation_filename).exists() && dir.join(emb.filename).exists()
 }
 
 /// Pre-process audio to 16kHz mono PCM via ffmpeg (if available).
@@ -3223,18 +3342,23 @@ impl Drop for OrtInferenceDeadline {
 #[cfg(feature = "diarize")]
 struct BoundedEmbeddingExtractor {
     session: ort::session::Session,
+    info: &'static EmbeddingModelInfo,
 }
 
 #[cfg(feature = "diarize")]
 impl BoundedEmbeddingExtractor {
-    fn new(model_path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+    fn new(
+        model_path: &Path,
+        info: &'static EmbeddingModelInfo,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         use ort::session::builder::GraphOptimizationLevel;
         let session = ort::session::Session::builder()?
             .with_optimization_level(GraphOptimizationLevel::Level3)?
             .with_intra_threads(1)?
             .with_inter_threads(1)?
             .commit_from_file(model_path)?;
-        Ok(Self { session })
+        validate_embedding_contract(&session, info)?;
+        Ok(Self { session, info })
     }
 
     fn compute(
@@ -3247,17 +3371,59 @@ impl BoundedEmbeddingExtractor {
 
         let mut samples_f32 = zeroize::Zeroizing::new(vec![0.0_f32; samples.len()]);
         knf_rs::convert_integer_to_float_audio(samples, &mut samples_f32);
+        if self.info.contract == EmbeddingContract::Community1ResNet34 {
+            for sample in samples_f32.iter_mut() {
+                *sample *= 32768.0;
+            }
+        }
         let features = knf_rs::compute_fbank(&samples_f32)?.insert_axis(Axis(0));
-        let outputs = self.session.run_with_options(
-            ort::inputs!["feats" => Tensor::from_array(features)?],
-            options,
-        )?;
+        let outputs = match self.info.contract {
+            EmbeddingContract::LegacyCamPlusPlus => self.session.run_with_options(
+                ort::inputs!["feats" => Tensor::from_array(features)?],
+                options,
+            )?,
+            EmbeddingContract::Community1ResNet34 => self.session.run_with_options(
+                ort::inputs!["fbank_features" => Tensor::from_array(features)?],
+                options,
+            )?,
+        };
         let embedding = outputs
-            .get("embs")
+            .get(self.info.output_name)
             .ok_or("embedding model output is missing")?
             .try_extract_tensor::<f32>()?;
         Ok(embedding.1.to_vec())
     }
+}
+
+#[cfg(feature = "diarize")]
+fn validate_embedding_contract(
+    session: &ort::session::Session,
+    info: &EmbeddingModelInfo,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let actual_input = session
+        .inputs
+        .first()
+        .map(|input| input.name.as_str())
+        .ok_or("embedding model has no input")?;
+    if actual_input != info.input_name {
+        return Err(format!(
+            "embedding model input mismatch: expected '{}', found '{}'",
+            info.input_name, actual_input
+        )
+        .into());
+    }
+    if !session
+        .outputs
+        .iter()
+        .any(|output| output.name == info.output_name)
+    {
+        return Err(format!(
+            "embedding model output mismatch: expected '{}'",
+            info.output_name
+        )
+        .into());
+    }
+    Ok(())
 }
 
 #[cfg(feature = "diarize")]
@@ -3268,7 +3434,8 @@ fn diarize_with_pyannote_rs(
 ) -> Result<DiarizationResult, Box<dyn std::error::Error>> {
     cancellation.check()?;
     let model_dir = &config.diarization.model_path;
-    let seg_model = model_dir.join(SEGMENTATION_MODEL);
+    let model_info = diarization_model_for_config(config);
+    let seg_model = model_dir.join(model_info.segmentation_filename);
     let emb_info = embedding_model_for_config(config);
     let emb_model = model_dir.join(emb_info.filename);
 
@@ -3306,6 +3473,7 @@ fn diarize_with_pyannote_rs(
         &f32_samples,
         sample_rate,
         &seg_model,
+        model_info,
         inference_deadline.options(),
     )?;
 
@@ -3331,6 +3499,7 @@ fn diarize_with_pyannote_rs(
                 &f32_samples,
                 sample_rate,
                 &seg_model,
+                model_info,
                 inference_deadline.options(),
             )?;
         }
@@ -3348,7 +3517,7 @@ fn diarize_with_pyannote_rs(
     // only stores the first segment's embedding per speaker, which causes
     // over-segmentation (one person → multiple speakers) as the reference
     // embedding becomes unrepresentative over time.
-    let mut extractor = BoundedEmbeddingExtractor::new(&emb_model)?;
+    let mut extractor = BoundedEmbeddingExtractor::new(&emb_model, emb_info)?;
     let threshold = config.diarization.threshold;
 
     // Merge adjacent speech segments that are separated by short gaps.
@@ -3720,6 +3889,7 @@ fn segment_speech(
     samples: &[f32],
     sample_rate: u32,
     model_path: &Path,
+    model_info: &DiarizationModelInfo,
     run_options: &ort::session::run_options::RunOptions,
 ) -> Result<Vec<SpeechSegment>, Box<dyn std::error::Error>> {
     use ndarray::{Array1, ArrayViewD, Axis, IxDyn};
@@ -3731,6 +3901,30 @@ fn segment_speech(
         .with_intra_threads(1)?
         .with_inter_threads(1)?
         .commit_from_file(model_path)?;
+
+    let actual_input = session
+        .inputs
+        .first()
+        .map(|input| input.name.as_str())
+        .ok_or("segmentation model has no input")?;
+    if actual_input != model_info.segmentation_input_name {
+        return Err(format!(
+            "segmentation model input mismatch: expected '{}', found '{}'",
+            model_info.segmentation_input_name, actual_input
+        )
+        .into());
+    }
+    if !session
+        .outputs
+        .iter()
+        .any(|output| output.name == model_info.segmentation_output_name)
+    {
+        return Err(format!(
+            "segmentation model output mismatch: expected '{}'",
+            model_info.segmentation_output_name
+        )
+        .into());
+    }
 
     // These constants come from the pyannote segmentation-3.0 model architecture:
     // - frame_size (270 samples @ 16kHz = 16.875ms) is the hop between output frames,
@@ -3770,8 +3964,8 @@ fn segment_speech(
 
         let ort_outs = session.run_with_options(inputs, run_options)?;
         let ort_out = ort_outs
-            .get("output")
-            .ok_or("segmentation model missing 'output' tensor")?;
+            .get(model_info.segmentation_output_name)
+            .ok_or("segmentation model output tensor is missing")?;
         let ort_out = ort_out
             .try_extract_tensor::<f32>()
             .map_err(|e| format!("tensor extract: {e:?}"))?;
@@ -5681,6 +5875,67 @@ mod tests {
     }
 
     #[test]
+    fn legacy_remains_the_default_model_set() {
+        let config = Config::default();
+        let model = diarization_model_for_config(&config);
+        let embedding = embedding_model_for_config(&config);
+
+        assert_eq!(config.diarization.model, DIARIZATION_MODEL_LEGACY);
+        assert_eq!(model.name, DIARIZATION_MODEL_LEGACY);
+        assert_eq!(model.segmentation_filename, SEGMENTATION_MODEL);
+        assert_eq!(embedding.filename, "wespeaker_en_voxceleb_CAM++.onnx");
+        assert_eq!(
+            crate::voice::model_version(&config),
+            "wespeaker_en_voxceleb_CAM++_v0.3"
+        );
+    }
+
+    #[test]
+    fn community_model_set_selects_compatible_pair_and_voice_model_id() {
+        let mut config = Config::default();
+        config.diarization.model = DIARIZATION_MODEL_COMMUNITY_1.into();
+        config.diarization.embedding_model = "cam++-lm".into();
+
+        let model = diarization_model_for_config(&config);
+        let embedding = embedding_model_for_config(&config);
+        assert_eq!(model.segmentation_filename, COMMUNITY_1_SEGMENTATION_MODEL);
+        assert_eq!(embedding.filename, "embedding-community-1.onnx");
+        assert_eq!(
+            crate::voice::model_version(&config),
+            "pyannote_community-1_wespeaker_resnet34_v1"
+        );
+    }
+
+    #[test]
+    fn models_installed_checks_only_the_selected_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(SEGMENTATION_MODEL), b"legacy-seg").unwrap();
+        std::fs::write(
+            dir.path().join("wespeaker_en_voxceleb_CAM++.onnx"),
+            b"legacy-embedding",
+        )
+        .unwrap();
+
+        let mut config = Config::default();
+        config.diarization.model_path = dir.path().to_path_buf();
+        assert!(models_installed(&config));
+
+        config.diarization.model = DIARIZATION_MODEL_COMMUNITY_1.into();
+        assert!(!models_installed(&config));
+        std::fs::write(
+            dir.path().join(COMMUNITY_1_SEGMENTATION_MODEL),
+            b"community-seg",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("embedding-community-1.onnx"),
+            b"community-embedding",
+        )
+        .unwrap();
+        assert!(models_installed(&config));
+    }
+
+    #[test]
     fn discover_stem_plan_prefers_full_stems_when_both_are_present() {
         let dir = tempfile::tempdir().unwrap();
         let audio = dir.path().join("call.mov");
@@ -6326,7 +6581,7 @@ mod tests {
         assert_ne!(samples.len() % (sample_rate as usize * 10), 0);
 
         let options = ort::session::RunOptions::new().expect("run options");
-        let segments = segment_speech(&samples, sample_rate, &model, &options)
+        let segments = segment_speech(&samples, sample_rate, &model, &LEGACY_MODEL_SET, &options)
             .expect("segmentation must not panic or fail on a partial final window");
         // The assertion that matters is that we got here at all; the panic
         // previously escaped into catch_unwind and yielded zero speakers.

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -416,6 +416,7 @@ pub fn diarization_status(config: &Config) -> HealthItem {
 
     if is_pyannote_rs {
         let installed = crate::diarize::models_installed(config);
+        let model = crate::diarize::diarization_model_for_config(config);
         return HealthItem {
             label: "Speaker diarization".into(),
             state: if installed {
@@ -430,14 +431,20 @@ pub fn diarization_status(config: &Config) -> HealthItem {
             .into(),
             detail: if installed {
                 let mode = if is_auto { "auto-detected" } else { "enabled" };
-                format!("pyannote-rs models installed ({mode}). Meetings will identify speakers.",)
+                format!(
+                    "pyannote-rs model set '{}' installed ({mode}). Meetings will identify speakers.",
+                    model.name
+                )
             } else if is_auto {
-                "Models not downloaded — diarization will be skipped. \
-                 Run `minutes setup --diarization` to enable speaker identification (~34 MB)."
-                    .into()
+                format!(
+                    "Model set '{}' not downloaded — diarization will be skipped. Run `minutes setup --diarization --model {}` to enable speaker identification.",
+                    model.name, model.name
+                )
             } else {
-                "Models not downloaded. Run `minutes setup --diarization` to install (~34 MB)."
-                    .into()
+                format!(
+                    "Model set '{}' not downloaded. Run `minutes setup --diarization --model {}` to install it.",
+                    model.name, model.name
+                )
             },
             optional: true,
         };
@@ -750,6 +757,35 @@ mod tests {
                 item.state
             );
         }
+    }
+
+    #[test]
+    fn diarization_health_names_the_selected_model_set() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.diarization.engine = "pyannote-rs".into();
+        config.diarization.model = crate::diarize::DIARIZATION_MODEL_COMMUNITY_1.into();
+        config.diarization.model_path = temp.path().to_path_buf();
+
+        let missing = diarization_status(&config);
+        assert_eq!(missing.state, "attention");
+        assert!(missing.detail.contains("community-1"));
+        assert!(missing
+            .detail
+            .contains("setup --diarization --model community-1"));
+
+        std::fs::write(
+            temp.path()
+                .join(crate::diarize::COMMUNITY_1_SEGMENTATION_MODEL),
+            b"segmentation",
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("embedding-community-1.onnx"), b"embedding").unwrap();
+        let installed = diarization_status(&config);
+        assert_eq!(installed.state, "ready");
+        assert!(installed
+            .detail
+            .contains("model set 'community-1' installed"));
     }
 
     #[test]

--- a/crates/core/src/voice.rs
+++ b/crates/core/src/voice.rs
@@ -37,7 +37,7 @@ const SOLO_MAX_CLIPPING_FRACTION: f32 = 0.05;
 // ──────────────────────────────────────────────────────────────
 
 /// Resolve the model version tag for the currently configured embedding model.
-/// Falls back to the cam++-lm version string if the config value is unrecognized.
+/// Falls back to the CAM++ version string if the legacy override is unrecognized.
 pub fn model_version(config: &Config) -> &'static str {
     crate::diarize::embedding_model_for_config(config).version
 }

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -44,8 +44,12 @@ changing `transcription.model`.
 | key | default | meaning |
 |---|---|---|
 | `engine` | `"none"` | `"none"` or `"pyannote-rs"` |
+| `model` | `"legacy"` | `"legacy"` (segmentation-3.0 + CAM++) or opt-in `"community-1"` |
 | `threshold` | `0.4` | Cosine similarity cutoff; lower merges more aggressively |
-| `embedding_model` | `"cam++"` | `"cam++"` or `"cam++-lm"` (lower EER, lower similarities) |
+| `embedding_model` | `"cam++"` | Legacy-only override: `"cam++"` or `"cam++-lm"` (lower EER, lower similarities) |
+
+See [Diarization model sets](diarization.md) for installation, licensing, and
+the compatibility boundary with saved voice profiles.
 
 ### `[summarization]` — post-record summaries
 

--- a/docs/architecture/diarization.md
+++ b/docs/architecture/diarization.md
@@ -1,0 +1,47 @@
+# Diarization model sets
+
+Minutes runs diarization locally through ONNX Runtime and the existing
+pyannote-rs-compatible pipeline. The model set is selected in configuration:
+
+```toml
+[diarization]
+engine = "pyannote-rs"
+model = "legacy"
+```
+
+`legacy` remains the default and uses `segmentation-3.0.onnx` with CAM++ speaker
+embeddings. Existing configurations and recordings therefore keep the same
+model files and inference path unless the user opts in.
+
+`community-1` uses the community-1 segmentation export and its WeSpeaker
+ResNet34 embedding export. Install and select it explicitly:
+
+```console
+minutes setup --diarization --model community-1
+```
+
+```toml
+[diarization]
+engine = "pyannote-rs"
+model = "community-1"
+```
+
+The community-1 model is licensed under CC BY 4.0. Distributions and derived
+uses must retain attribution to pyannote and the model authors. The ONNX export
+used by Minutes is published in the
+[`altunenes/speaker-diarization-community-1-onnx`](https://huggingface.co/altunenes/speaker-diarization-community-1-onnx)
+repository and points back to the original
+[`pyannote/speaker-diarization-community-1`](https://huggingface.co/pyannote/speaker-diarization-community-1)
+model card.
+
+The exports keep the 16 kHz, 10-second segmentation window and seven powerset
+classes used by the legacy path, but rename the segmentation tensors. The
+community embedding also renames its tensors and expects filter-bank input on
+the original 16-bit PCM scale. Minutes adapts those contracts without Python.
+The upstream pyannote.audio-only `exclusive_speaker_diarization` reconciliation
+is not part of these two ONNX exports, so Minutes continues to use its own
+segment clustering and transcript reconciliation.
+
+Voice profiles are isolated by embedding model id in `voices.db`. Community-1
+embeddings are never silently compared with profiles enrolled using CAM++;
+enroll a new profile under the active model set if voice matching is needed.

--- a/scripts/run_diarization_eval.sh
+++ b/scripts/run_diarization_eval.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+model=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)
+      model="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$model" in
+  legacy|community-1) ;;
+  *)
+    echo "usage: $0 --model legacy|community-1" >&2
+    exit 2
+    ;;
+esac
+
+cd "$repo_root"
+if command -v xcrun >/dev/null 2>&1; then
+  export CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1"
+fi
+
+# Models are deliberately downloaded at evaluation time rather than committed.
+cargo run -q -p minutes-cli --no-default-features --features diarize -- \
+  setup --diarization --model "$model"
+cargo run -q -p minutes-core --no-default-features --features diarize \
+  --example diarization_eval -- --model "$model"

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,5 +1,20 @@
 # Minutes Eval v0.1
 
+## Diarization model-set comparison
+
+The diarization eval uses repository-owned one-speaker audio with a small
+hand-authored reference. It reports zero-collar, overlap-scored 10 ms DER,
+speaker-count accuracy, and segment-boundary mean absolute error. It is a
+boundary/count regression corpus, not a multi-speaker quality benchmark.
+
+```bash
+./scripts/run_diarization_eval.sh --model legacy
+./scripts/run_diarization_eval.sh --model community-1
+```
+
+The script downloads the selected ONNX model set when it is not installed;
+model binaries are not committed to the repository.
+
 Can an AI agent actually answer real questions about your meetings?
 
 Cloud meeting tools cap cross-meeting chat at somewhere between one meeting (Fireflies' Fred) and twenty-five (Granola). Nobody publishes a head-to-head on whether agents can synthesize across real meeting corpora. v0.1 is a starter shot at that gap.

--- a/tests/eval/fixtures/diarization-reference.json
+++ b/tests/eval/fixtures/diarization-reference.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "demo-continuous",
+    "audio": "crates/assets/demo.wav",
+    "duration": 10.625813,
+    "segments": [
+      { "speaker": "REFERENCE_1", "start": 0.0, "end": 10.625813 }
+    ]
+  },
+  {
+    "id": "three-utterances",
+    "audio": "crates/assets/parity_three_utterances.wav",
+    "duration": 7.1,
+    "segments": [
+      { "speaker": "REFERENCE_1", "start": 0.2, "end": 1.7 },
+      { "speaker": "REFERENCE_1", "start": 2.0, "end": 3.5 },
+      { "speaker": "REFERENCE_1", "start": 4.0, "end": 5.5 }
+    ]
+  }
+]


### PR DESCRIPTION
Adds pyannote `speaker-diarization-community-1` (pyannote.audio 4.0, CC-BY-4.0) as an opt-in model set next to the current `segmentation-3.0` + CAM++ pair. Default behavior is unchanged; `diarization.model = "community-1"` selects it, `minutes setup --diarization` learns the corresponding download, and `minutes health` reports which set is active.

Compatibility: no fork or bump of pyannote-rs. Minutes already runs segmentation through its own `ort` path, and the community-1 segmentation export keeps the legacy 16 kHz / 10 s chunk / 270-sample hop / 7-class powerset contract; only tensor names differ. The embedding model does change (WeSpeaker ResNet34, 256-d, expects 16-bit-range samples, so the adapter scales for that model only). It carries its own `model_id`, so existing CAM++ voice profiles are never compared against it; users who want voice matching under community-1 enroll again.

Measured on the repo's fixtures with the new `scripts/run_diarization_eval.sh --model legacy|community-1` (aggregate DER / miss / false alarm / confusion / speaker count / boundary MAE): identical for both sets on this small corpus (7.01% DER, 2/2 speakers). That is enough to catch regressions in loading, segmentation, and speaker count; it is not evidence of equivalence on multi-speaker meetings and does not justify changing the default. A larger reference corpus is the next step before any default flip.

Not in the ONNX export: pyannote.audio's Python-side `exclusive` reconciliation, so Minutes keeps its existing clustering and transcript reconciliation around the alternate networks.

Docs: `docs/architecture/diarization.md` (model sets, licenses incl. the CC-BY attribution requirement, how to switch), `docs/architecture/config.md`, `tests/eval/README.md`.