### PR TITLE
site: Google Consent Mode defaults for the GA4 tag

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -89,6 +89,23 @@ export default function RootLayout({
           {`
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
+            // Consent Mode defaults, set before config so the first hit honors them.
+            // No ads run on this site, so ad storage is denied everywhere. Analytics
+            // cookies are denied by default in the EEA, UK, and Switzerland, where
+            // consent is required first; GA still receives cookieless pings from
+            // those visitors. Elsewhere analytics runs normally. No banner is shown.
+            gtag('consent', 'default', {
+              ad_storage: 'denied',
+              ad_user_data: 'denied',
+              ad_personalization: 'denied',
+              analytics_storage: 'granted'
+            });
+            gtag('consent', 'default', {
+              analytics_storage: 'denied',
+              region: ['AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU',
+                       'IE','IT','LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES',
+                       'SE','IS','LI','NO','GB','CH']
+            });
             gtag('js', new Date());
             gtag('config', 'G-998FBH4EMM');
           `}


### PR DESCRIPTION
## What

Adds `gtag('consent', 'default', ...)` calls ahead of the GA4 `config` call in `site/app/layout.tsx`.

- Ad storage, ad user data, and ad personalization: denied everywhere. The site runs no ads.
- Analytics storage: denied by default for visitors in the EEA, UK, and Switzerland, where consent is required before a non-essential cookie is set. GA still receives cookieless pings from those visitors. Granted everywhere else, so existing reporting is unchanged for most traffic.
- No consent banner. This is the no-UI middle ground between doing nothing and adding a cookie prompt.

## Validation

- `npm run build` in `site/`: all routes prerendered; consent defaults present in the rendered homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
