### PR TITLE
site: add Google Analytics (GA4) to the root layout

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Instrument_Serif } from "next/font/google";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
@@ -78,7 +79,21 @@ export default function RootLayout({
           content="#0D0D0B"
         />
       </head>
-      <body className="font-sans antialiased">{children}</body>
+      <body className="font-sans antialiased">
+        {children}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-998FBH4EMM"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-998FBH4EMM');
+          `}
+        </Script>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## What

Adds the GA4 tag for the useminutes.app property to `site/app/layout.tsx`, loaded through `next/script` with `strategy="afterInteractive"` so it does not block first paint. One file changed.

## Why

The site has had no page-level analytics. Search Console shows what Google sends; this shows what visitors do once they arrive, including which resource and comparison pages lead to the download and install paths.

## Notes

- Measurement ID is for the "Minutes" GA4 property.
- No CSP header is set on the site, so no allowlist change is needed.
- Follow-up, not in this PR: decide whether the site needs a consent notice for EU visitors, and link the GA4 property to Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
