### PR TITLE
feat(mcp): auto-install fetches the signed macOS sherpa archive so agent installs get Parakeet

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -130,39 +130,6 @@ jobs:
           draft: true
           files: ${{ matrix.asset }}
 
-      - name: Package macOS CLI with the in-process sherpa plugin
-        id: sherpa-macos-archive
-        if: matrix.target == 'aarch64-apple-darwin'
-        shell: bash
-        run: |
-          set -euo pipefail
-          ( cd crates/sherpa-plugin && cargo build --release --locked )
-          plugin="crates/sherpa-plugin/target/release/libminutes_sherpa.dylib"
-          out="minutes-macos-arm64-sherpa"
-          test -f "$plugin"
-          rm -rf "$out"
-          mkdir -p "$out"
-          cp -f "target/${{ matrix.target }}/release/${{ matrix.binary }}" "$out/minutes"
-          cp -f "$plugin" "$out/"
-          ( cd /tmp && python3 \
-              "$GITHUB_WORKSPACE/scripts/verify_sherpa_plugin_loads.py" \
-              "$GITHUB_WORKSPACE/$out/libminutes_sherpa.dylib" )
-          tar czf "$out.tar.gz" "$out"
-
-      - name: Upload macOS sherpa archive artifact
-        if: matrix.target == 'aarch64-apple-darwin'
-        uses: actions/upload-artifact@v7
-        with:
-          name: minutes-macos-arm64-sherpa.tar.gz
-          path: minutes-macos-arm64-sherpa.tar.gz
-
-      - name: Upload macOS sherpa archive release asset
-        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'aarch64-apple-darwin'
-        uses: softprops/action-gh-release@v3
-        with:
-          draft: true
-          files: minutes-macos-arm64-sherpa.tar.gz
-
       # Windows needs the MSVC runtime beside the executable. Nothing ships it
       # today, so on a PC that has never had the Visual C++ Redistributable the
       # binary exits 0xC0000135 (STATUS_DLL_NOT_FOUND) printing nothing at all
@@ -327,6 +294,99 @@ jobs:
           draft: true
           files: minutes-linux-x64-sherpa.tar.gz
 
+  macos_sherpa_archive:
+    name: Package signed macOS sherpa CLI archive
+    needs: [release_readiness, build]
+    runs-on: macos-latest
+    # The Developer ID credentials are environment-scoped. Keep them out of
+    # the cross-platform build matrix and expose them only to this macOS job.
+    environment: production-release
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set CXXFLAGS for sherpa-onnx
+        run: echo "CXXFLAGS=-I$(xcrun --show-sdk-path)/usr/include/c++/v1" >> "$GITHUB_ENV"
+
+      - name: Download the arm64 CLI artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: minutes-macos-arm64
+          path: release-input
+
+      - name: Package macOS CLI with the signed in-process sherpa plugin
+        id: sherpa-macos-archive
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          set -euo pipefail
+          ( cd crates/sherpa-plugin && cargo build --release --locked )
+          plugin="crates/sherpa-plugin/target/release/libminutes_sherpa.dylib"
+          out="minutes-macos-arm64-sherpa"
+          test -f "$plugin"
+          rm -rf "$out"
+          mkdir -p "$out"
+          cp -f "release-input/minutes-macos-arm64" "$out/minutes"
+          cp -f "$plugin" "$out/"
+
+          if [[ -n "$APPLE_CERTIFICATE" && -n "$APPLE_CERTIFICATE_PASSWORD" && -n "$APPLE_SIGNING_IDENTITY" ]]; then
+            keychain="$RUNNER_TEMP/minutes-cli-release.keychain-db"
+            certificate="$RUNNER_TEMP/minutes-cli-release.p12"
+            keychain_password="$(openssl rand -hex 24)"
+            python3 - "$certificate" <<'PY'
+          import base64
+          import os
+          import pathlib
+          import sys
+
+          pathlib.Path(sys.argv[1]).write_bytes(
+              base64.b64decode(os.environ["APPLE_CERTIFICATE"], validate=True)
+          )
+          PY
+            security create-keychain -p "$keychain_password" "$keychain"
+            security set-keychain-settings -lut 21600 "$keychain"
+            security unlock-keychain -p "$keychain_password" "$keychain"
+            security import "$certificate" -k "$keychain" \
+              -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+            security set-key-partition-list -S apple-tool:,apple:,codesign: \
+              -s -k "$keychain_password" "$keychain" >/dev/null
+            security list-keychains -d user -s "$keychain"
+            security find-identity -v -p codesigning "$keychain" \
+              | grep -Fq "$APPLE_SIGNING_IDENTITY"
+            codesign --force --options runtime --timestamp \
+              --sign "$APPLE_SIGNING_IDENTITY" "$out/libminutes_sherpa.dylib"
+            codesign --verify --strict --verbose=4 "$out/libminutes_sherpa.dylib"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "::error::Apple signing credentials are required for a release archive"
+            exit 1
+          else
+            echo "Apple signing credentials unavailable; producing an unsigned workflow-dispatch artifact"
+          fi
+
+          # Loader verification must inspect the packaged copy after signing.
+          ( cd /tmp && python3 \
+              "$GITHUB_WORKSPACE/scripts/verify_sherpa_plugin_loads.py" \
+              "$GITHUB_WORKSPACE/$out/libminutes_sherpa.dylib" )
+          COPYFILE_DISABLE=1 tar czf "$out.tar.gz" "$out"
+
+      - name: Upload macOS sherpa archive artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: minutes-macos-arm64-sherpa.tar.gz
+          path: minutes-macos-arm64-sherpa.tar.gz
+
+      - name: Upload macOS sherpa archive release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: true
+          files: minutes-macos-arm64-sherpa.tar.gz
+
   # The Desktop Extension bundle. Built here rather than by hand because it is
   # the artifact the Claude Desktop directory serves, and a hand step is one
   # that gets skipped: v0.25.1 shipped every other asset automatically and was
@@ -400,7 +460,7 @@ jobs:
 
   checksums:
     name: Publish CLI checksums
-    needs: [release_readiness, build, mcpb]
+    needs: [release_readiness, build, macos_sherpa_archive, mcpb]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/crates/mcp/src/autoInstall.test.ts
+++ b/crates/mcp/src/autoInstall.test.ts
@@ -2,17 +2,39 @@ import { mkdtemp, readFile, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createHash } from "crypto";
+import { gzipSync } from "zlib";
 import { describe, expect, it } from "vitest";
 
 import {
   downloadReleaseBinaryWithChecksum,
+  extractMacSherpaArchive,
   extractZipWithPowerShell,
   findSha256ForAsset,
+  installMacSherpaArchiveWithFallback,
+  MACOS_BARE_BINARY,
+  MACOS_SHERPA_ARCHIVE,
   parseSha256Sums,
+  ReleaseAssetUnavailableError,
 } from "./autoInstall.js";
 
 function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
+}
+
+function tarArchive(files: Array<{ name: string; contents: string }>): Buffer {
+  const blocks: Buffer[] = [];
+  for (const file of files) {
+    const contents = Buffer.from(file.contents);
+    const header = Buffer.alloc(512);
+    header.write(file.name, 0, 100, "utf8");
+    header.write(`${contents.length.toString(8).padStart(11, "0")}\0`, 124, 12, "ascii");
+    header[156] = "0".charCodeAt(0);
+    blocks.push(header, contents);
+    const padding = (512 - (contents.length % 512)) % 512;
+    if (padding) blocks.push(Buffer.alloc(padding));
+  }
+  blocks.push(Buffer.alloc(1024));
+  return Buffer.concat(blocks);
 }
 
 describe("parseSha256Sums", () => {
@@ -110,6 +132,85 @@ describe("downloadReleaseBinaryWithChecksum", () => {
       })
     ).rejects.toThrow("checksum mismatch");
     await expect(stat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("macOS sherpa archive installation", () => {
+  it("extracts the fixed binary and plugin layout from a fixture tar.gz", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "minutes-mcp-sherpa-tar-"));
+    const archivePath = join(dir, MACOS_SHERPA_ARCHIVE);
+    const archive = tarArchive([
+      { name: "minutes-macos-arm64-sherpa/minutes", contents: "fixture cli" },
+      {
+        name: "minutes-macos-arm64-sherpa/libminutes_sherpa.dylib",
+        contents: "fixture plugin",
+      },
+    ]);
+    await writeFile(archivePath, gzipSync(archive));
+
+    const extracted = await extractMacSherpaArchive({
+      archivePath,
+      destDir: join(dir, "out"),
+    });
+
+    await expect(readFile(extracted.binaryPath, "utf8")).resolves.toBe("fixture cli");
+    await expect(readFile(extracted.pluginPath, "utf8")).resolves.toBe("fixture plugin");
+  });
+
+  it("falls back to the bare asset only when the archive is unavailable", async () => {
+    const installDir = await mkdtemp(join(tmpdir(), "minutes-mcp-sherpa-fallback-"));
+    const downloads: string[] = [];
+    const downloadAsset = async (input: {
+      binaryName: string;
+      targetPath: string;
+    }): Promise<void> => {
+      downloads.push(input.binaryName);
+      if (input.binaryName === MACOS_SHERPA_ARCHIVE) {
+        throw new ReleaseAssetUnavailableError(input.binaryName, "fixture archive is absent");
+      }
+      await writeFile(input.targetPath, "bare cli");
+    };
+
+    const result = await installMacSherpaArchiveWithFallback({
+      installDir,
+      execFileAsync: async () => undefined,
+      downloadAsset,
+    });
+
+    expect(downloads).toEqual([MACOS_SHERPA_ARCHIVE, MACOS_BARE_BINARY]);
+    expect(result).toEqual({ assetName: MACOS_BARE_BINARY, usedFallback: true });
+    await expect(readFile(join(installDir, "minutes"), "utf8")).resolves.toBe("bare cli");
+  });
+
+  it("keeps the previous binary and plugin when staged --version fails", async () => {
+    const installDir = await mkdtemp(join(tmpdir(), "minutes-mcp-sherpa-atomic-"));
+    const targetBinary = join(installDir, "minutes");
+    const targetPlugin = join(installDir, "libminutes_sherpa.dylib");
+    await writeFile(targetBinary, "old cli");
+    await writeFile(targetPlugin, "old plugin");
+
+    await expect(
+      installMacSherpaArchiveWithFallback({
+        installDir,
+        execFileAsync: async () => undefined,
+        downloadAsset: async (input: { targetPath: string }) => {
+          await writeFile(input.targetPath, "verified archive fixture");
+        },
+        extractArchive: async ({ destDir }) => {
+          const binaryPath = join(destDir, "minutes");
+          const pluginPath = join(destDir, "libminutes_sherpa.dylib");
+          await writeFile(binaryPath, "new cli");
+          await writeFile(pluginPath, "new plugin");
+          return { binaryPath, pluginPath };
+        },
+        verifyExecutable: async () => {
+          throw new Error("--version failed");
+        },
+      })
+    ).rejects.toThrow("--version failed");
+
+    await expect(readFile(targetBinary, "utf8")).resolves.toBe("old cli");
+    await expect(readFile(targetPlugin, "utf8")).resolves.toBe("old plugin");
   });
 });
 

--- a/crates/mcp/src/autoInstall.ts
+++ b/crates/mcp/src/autoInstall.ts
@@ -1,12 +1,39 @@
 import { createHash } from "crypto";
-import { basename } from "path";
-import { readFile, rename, rm } from "fs/promises";
+import { gunzip } from "zlib";
+import { promisify } from "util";
+import { basename, join } from "path";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "fs/promises";
 
 type ExecFileAsync = (
   file: string,
   args: readonly string[],
   options?: { timeout?: number; env?: NodeJS.ProcessEnv }
 ) => Promise<unknown>;
+
+const gunzipAsync = promisify(gunzip);
+
+export const MACOS_SHERPA_ARCHIVE = "minutes-macos-arm64-sherpa.tar.gz";
+export const MACOS_BARE_BINARY = "minutes-macos-arm64";
+
+export class ReleaseAssetUnavailableError extends Error {
+  readonly assetName: string;
+
+  constructor(assetName: string, message: string) {
+    super(message);
+    this.name = "ReleaseAssetUnavailableError";
+    this.assetName = assetName;
+  }
+}
 
 export type Sha256Entry = {
   filename: string;
@@ -56,6 +83,205 @@ export async function verifyDownloadedAsset(
     throw new Error(
       `checksum mismatch: expected ${expectedSha256.toLowerCase()}, got ${actual}`
     );
+  }
+}
+
+function tarString(header: Buffer, offset: number, length: number): string {
+  const field = header.subarray(offset, offset + length);
+  const nul = field.indexOf(0);
+  return field.subarray(0, nul === -1 ? field.length : nul).toString("utf8").trim();
+}
+
+function tarSize(header: Buffer): number {
+  const raw = tarString(header, 124, 12).replace(/\0/g, "").trim();
+  if (!/^[0-7]+$/.test(raw)) {
+    throw new Error(`invalid tar entry size ${JSON.stringify(raw)}`);
+  }
+  return Number.parseInt(raw, 8);
+}
+
+/**
+ * Extract the two files from the macOS sherpa release archive.
+ *
+ * The release archive has one fixed directory and two fixed regular files.
+ * Keeping this reader deliberately narrow avoids a package dependency and,
+ * more importantly, prevents path traversal, links, devices, or unexpected
+ * files from ever being materialized. The archive itself is SHA-256 verified
+ * before this function is called.
+ */
+export async function extractMacSherpaArchive(options: {
+  archivePath: string;
+  destDir: string;
+}): Promise<{ binaryPath: string; pluginPath: string }> {
+  const compressed = await readFile(options.archivePath);
+  const tar = await gunzipAsync(compressed);
+  const expected = new Map<string, Buffer>();
+  const root = "minutes-macos-arm64-sherpa";
+  const expectedNames = new Set([
+    `${root}/minutes`,
+    `${root}/libminutes_sherpa.dylib`,
+  ]);
+
+  let offset = 0;
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = tarString(header, 0, 100);
+    const prefix = tarString(header, 345, 155);
+    const archivePath = `${prefix ? `${prefix}/` : ""}${name}`.replace(/^\.\//, "");
+    const size = tarSize(header);
+    const type = String.fromCharCode(header[156] || 0);
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > tar.length) {
+      throw new Error(`truncated tar entry ${archivePath}`);
+    }
+
+    if (type === "\0" || type === "0") {
+      if (!expectedNames.has(archivePath)) {
+        throw new Error(`unexpected file in macOS sherpa archive: ${archivePath}`);
+      }
+      if (expected.has(archivePath)) {
+        throw new Error(`duplicate file in macOS sherpa archive: ${archivePath}`);
+      }
+      expected.set(archivePath, Buffer.from(tar.subarray(dataStart, dataEnd)));
+    } else if (type !== "5" && type !== "x" && type !== "g") {
+      throw new Error(`unsupported tar entry type ${JSON.stringify(type)} for ${archivePath}`);
+    }
+
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+
+  for (const name of expectedNames) {
+    if (!expected.has(name)) {
+      throw new Error(`macOS sherpa archive is missing ${name}`);
+    }
+  }
+
+  await mkdir(options.destDir, { recursive: true });
+  const binaryPath = join(options.destDir, "minutes");
+  const pluginPath = join(options.destDir, "libminutes_sherpa.dylib");
+  await writeFile(binaryPath, expected.get(`${root}/minutes`)!, { mode: 0o755 });
+  await writeFile(pluginPath, expected.get(`${root}/libminutes_sherpa.dylib`)!, {
+    mode: 0o755,
+  });
+  return { binaryPath, pluginPath };
+}
+
+/**
+ * Commit a verified binary/plugin pair. The binary rename is the commit point:
+ * it is never touched until the staged binary passes `--version`. If that
+ * final rename fails, restore the previous plugin so callers never observe a
+ * completed-but-partial install.
+ */
+export async function atomicReplaceMacSherpaFiles(options: {
+  stagedBinaryPath: string;
+  stagedPluginPath: string;
+  targetBinaryPath: string;
+  targetPluginPath: string;
+  backupDir: string;
+}): Promise<void> {
+  const pluginBackup = join(options.backupDir, "previous-libminutes_sherpa.dylib");
+  let hadPlugin = false;
+  try {
+    await stat(options.targetPluginPath);
+    hadPlugin = true;
+    await copyFile(options.targetPluginPath, pluginBackup);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  let pluginReplaced = false;
+  try {
+    await rename(options.stagedPluginPath, options.targetPluginPath);
+    pluginReplaced = true;
+    await rename(options.stagedBinaryPath, options.targetBinaryPath);
+  } catch (error) {
+    if (pluginReplaced) {
+      if (hadPlugin) {
+        await rename(pluginBackup, options.targetPluginPath).catch(() => {});
+      } else {
+        await rm(options.targetPluginPath, { force: true }).catch(() => {});
+      }
+    }
+    throw error;
+  } finally {
+    await rm(pluginBackup, { force: true }).catch(() => {});
+  }
+}
+
+export type MacSherpaInstallResult = {
+  assetName: string;
+  usedFallback: boolean;
+};
+
+/** Install the signed macOS sherpa archive, falling back only when unavailable. */
+export async function installMacSherpaArchiveWithFallback(options: {
+  installDir: string;
+  execFileAsync: ExecFileAsync;
+  baseUrl?: string;
+  log?: (message: string) => void;
+  downloadAsset?: typeof downloadReleaseBinaryWithChecksum;
+  extractArchive?: typeof extractMacSherpaArchive;
+  verifyExecutable?: (binaryPath: string) => Promise<void>;
+}): Promise<MacSherpaInstallResult> {
+  const log = options.log ?? (() => {});
+  const downloadAsset = options.downloadAsset ?? downloadReleaseBinaryWithChecksum;
+  const extractArchive = options.extractArchive ?? extractMacSherpaArchive;
+  await mkdir(options.installDir, { recursive: true });
+  const temporaryDir = await mkdtemp(join(options.installDir, ".minutes-sherpa-install-"));
+
+  try {
+    const archivePath = join(temporaryDir, MACOS_SHERPA_ARCHIVE);
+    try {
+      await downloadAsset({
+        binaryName: MACOS_SHERPA_ARCHIVE,
+        targetPath: archivePath,
+        execFileAsync: options.execFileAsync,
+        baseUrl: options.baseUrl,
+      });
+    } catch (error) {
+      if (!(error instanceof ReleaseAssetUnavailableError)) throw error;
+
+      log(
+        `[Minutes] ${MACOS_SHERPA_ARCHIVE} is unavailable in this release (${error.message}); ` +
+          `falling back to the bare ${MACOS_BARE_BINARY} asset`
+      );
+      const targetBinaryPath = join(options.installDir, "minutes");
+      await downloadAsset({
+        binaryName: MACOS_BARE_BINARY,
+        targetPath: targetBinaryPath,
+        execFileAsync: options.execFileAsync,
+        baseUrl: options.baseUrl,
+      });
+      await chmod(targetBinaryPath, 0o755);
+      return { assetName: MACOS_BARE_BINARY, usedFallback: true };
+    }
+
+    const extractedDir = join(temporaryDir, "extracted");
+    await mkdir(extractedDir, { recursive: true });
+    const { binaryPath, pluginPath } = await extractArchive({
+      archivePath,
+      destDir: extractedDir,
+    });
+    await chmod(binaryPath, 0o755);
+
+    const verifyExecutable = options.verifyExecutable ?? (async (path: string) => {
+      await options.execFileAsync(path, ["--version"], { timeout: 5000 });
+    });
+    await verifyExecutable(binaryPath);
+
+    await atomicReplaceMacSherpaFiles({
+      stagedBinaryPath: binaryPath,
+      stagedPluginPath: pluginPath,
+      targetBinaryPath: join(options.installDir, "minutes"),
+      targetPluginPath: join(options.installDir, "libminutes_sherpa.dylib"),
+      backupDir: temporaryDir,
+    });
+    return { assetName: MACOS_SHERPA_ARCHIVE, usedFallback: false };
+  } finally {
+    await rm(temporaryDir, { recursive: true, force: true }).catch(() => {});
   }
 }
 
@@ -121,12 +347,26 @@ export async function downloadReleaseBinaryWithChecksum(options: {
     const sums = await readFile(tempSumsPath, "utf8");
     const expectedSha256 = findSha256ForAsset(sums, binaryName);
     if (!expectedSha256) {
-      throw new Error(`SHA256SUMS.txt has no entry for ${binaryName}`);
+      throw new ReleaseAssetUnavailableError(
+        binaryName,
+        `SHA256SUMS.txt has no entry for ${binaryName}`
+      );
     }
 
-    await execFileAsync("curl", ["-fSL", "-o", tempBinaryPath, binaryUrl], {
-      timeout: 120000,
-    });
+    try {
+      await execFileAsync("curl", ["-fSL", "-o", tempBinaryPath, binaryUrl], {
+        timeout: 120000,
+      });
+    } catch (error) {
+      const stderr = String((error as { stderr?: unknown })?.stderr ?? "");
+      if (/\b404\b|not found/i.test(stderr)) {
+        throw new ReleaseAssetUnavailableError(
+          binaryName,
+          `${binaryName} returned HTTP 404`
+        );
+      }
+      throw error;
+    }
     await verifyDownloadedAsset(tempBinaryPath, expectedSha256);
     await rename(tempBinaryPath, targetPath);
   } catch (error) {

--- a/crates/mcp/src/index.test.ts
+++ b/crates/mcp/src/index.test.ts
@@ -53,6 +53,7 @@ import {
   enrichWithFrontmatter,
   extractMarkdownSection,
   getEffectiveMeetingsDir,
+  getReleaseBinaryName,
   handleMcpProcessAudioRequest,
   historicalCommitmentRows,
   isActiveCorpusMeetingPath,
@@ -206,8 +207,8 @@ describe("Whisper model auto-setup", () => {
   async function runModelCheck(input: {
     health: unknown;
     configExists?: boolean;
-  }): Promise<{ setups: string[]; logs: string[] }> {
-    const setups: string[] = [];
+  }): Promise<{ setups: Array<string | undefined>; logs: string[] }> {
+    const setups: Array<string | undefined> = [];
     const logs: string[] = [];
     await ensureWhisperModel({
       checkState: { done: false },
@@ -238,6 +239,7 @@ describe("Whisper model auto-setup", () => {
           data: {
             engine: "parakeet",
             effective_engine: "whisper",
+            reason: "whisper: configured engine unavailable",
             model: "small",
             items: [missingItem],
           },
@@ -248,6 +250,7 @@ describe("Whisper model auto-setup", () => {
       items: [missingItem],
       engine: "parakeet",
       effectiveEngine: "whisper",
+      reason: "whisper: configured engine unavailable",
       model: "small",
     });
   });
@@ -355,6 +358,41 @@ describe("Whisper model auto-setup", () => {
     );
   });
 
+  it("runs plain setup when auto has the plugin but the Parakeet model is missing", async () => {
+    const result = await runModelCheck({
+      health: {
+        ok: true,
+        data: {
+          engine: "auto",
+          effective_engine: "whisper",
+          reason: "whisper: parakeet model missing — run minutes setup",
+          model: "small",
+          items: [readyItem],
+        },
+      },
+    });
+
+    expect(result.setups).toEqual([undefined]);
+    expect(result.logs.join("\n")).toContain("running minutes setup");
+  });
+
+  it("keeps explicit Whisper on the model-specific setup path for the same reason text", async () => {
+    const result = await runModelCheck({
+      health: {
+        ok: true,
+        data: {
+          engine: "whisper",
+          effective_engine: "whisper",
+          reason: "whisper: parakeet model missing — run minutes setup",
+          model: "medium",
+          items: [missingItem],
+        },
+      },
+    });
+
+    expect(result.setups).toEqual(["medium"]);
+  });
+
   it("conservatively skips an old CLI non-Whisper engine with upgrade guidance", async () => {
     const result = await runModelCheck({
       health: { ok: true, data: { engine: "parakeet", items: [missingItem] } },
@@ -408,6 +446,18 @@ describe("Whisper model auto-setup", () => {
     });
 
     expect(result.setups).toEqual(["tiny"]);
+  });
+});
+
+describe("release asset selection", () => {
+  it.each([
+    ["darwin", "arm64", "minutes-macos-arm64-sherpa.tar.gz"],
+    ["darwin", "x64", "minutes-macos-arm64-sherpa.tar.gz"],
+    ["linux", "x64", "minutes-linux-x64"],
+    ["win32", "x64", "minutes-windows-x64.zip"],
+    ["linux", "arm64", null],
+  ] as const)("selects %s/%s", (platform, arch, expected) => {
+    expect(getReleaseBinaryName(platform, arch)).toBe(expected);
   });
 });
 

--- a/crates/mcp/src/index.ts
+++ b/crates/mcp/src/index.ts
@@ -94,6 +94,8 @@ import {
 import {
   downloadReleaseBinaryWithChecksum,
   extractZipWithPowerShell,
+  installMacSherpaArchiveWithFallback,
+  MACOS_SHERPA_ARCHIVE,
 } from "./autoInstall.js";
 import {
   attachCaptureRelay,
@@ -2275,13 +2277,14 @@ const runCapabilityRepair = createCapabilityRepairCoordinator(
   () => tryAutoInstallAttempt(true)
 );
 
-function getReleaseBinaryName(): string | null {
-  const platform = process.platform;
-  const arch = process.arch;
-  if (platform === "darwin" && arch === "arm64") return "minutes-macos-arm64";
-  if (platform === "darwin" && arch === "x64") return "minutes-macos-arm64"; // Rosetta handles it
+export function getReleaseBinaryName(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch
+): string | null {
+  if (platform === "darwin" && arch === "arm64") return MACOS_SHERPA_ARCHIVE;
+  if (platform === "darwin" && arch === "x64") return MACOS_SHERPA_ARCHIVE; // Rosetta runs arm64 CLI
   if (platform === "linux" && arch === "x64") return "minutes-linux-x64";
-  if (platform === "win32" && arch === "x64") return "minutes-windows-x64.exe";
+  if (platform === "win32" && arch === "x64") return "minutes-windows-x64.zip";
   return null;
 }
 
@@ -2323,7 +2326,23 @@ async function tryAutoInstallAttempt(capabilityRepair: boolean = false): Promise
       // Ensure install directory exists
       await mkdir(installDir, { recursive: true });
 
-      if (isWindows) {
+      if (binaryName === MACOS_SHERPA_ARCHIVE) {
+        console.error(
+          `[Minutes] Selected ${MACOS_SHERPA_ARCHIVE}: Apple Silicon auto-install ` +
+            "includes the Parakeet plugin beside the CLI"
+        );
+        const result = await installMacSherpaArchiveWithFallback({
+          installDir,
+          execFileAsync,
+          log: (message) => console.error(message),
+        });
+        if (!result.usedFallback) {
+          console.error(
+            `[Minutes] Verified ${result.assetName}, validated its CLI with --version, ` +
+              "and atomically installed the binary + sherpa plugin"
+          );
+        }
+      } else if (isWindows) {
         // The Windows binary imports the MSVC runtime (VCRUNTIME140.dll,
         // MSVCP140.dll and friends), which is not part of Windows. On a PC
         // that has never had the Visual C++ Redistributable, the bare .exe
@@ -2334,11 +2353,12 @@ async function tryAutoInstallAttempt(capabilityRepair: boolean = false): Promise
         // resolves the application's own directory ahead of the system path,
         // so extracting them next to the executable is sufficient and needs no
         // installer and no admin rights. Verified on a clean Windows 11 VM.
-        const archiveName = "minutes-windows-x64.zip";
-        const archivePath = join(installDir, archiveName);
-        console.error(`[Minutes] Downloading ${archiveName} from latest release...`);
+        const archivePath = join(installDir, binaryName);
+        console.error(
+          `[Minutes] Selected ${binaryName}: Windows needs the bundled MSVC runtime DLLs`
+        );
         await downloadReleaseBinaryWithChecksum({
-          binaryName: archiveName,
+          binaryName,
           targetPath: archivePath,
           execFileAsync,
         });
@@ -2353,7 +2373,9 @@ async function tryAutoInstallAttempt(capabilityRepair: boolean = false): Promise
         // layout would report success while MINUTES_BIN points at nothing.
         await stat(targetPath);
       } else {
-        console.error(`[Minutes] Downloading ${binaryName} from latest release...`);
+        console.error(
+          `[Minutes] Selected ${binaryName}: this platform uses the standalone CLI asset`
+        );
         // Download with curl, verify SHA256SUMS.txt, then move the verified
         // binary into place.
         await downloadReleaseBinaryWithChecksum({
@@ -2462,6 +2484,7 @@ export type HealthOutput = {
   items: HealthItem[] | null;
   engine?: string;
   effectiveEngine?: string;
+  reason?: string;
   model?: string;
 };
 
@@ -2510,6 +2533,7 @@ export function parseHealthOutput(stdout: string): HealthOutput {
     ...(typeof dataRecord.effective_engine === "string"
       ? { effectiveEngine: dataRecord.effective_engine }
       : {}),
+    ...(typeof dataRecord.reason === "string" ? { reason: dataRecord.reason } : {}),
     ...(typeof dataRecord.model === "string" ? { model: dataRecord.model } : {}),
   };
 }
@@ -2531,7 +2555,7 @@ export type EnsureWhisperModelOptions = {
   checkState?: WhisperModelCheckState;
   health?: () => Promise<string>;
   configFileExists?: () => Promise<boolean>;
-  setup?: (model: string) => Promise<void>;
+  setup?: (model?: string) => Promise<void>;
   log?: (message: string) => void;
 };
 
@@ -2551,8 +2575,9 @@ export async function ensureWhisperModel(
     });
     return stdout;
   });
-  const setup = options.setup ?? (async (model: string) => {
-    await execFileAsync(MINUTES_BIN, ["setup", "--model", model], {
+  const setup = options.setup ?? (async (model?: string) => {
+    const args = model === undefined ? ["setup"] : ["setup", "--model", model];
+    await execFileAsync(MINUTES_BIN, args, {
       timeout: 300000,
       env: mcpCliChildEnv(),
     });
@@ -2572,6 +2597,22 @@ export async function ensureWhisperModel(
 
   if (!healthOutput.ok || healthOutput.items === null) {
     log("[Minutes] Unrecognized health --json output — skipping Whisper auto-setup");
+    return;
+  }
+
+  const parakeetModelMissing =
+    healthOutput.engine?.toLowerCase() === "auto" &&
+    healthOutput.effectiveEngine?.toLowerCase() === "whisper" &&
+    healthOutput.reason === "whisper: parakeet model missing — run minutes setup";
+  if (parakeetModelMissing) {
+    log("[Minutes] Auto found the sherpa plugin but Parakeet is missing — running minutes setup...");
+    try {
+      await setup();
+      log("[Minutes] ✓ Parakeet and Whisper fallback models downloaded — recording is ready");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`[Minutes] Model download failed: ${message}. Run manually: minutes setup`);
+    }
     return;
   }
 

--- a/docs/architecture/sherpa-engine.md
+++ b/docs/architecture/sherpa-engine.md
@@ -14,14 +14,16 @@ sherpa requests still fall back to Whisper so a recording never breaks.
 ## Which install gets Parakeet by default
 
 - The signed desktop app does: the plugin is bundled and signed inside the app.
-- `minutes-macos-arm64-sherpa.tar.gz` does: keep the plugin beside the binary.
+- `minutes-macos-arm64-sherpa.tar.gz` does: keep its Developer ID-signed plugin
+  beside the binary.
 - The bare `minutes-macos-arm64` asset, `cargo install`, and the Homebrew CLI
   formula do not. They use Whisper until a compatible plugin is placed in a
   loader search path.
 
-The MCP server's auto-install currently downloads the bare macOS binary, so
-agent-driven installs stay on Whisper for now. A follow-up will switch that
-installer to the sherpa archive.
+The MCP server's Apple Silicon auto-install downloads and checksum-verifies the
+sherpa archive, verifies the staged CLI with `--version`, and then atomically
+replaces the binary and plugin. It falls back to the bare binary for older
+releases that do not publish the archive.
 
 ## Quick Start (recommended)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,14 +18,18 @@ cargo install --path crates/cli
 #### Which install gets Parakeet by default
 
 - The signed desktop app does: its sherpa plugin is bundled and signed.
-- `minutes-macos-arm64-sherpa.tar.gz` does: its plugin sits beside the binary.
+- `minutes-macos-arm64-sherpa.tar.gz` does: its Developer ID-signed plugin sits
+  beside the binary.
 - The bare `minutes-macos-arm64` asset, `cargo install`, and the Homebrew CLI
   formula do not. Those installs use Whisper until the plugin is placed beside
   the binary or in another documented loader path.
 
-The MCP server's auto-install currently fetches the bare binary, so
-agent-driven installs stay on Whisper for now. A follow-up will move that path
-to the sherpa archive.
+On Apple Silicon, the MCP server's auto-install fetches and checksum-verifies
+the sherpa archive, validates the extracted CLI, then atomically installs the
+binary and plugin together. Older releases without the archive fall back to the
+checksum-verified bare binary and stay on Whisper. When `auto` sees the plugin
+but the Parakeet model is missing, the MCP server runs plain `minutes setup`,
+which installs Parakeet plus the Whisper tiny fallback.
 
 ### Windows
 

--- a/docs/integration/agent-integrations.md
+++ b/docs/integration/agent-integrations.md
@@ -17,6 +17,22 @@ claude plugin install minutes@minutes
 The plugin starts `npx -y minutes-mcp` automatically, so its Minutes tools are
 available without a separate MCP configuration.
 
+## MCP server CLI auto-install
+
+When an MCP host starts `minutes-mcp` without a compatible Minutes CLI, the
+server installs a checksum-verified release asset. On Apple Silicon (including
+Node running under Rosetta), it selects `minutes-macos-arm64-sherpa.tar.gz`,
+which contains the CLI and its Developer ID-signed sherpa plugin. The server
+extracts into a temporary directory, confirms the staged CLI runs, and then
+atomically replaces the installed binary and plugin. Releases from before the
+archive existed fall back to the checksum-verified bare macOS binary and log
+that Parakeet is unavailable.
+
+After installation, a default `engine = "auto"` health check that finds the
+plugin but no Parakeet model triggers plain `minutes setup`. That installs the
+Parakeet model and the Whisper tiny fallback without changing explicit engine
+choices.
+
 ## Surfaces
 
 | Surface | Use when | Examples |

--- a/scripts/check_sherpa_packaging.py
+++ b/scripts/check_sherpa_packaging.py
@@ -232,6 +232,23 @@ def check(workflow_text: str) -> list[str]:
             f"the macOS sherpa archive must run {LOADER} against its packaged dylib"
         )
 
+    mac_sign = re.search(
+        r"codesign\s+--force\s+--options\s+runtime\s+--timestamp[\s\S]*?"
+        r"\$out/libminutes_sherpa\.dylib",
+        mac_live,
+    )
+    if not mac_sign:
+        failures.append(
+            "the macOS sherpa archive must Developer ID-sign its packaged dylib "
+            "with the hardened runtime and timestamp"
+        )
+    else:
+        loader_position = mac_live.find(LOADER)
+        if loader_position != -1 and loader_position < mac_sign.end():
+            failures.append(
+                f"{LOADER} must run after the packaged macOS dylib is signed"
+            )
+
     return failures
 
 
@@ -263,6 +280,10 @@ MUTATIONS: list[tuple[str, object]] = [
         "features: parakeet,metal,engine-sherpa", "features: parakeet,metal")),
     ("deletes the macOS plugin copy", lambda s: s.replace(
         '          cp -f "$plugin" "$out/"\n', "")),
+    ("deletes macOS plugin signing", lambda s: s.replace(
+        '            codesign --force --options runtime --timestamp \\\n'
+        '              --sign "$APPLE_SIGNING_IDENTITY" "$out/libminutes_sherpa.dylib"\n',
+        "")),
 ]
 
 # Correct alternatives that must NOT be rejected, because a guard that only


### PR DESCRIPTION
Stacked on #922. Retarget to `main` after that merges.

The MCP server is the dominant install channel, and after #922 `auto` only selects Parakeet when the sherpa plugin sits beside the binary. This makes the server's auto-install on Apple Silicon fetch `minutes-macos-arm64-sherpa.tar.gz` (binary + `libminutes_sherpa.dylib`) instead of the bare binary.

Safety properties, each with a test in `crates/mcp/src/autoInstall.test.ts`:
- SHA-256 of the archive is verified against `SHA256SUMS.txt` before anything is extracted; a mismatch leaves no target files.
- Extraction is a minimal tar reader over Node's built-in zlib (no new dependencies). The archive layout is pinned to exactly the two expected files; unexpected or duplicate entries throw.
- The staged binary must pass `--version` before commit. The binary rename is the commit point; if it fails, the previous plugin is restored, so a half-installed pair is never observable.
- If the archive asset is absent for a release (older tags), it falls back to the bare binary exactly as before and logs why.
- Auto-setup: when `auto` reports the plugin present but the Parakeet model missing, run plain `minutes setup` (which #922 made install Parakeet plus Whisper tiny) instead of `setup --model tiny`. Explicit engines and old CLIs keep their existing skip rules.

Release workflow: a `macos_sherpa_archive` job builds the plugin, Developer-ID-signs it with the hardened runtime and timestamp when the signing secrets are present (skipped cleanly otherwise), verifies it loads, and uploads the archive as an artifact so the checksums job includes it in `SHA256SUMS.txt`. `scripts/check_sherpa_packaging.py` now enforces the signing step. actionlint passes.

Docs: `docs/integration/agent-integrations.md` (MCP install), `docs/install.md`, `docs/architecture/sherpa-engine.md` updated so "which install gets Parakeet" now includes agent-driven installs.

Verified: MCP build, 8 integration tests, vitest 353/353 (autoInstall suite run three times), version sync, sherpa packaging check.