### PR TITLE
feat(transcribe): engine "auto" selects Parakeet v3 on Apple Silicon when it can actually run

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -46,13 +46,10 @@ jobs:
             os: macos-latest
             binary: minutes
             asset: minutes-macos-arm64
-            # engine-sherpa is OFF here until #683's isolation work lands:
-            # the release CLI carries diarize (default), and on macOS static
-            # sherpa and pyannote vendor conflicting copies of ONNX Runtime and
-            # kaldi-native-fbank, so one of them always breaks at runtime. The
-            # compile guard in crates/core/src/lib.rs enforces this; do not add
-            # engine-sherpa back without removing that guard's reason first.
-            features: parakeet,metal
+            # The loader adds about 0.1 MiB to the CLI. The isolated runtime is
+            # packaged in the sherpa archive below so it does not conflict with
+            # diarization's newer ONNX Runtime.
+            features: parakeet,metal,engine-sherpa
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             binary: minutes.exe
@@ -132,6 +129,39 @@ jobs:
         with:
           draft: true
           files: ${{ matrix.asset }}
+
+      - name: Package macOS CLI with the in-process sherpa plugin
+        id: sherpa-macos-archive
+        if: matrix.target == 'aarch64-apple-darwin'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ( cd crates/sherpa-plugin && cargo build --release --locked )
+          plugin="crates/sherpa-plugin/target/release/libminutes_sherpa.dylib"
+          out="minutes-macos-arm64-sherpa"
+          test -f "$plugin"
+          rm -rf "$out"
+          mkdir -p "$out"
+          cp -f "target/${{ matrix.target }}/release/${{ matrix.binary }}" "$out/minutes"
+          cp -f "$plugin" "$out/"
+          ( cd /tmp && python3 \
+              "$GITHUB_WORKSPACE/scripts/verify_sherpa_plugin_loads.py" \
+              "$GITHUB_WORKSPACE/$out/libminutes_sherpa.dylib" )
+          tar czf "$out.tar.gz" "$out"
+
+      - name: Upload macOS sherpa archive artifact
+        if: matrix.target == 'aarch64-apple-darwin'
+        uses: actions/upload-artifact@v7
+        with:
+          name: minutes-macos-arm64-sherpa.tar.gz
+          path: minutes-macos-arm64-sherpa.tar.gz
+
+      - name: Upload macOS sherpa archive release asset
+        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'aarch64-apple-darwin'
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: true
+          files: minutes-macos-arm64-sherpa.tar.gz
 
       # Windows needs the MSVC runtime beside the executable. Nothing ships it
       # today, so on a PC that has never had the Visual C++ Redistributable the

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -189,17 +189,15 @@ jobs:
             | grep -Fq "$APPLE_SIGNING_IDENTITY"
           echo "MINUTES_RELEASE_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
 
+      - name: Build isolated sherpa plugin
+        working-directory: crates/sherpa-plugin
+        run: cargo build --release --locked
+
       # The bundle ships the CLI as a sidecar (in-app "Set up CLI" symlinks to
       # it). build.rs stages it from target/release/minutes, so the CLI must be
       # built first or the bundle ships a placeholder stub (#324).
       - name: Build release CLI for bundling
-        # engine-sherpa held out pending packaging (#369), not because it
-        # conflicts. #685 moved sherpa into a dlopened plugin with its own
-        # ONNX Runtime, so it coexists with diarize now and CI compiles the
-        # pair on purpose. What is missing is a signed, notarized plugin
-        # beside the binary; an unsigned dylib loaded by this hardened,
-        # notarized app is refused at load.
-        run: cargo build --release -p minutes-cli --features parakeet,metal
+        run: cargo build --release -p minutes-cli --features parakeet,metal,engine-sherpa
 
       - name: Build signed bundle (helper identity is repaired before notarization)
         env:
@@ -212,14 +210,9 @@ jobs:
         # workspace, so cargo resolves --features against every member, and
         # minutes-archive-app has neither parakeet nor metal.
         working-directory: tauri/src-tauri
-        # engine-sherpa held out pending packaging (#369). The #683 conflict
-        # that once justified this is gone: #685 put sherpa in its own
-        # dlopened image, so the app can hard-enable diarize and still load
-        # it. The plugin just is not signed and shipped inside the bundle
-        # yet.
-        run: cargo tauri build --features parakeet,metal --bundles app
+        run: cargo tauri build --features parakeet,metal,engine-sherpa --bundles app
 
-      - name: Sign graph helper inside-out and notarize the final exact app
+      - name: Sign nested code inside-out and notarize the final exact app
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -230,9 +223,12 @@ jobs:
           set -euo pipefail
           app="target/release/bundle/macos/Minutes.app"
           sidecar="target/release/bundle/macos/Minutes.app/Contents/MacOS/minutes"
+          sherpa_plugin="$app/Contents/MacOS/libminutes_sherpa.dylib"
+          cp -f crates/sherpa-plugin/target/release/libminutes_sherpa.dylib "$sherpa_plugin"
           staged_graph_worker="$app/Contents/MacOS/minutes-graph-worker"
           staged_apple_speech_worker="$app/Contents/MacOS/minutes-apple-speech-worker"
           test -f "$sidecar" || { echo "ERROR: bundled CLI sidecar missing" >&2; exit 1; }
+          test -f "$sherpa_plugin" || { echo "ERROR: bundled sherpa plugin missing" >&2; exit 1; }
           test -f "$staged_graph_worker" || { echo "ERROR: bundled graph worker missing" >&2; exit 1; }
           test -f "$staged_apple_speech_worker" || { echo "ERROR: bundled Apple Speech worker missing" >&2; exit 1; }
           size=$(stat -f%z "$sidecar")
@@ -242,9 +238,12 @@ jobs:
             exit 1
           fi
           file "$sidecar" | grep -q "Mach-O" || { echo "ERROR: bundled CLI sidecar is not a Mach-O binary" >&2; exit 1; }
+          file "$sherpa_plugin" | grep -q "Mach-O" || { echo "ERROR: bundled sherpa plugin is not a Mach-O binary" >&2; exit 1; }
           file "$staged_graph_worker" | grep -q "Mach-O" || { echo "ERROR: bundled graph worker is not a Mach-O binary" >&2; exit 1; }
           file "$staged_apple_speech_worker" | grep -q "Mach-O" || { echo "ERROR: bundled Apple Speech worker is not a Mach-O binary" >&2; exit 1; }
 
+          codesign --force --options runtime --timestamp \
+            --sign "$APPLE_SIGNING_IDENTITY" "$sherpa_plugin"
           codesign --force --options runtime --timestamp \
             --entitlements tauri/src-tauri/minutes-cli.entitlements \
             --sign "$APPLE_SIGNING_IDENTITY" "$sidecar"
@@ -269,6 +268,7 @@ jobs:
             --entitlements tauri/src-tauri/entitlements.plist \
             --sign "$APPLE_SIGNING_IDENTITY" "$app"
           codesign --verify --deep --strict --verbose=4 "$app"
+          codesign --verify --strict --verbose=4 "$sherpa_plugin"
           codesign --verify --strict --verbose=4 "$graph_worker_bundle"
           codesign --verify --strict --verbose=4 "$apple_speech_worker_bundle"
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7311,6 +7311,11 @@ struct SetupPlan {
 }
 
 fn setup_plan(explicit_model: Option<&str>) -> SetupPlan {
+    #[cfg(feature = "engine-sherpa")]
+    let plugin_present = minutes_core::sherpa_plugin::plugin_available();
+    #[cfg(not(feature = "engine-sherpa"))]
+    let plugin_present = false;
+
     setup_plan_for(
         explicit_model,
         cfg!(all(
@@ -7318,10 +7323,15 @@ fn setup_plan(explicit_model: Option<&str>) -> SetupPlan {
             target_os = "macos",
             target_arch = "aarch64"
         )),
+        plugin_present,
     )
 }
 
-fn setup_plan_for(explicit_model: Option<&str>, sherpa_auto_available: bool) -> SetupPlan {
+fn setup_plan_for(
+    explicit_model: Option<&str>,
+    sherpa_auto_supported: bool,
+    plugin_present: bool,
+) -> SetupPlan {
     if let Some(model) = explicit_model {
         return SetupPlan {
             whisper_model: model.to_string(),
@@ -7330,11 +7340,17 @@ fn setup_plan_for(explicit_model: Option<&str>, sherpa_auto_available: bool) -> 
         };
     }
 
-    if sherpa_auto_available {
+    if sherpa_auto_supported && plugin_present {
         SetupPlan {
             whisper_model: "tiny".into(),
             install_sherpa: true,
             reason: "this Apple Silicon build includes sherpa, so setup will install Parakeet v3 plus Whisper tiny for live and dictation fallback.".into(),
+        }
+    } else if sherpa_auto_supported {
+        SetupPlan {
+            whisper_model: "small".into(),
+            install_sherpa: false,
+            reason: "this Apple Silicon build includes sherpa but its plugin is missing, so setup will install Whisper small. Install `minutes-macos-arm64-sherpa.tar.gz` or the signed desktop app to get the plugin and Parakeet v3.".into(),
         }
     } else {
         SetupPlan {
@@ -9482,16 +9498,24 @@ life (qmd://life/)
 
     #[test]
     fn setup_plan_keeps_explicit_model_and_platform_defaults() {
-        let explicit = setup_plan_for(Some("medium"), true);
+        let explicit = setup_plan_for(Some("medium"), true, false);
         assert_eq!(explicit.whisper_model, "medium");
         assert!(!explicit.install_sherpa);
 
-        let apple_silicon = setup_plan_for(None, true);
+        let apple_silicon = setup_plan_for(None, true, true);
         assert_eq!(apple_silicon.whisper_model, "tiny");
         assert!(apple_silicon.install_sherpa);
         assert!(apple_silicon.reason.contains("Apple Silicon"));
 
-        let fallback = setup_plan_for(None, false);
+        let plugin_missing = setup_plan_for(None, true, false);
+        assert_eq!(plugin_missing.whisper_model, "small");
+        assert!(!plugin_missing.install_sherpa);
+        assert!(plugin_missing
+            .reason
+            .contains("minutes-macos-arm64-sherpa.tar.gz"));
+        assert!(plugin_missing.reason.contains("desktop app"));
+
+        let fallback = setup_plan_for(None, false, false);
         assert_eq!(fallback.whisper_model, "small");
         assert!(!fallback.install_sherpa);
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -931,9 +931,10 @@ enum Commands {
 
     /// Download whisper model and set up minutes
     Setup {
-        /// Model to download: a Whisper model, or legacy/community-1 with --diarization
-        #[arg(short, long, default_value = "small")]
-        model: String,
+        /// Whisper model to download (tiny, base, small, medium, large-v3), or with
+        /// --diarization the model set: legacy or community-1. Omit to let setup choose.
+        #[arg(short, long)]
+        model: Option<String>,
 
         /// Download only the Silero VAD model(s) into the configured model directory; takes precedence over --model
         #[arg(long)]
@@ -2383,9 +2384,19 @@ fn main() -> Result<()> {
             } else if parakeet {
                 cmd_setup_parakeet(&parakeet_model)
             } else if sherpa {
-                cmd_setup_sherpa(&config)
+                cmd_setup_sherpa(&config, true)
+            } else if list {
+                cmd_setup("small", true, false)
+            } else if diarization {
+                cmd_setup(model.as_deref().unwrap_or("small"), false, true)
             } else {
-                cmd_setup(&model, list, diarization)
+                let plan = setup_plan(model.as_deref());
+                eprintln!("Setup selection: {}", plan.reason);
+                cmd_setup(&plan.whisper_model, false, false)?;
+                if plan.install_sherpa {
+                    cmd_setup_sherpa(&config, false)?;
+                }
+                Ok(())
             }
         }
         Commands::Qmd { action, collection } => cmd_qmd(&action, &collection),
@@ -7292,6 +7303,48 @@ fn cmd_sources() -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SetupPlan {
+    whisper_model: String,
+    install_sherpa: bool,
+    reason: String,
+}
+
+fn setup_plan(explicit_model: Option<&str>) -> SetupPlan {
+    setup_plan_for(
+        explicit_model,
+        cfg!(all(
+            feature = "engine-sherpa",
+            target_os = "macos",
+            target_arch = "aarch64"
+        )),
+    )
+}
+
+fn setup_plan_for(explicit_model: Option<&str>, sherpa_auto_available: bool) -> SetupPlan {
+    if let Some(model) = explicit_model {
+        return SetupPlan {
+            whisper_model: model.to_string(),
+            install_sherpa: false,
+            reason: format!("--model selected Whisper {model}."),
+        };
+    }
+
+    if sherpa_auto_available {
+        SetupPlan {
+            whisper_model: "tiny".into(),
+            install_sherpa: true,
+            reason: "this Apple Silicon build includes sherpa, so setup will install Parakeet v3 plus Whisper tiny for live and dictation fallback.".into(),
+        }
+    } else {
+        SetupPlan {
+            whisper_model: "small".into(),
+            install_sherpa: false,
+            reason: "sherpa auto-selection is unavailable on this build or platform, so setup will install Whisper small.".into(),
+        }
+    }
+}
+
 fn cmd_setup(model: &str, list: bool, diarization: bool) -> Result<()> {
     if list {
         eprintln!("Available whisper models:");
@@ -7782,7 +7835,7 @@ fn cmd_setup_parakeet(model: &str) -> Result<()> {
 /// Download a file from a URL to a destination path, with progress reporting.
 /// Download the sherpa-onnx parakeet-tdt-0.6b-v3 (int8) model for the opt-in
 /// `engine-sherpa` transcription engine into the resolved model directory.
-fn cmd_setup_sherpa(config: &Config) -> Result<()> {
+fn cmd_setup_sherpa(config: &Config, select_sherpa: bool) -> Result<()> {
     let dir = minutes_core::sherpa_engine::model_dir(config);
     eprintln!("Installing sherpa-onnx parakeet-tdt-0.6b-v3 (int8) model");
     eprintln!("  Dir: {}", dir.display());
@@ -7809,12 +7862,11 @@ fn cmd_setup_sherpa(config: &Config) -> Result<()> {
     }
     eprintln!("\nSherpa model ready.");
 
-    // One-command UX: make sherpa the active engine. Safe to set unconditionally
-    // -- if this binary wasn't built with `--features engine-sherpa`, or the model
-    // ever goes missing, transcription auto-falls-back to whisper (with a warning),
-    // so the recording never breaks.
+    // Explicit `--sherpa` keeps the one-command UX and selects sherpa. Plain setup
+    // installs the model for `engine = "auto"` without overwriting an existing
+    // engine choice.
     let mut cfg = Config::load();
-    if cfg.transcription.engine != "sherpa" {
+    if select_sherpa && cfg.transcription.engine != "sherpa" {
         cfg.transcription.engine = "sherpa".to_string();
         match cfg.save() {
             Ok(()) => eprintln!(
@@ -7827,7 +7879,7 @@ fn cmd_setup_sherpa(config: &Config) -> Result<()> {
             ),
         }
     }
-    if !cfg!(feature = "engine-sherpa") {
+    if select_sherpa && !cfg!(feature = "engine-sherpa") {
         eprintln!(
             "Note: this build lacks the sherpa engine, so transcription falls back to whisper \
              until you build with `--features engine-sherpa`."
@@ -9413,7 +9465,7 @@ life (qmd://life/)
                 vad: true,
                 ref model,
                 ..
-            } if model == "small"
+            } if model.is_none()
         ));
 
         let parsed = parse_cli(["minutes", "setup", "--vad", "--model", "large-v3"])
@@ -9424,8 +9476,24 @@ life (qmd://life/)
                 vad: true,
                 ref model,
                 ..
-            } if model == "large-v3"
+            } if model.as_deref() == Some("large-v3")
         ));
+    }
+
+    #[test]
+    fn setup_plan_keeps_explicit_model_and_platform_defaults() {
+        let explicit = setup_plan_for(Some("medium"), true);
+        assert_eq!(explicit.whisper_model, "medium");
+        assert!(!explicit.install_sherpa);
+
+        let apple_silicon = setup_plan_for(None, true);
+        assert_eq!(apple_silicon.whisper_model, "tiny");
+        assert!(apple_silicon.install_sherpa);
+        assert!(apple_silicon.reason.contains("Apple Silicon"));
+
+        let fallback = setup_plan_for(None, false);
+        assert_eq!(fallback.whisper_model, "small");
+        assert!(!fallback.install_sherpa);
     }
 
     #[test]
@@ -9680,14 +9748,16 @@ life (qmd://life/)
 
     #[test]
     fn health_json_envelope_includes_effective_transcription_metadata() {
-        let report = health_json_report(&Config::default(), &[]);
-        let envelope = json_envelope("minutes health", report);
-        let value = serde_json::to_value(envelope).unwrap();
+        let value = health_json_envelope(&Config::default(), &[]).unwrap();
         assert_eq!(value["ok"], true);
         assert_eq!(value["command"], "minutes health");
         assert_eq!(value["meta"]["schemaVersion"], 1);
+        assert!(value["engine"].is_string());
+        assert!(value["effective_engine"].is_string());
+        assert!(value["reason"].is_string());
         assert!(value["data"]["engine"].is_string());
         assert!(value["data"]["effective_engine"].is_string());
+        assert!(value["data"]["reason"].is_string());
         assert!(value["data"]["model"].is_string());
         assert!(value["meta"]["generatedAt"].is_string());
     }
@@ -16680,8 +16750,7 @@ fn cmd_health(json: bool) -> Result<()> {
     let items = minutes_core::health::check_all(&config);
 
     if json {
-        let report = health_json_report(&config, &items);
-        let envelope = json_envelope("minutes health", report);
+        let envelope = health_json_envelope(&config, &items)?;
         println!("{}", serde_json::to_string_pretty(&envelope)?);
     } else {
         let all_ready = items.iter().all(|i| i.state == "ready");
@@ -16710,6 +16779,21 @@ fn cmd_health(json: bool) -> Result<()> {
     Ok(())
 }
 
+fn health_json_envelope(
+    config: &Config,
+    items: &[minutes_core::health::HealthItem],
+) -> Result<serde_json::Value> {
+    let report = health_json_report(config, items);
+    let mut envelope = serde_json::to_value(json_envelope("minutes health", report.clone()))?;
+    let object = envelope
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("health JSON envelope must be an object"))?;
+    for key in ["engine", "effective_engine", "reason"] {
+        object.insert(key.to_string(), report[key].clone());
+    }
+    Ok(envelope)
+}
+
 fn health_json_report(
     config: &Config,
     items: &[minutes_core::health::HealthItem],
@@ -16718,9 +16802,11 @@ fn health_json_report(
         .iter()
         .filter(|item| item.state == "attention")
         .count();
+    let resolution = minutes_core::transcribe::transcription_engine_resolution(config);
     serde_json::json!({
         "engine": config.transcription.engine,
-        "effective_engine": minutes_core::transcribe::effective_transcription_engine(config),
+        "effective_engine": resolution.engine,
+        "reason": resolution.reason,
         "model": config.transcription.model,
         "all_ready": attention_count == 0,
         "attention_count": attention_count,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -233,10 +233,10 @@ impl Default for VoiceConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TranscriptionConfig {
-    /// Transcription engine preference: "whisper" (default), "parakeet", or
-    /// "apple-speech". Apple Speech remains a retained preference and resolves
-    /// to Whisper while its authenticated byte transport awaits signed runtime
-    /// acceptance.
+    /// Transcription engine preference: "auto" (default), "whisper", "sherpa",
+    /// "parakeet", or "apple-speech". Auto selects sherpa Parakeet v3 only on
+    /// Apple Silicon when the engine is compiled and the model is installed;
+    /// otherwise it resolves to Whisper.
     pub engine: String,
     pub model: String,
     pub model_path: PathBuf,
@@ -1379,7 +1379,7 @@ impl Default for Config {
 impl Default for TranscriptionConfig {
     fn default() -> Self {
         Self {
-            engine: "whisper".into(),
+            engine: "auto".into(),
             model: "small".into(),
             model_path: minutes_dir().join("models"),
             min_words: 3,
@@ -1511,12 +1511,11 @@ impl Default for WatchConfig {
 impl Config {
     /// Effective backend for the standalone live transcript path.
     ///
-    /// `live_transcript.backend = "inherit"` follows `transcription.engine`,
-    /// except for the legacy `transcription.engine = "apple-speech"` case,
-    /// which older configs used to express the standalone-live-only Apple
-    /// experiment. We retain that preference here so non-Tauri consumers keep
-    /// the user's intent even though runtime selection currently resolves it to
-    /// sealed Whisper.
+    /// `live_transcript.backend = "inherit"` follows an explicit
+    /// `transcription.engine`, except that the batch-only `"auto"` setting
+    /// resolves to Whisper for live transcription. The legacy
+    /// `transcription.engine = "apple-speech"` case is retained here because
+    /// older configs used it to express the standalone-live-only experiment.
     pub fn effective_live_transcript_backend(&self) -> &str {
         let backend = self.live_transcript.backend.trim();
         // Case-insensitive: engine/backend matching is case-insensitive
@@ -1529,6 +1528,8 @@ impl Config {
                 .eq_ignore_ascii_case("apple-speech")
             {
                 "apple-speech"
+            } else if self.transcription.engine.eq_ignore_ascii_case("auto") {
+                "whisper"
             } else {
                 &self.transcription.engine
             }
@@ -2022,7 +2023,7 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         let config = Config::default();
-        assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(config.transcription.engine, "auto");
         assert_eq!(
             config.live_transcript.backend,
             LIVE_TRANSCRIPT_BACKEND_INHERIT
@@ -2490,7 +2491,7 @@ parakeet_binary = "/usr/local/bin/parakeet"
     }
 
     #[test]
-    fn omitted_engine_defaults_to_whisper() {
+    fn omitted_engine_defaults_to_auto() {
         let dir = TempDir::new().unwrap();
         let config_path = dir.path().join("config.toml");
         std::fs::write(
@@ -2503,7 +2504,7 @@ model = "tiny"
         .unwrap();
 
         let config = Config::load_from(&config_path);
-        assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(config.transcription.engine, "auto");
         assert_eq!(config.transcription.parakeet_binary, "parakeet");
     }
 
@@ -2514,6 +2515,13 @@ model = "tiny"
 
         assert_eq!(config.standalone_live_backend_setting(), "inherit");
         assert_eq!(config.effective_live_transcript_backend(), "parakeet");
+    }
+
+    #[test]
+    fn effective_live_transcript_backend_keeps_auto_on_whisper() {
+        let config = Config::default();
+        assert_eq!(config.transcription.engine, "auto");
+        assert_eq!(config.effective_live_transcript_backend(), "whisper");
     }
 
     #[test]
@@ -2641,7 +2649,7 @@ backend = "apple-speech"
 
         let config = Config::load_from(&config_path);
         assert_eq!(config.dictation.backend, "apple-speech");
-        assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(config.transcription.engine, "auto");
     }
 
     #[test]
@@ -2659,7 +2667,7 @@ backend = "parakeet"
 
         let config = Config::load_from(&config_path);
         assert_eq!(config.dictation.backend, "parakeet");
-        assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(config.transcription.engine, "auto");
     }
 
     // ── Call detection: stop-when-call-ends opt-in ────────────

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -253,6 +253,24 @@ pub fn append_native_call_invalid_stem_warning(
 /// Apple Speech's authenticated transport is live/dictation-only; health must
 /// describe that configured/resolved split while checking the model runtime.
 pub fn model_status(config: &Config) -> HealthItem {
+    if crate::transcribe::effective_batch_engine(config) == "sherpa" {
+        let model_dir = crate::sherpa_engine::model_dir(config);
+        let exists = crate::sherpa_engine::model_files_present(&model_dir);
+        return HealthItem {
+            label: "Speech model".into(),
+            state: if exists { "ready" } else { "attention" }.into(),
+            detail: if exists {
+                format!("Parakeet v3 is installed at {}.", model_dir.display())
+            } else {
+                format!(
+                    "Parakeet v3 is not installed at {}. Run `minutes setup` to download it.",
+                    model_dir.display()
+                )
+            },
+            optional: false,
+        };
+    }
+
     let configured_parakeet = config.transcription.engine.eq_ignore_ascii_case("parakeet");
     if configured_parakeet
         && crate::pipeline::parakeet_capability(cfg!(feature = "parakeet")).selectable

--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -253,6 +253,24 @@ pub fn append_native_call_invalid_stem_warning(
 /// Apple Speech's authenticated transport is live/dictation-only; health must
 /// describe that configured/resolved split while checking the model runtime.
 pub fn model_status(config: &Config) -> HealthItem {
+    let requested = config.transcription.engine.as_str();
+    let sherpa_plugin_required = cfg!(feature = "engine-sherpa")
+        && (requested.eq_ignore_ascii_case("sherpa")
+            || (requested.eq_ignore_ascii_case("auto")
+                && cfg!(all(
+                    feature = "engine-sherpa",
+                    target_os = "macos",
+                    target_arch = "aarch64"
+                ))));
+    if sherpa_plugin_required && !crate::transcribe::sherpa_plugin_present(config) {
+        return HealthItem {
+            label: "Speech model".into(),
+            state: "attention".into(),
+            detail: "The sherpa plugin is not installed beside this binary. Install `minutes-macos-arm64-sherpa.tar.gz` or the signed desktop app to use Parakeet v3; this install will use Whisper instead.".into(),
+            optional: false,
+        };
+    }
+
     if crate::transcribe::effective_batch_engine(config) == "sherpa" {
         let model_dir = crate::sherpa_engine::model_dir(config);
         let exists = crate::sherpa_engine::model_files_present(&model_dir);
@@ -986,6 +1004,38 @@ mod tests {
         let status = model_status(&config);
         assert_eq!(status.state, "attention");
         assert!(!status.optional);
+    }
+
+    #[cfg(feature = "engine-sherpa")]
+    #[test]
+    fn sherpa_health_names_the_packaged_installs_when_plugin_is_missing() {
+        let _env_lock = crate::test_home_env_lock();
+        let previous = std::env::var_os("MINUTES_SHERPA_PLUGIN");
+        let temp = tempfile::TempDir::new().unwrap();
+        std::env::set_var(
+            "MINUTES_SHERPA_PLUGIN",
+            temp.path().join("definitely-missing-sherpa-plugin"),
+        );
+        let config = Config {
+            transcription: crate::config::TranscriptionConfig {
+                engine: "sherpa".into(),
+                model_path: temp.path().to_path_buf(),
+                ..Config::default().transcription
+            },
+            ..Config::default()
+        };
+
+        let status = model_status(&config);
+
+        if let Some(previous) = previous {
+            std::env::set_var("MINUTES_SHERPA_PLUGIN", previous);
+        } else {
+            std::env::remove_var("MINUTES_SHERPA_PLUGIN");
+        }
+        assert_eq!(status.state, "attention");
+        assert!(status.detail.contains("minutes-macos-arm64-sherpa.tar.gz"));
+        assert!(status.detail.contains("signed desktop app"));
+        assert!(!status.detail.contains("Parakeet v3 is not installed"));
     }
 
     #[test]

--- a/crates/core/src/sherpa_plugin.rs
+++ b/crates/core/src/sherpa_plugin.rs
@@ -116,6 +116,24 @@ pub fn candidate_paths(config: &Config) -> Vec<PathBuf> {
     candidates
 }
 
+fn plugin_available_for_config(config: &Config) -> bool {
+    candidate_paths(config).iter().any(|path| path.is_file())
+}
+
+/// Whether a sherpa plugin file exists in one of the loader's search paths.
+///
+/// This intentionally does not call `dlopen`: auto-selection, health, and
+/// setup need a cheap, side-effect-free filesystem probe. The real loader
+/// still validates the plugin ABI and symbols before transcription begins.
+pub fn plugin_available() -> bool {
+    plugin_available_for_config(&Config::default())
+}
+
+/// Config-aware form used by core engine resolution.
+pub(crate) fn plugin_available_with_config(config: &Config) -> bool {
+    plugin_available_for_config(config)
+}
+
 /// Load the plugin from `path`, checking the ABI before taking any symbol.
 fn load_from(path: &Path) -> Result<PluginApi, String> {
     // SAFETY: dlopen runs the library's initializers. The path is one Minutes
@@ -484,6 +502,17 @@ mod tests {
     }
 
     #[test]
+    fn plugin_available_checks_file_presence_without_loading_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let fake = dir.path().join(plugin_file_name());
+        std::fs::write(&fake, b"not a dynamic library").unwrap();
+
+        temp_env_var("MINUTES_SHERPA_PLUGIN", fake.to_str(), || {
+            assert!(plugin_available())
+        });
+    }
+
+    #[test]
     fn loading_a_file_that_is_not_a_library_reports_the_path() {
         let dir = tempfile::tempdir().unwrap();
         let fake = dir.path().join(plugin_file_name());
@@ -501,6 +530,7 @@ mod tests {
     }
 
     fn temp_env_var(key: &str, value: Option<&str>, body: impl FnOnce()) {
+        let _env_lock = crate::test_home_env_lock();
         let previous = std::env::var(key).ok();
         match value {
             Some(v) => std::env::set_var(key, v),

--- a/crates/core/src/sherpa_plugin.rs
+++ b/crates/core/src/sherpa_plugin.rs
@@ -93,9 +93,9 @@ fn plugin_file_name() -> &'static str {
 /// `MINUTES_SHERPA_PLUGIN` wins so a developer can point at a freshly built
 /// dylib in `target/` without installing it. Otherwise it is looked for beside
 /// the running executable, which is how a packaged app carries it, and then in
-/// the Minutes install root, which is the intended install location once the
-/// plugin ships as a release asset. Nothing installs it there automatically
-/// yet, so a source build copies it or points the variable at `target/`.
+/// the Minutes install root. Release archives and the macOS app carry it beside
+/// the executable; a source build copies it there or points the variable at
+/// `target/`.
 pub fn candidate_paths(config: &Config) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     if let Ok(explicit) = std::env::var("MINUTES_SHERPA_PLUGIN") {

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -502,8 +502,8 @@ pub fn effective_transcription_engine(config: &Config) -> &str {
 }
 
 /// The effective engine and stable, user-facing reason reported by health and
-/// desktop settings. Auto resolution only checks build/platform flags and model
-/// files; it never loads a model or starts the optional engine.
+/// desktop settings. Auto resolution only checks build/platform flags, plugin
+/// presence, and model files; it never loads a plugin or model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TranscriptionEngineResolution<'a> {
     pub engine: &'a str,
@@ -513,6 +513,7 @@ pub struct TranscriptionEngineResolution<'a> {
 fn resolve_auto_transcription_engine(
     sherpa_compiled: bool,
     apple_silicon: bool,
+    plugin_present: bool,
     model_present: bool,
 ) -> TranscriptionEngineResolution<'static> {
     if !sherpa_compiled {
@@ -524,6 +525,11 @@ fn resolve_auto_transcription_engine(
         TranscriptionEngineResolution {
             engine: "whisper",
             reason: "whisper: sherpa auto-selection requires Apple Silicon",
+        }
+    } else if !plugin_present {
+        TranscriptionEngineResolution {
+            engine: "whisper",
+            reason: "whisper: sherpa plugin not found beside the binary — install the macOS sherpa archive or the desktop app",
         }
     } else if !model_present {
         TranscriptionEngineResolution {
@@ -547,6 +553,7 @@ pub fn auto_transcription_engine_resolution(
     resolve_auto_transcription_engine(
         cfg!(feature = "engine-sherpa"),
         cfg!(all(target_os = "macos", target_arch = "aarch64")),
+        sherpa_plugin_present(config),
         crate::sherpa_engine::model_files_present(&crate::sherpa_engine::model_dir(config)),
     )
 }
@@ -562,8 +569,16 @@ pub fn transcription_engine_resolution(config: &Config) -> TranscriptionEngineRe
         "whisper: configured"
     } else if requested.eq_ignore_ascii_case("sherpa") && engine == "sherpa" {
         "sherpa: configured and available"
+    } else if requested.eq_ignore_ascii_case("sherpa") && !cfg!(feature = "engine-sherpa") {
+        "whisper: configured sherpa not compiled"
+    } else if requested.eq_ignore_ascii_case("sherpa") && !sherpa_plugin_present(config) {
+        "whisper: configured sherpa plugin missing"
+    } else if requested.eq_ignore_ascii_case("sherpa")
+        && !crate::sherpa_engine::model_files_present(&crate::sherpa_engine::model_dir(config))
+    {
+        "whisper: configured sherpa model missing"
     } else if requested.eq_ignore_ascii_case("sherpa") {
-        "whisper: configured sherpa unavailable"
+        "whisper: configured sherpa plugin could not be loaded"
     } else if engine == "whisper" {
         "whisper: configured engine unavailable"
     } else {
@@ -1021,10 +1036,22 @@ pub(crate) fn sherpa_selectable(config: &Config) -> bool {
         && sherpa_plugin_unavailable_reason(config).is_none()
 }
 
+#[cfg(feature = "engine-sherpa")]
+pub(crate) fn sherpa_plugin_present(config: &Config) -> bool {
+    crate::sherpa_plugin::plugin_available_with_config(config)
+}
+
+#[cfg(not(feature = "engine-sherpa"))]
+pub(crate) fn sherpa_plugin_present(_config: &Config) -> bool {
+    false
+}
+
 /// Why sherpa is unavailable, phrased for the processing artifact.
 pub(crate) fn sherpa_unavailable_reason(config: &Config) -> &'static str {
     if !cfg!(feature = "engine-sherpa") {
         "this build was compiled without the sherpa engine"
+    } else if !sherpa_plugin_present(config) {
+        "the sherpa plugin is not installed"
     } else if !crate::sherpa_engine::model_files_present(&crate::sherpa_engine::model_dir(config)) {
         "the sherpa model is not installed"
     } else {
@@ -5066,38 +5093,84 @@ mod tests {
     }
 
     #[test]
-    fn auto_engine_resolution_covers_compiled_platform_and_model_table() {
+    fn resolve_auto_engine_covers_compiled_platform_plugin_and_model_table() {
         for sherpa_compiled in [false, true] {
             for apple_silicon in [false, true] {
-                for model_present in [false, true] {
-                    let resolution = resolve_auto_transcription_engine(
-                        sherpa_compiled,
-                        apple_silicon,
-                        model_present,
-                    );
-                    let expected = if !sherpa_compiled {
-                        ("whisper", "whisper: sherpa not compiled")
-                    } else if !apple_silicon {
-                        (
-                            "whisper",
-                            "whisper: sherpa auto-selection requires Apple Silicon",
-                        )
-                    } else if !model_present {
-                        (
-                            "whisper",
-                            "whisper: parakeet model missing — run minutes setup",
-                        )
-                    } else {
-                        ("sherpa", "sherpa: model present")
-                    };
-                    assert_eq!(
-                        (resolution.engine, resolution.reason),
-                        expected,
-                        "compiled={sherpa_compiled} apple_silicon={apple_silicon} model_present={model_present}"
-                    );
+                for plugin_present in [false, true] {
+                    for model_present in [false, true] {
+                        let resolution = resolve_auto_transcription_engine(
+                            sherpa_compiled,
+                            apple_silicon,
+                            plugin_present,
+                            model_present,
+                        );
+                        let expected = if !sherpa_compiled {
+                            ("whisper", "whisper: sherpa not compiled")
+                        } else if !apple_silicon {
+                            (
+                                "whisper",
+                                "whisper: sherpa auto-selection requires Apple Silicon",
+                            )
+                        } else if !plugin_present {
+                            (
+                                "whisper",
+                                "whisper: sherpa plugin not found beside the binary — install the macOS sherpa archive or the desktop app",
+                            )
+                        } else if !model_present {
+                            (
+                                "whisper",
+                                "whisper: parakeet model missing — run minutes setup",
+                            )
+                        } else {
+                            ("sherpa", "sherpa: model present")
+                        };
+                        assert_eq!(
+                            (resolution.engine, resolution.reason),
+                            expected,
+                            "compiled={sherpa_compiled} apple_silicon={apple_silicon} plugin_present={plugin_present} model_present={model_present}"
+                        );
+                    }
                 }
             }
         }
+    }
+
+    #[cfg(feature = "engine-sherpa")]
+    #[test]
+    fn explicit_sherpa_resolution_distinguishes_plugin_and_model_failures() {
+        let _env_lock = crate::test_home_env_lock();
+        let previous = std::env::var_os("MINUTES_SHERPA_PLUGIN");
+        let temp = tempfile::TempDir::new().unwrap();
+        let plugin = temp.path().join("synthetic-sherpa-plugin");
+        let config = Config {
+            transcription: crate::config::TranscriptionConfig {
+                engine: "sherpa".into(),
+                model_path: temp.path().join("models"),
+                ..Config::default().transcription
+            },
+            ..Config::default()
+        };
+
+        std::env::set_var("MINUTES_SHERPA_PLUGIN", temp.path().join("missing-plugin"));
+        let plugin_missing = transcription_engine_resolution(&config);
+        assert_eq!(
+            plugin_missing.reason,
+            "whisper: configured sherpa plugin missing"
+        );
+
+        std::fs::write(&plugin, b"presence is enough for the cheap probe").unwrap();
+        std::env::set_var("MINUTES_SHERPA_PLUGIN", &plugin);
+        let model_missing = transcription_engine_resolution(&config);
+
+        if let Some(previous) = previous {
+            std::env::set_var("MINUTES_SHERPA_PLUGIN", previous);
+        } else {
+            std::env::remove_var("MINUTES_SHERPA_PLUGIN");
+        }
+        assert_eq!(
+            model_missing.reason,
+            "whisper: configured sherpa model missing"
+        );
     }
 
     #[test]

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -339,17 +339,21 @@ fn normalize_decode_hint_candidate(
 //                                (to 16kHz mono PCM)
 //
 // Engines:
-//   - whisper (default): whisper.cpp via whisper-rs, Apple Accelerate on M-series
-//   - parakeet (opt-in): parakeet.cpp via subprocess, Metal on Apple Silicon
+//   - auto (default): sherpa Parakeet v3 on ready Apple Silicon builds, else whisper
+//   - whisper: whisper.cpp via whisper-rs, Apple Accelerate on M-series
+//   - sherpa: in-process Parakeet v3 via the isolated sherpa plugin
+//   - parakeet (retained): dormant parakeet.cpp subprocess preference
 //
-// Engine is selected via config.transcription.engine ("whisper" or "parakeet").
+// Engine is selected via config.transcription.engine.
 // Model must be downloaded first via `minutes setup`.
 // ──────────────────────────────────────────────────────────────
 
 /// Transcribe an audio file to text.
 ///
 /// Dispatches to the engine configured in `config.transcription.engine`:
-/// - `"whisper"` (default): whisper.cpp via whisper-rs
+/// - `"auto"` (default): sherpa on ready Apple Silicon builds, else whisper
+/// - `"whisper"`: whisper.cpp via whisper-rs
+/// - `"sherpa"`: in-process Parakeet v3 via the isolated sherpa plugin
 /// - `"parakeet"`: parakeet.cpp via subprocess
 /// - `"apple-speech"`: currently live-transcript-only; batch/default paths
 ///   fall back to whisper until the experiment graduates
@@ -407,7 +411,7 @@ fn transcribe_dispatch(
 ) -> Result<TranscribeResult, TranscribeError> {
     let requested_engine = config.transcription.engine.as_str();
     let effective_engine = effective_batch_engine(config);
-    if requested_engine != effective_engine {
+    if requested_engine != effective_engine && !requested_engine.eq_ignore_ascii_case("auto") {
         tracing::warn!(
             requested_engine,
             effective_engine,
@@ -473,6 +477,9 @@ fn transcribe_dispatch(
 /// only falling back after model or transport work has begun.
 pub(crate) fn effective_batch_engine(config: &Config) -> &str {
     let requested = config.transcription.engine.as_str();
+    if requested.eq_ignore_ascii_case("auto") {
+        return auto_transcription_engine_resolution(config).engine;
+    }
     if (requested.eq_ignore_ascii_case("parakeet")
         && !crate::pipeline::parakeet_capability(cfg!(feature = "parakeet")).selectable)
         || requested.eq_ignore_ascii_case("apple-speech")
@@ -492,6 +499,77 @@ pub(crate) fn effective_batch_engine(config: &Config) -> &str {
 /// actually use after resolving unavailable or unsupported configured engines.
 pub fn effective_transcription_engine(config: &Config) -> &str {
     effective_batch_engine(config)
+}
+
+/// The effective engine and stable, user-facing reason reported by health and
+/// desktop settings. Auto resolution only checks build/platform flags and model
+/// files; it never loads a model or starts the optional engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TranscriptionEngineResolution<'a> {
+    pub engine: &'a str,
+    pub reason: &'static str,
+}
+
+fn resolve_auto_transcription_engine(
+    sherpa_compiled: bool,
+    apple_silicon: bool,
+    model_present: bool,
+) -> TranscriptionEngineResolution<'static> {
+    if !sherpa_compiled {
+        TranscriptionEngineResolution {
+            engine: "whisper",
+            reason: "whisper: sherpa not compiled",
+        }
+    } else if !apple_silicon {
+        TranscriptionEngineResolution {
+            engine: "whisper",
+            reason: "whisper: sherpa auto-selection requires Apple Silicon",
+        }
+    } else if !model_present {
+        TranscriptionEngineResolution {
+            engine: "whisper",
+            reason: "whisper: parakeet model missing — run minutes setup",
+        }
+    } else {
+        TranscriptionEngineResolution {
+            engine: "sherpa",
+            reason: "sherpa: model present",
+        }
+    }
+}
+
+/// Resolve what `engine = "auto"` would choose for this config, regardless of
+/// the currently configured explicit engine. This is also used to label the
+/// desktop's Auto option accurately.
+pub fn auto_transcription_engine_resolution(
+    config: &Config,
+) -> TranscriptionEngineResolution<'static> {
+    resolve_auto_transcription_engine(
+        cfg!(feature = "engine-sherpa"),
+        cfg!(all(target_os = "macos", target_arch = "aarch64")),
+        crate::sherpa_engine::model_files_present(&crate::sherpa_engine::model_dir(config)),
+    )
+}
+
+pub fn transcription_engine_resolution(config: &Config) -> TranscriptionEngineResolution<'_> {
+    let requested = config.transcription.engine.as_str();
+    if requested.eq_ignore_ascii_case("auto") {
+        return auto_transcription_engine_resolution(config);
+    }
+
+    let engine = effective_batch_engine(config);
+    let reason = if requested.eq_ignore_ascii_case("whisper") {
+        "whisper: configured"
+    } else if requested.eq_ignore_ascii_case("sherpa") && engine == "sherpa" {
+        "sherpa: configured and available"
+    } else if requested.eq_ignore_ascii_case("sherpa") {
+        "whisper: configured sherpa unavailable"
+    } else if engine == "whisper" {
+        "whisper: configured engine unavailable"
+    } else {
+        "configured engine selected"
+    };
+    TranscriptionEngineResolution { engine, reason }
 }
 
 #[cfg(feature = "parakeet")]
@@ -4982,10 +5060,44 @@ mod tests {
     }
 
     #[test]
-    fn engine_defaults_to_whisper_dispatch() {
-        // Verify that the default engine config takes the whisper path
+    fn engine_defaults_to_auto() {
         let config = Config::default();
-        assert_eq!(config.transcription.engine, "whisper");
+        assert_eq!(config.transcription.engine, "auto");
+    }
+
+    #[test]
+    fn auto_engine_resolution_covers_compiled_platform_and_model_table() {
+        for sherpa_compiled in [false, true] {
+            for apple_silicon in [false, true] {
+                for model_present in [false, true] {
+                    let resolution = resolve_auto_transcription_engine(
+                        sherpa_compiled,
+                        apple_silicon,
+                        model_present,
+                    );
+                    let expected = if !sherpa_compiled {
+                        ("whisper", "whisper: sherpa not compiled")
+                    } else if !apple_silicon {
+                        (
+                            "whisper",
+                            "whisper: sherpa auto-selection requires Apple Silicon",
+                        )
+                    } else if !model_present {
+                        (
+                            "whisper",
+                            "whisper: parakeet model missing — run minutes setup",
+                        )
+                    } else {
+                        ("sherpa", "sherpa: model present")
+                    };
+                    assert_eq!(
+                        (resolution.engine, resolution.reason),
+                        expected,
+                        "compiled={sherpa_compiled} apple_silicon={apple_silicon} model_present={model_present}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/mcp/src/index.test.ts
+++ b/crates/mcp/src/index.test.ts
@@ -337,6 +337,24 @@ describe("Whisper model auto-setup", () => {
     expect(result.logs.join("\n")).toContain("skipping Whisper auto-setup");
   });
 
+  it("does not run tiny setup when auto resolves to sherpa", async () => {
+    const result = await runModelCheck({
+      health: {
+        ok: true,
+        data: {
+          engine: "auto",
+          effective_engine: "sherpa",
+          items: [missingItem],
+        },
+      },
+    });
+
+    expect(result.setups).toEqual([]);
+    expect(result.logs).toContain(
+      "[Minutes] Auto transcription resolved to sherpa — skipping Whisper auto-setup"
+    );
+  });
+
   it("conservatively skips an old CLI non-Whisper engine with upgrade guidance", async () => {
     const result = await runModelCheck({
       health: { ok: true, data: { engine: "parakeet", items: [missingItem] } },

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -2575,6 +2575,14 @@ export async function ensureWhisperModel(
     return;
   }
 
+  // Auto may resolve to sherpa when Parakeet v3 is installed. In that case
+  // Whisper readiness is irrelevant to MCP startup and must not trigger the
+  // legacy `setup --model tiny` path.
+  if (healthOutput.effectiveEngine?.toLowerCase() === "sherpa") {
+    log("[Minutes] Auto transcription resolved to sherpa — skipping Whisper auto-setup");
+    return;
+  }
+
   const modelItem = healthOutput.items.find((item) => item.label === "Speech model");
   if (!modelItem) {
     log("[Minutes] unrecognized health items — skipping Whisper auto-setup");

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -21,7 +21,7 @@ So `minutes record --device "MacBook Pro Microphone"` always wins over `[recordi
 
 | key | default | meaning |
 |---|---|---|
-| `engine` | `"whisper"` | `"whisper"` (default), or a retained `"parakeet"` preference. Parakeet is not currently selectable on any platform, so retained values resolve visibly to Whisper. |
+| `engine` | `"auto"` | `"auto"` selects sherpa Parakeet v3 on Apple Silicon when the build includes `engine-sherpa` and the model is installed, otherwise Whisper. Explicit `"whisper"` and `"sherpa"` keep their meanings; `"parakeet"` remains a retained, currently unavailable sidecar preference. |
 | `model` | `"base"` | Whisper model: `tiny` / `base` / `small` / `medium` / `large-v3` |
 | `parakeet_model` | `"tdt-ctc-110m"` | Parakeet model: `tdt-ctc-110m` or `tdt-600m` |
 | `language` | auto-detect | BCP-47 tag (e.g. `"en"`, `"es"`) to force a specific language |

--- a/docs/architecture/sherpa-engine.md
+++ b/docs/architecture/sherpa-engine.md
@@ -5,12 +5,11 @@ as the recommended SOTA / multilingual transcription engine. The Sherpa path
 runs parakeet-tdt-0.6b-v3 through the Rust `sherpa-rs` crate in-process, without
 Python and without a separate sidecar binary.
 
-Whisper.cpp remains the **bundled default** (it ships in every build and works
-on every platform with no extra download). Sherpa is **opt-in**: it is compiled
-when the `engine-sherpa` Cargo feature is enabled and selected at runtime with
-`transcription.engine = "sherpa"`. If you select Sherpa on a build/platform that
-does not have it, or before the model is installed, transcription automatically
-falls back to Whisper (with a warning) so a recording never breaks.
+`transcription.engine = "auto"` is the compiled default. On Apple Silicon it
+selects sherpa when the build includes `engine-sherpa` and the Parakeet v3 model
+is installed; otherwise it selects Whisper. Explicit `"whisper"` and `"sherpa"`
+values keep their meaning, and unavailable sherpa requests still fall back to
+Whisper so a recording never breaks.
 
 ## Quick Start (recommended)
 
@@ -75,15 +74,16 @@ minutes setup --sherpa     # downloads the int8 ONNX model + sets engine = "sher
 > cp crates/sherpa-plugin/target/release/*.so ~/.minutes/lib/
 > ```
 >
-> The binary itself no longer links sherpa at all, so it needs nothing beside
-> it. The released `minutes-linux-x64-sherpa.tar.gz` ships exactly this layout,
-> with the plugin next to the executable instead, which is the other path the
-> loader searches.
+> The binary itself no longer links sherpa at all, so the plugin must remain
+> beside it. The released Linux and macOS sherpa archives ship exactly this
+> layout, which is one of the paths the loader searches.
 >
 > Windows resolves a DLL's dependencies from the loading process's search path
 > rather than the DLL's own directory, so the same trick does not apply there
 > and it needs its own packaging. That is tracked in #645.
 
+On Apple Silicon builds with `engine-sherpa`, plain `minutes setup` downloads
+the four model files plus Whisper tiny for live and dictation fallback.
 `minutes setup --sherpa` downloads the four model files (with a size-floor
 integrity check) and writes `transcription.engine = "sherpa"` to your config, so
 no manual edit is needed. If the binary lacks the `engine-sherpa` feature, setup
@@ -106,7 +106,7 @@ The bundled engine target is:
 
 | Engine | Runtime | Model | Install shape |
 |--------|---------|-------|---------------|
-| Whisper | whisper.cpp via `whisper-rs` | small by default | default build |
+| Whisper | whisper.cpp via `whisper-rs` | small by default; tiny alongside Apple Silicon auto | every build |
 | Parakeet | external `parakeet.cpp` binary / sidecar | tdt-ctc-110m or tdt-600m | opt-in feature + external binary |
 | **Sherpa** | **in-process `sherpa-rs`** | **parakeet-tdt-0.6b-v3 int8** | **opt-in feature + ONNX files** |
 
@@ -119,7 +119,7 @@ to 16 kHz mono samples, and calls the in-process Sherpa recognizer.
 If Sherpa support is not compiled into the current build, or the model files
 are not yet installed, selecting `engine = "sherpa"` transparently falls back to
 Whisper for that recording and logs a warning (with the resolved model directory
-and whether the feature was compiled in). Whisper is the bundled default and the
+and whether the feature was compiled in). Whisper is the universal fallback and the
 fallback target, so a selected-but-unavailable Sherpa engine never breaks a
 recording.
 
@@ -199,7 +199,7 @@ configure it by hand (or to point at a custom model directory), edit
 
 ```toml
 [transcription]
-engine = "sherpa"               # "whisper" (default), "parakeet", or "sherpa"
+engine = "sherpa"               # default is "auto"; explicit "whisper" and "sherpa" are supported
 # sherpa_model_dir = "/absolute/path/to/parakeet-tdt-0.6b-v3-int8"
 ```
 
@@ -228,7 +228,8 @@ cargo build --release -p minutes-cli --features engine-sherpa,metal
 (cd crates/sherpa-plugin && cargo build --release)
 ```
 
-The feature is opt-in and not included in the default build.
+The feature is opt-in for source builds and enabled in macOS arm64 release
+builds.
 
 `engine-sherpa` and `diarize` coexist on every platform since #685, so there is
 no longer any reason to drop the default features. Before that, both stacks
@@ -261,9 +262,10 @@ Change `engine = "whisper"` in config.toml. No model deletion is required.
 The binary was built without the `engine-sherpa` feature. Rebuild with:
 
 ```bash
-# macOS: the defaults include diarize, which cannot share a binary with
-# engine-sherpa (issue #683), so drop them and re-add whisper:
-cargo build -p minutes-cli --no-default-features --features whisper,engine-sherpa,metal
+# macOS: the isolated plugin keeps sherpa's ONNX Runtime separate from
+# diarization, so the ordinary defaults can remain enabled:
+cargo build -p minutes-cli --features engine-sherpa,metal
+(cd crates/sherpa-plugin && cargo build --release)
 ```
 
 ### "sherpa model not found"

--- a/docs/architecture/sherpa-engine.md
+++ b/docs/architecture/sherpa-engine.md
@@ -6,10 +6,22 @@ runs parakeet-tdt-0.6b-v3 through the Rust `sherpa-rs` crate in-process, without
 Python and without a separate sidecar binary.
 
 `transcription.engine = "auto"` is the compiled default. On Apple Silicon it
-selects sherpa when the build includes `engine-sherpa` and the Parakeet v3 model
-is installed; otherwise it selects Whisper. Explicit `"whisper"` and `"sherpa"`
-values keep their meaning, and unavailable sherpa requests still fall back to
-Whisper so a recording never breaks.
+selects sherpa when the build includes `engine-sherpa`, the sherpa plugin is
+present, and the Parakeet v3 model is installed; otherwise it selects Whisper.
+Explicit `"whisper"` and `"sherpa"` values keep their meaning, and unavailable
+sherpa requests still fall back to Whisper so a recording never breaks.
+
+## Which install gets Parakeet by default
+
+- The signed desktop app does: the plugin is bundled and signed inside the app.
+- `minutes-macos-arm64-sherpa.tar.gz` does: keep the plugin beside the binary.
+- The bare `minutes-macos-arm64` asset, `cargo install`, and the Homebrew CLI
+  formula do not. They use Whisper until a compatible plugin is placed in a
+  loader search path.
+
+The MCP server's auto-install currently downloads the bare macOS binary, so
+agent-driven installs stay on Whisper for now. A follow-up will switch that
+installer to the sherpa archive.
 
 ## Quick Start (recommended)
 
@@ -82,8 +94,10 @@ minutes setup --sherpa     # downloads the int8 ONNX model + sets engine = "sher
 > rather than the DLL's own directory, so the same trick does not apply there
 > and it needs its own packaging. That is tracked in #645.
 
-On Apple Silicon builds with `engine-sherpa`, plain `minutes setup` downloads
-the four model files plus Whisper tiny for live and dictation fallback.
+On Apple Silicon builds with `engine-sherpa` and a plugin present, plain
+`minutes setup` downloads the four model files plus Whisper tiny for live and
+dictation fallback. Without the plugin it installs Whisper small and explains
+which packaged install includes Parakeet; setup does not download the plugin.
 `minutes setup --sherpa` downloads the four model files (with a size-floor
 integrity check) and writes `transcription.engine = "sherpa"` to your config, so
 no manual edit is needed. If the binary lacks the `engine-sherpa` feature, setup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,9 @@ Optional — minutes works out of the box.
 # Or: $XDG_CONFIG_HOME/minutes/config.toml when XDG_CONFIG_HOME is set
 
 [transcription]
-engine = "whisper"        # "whisper" is the executable private-audio backend
+engine = "auto"           # Apple Silicon release builds use Parakeet v3 when installed, otherwise Whisper
+# engine = "whisper"      # Keep Whisper explicitly on every platform
+# engine = "sherpa"       # Select the in-process Parakeet v3 engine explicitly
 model = "small"           # whisper: tiny (75MB), base, small (466MB), medium, large-v3 (3.1GB)
 # language = "ur"          # Force transcription language (ISO 639-1 code, e.g. "en", "ur", "es", "zh")
                           # Default: auto-detect. Set this for similar-sounding languages (Urdu/Hindi, etc.)

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,6 +15,18 @@ export CXXFLAGS="-I$(xcrun --show-sdk-path)/usr/include/c++/v1"
 cargo install --path crates/cli
 ```
 
+#### Which install gets Parakeet by default
+
+- The signed desktop app does: its sherpa plugin is bundled and signed.
+- `minutes-macos-arm64-sherpa.tar.gz` does: its plugin sits beside the binary.
+- The bare `minutes-macos-arm64` asset, `cargo install`, and the Homebrew CLI
+  formula do not. Those installs use Whisper until the plugin is placed beside
+  the binary or in another documented loader path.
+
+The MCP server's auto-install currently fetches the bare binary, so
+agent-driven installs stay on Whisper for now. A follow-up will move that path
+to the sherpa archive.
+
 ### Windows
 
 Download **`minutes-windows-x64.zip`** from the

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from "node:fs";
 // These whole-file hashes prevent dead/comment-only duplicate code from
 // satisfying the structural checks below.
 const EXPECTED_SOURCE_SHA256 = {
-  release: "3a71697445c183e033afeaa9fc097de990870d934933a2cbba35c2e0289d677a",
+  release: "49fb19ea5b80db818e384b3bf686047577c27216000fceda3e25912b62c05354",
   acceptance: "8ae35943181c6d0f248f580587b894c53db9c30257f307c5aa5264a83f13969d",
   build: "cbc8570be555a3d5c5679166150cdfaebaa1d15b7eaaea8cda88dc135e77e405",
   dev: "4b8cacb078a06320c9718c6f4d35801125bfa8629e71962caa841a36dcf600b4",

--- a/scripts/check_sherpa_packaging.py
+++ b/scripts/check_sherpa_packaging.py
@@ -39,6 +39,7 @@ REPO = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO / ".github/workflows/release-cli.yml"
 WORKFLOW_NAME = ".github/workflows/release-cli.yml"
 STEP_ID = "sherpa-archive"
+MAC_STEP_ID = "sherpa-macos-archive"
 LOADER = "scripts/verify_sherpa_plugin_loads.py"
 PLUGIN = "libminutes_sherpa.so"
 # Every library the archive must contain. The plugin resolves the sherpa pair
@@ -47,7 +48,7 @@ PLUGIN = "libminutes_sherpa.so"
 REQUIRED_LIBS = [PLUGIN, "libsherpa-onnx-c-api.so", "libonnxruntime.so"]
 
 
-def archive_script(workflow_text: str) -> str | None:
+def step_script(workflow_text: str, step_id: str) -> str | None:
     """The `run:` body of the archive step, found by id rather than by name."""
     try:
         document = yaml.safe_load(workflow_text)
@@ -59,7 +60,7 @@ def archive_script(workflow_text: str) -> str | None:
         return None
     for job in (document.get("jobs") or {}).values():
         for step in job.get("steps") or []:
-            if isinstance(step, dict) and step.get("id") == STEP_ID:
+            if isinstance(step, dict) and step.get("id") == step_id:
                 return step.get("run") or ""
     return None
 
@@ -76,12 +77,11 @@ def strip_comments(script: str) -> str:
 
 
 def check(workflow_text: str) -> list[str]:
-    script = archive_script(workflow_text)
+    script = step_script(workflow_text, STEP_ID)
     if script is None:
         return [
             f"no step with `id: {STEP_ID}` in {WORKFLOW_NAME}. The Linux sherpa "
-            "archive is the only shipping sherpa engine today, and this id is "
-            "what keeps its packaging gated."
+            "archive is a shipping engine, and this id keeps its packaging gated."
         ]
 
     live = strip_comments(script)
@@ -177,6 +177,61 @@ def check(workflow_text: str) -> list[str]:
             "nothing about what shipped"
         )
 
+    try:
+        document = yaml.safe_load(workflow_text)
+        matrix = document["jobs"]["build"]["strategy"]["matrix"]["include"]
+    except (KeyError, TypeError, yaml.YAMLError):
+        matrix = []
+    mac_entry = next(
+        (
+            entry
+            for entry in matrix
+            if isinstance(entry, dict)
+            and entry.get("target") == "aarch64-apple-darwin"
+        ),
+        None,
+    )
+    mac_features = str((mac_entry or {}).get("features", "")).split(",")
+    if "engine-sherpa" not in mac_features:
+        failures.append(
+            "the macOS arm64 release CLI must compile the engine-sherpa loader"
+        )
+
+    mac_script = step_script(workflow_text, MAC_STEP_ID)
+    if mac_script is None:
+        failures.append(
+            f"no step with `id: {MAC_STEP_ID}` in {WORKFLOW_NAME}; the macOS CLI "
+            "needs its in-process plugin beside the binary"
+        )
+        return failures
+
+    mac_live = strip_comments(mac_script)
+    mac_builds_plugin = re.search(
+        r"cd\s+crates/sherpa-plugin\b[^\n]*cargo\s+build", mac_live
+    ) or re.search(
+        r"cargo\s+build[^\n]*--manifest-path[^\n]*crates/sherpa-plugin",
+        mac_live,
+    )
+    if not mac_builds_plugin:
+        failures.append("the macOS sherpa archive must build crates/sherpa-plugin")
+    mac_plugin_variable = re.search(
+        r"plugin=\"[^\n]*libminutes_sherpa\.dylib\"", mac_live
+    )
+    mac_plugin_copy = re.search(
+        r"cp(?:\s+-f)?\s+\"\$plugin\"\s+\"\$out", mac_live
+    )
+    if not (mac_plugin_variable and mac_plugin_copy):
+        failures.append(
+            "the macOS sherpa archive must copy libminutes_sherpa.dylib beside the CLI"
+        )
+    if not re.search(
+        rf"{re.escape(LOADER)}[^\n]*\\[\s\S]*?\$out/libminutes_sherpa\.dylib",
+        mac_live,
+    ):
+        failures.append(
+            f"the macOS sherpa archive must run {LOADER} against its packaged dylib"
+        )
+
     return failures
 
 
@@ -202,6 +257,12 @@ MUTATIONS: list[tuple[str, object]] = [
         '              || { echo "::error::$lib missing from the sherpa archive"; exit 1; }\n',
         "            :\n")),
     ("removes the step id", lambda s: s.replace(f"        id: {STEP_ID}\n", "")),
+    ("removes the macOS step id", lambda s: s.replace(
+        f"        id: {MAC_STEP_ID}\n", "")),
+    ("drops engine-sherpa from macOS arm64", lambda s: s.replace(
+        "features: parakeet,metal,engine-sherpa", "features: parakeet,metal")),
+    ("deletes the macOS plugin copy", lambda s: s.replace(
+        '          cp -f "$plugin" "$out/"\n', "")),
 ]
 
 # Correct alternatives that must NOT be rejected, because a guard that only

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -12843,6 +12843,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
     let live_readiness = standalone_live_readiness_view(&config);
     let parakeet_capability =
         minutes_core::pipeline::parakeet_capability(cfg!(feature = "parakeet"));
+    let auto_engine = minutes_core::transcribe::auto_transcription_engine_resolution(&config);
 
     serde_json::json!({
         "config_path": path.display().to_string(),
@@ -12852,6 +12853,7 @@ pub fn cmd_get_settings() -> serde_json::Value {
         "transcription": {
             "engine": config.transcription.engine,
             "resolved_engine": batch_readiness.resolved_backend,
+            "auto_engine_reason": auto_engine.reason,
             "model": config.transcription.model,
             "downloaded_models": downloaded_models,
             "language": config.transcription.language,

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -6648,6 +6648,7 @@
           <div class="about-controls-group">
             <div class="about-controls-copy">Engine</div>
             <select id="settings-transcription-engine" class="settings-field">
+              <option value="auto">Auto (Whisper)</option>
               <option value="whisper">Whisper — broad language support, built-in</option>
               <option value="parakeet" disabled>Parakeet — unavailable</option>
               <option value="apple-speech" disabled>Apple Speech — unavailable, using Whisper</option>
@@ -12320,7 +12321,7 @@
           if (hkStatus) hkStatus.textContent = hotkeyEnabled ? 'Active' : 'Off';
         }
         // Engine selector
-        const eng = s.transcription.engine || 'whisper';
+        const eng = s.transcription.engine || 'auto';
         const resolvedBatchEngine = s.transcription.resolved_engine || eng;
         const liveTranscript = s.live_transcript || {};
         const liveBackend = liveTranscript.backend || 'inherit';
@@ -12332,6 +12333,7 @@
         const parakeetStatus = s.transcription.parakeet_status || null;
         const appleSpeechStatus = s.transcription.apple_speech_status || null;
         const engineSelect = document.getElementById('settings-transcription-engine');
+        const autoOpt = engineSelect.querySelector('option[value="auto"]');
         const parakeetOpt = engineSelect.querySelector('option[value="parakeet"]');
         const engineAppleOpt = engineSelect.querySelector('option[value="apple-speech"]');
         const engineDetail = document.getElementById('settings-transcription-engine-detail');
@@ -12339,6 +12341,11 @@
         const liveBackendDetail = document.getElementById('settings-live-backend-detail');
         const liveParakeetOpt = liveBackendSelect ? liveBackendSelect.querySelector('option[value="parakeet"]') : null;
         const liveAppleOpt = liveBackendSelect ? liveBackendSelect.querySelector('option[value="apple-speech"]') : null;
+        if (autoOpt) {
+          autoOpt.textContent = s.transcription.auto_engine_reason === 'sherpa: model present'
+            ? 'Auto (Parakeet)'
+            : 'Auto (Whisper)';
+        }
         if (parakeetOpt) {
           parakeetOpt.disabled = !parakeetSelectable;
           parakeetOpt.textContent = parakeetSelectable


### PR DESCRIPTION
Closes #369.

`transcription.engine = "auto"` becomes the compiled default. It resolves to the in-process sherpa Parakeet v3 engine only when all of these hold: the build compiled `engine-sherpa`, the target is Apple Silicon, the sherpa plugin is loadable beside the binary, and the Parakeet model files are present. Otherwise it resolves to Whisper with a reason string that says which condition failed. Explicit `"whisper"` and `"sherpa"` keep their meaning; an explicit sherpa request that cannot load still falls back to Whisper with a warning, as before. The resolution table is covered by an exhaustive unit test over all sixteen combinations.

Surfaces:
- `minutes health --json` reports `engine`, `effective_engine`, and `reason`; the "Speech model" item names the archive or the desktop app when the plugin is missing.
- Plain `minutes setup` on an Apple Silicon sherpa build with the plugin present downloads Parakeet v3 plus Whisper `tiny` (live and dictation fallback); without the plugin it installs Whisper `small` and says how to get the plugin. `--model` and `--sherpa` unchanged.
- MCP auto-setup skips Whisper setup when auto resolves to sherpa (test added).
- Desktop engine picker shows "Auto (Parakeet)" or "Auto (Whisper)" from the health reason; no new UI.
- Release workflows: macOS arm64 CLI and the Tauri app compile `engine-sherpa`; the plugin is built, signed inside-out with the app, and shipped as a new `minutes-macos-arm64-sherpa.tar.gz` asset (binary + plugin), verified by the packaging check. Binary size is unchanged (35.37 MB → 35.34 MB): sherpa lives in the dlopened plugin.

Which installs get Parakeet by default is documented in `docs/install.md` and `docs/architecture/sherpa-engine.md`: the signed desktop app and the sherpa archive do; the bare binary, `cargo install`, and the Homebrew formula stay on Whisper until the plugin sits beside them. The MCP server's auto-install still fetches the bare binary; a follow-up moves it to the archive so agent-driven installs get Parakeet.

Verified locally: `health --json` with no user config reports `auto -> whisper | whisper: sherpa plugin not found beside the binary — install the macOS sherpa archive or the desktop app`. fmt, clippy, core/CLI/MCP tests, version sync, packaging guards.