### PR TITLE
feat: add PocketStation application capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,19 @@ jobs:
         # breakage here only surfaces when Prompter next runs cargo build.
         run: cargo build -p minutes-core --no-default-features --features streaming
 
+      - name: Build PocketStation capture (Windows and Linux)
+        if: runner.os == 'Windows' || runner.os == 'Linux'
+        run: cargo build -p minutes-core --no-default-features --features pocketstation-capture
+
+      - name: Test PocketStation capture (Windows and Linux)
+        if: runner.os == 'Windows' || runner.os == 'Linux'
+        run: cargo test -p minutes-core --no-default-features --features pocketstation-capture --lib -- --test-threads=1 --nocapture
+        timeout-minutes: 15
+
+      - name: Clippy PocketStation capture (Windows and Linux)
+        if: runner.os == 'Windows' || runner.os == 'Linux'
+        run: cargo clippy -p minutes-core --no-default-features --features pocketstation-capture -- -D warnings
+
       - name: Build core with parakeet (cross-platform)
         # Guards against Linux-parakeet breakage that today only surfaces
         # at tag push via release-cli.yml. The parakeet feature compiles

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,6 +4066,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-av-foundation",
  "ort",
+ "pocketstation",
  "pyannote-rs",
  "rusqlite",
  "schemars 1.2.2",
@@ -5277,6 +5278,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocketstation"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419bd4c5dac0735627be925273e2c92d4ab4c8d75982c248707797ff01eaafa5"
+dependencies = [
+ "alsa",
+ "cc",
+ "cpal",
+ "hound",
+ "libc",
+ "libloading 0.8.9",
+ "pipewire",
+ "rtrb",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "wasapi",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5984,6 +6008,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rtrb"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae8ee26b0371a29a77d2b2d6b3ae13aa81def6f9bf1b1b92a32d279a5e709b7"
 
 [[package]]
 name = "rusqlite"
@@ -7773,7 +7803,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8390,6 +8432,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasapi"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c3aa5d6b0e7acc3ea10cb19c334df0c8d825060f14a30d9e3b03385e6e5175"
+dependencies = [
+ "log",
+ "num-integer",
+ "thiserror 2.0.20",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8642,8 +8697,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -8798,6 +8853,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -8841,12 +8906,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -8858,8 +8936,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -8889,9 +8967,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8943,6 +9043,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -8957,6 +9066,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5279,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "pocketstation"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419bd4c5dac0735627be925273e2c92d4ab4c8d75982c248707797ff01eaafa5"
+checksum = "eeb23694072ba182d17175e966fe75c67a18632de517e7d78d6197af3d23a127"
 dependencies = [
  "alsa",
  "cc",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ parakeet = ["whisper", "minutes-core/parakeet"]
 # `minutes setup --sherpa` works without this feature (path helpers are ungated);
 # this feature compiles the actual engine so `engine = "sherpa"` transcribes.
 engine-sherpa = ["minutes-core/engine-sherpa"]
+pocketstation-capture = ["minutes-core/pocketstation-capture"]
 # Streaming Silero VAD via ort. Pulls minutes-core's vad-ort. Also
 # wires the setup-time download for silero-vad-v6.2.0.onnx.
 vad-ort = ["minutes-core/vad-ort", "dep:ort"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,6 +26,7 @@ hipblas = ["whisper-rs/hipblas"]
 metal = ["whisper-rs/metal"]
 vulkan = ["whisper-rs/vulkan"]
 streaming = ["dep:crossbeam-channel"]
+pocketstation-capture = ["streaming", "dep:pocketstation"]
 denoise = ["dep:nnnoiseless"]
 # Streaming Silero VAD via ort. Implies streaming because every consumer
 # (recording sidecar) needs streaming audio. ort + ndarray are already
@@ -104,6 +105,7 @@ mach2 = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = "5.14.0"
+pocketstation = { version = "=1.1.8", default-features = false, features = ["native-capture"], optional = true }
 # sherpa-rs moved to crates/sherpa-plugin (#685).
 
 # Native hotkey (CGEventTap) uses raw FFI — no extra crate deps needed.
@@ -111,6 +113,7 @@ zbus = "5.14.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Kernel", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
+pocketstation = { version = "=1.1.8", default-features = false, features = ["native-capture"], optional = true }
 # Dynamic on Windows, as before the macOS static fix (CI builds this gate on
 # all three platforms; static archives are only wired up for macOS).
 # sherpa-rs moved to crates/sherpa-plugin (#685).

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -105,7 +105,7 @@ mach2 = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = "5.14.0"
-pocketstation = { version = "=1.1.8", default-features = false, features = ["native-capture"], optional = true }
+pocketstation = { version = "=1.1.10", default-features = false, features = ["native-capture"], optional = true }
 # sherpa-rs moved to crates/sherpa-plugin (#685).
 
 # Native hotkey (CGEventTap) uses raw FFI — no extra crate deps needed.
@@ -113,7 +113,7 @@ pocketstation = { version = "=1.1.8", default-features = false, features = ["nat
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Kernel", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
-pocketstation = { version = "=1.1.8", default-features = false, features = ["native-capture"], optional = true }
+pocketstation = { version = "=1.1.10", default-features = false, features = ["native-capture"], optional = true }
 # Dynamic on Windows, as before the macOS static fix (CI builds this gate on
 # all three platforms; static archives are only wired up for macOS).
 # sherpa-rs moved to crates/sherpa-plugin (#685).

--- a/crates/core/src/bounded_child.rs
+++ b/crates/core/src/bounded_child.rs
@@ -57,6 +57,15 @@ type ImmutableUnixExecutableSnapshot = (
     [u8; 32],
 );
 
+#[cfg(windows)]
+type ImmutableWindowsExecutableSnapshot = (
+    std::fs::File,
+    PathBuf,
+    Arc<WindowsExecutableSnapshotOwner>,
+    u64,
+    [u8; 32],
+);
+
 impl BoundExecutable {
     #[cfg(target_os = "linux")]
     fn verify(&self) -> std::io::Result<()> {
@@ -332,13 +341,7 @@ fn copy_executable_snapshot(
 #[cfg(windows)]
 fn immutable_windows_executable_snapshot(
     source: &std::fs::File,
-) -> std::io::Result<(
-    std::fs::File,
-    PathBuf,
-    Arc<WindowsExecutableSnapshotOwner>,
-    u64,
-    [u8; 32],
-)> {
+) -> std::io::Result<ImmutableWindowsExecutableSnapshot> {
     use sha2::{Digest, Sha256};
     use std::io::{Seek, SeekFrom};
     use std::os::windows::fs::OpenOptionsExt;

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -439,6 +439,7 @@ struct DualCapturePlan {
     voice_device_name: String,
     call_override: String,
     call_device_name: String,
+    call_capture_backend: crate::system_audio_backend::CaptureBackendKind,
 }
 
 #[derive(Debug, Clone)]
@@ -469,7 +470,13 @@ impl CapturePlan {
         match self {
             Self::Single(plan) => is_system_audio_route(host, &plan.device_name),
             #[cfg(feature = "streaming")]
-            Self::Dual(plan) => is_system_audio_route(host, &plan.call_device_name),
+            Self::Dual(plan) => match plan.call_capture_backend {
+                crate::system_audio_backend::CaptureBackendKind::Cpal => {
+                    is_system_audio_route(host, &plan.call_device_name)
+                }
+                crate::system_audio_backend::CaptureBackendKind::CoreAudioTap
+                | crate::system_audio_backend::CaptureBackendKind::PocketStation => true,
+            },
         }
     }
 }
@@ -557,8 +564,7 @@ fn resolve_capture_plan(config: &Config) -> Result<CapturePlan, CaptureError> {
 }
 
 pub fn resolve_system_audio_probe_device(config: &Config) -> Result<Option<String>, String> {
-    let use_core_audio_tap = crate::system_audio_backend::configured_capture_backend(config)?
-        == crate::system_audio_backend::CaptureBackendKind::CoreAudioTap;
+    let capture_backend = crate::system_audio_backend::configured_capture_backend(config)?;
     let Some(call_override) = config
         .recording
         .sources
@@ -570,7 +576,7 @@ pub fn resolve_system_audio_probe_device(config: &Config) -> Result<Option<Strin
         return Ok(None);
     };
 
-    if use_core_audio_tap {
+    if capture_backend == crate::system_audio_backend::CaptureBackendKind::CoreAudioTap {
         if crate::system_audio_backend::core_audio_tap_source_is_supported(call_override) {
             return Ok(Some(
                 crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND.to_string(),
@@ -581,6 +587,16 @@ pub fn resolve_system_audio_probe_device(config: &Config) -> Result<Option<Strin
             crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND,
             call_override
         ));
+    }
+
+    if capture_backend == crate::system_audio_backend::CaptureBackendKind::PocketStation {
+        if call_override.eq_ignore_ascii_case("auto") {
+            return Err(
+                "recording.capture_backend = 'pocketstation' requires an application name, application ID, or pid:<process id> in [recording.sources] call"
+                    .to_string(),
+            );
+        }
+        return Ok(Some(call_override.to_string()));
     }
 
     if call_override.eq_ignore_ascii_case("auto") {
@@ -621,10 +637,9 @@ fn resolve_capture_plan_with_host(
     #[cfg(feature = "streaming")]
     if let Some(call_override) = call_override {
         let (_, voice_name) = select_device_with_override(host, voice_override.as_deref())?;
-        let use_core_audio_tap = crate::system_audio_backend::configured_capture_backend(config)
-            .map_err(|error| CaptureError::Io(std::io::Error::other(error)))?
-            == crate::system_audio_backend::CaptureBackendKind::CoreAudioTap;
-        if use_core_audio_tap {
+        let capture_backend = crate::system_audio_backend::configured_capture_backend(config)
+            .map_err(|error| CaptureError::Io(std::io::Error::other(error)))?;
+        if capture_backend == crate::system_audio_backend::CaptureBackendKind::CoreAudioTap {
             if !crate::system_audio_backend::core_audio_tap_source_is_supported(call_override) {
                 return Err(CaptureError::Io(std::io::Error::other(format!(
                     "recording.capture_backend = '{}' captures the default system output; set [recording.sources] call = \"auto\" instead of '{}'",
@@ -637,6 +652,21 @@ fn resolve_capture_plan_with_host(
                 voice_device_name: voice_name,
                 call_override: crate::system_audio_backend::CORE_AUDIO_TAP_CAPTURE_BACKEND.into(),
                 call_device_name: crate::system_audio_backend::CORE_AUDIO_TAP_ROUTE_NAME.into(),
+                call_capture_backend: capture_backend,
+            }));
+        }
+        if capture_backend == crate::system_audio_backend::CaptureBackendKind::PocketStation {
+            if call_override.eq_ignore_ascii_case("auto") {
+                return Err(CaptureError::Io(std::io::Error::other(
+                    "recording.capture_backend = 'pocketstation' requires an application name, application ID, or pid:<process id> in [recording.sources] call",
+                )));
+            }
+            return Ok(CapturePlan::Dual(DualCapturePlan {
+                voice_override,
+                voice_device_name: voice_name,
+                call_override: call_override.to_string(),
+                call_device_name: format!("PocketStation application: {call_override}"),
+                call_capture_backend: capture_backend,
             }));
         }
         let resolved_call = if call_override.eq_ignore_ascii_case("auto") {
@@ -657,6 +687,7 @@ fn resolve_capture_plan_with_host(
             voice_device_name: voice_name,
             call_override: resolved_call,
             call_device_name: call_name,
+            call_capture_backend: capture_backend,
         }));
     }
 
@@ -3397,6 +3428,36 @@ mod tests {
         let error = resolve_system_audio_probe_device(&config).unwrap_err();
 
         assert!(error.contains("call = \"auto\""));
+    }
+
+    #[test]
+    fn given_pocketstation_application_when_probe_route_resolves_then_value_is_preserved() {
+        let mut config = Config::default();
+        config.recording.capture_backend =
+            crate::system_audio_backend::POCKETSTATION_CAPTURE_BACKEND.into();
+        config.recording.sources = Some(crate::config::SourcesConfig {
+            voice: Some("default".into()),
+            call: Some("Zoom".into()),
+        });
+
+        let route = resolve_system_audio_probe_device(&config).unwrap();
+
+        assert_eq!(route.as_deref(), Some("Zoom"));
+    }
+
+    #[test]
+    fn given_pocketstation_auto_selection_when_probe_route_resolves_then_error_explains_choice() {
+        let mut config = Config::default();
+        config.recording.capture_backend =
+            crate::system_audio_backend::POCKETSTATION_CAPTURE_BACKEND.into();
+        config.recording.sources = Some(crate::config::SourcesConfig {
+            voice: Some("default".into()),
+            call: Some("auto".into()),
+        });
+
+        let error = resolve_system_audio_probe_device(&config).unwrap_err();
+
+        assert!(error.contains("application name"));
     }
 
     #[test]

--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -1177,11 +1177,11 @@ fn finalize_wav_writer(
         .map_err(|e| CaptureError::Io(std::io::Error::other(format!("WAV finalize: {}", e))))
 }
 
-fn set_capture_permissions(path: &Path) {
+fn set_capture_permissions(_path: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).ok();
+        std::fs::set_permissions(_path, std::fs::Permissions::from_mode(0o600)).ok();
     }
 }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1071,8 +1071,8 @@ pub struct RecordingConfig {
     /// Allow Minutes to start a call capture even when the selected input
     /// looks like a plain microphone rather than a system-audio route.
     pub allow_degraded_call_capture: bool,
-    /// System-audio capture backend. "cpal" keeps the current loopback-device
-    /// path. "core-audio-tap" opts into Apple's macOS Process Tap backend.
+    /// Selects CPAL loopback capture, the macOS Core Audio tap, or
+    /// PocketStation application capture on Windows and Linux.
     pub capture_backend: String,
     /// Multi-source capture: explicit voice + call device names.
     /// When set, `device` is ignored. CLI `--source` flags override this.
@@ -1086,7 +1086,8 @@ pub struct RecordingConfig {
 pub struct SourcesConfig {
     /// Voice (microphone) device name, or "default" for system default.
     pub voice: Option<String>,
-    /// Call (system audio) device name, or "auto" to detect loopback devices.
+    /// Call audio device. PocketStation accepts an application name,
+    /// application ID, or `pid:<process id>` here.
     pub call: Option<String>,
 }
 

--- a/crates/core/src/context_store.rs
+++ b/crates/core/src/context_store.rs
@@ -415,6 +415,7 @@ pub fn open_db_at(path: &Path) -> Result<Connection, ContextStoreError> {
     Ok(conn)
 }
 
+#[cfg(unix)]
 fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
     let mut sidecar = path.as_os_str().to_os_string();
     sidecar.push(suffix);

--- a/crates/core/src/copilot/relay.rs
+++ b/crates/core/src/copilot/relay.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 const RELAY_PROTOCOL_VERSION: u32 = 1;
 const DISCOVERY_FILE: &str = "capture-relay.json";
 const OWNER_LOCK_FILE: &str = "capture-relay.lock";
+#[cfg(not(windows))]
 const UNIX_SOCKET_FILE: &str = "capture-relay.sock";
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 const HEARTBEAT_STALE_AFTER: Duration = Duration::from_secs(5);

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -438,6 +438,7 @@ fn with_event_log_lock<T>(f: impl FnOnce() -> std::io::Result<T>) -> std::io::Re
         fs::create_dir_all(parent)?;
     }
 
+    #[cfg(unix)]
     let creating = !path.exists();
     let file = OpenOptions::new()
         .create(true)
@@ -656,6 +657,7 @@ fn append_event_inner(envelope: &EventEnvelope) -> std::io::Result<EventEnvelope
             fs::create_dir_all(parent)?;
         }
 
+        #[cfg(unix)]
         let creating = !path.exists();
         let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
 

--- a/crates/core/src/graph.rs
+++ b/crates/core/src/graph.rs
@@ -1463,7 +1463,7 @@ mod windows_graph_journal {
             let next = u32::from_le_bytes(buffer[offset..offset + 4].try_into().ok()?) as usize;
             let name_bytes =
                 u32::from_le_bytes(buffer[offset + 8..offset + 12].try_into().ok()?) as usize;
-            if name_bytes == 0 || name_bytes % 2 != 0 {
+            if name_bytes == 0 || !name_bytes.is_multiple_of(2) {
                 return None;
             }
             let name_end = header_end.checked_add(name_bytes)?;
@@ -1487,7 +1487,7 @@ mod windows_graph_journal {
             if next == 0 {
                 break;
             }
-            if next < name_end - offset || next % 4 != 0 {
+            if next < name_end - offset || !next.is_multiple_of(4) {
                 return None;
             }
             offset = offset.checked_add(next)?;

--- a/crates/core/src/knowledge.rs
+++ b/crates/core/src/knowledge.rs
@@ -4242,13 +4242,13 @@ fn qmd_file_identity_and_links(file: &File) -> Option<(QmdObjectIdentity, u64)> 
         if unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, &mut info) } == 0 {
             return None;
         }
-        return Some((
+        Some((
             QmdObjectIdentity {
                 scope: u64::from(info.dwVolumeSerialNumber),
                 object: (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow),
             },
             u64::from(info.nNumberOfLinks),
-        ));
+        ))
     }
     #[cfg(not(any(unix, windows)))]
     {
@@ -11565,7 +11565,7 @@ fn set_restrictive_permissions(path: &Path) -> std::io::Result<()> {
 fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
     #[cfg(windows)]
     {
-        return create_private_dir_all_no_follow(path);
+        create_private_dir_all_no_follow(path)
     }
     #[cfg(not(windows))]
     fs::create_dir_all(path)?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -78,6 +78,11 @@ pub mod partial_quality;
 pub(crate) mod person_identity;
 pub mod pid;
 pub mod pipeline;
+#[cfg(all(
+    feature = "pocketstation-capture",
+    any(target_os = "linux", target_os = "windows")
+))]
+mod pocketstation_capture;
 pub mod policy_fs;
 pub mod process_trace;
 pub mod resummarize;

--- a/crates/core/src/overlays.rs
+++ b/crates/core/src/overlays.rs
@@ -366,7 +366,7 @@ mod windows_private {
             }
             let mut descriptor = Box::new(unsafe { zeroed::<SECURITY_DESCRIPTOR>() });
             let descriptor_ptr = descriptor.as_mut() as *mut SECURITY_DESCRIPTOR as *mut c_void;
-            if unsafe {
+            let initialized = unsafe {
                 InitializeSecurityDescriptor(descriptor_ptr, SECURITY_DESCRIPTOR_REVISION) != 0
                     && SetSecurityDescriptorOwner(descriptor_ptr, sid, 0) != 0
                     && SetSecurityDescriptorDacl(descriptor_ptr, 1, acl, 0) != 0
@@ -375,8 +375,8 @@ mod windows_private {
                         SE_DACL_PROTECTED,
                         SE_DACL_PROTECTED,
                     ) != 0
-            } == false
-            {
+            };
+            if !initialized {
                 unsafe { LocalFree(acl.cast()) };
                 return Err(io::Error::last_os_error());
             }

--- a/crates/core/src/pocketstation_capture.rs
+++ b/crates/core/src/pocketstation_capture.rs
@@ -1,0 +1,508 @@
+use crate::diarize::{DiagnosticConfidence, FailureKind, ObservedSignal};
+use crate::error::CaptureError;
+use crate::streaming::{AudioChunk, ChunkAccumulator, SourceRole};
+use crate::system_audio_backend::{
+    AudioSink, PermissionStatus, ProbeResult, RouteDescription, StreamHandle, SystemAudioBackend,
+    SystemAudioStreamHandle, POCKETSTATION_CAPTURE_BACKEND,
+};
+use pocketstation::{AudioFrameDuration, ProcessId, Session, SessionEventKind, Source};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+const POCKETSTATION_SAMPLE_RATE_HZ: u32 = 48_000;
+const MINUTES_SAMPLE_RATE_HZ: u32 = 16_000;
+const AUDIO_POLL_TIMEOUT_MS: u64 = 50;
+const PROBE_QUEUE_CAPACITY_CHUNKS: usize = 64;
+
+#[derive(Debug, Clone)]
+enum ApplicationSelection {
+    NameOrId(String),
+    Process(ProcessId),
+}
+
+impl ApplicationSelection {
+    fn parse(value: &str) -> Result<Self, CaptureError> {
+        let value = value.trim();
+        if value.is_empty() || value.eq_ignore_ascii_case("auto") {
+            return Err(capture_error(
+                "configure PocketStation capture",
+                "choose an application name, application ID, or pid:<process id>",
+            ));
+        }
+        let Some(process_id) = value.strip_prefix("pid:") else {
+            return Ok(Self::NameOrId(value.to_owned()));
+        };
+        let process_id = process_id.trim().parse::<u32>().map_err(|_| {
+            capture_error(
+                "parse PocketStation application",
+                format!("'{value}' is not a valid pid:<process id> selector"),
+            )
+        })?;
+        if process_id == 0 {
+            return Err(capture_error(
+                "parse PocketStation application",
+                "process id must be greater than zero",
+            ));
+        }
+        Ok(Self::Process(ProcessId::new(process_id)))
+    }
+
+    fn source(&self) -> Source {
+        match self {
+            Self::NameOrId(value) => Source::application(value.clone()),
+            Self::Process(process_id) => Source::application(*process_id),
+        }
+    }
+
+    fn route_name(&self) -> String {
+        match self {
+            Self::NameOrId(value) => format!("PocketStation application: {value}"),
+            Self::Process(process_id) => {
+                format!("PocketStation application process: {}", process_id.get())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PocketStationCapture {
+    application: ApplicationSelection,
+    route: RouteDescription,
+}
+
+impl PocketStationCapture {
+    pub(crate) fn new(value: String) -> Result<Self, CaptureError> {
+        let application = ApplicationSelection::parse(&value)?;
+        let route = RouteDescription {
+            capture_backend: POCKETSTATION_CAPTURE_BACKEND.into(),
+            device_name: Some(application.route_name()),
+        };
+        Ok(Self { application, route })
+    }
+
+    fn start_session(&self) -> Result<pocketstation::RunningSession, CaptureError> {
+        let session = Session::builder()
+            .audio_frame_duration(AudioFrameDuration::Ms10)
+            .build();
+        let application = session
+            .capture(self.application.source())
+            .map_err(|error| capture_error("select PocketStation application", error))?;
+        let output = session
+            .polled_audio()
+            .map_err(|error| capture_error("open PocketStation audio output", error))?;
+        application
+            .send(output)
+            .map_err(|error| capture_error("connect PocketStation application audio", error))?;
+        session
+            .start()
+            .map_err(|error| capture_error("start PocketStation capture", error))
+    }
+}
+
+impl SystemAudioBackend for PocketStationCapture {
+    fn probe(&self, duration_s: u32) -> Result<ProbeResult, CaptureError> {
+        let (sender, receiver) = crossbeam_channel::bounded(PROBE_QUEUE_CAPACITY_CHUNKS);
+        let stream =
+            PocketStationCaptureStream::start(self.start_session()?, sender, self.route.clone())?;
+        let deadline = Instant::now() + Duration::from_secs(u64::from(duration_s));
+        let mut frames_captured = 0usize;
+        let mut sum_square = 0.0f64;
+        let mut max_rms = 0.0f32;
+
+        while Instant::now() < deadline {
+            let timeout = deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(100));
+            match receiver.recv_timeout(timeout) {
+                Ok(chunk) => {
+                    frames_captured += chunk.samples.len();
+                    max_rms = max_rms.max(chunk.rms);
+                    sum_square += chunk
+                        .samples
+                        .iter()
+                        .map(|sample| f64::from(*sample) * f64::from(*sample))
+                        .sum::<f64>();
+                }
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        let stream_failed = stream.has_error();
+        drop(stream);
+        let avg_rms = if frames_captured == 0 {
+            0.0
+        } else {
+            (sum_square / frames_captured as f64).sqrt() as f32
+        };
+        let failure_kind = if stream_failed {
+            Some(FailureKind::StreamError)
+        } else if frames_captured == 0 {
+            Some(FailureKind::SourceStarved)
+        } else if max_rms <= 0.001 {
+            Some(FailureKind::Silent)
+        } else {
+            None
+        };
+
+        Ok(ProbeResult {
+            observed_signal: ObservedSignal {
+                frames_captured,
+                max_rms,
+                avg_rms,
+            },
+            failure_kind,
+            diagnostic_confidence: DiagnosticConfidence::High,
+        })
+    }
+
+    fn start(&mut self, sink: AudioSink) -> Result<StreamHandle, CaptureError> {
+        PocketStationCaptureStream::start(self.start_session()?, sink, self.route.clone())
+            .map(StreamHandle::new)
+    }
+
+    fn current_route(&self) -> RouteDescription {
+        self.route.clone()
+    }
+
+    fn permission_status(&self) -> Option<PermissionStatus> {
+        None
+    }
+}
+
+struct PocketStationCaptureStream {
+    stop: Arc<AtomicBool>,
+    failed: Arc<AtomicBool>,
+    dropped_chunks_total: Arc<AtomicU64>,
+    worker: Option<JoinHandle<()>>,
+    route: RouteDescription,
+}
+
+impl PocketStationCaptureStream {
+    fn start(
+        running: pocketstation::RunningSession,
+        sink: AudioSink,
+        route: RouteDescription,
+    ) -> Result<Self, CaptureError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let failed = Arc::new(AtomicBool::new(false));
+        let dropped_chunks_total = Arc::new(AtomicU64::new(0));
+        let worker = Self::spawn(
+            running,
+            sink,
+            Arc::clone(&stop),
+            Arc::clone(&failed),
+            Arc::clone(&dropped_chunks_total),
+        )?;
+        Ok(Self {
+            stop,
+            failed,
+            dropped_chunks_total,
+            worker: Some(worker),
+            route,
+        })
+    }
+
+    fn spawn(
+        mut running: pocketstation::RunningSession,
+        sink: AudioSink,
+        stop: Arc<AtomicBool>,
+        failed: Arc<AtomicBool>,
+        dropped_chunks_total: Arc<AtomicU64>,
+    ) -> Result<JoinHandle<()>, CaptureError> {
+        std::thread::Builder::new()
+            .name("minutes-pocketstation-capture".into())
+            .spawn(move || {
+                let mut writer = CallAudioChunkWriter::default();
+                while !stop.load(Ordering::Relaxed) {
+                    match running.wait_audio(Duration::from_millis(AUDIO_POLL_TIMEOUT_MS)) {
+                        Ok(Some(batch)) => {
+                            for frame_index in 0..batch.len() {
+                                let Some(frame) = batch.frame(frame_index) else {
+                                    failed.store(true, Ordering::Relaxed);
+                                    break;
+                                };
+                                if let Err(error) = writer.write_frame(
+                                    frame.sample_rate_hz(),
+                                    frame.channels(),
+                                    frame.samples(),
+                                    &sink,
+                                    &dropped_chunks_total,
+                                ) {
+                                    tracing::error!(error = %error, "PocketStation capture stopped");
+                                    failed.store(true, Ordering::Relaxed);
+                                    break;
+                                }
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(error) => {
+                            tracing::error!(error = %error, "PocketStation audio polling failed");
+                            failed.store(true, Ordering::Relaxed);
+                        }
+                    }
+                    while let pocketstation::SessionEventReceive::Event(event) =
+                        running.try_recv_event()
+                    {
+                        if Self::event_failed(event.kind()) {
+                            tracing::error!(event = ?event, "PocketStation capture failed");
+                            failed.store(true, Ordering::Relaxed);
+                        }
+                    }
+                    if failed.load(Ordering::Relaxed) {
+                        break;
+                    }
+                }
+                if !running.stop().is_success() {
+                    failed.store(true, Ordering::Relaxed);
+                }
+            })
+            .map_err(|error| capture_error("start PocketStation capture worker", error))
+    }
+
+    fn event_failed(event: &SessionEventKind) -> bool {
+        match event {
+            SessionEventKind::Source(_)
+            | SessionEventKind::Endpoint(_)
+            | SessionEventKind::Rollback(_)
+            | SessionEventKind::Finalization(_)
+            | SessionEventKind::Lifecycle(pocketstation::SessionLifecycleState::Failed) => true,
+            SessionEventKind::Terminal(outcome) => {
+                outcome.state() == pocketstation::SessionTerminalState::Failed
+            }
+            _ => false,
+        }
+    }
+}
+
+impl SystemAudioStreamHandle for PocketStationCaptureStream {
+    fn has_error(&self) -> bool {
+        self.failed.load(Ordering::Relaxed)
+    }
+
+    fn route(&self) -> RouteDescription {
+        self.route.clone()
+    }
+}
+
+/// Drop invariant — request Session shutdown before joining its owning thread,
+/// report delivery loss, and never panic.
+impl Drop for PocketStationCaptureStream {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if self
+            .worker
+            .take()
+            .is_some_and(|worker| worker.join().is_err())
+        {
+            self.failed.store(true, Ordering::Relaxed);
+            tracing::error!("PocketStation capture worker panicked");
+        }
+        let dropped_chunks_total = self.dropped_chunks_total.load(Ordering::Relaxed);
+        if dropped_chunks_total > 0 {
+            tracing::warn!(
+                dropped_chunks_total,
+                "Minutes dropped PocketStation audio because its call-audio queue was full"
+            );
+        }
+    }
+}
+
+#[derive(Default)]
+struct CallAudioChunkWriter {
+    downsample_phase_samples: usize,
+    resampled_samples: Vec<f32>,
+    chunks: ChunkAccumulator,
+}
+
+impl CallAudioChunkWriter {
+    fn write_frame(
+        &mut self,
+        sample_rate_hz: u32,
+        channels: u8,
+        samples: &[f32],
+        sink: &AudioSink,
+        dropped_chunks_total: &AtomicU64,
+    ) -> Result<(), CaptureError> {
+        if sample_rate_hz != POCKETSTATION_SAMPLE_RATE_HZ {
+            return Err(capture_error(
+                "read PocketStation audio",
+                format!(
+                    "expected {POCKETSTATION_SAMPLE_RATE_HZ} Hz audio, received {sample_rate_hz} Hz"
+                ),
+            ));
+        }
+        let channel_count = usize::from(channels);
+        if channel_count == 0 || !samples.len().is_multiple_of(channel_count) {
+            return Err(capture_error(
+                "read PocketStation audio",
+                "received an invalid channel layout",
+            ));
+        }
+
+        self.resampled_samples.clear();
+        let downsample_ratio = (POCKETSTATION_SAMPLE_RATE_HZ / MINUTES_SAMPLE_RATE_HZ) as usize;
+        for frame in samples.chunks_exact(channel_count) {
+            let mono = frame.iter().copied().sum::<f32>() / channel_count as f32;
+            if self.downsample_phase_samples == 0 {
+                self.resampled_samples.push(mono);
+            }
+            self.downsample_phase_samples = (self.downsample_phase_samples + 1) % downsample_ratio;
+        }
+
+        let mut sink_disconnected = false;
+        self.chunks.push(&self.resampled_samples, |index, samples| {
+            let rms = (samples.iter().map(|sample| sample * sample).sum::<f32>()
+                / samples.len() as f32)
+                .sqrt();
+            let chunk = AudioChunk {
+                samples,
+                rms,
+                timestamp: Instant::now(),
+                index,
+                source: SourceRole::Call,
+            };
+            match sink.try_send(chunk) {
+                Ok(()) => {}
+                Err(crossbeam_channel::TrySendError::Full(_)) => {
+                    dropped_chunks_total.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(crossbeam_channel::TrySendError::Disconnected(_)) => {
+                    sink_disconnected = true;
+                }
+            }
+        });
+        if sink_disconnected {
+            return Err(capture_error(
+                "deliver PocketStation audio",
+                "Minutes stopped receiving call audio",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn capture_error(operation: &str, error: impl std::fmt::Display) -> CaptureError {
+    CaptureError::Io(std::io::Error::other(format!("{operation}: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn given_supported_application_values_when_parsed_then_selection_succeeds() {
+        assert!(ApplicationSelection::parse("Zoom").is_ok());
+        assert!(ApplicationSelection::parse("us.zoom.xos").is_ok());
+        assert!(ApplicationSelection::parse("pid:1234").is_ok());
+    }
+
+    #[test]
+    fn given_automatic_or_invalid_process_values_when_parsed_then_selection_fails() {
+        assert!(ApplicationSelection::parse("auto").is_err());
+        assert!(ApplicationSelection::parse("pid:0").is_err());
+        assert!(ApplicationSelection::parse("pid:not-a-number").is_err());
+    }
+
+    #[test]
+    fn given_variable_frame_sizes_when_written_then_minutes_chunks_are_complete() {
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let dropped_chunks_total = AtomicU64::new(0);
+        let mut writer = CallAudioChunkWriter::default();
+        let samples = vec![0.25; POCKETSTATION_SAMPLE_RATE_HZ as usize / 10];
+
+        for frame_size_samples in [127usize, 480, 961, 3232] {
+            let mut offset_samples = 0;
+            while offset_samples < samples.len() {
+                let end_samples = (offset_samples + frame_size_samples).min(samples.len());
+                writer
+                    .write_frame(
+                        POCKETSTATION_SAMPLE_RATE_HZ,
+                        1,
+                        &samples[offset_samples..end_samples],
+                        &sender,
+                        &dropped_chunks_total,
+                    )
+                    .unwrap();
+                offset_samples = end_samples;
+            }
+        }
+
+        let chunks: Vec<_> = receiver.try_iter().collect();
+        assert_eq!(chunks.len(), 4);
+        for (index, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.samples.len(), crate::streaming::CHUNK_SAMPLES);
+            assert_eq!(chunk.index, index as u64);
+            assert_eq!(chunk.source, SourceRole::Call);
+            assert!((chunk.rms - 0.25).abs() < f32::EPSILON);
+        }
+        assert_eq!(dropped_chunks_total.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn given_unexpected_audio_format_when_written_then_capture_fails() {
+        let (sender, _receiver) = crossbeam_channel::bounded(1);
+        let dropped_chunks_total = AtomicU64::new(0);
+        let mut writer = CallAudioChunkWriter::default();
+
+        assert!(writer
+            .write_frame(44_100, 1, &[0.0; 441], &sender, &dropped_chunks_total)
+            .is_err());
+        assert!(writer
+            .write_frame(48_000, 0, &[0.0; 480], &sender, &dropped_chunks_total)
+            .is_err());
+    }
+
+    #[test]
+    fn given_closed_minutes_receiver_when_frame_is_written_then_capture_fails() {
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        drop(receiver);
+        let dropped_chunks_total = AtomicU64::new(0);
+        let mut writer = CallAudioChunkWriter::default();
+        let samples = vec![0.25; POCKETSTATION_SAMPLE_RATE_HZ as usize / 10];
+
+        let error = writer
+            .write_frame(
+                POCKETSTATION_SAMPLE_RATE_HZ,
+                1,
+                &samples,
+                &sender,
+                &dropped_chunks_total,
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("stopped receiving call audio"));
+        assert_eq!(dropped_chunks_total.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn given_full_minutes_queue_when_frame_is_written_then_drop_is_counted() {
+        let (sender, _receiver) = crossbeam_channel::bounded(1);
+        let dropped_chunks_total = AtomicU64::new(0);
+        let mut writer = CallAudioChunkWriter::default();
+        let samples = vec![0.25; POCKETSTATION_SAMPLE_RATE_HZ as usize / 10];
+
+        writer
+            .write_frame(
+                POCKETSTATION_SAMPLE_RATE_HZ,
+                1,
+                &samples,
+                &sender,
+                &dropped_chunks_total,
+            )
+            .unwrap();
+        writer
+            .write_frame(
+                POCKETSTATION_SAMPLE_RATE_HZ,
+                1,
+                &samples,
+                &sender,
+                &dropped_chunks_total,
+            )
+            .unwrap();
+
+        assert_eq!(dropped_chunks_total.load(Ordering::Relaxed), 1);
+    }
+}

--- a/crates/core/src/pocketstation_capture.rs
+++ b/crates/core/src/pocketstation_capture.rs
@@ -255,7 +255,11 @@ impl PocketStationCaptureStream {
                         break;
                     }
                 }
-                if !running.stop().is_success() {
+                // This Endpoint is polled by Minutes and has no accepted work
+                // that must be drained. Cancellation keeps Stop Recording
+                // independent from downstream delivery and asks Core to close
+                // its capture resources immediately.
+                if !running.cancel().is_success() {
                     failed.store(true, Ordering::Relaxed);
                 }
             })
@@ -287,7 +291,7 @@ impl SystemAudioStreamHandle for PocketStationCaptureStream {
     }
 }
 
-/// Drop invariant — request Session shutdown before joining its owning thread,
+/// Drop invariant — request cancellation before joining the capture worker,
 /// report delivery loss, and never panic.
 impl Drop for PocketStationCaptureStream {
     fn drop(&mut self) {
@@ -391,6 +395,8 @@ fn capture_error(operation: &str, error: impl std::fmt::Display) -> CaptureError
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const DROP_DEADLINE: Duration = Duration::from_secs(1);
 
     #[test]
     fn given_supported_application_values_when_parsed_then_selection_succeeds() {
@@ -504,5 +510,47 @@ mod tests {
             .unwrap();
 
         assert_eq!(dropped_chunks_total.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn given_running_session_when_capture_stream_is_dropped_then_shutdown_is_prompt() {
+        let session = Session::builder()
+            .audio_frame_duration(AudioFrameDuration::Ms10)
+            .build();
+        let input = session
+            .audio_input(
+                pocketstation::AudioInputConfig::new(
+                    pocketstation::SampleSpec::new(
+                        POCKETSTATION_SAMPLE_RATE_HZ,
+                        1,
+                        pocketstation::SampleFormat::F32Interleaved,
+                    ),
+                    2,
+                    480,
+                )
+                .expect("valid test audio input"),
+            )
+            .expect("application-owned test input");
+        let output = session.polled_audio().expect("test audio output");
+        input.output().send(output).expect("test audio route");
+        let running = session.start().expect("running test Session");
+        let (sink, _receiver) = crossbeam_channel::bounded(1);
+        let stream = PocketStationCaptureStream::start(
+            running,
+            sink,
+            RouteDescription {
+                capture_backend: POCKETSTATION_CAPTURE_BACKEND.into(),
+                device_name: Some("application-owned test input".into()),
+            },
+        )
+        .expect("capture worker");
+
+        let started = Instant::now();
+        drop(stream);
+
+        assert!(
+            started.elapsed() < DROP_DEADLINE,
+            "dropping PocketStation capture must not wait for orderly delivery"
+        );
     }
 }

--- a/crates/core/src/screen.rs
+++ b/crates/core/src/screen.rs
@@ -323,14 +323,18 @@ fn capture_screenshot(path: &Path) -> std::io::Result<()> {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
-        return Err(std::io::Error::other(
-            "screen capture not supported on this platform",
-        ));
+        Ok(())
     }
 
-    Ok(())
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = path;
+        Err(std::io::Error::other(
+            "screen capture not supported on this platform",
+        ))
+    }
 }
 
 /// Derive the screenshots directory for a given audio recording path.

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -508,6 +508,7 @@ impl MeetingMutation {
         }
         #[cfg(windows)]
         {
+            let _ = writable;
             use windows_sys::Win32::Foundation::GENERIC_READ;
             use windows_sys::Win32::Storage::FileSystem::{
                 DELETE, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE, FILE_SHARE_READ,
@@ -763,6 +764,9 @@ impl MeetingMutation {
         after_atomic_claim: impl FnOnce(),
         after_atomic_promotion: impl FnOnce(),
     ) -> std::io::Result<()> {
+        #[cfg(not(unix))]
+        let _ = (source_path, destination_path);
+
         #[cfg(unix)]
         {
             // POSIX cannot rename an opened file handle. First atomically claim

--- a/crates/core/src/system_audio_backend.rs
+++ b/crates/core/src/system_audio_backend.rs
@@ -36,6 +36,7 @@ pub struct ProbeResult {
 
 pub const CPAL_CAPTURE_BACKEND: &str = "cpal";
 pub const CORE_AUDIO_TAP_CAPTURE_BACKEND: &str = "core-audio-tap";
+pub const POCKETSTATION_CAPTURE_BACKEND: &str = "pocketstation";
 pub const CORE_AUDIO_TAP_ROUTE_NAME: &str = "Core Audio Process Tap";
 pub const CORE_AUDIO_TAP_MIN_MACOS: MacOsVersion = MacOsVersion {
     major: 14,
@@ -46,6 +47,7 @@ pub const CORE_AUDIO_TAP_MIN_MACOS: MacOsVersion = MacOsVersion {
 pub enum CaptureBackendKind {
     Cpal,
     CoreAudioTap,
+    PocketStation,
 }
 
 impl CaptureBackendKind {
@@ -53,6 +55,7 @@ impl CaptureBackendKind {
         match self {
             Self::Cpal => CPAL_CAPTURE_BACKEND,
             Self::CoreAudioTap => CORE_AUDIO_TAP_CAPTURE_BACKEND,
+            Self::PocketStation => POCKETSTATION_CAPTURE_BACKEND,
         }
     }
 }
@@ -92,8 +95,9 @@ pub fn parse_capture_backend(value: &str) -> Result<CaptureBackendKind, String> 
         "core-audio-tap" | "core_audio_tap" | "coreaudio-tap" | "process-tap" => {
             Ok(CaptureBackendKind::CoreAudioTap)
         }
+        "pocketstation" => Ok(CaptureBackendKind::PocketStation),
         other => Err(format!(
-            "unknown recording.capture_backend '{other}'; expected 'cpal' or 'core-audio-tap'"
+            "unknown recording.capture_backend '{other}'; expected 'cpal', 'core-audio-tap', or 'pocketstation'"
         )),
     }
 }
@@ -131,6 +135,33 @@ pub fn system_audio_backend_for_config(
                 ))
             }
         }
+        CaptureBackendKind::PocketStation => {
+            if route_hint.trim().is_empty() || route_hint.eq_ignore_ascii_case("auto") {
+                return Err(capture_config_error(
+                    "recording.capture_backend = 'pocketstation' requires an application name, application ID, or pid:<process id> in [recording.sources] call",
+                ));
+            }
+
+            #[cfg(all(
+                feature = "pocketstation-capture",
+                any(target_os = "linux", target_os = "windows")
+            ))]
+            {
+                Ok(Box::new(
+                    crate::pocketstation_capture::PocketStationCapture::new(route_hint)?,
+                ))
+            }
+            #[cfg(not(all(
+                feature = "pocketstation-capture",
+                any(target_os = "linux", target_os = "windows")
+            )))]
+            {
+                let _ = route_hint;
+                Err(capture_config_error(
+                    "recording.capture_backend = 'pocketstation' is available on Windows and Linux when minutes-core is built with the 'pocketstation-capture' feature",
+                ))
+            }
+        }
     }
 }
 
@@ -145,7 +176,7 @@ pub trait SystemAudioBackend {
     fn permission_status(&self) -> Option<PermissionStatus>;
 }
 
-trait SystemAudioStreamHandle: Send {
+pub(crate) trait SystemAudioStreamHandle: Send {
     fn has_error(&self) -> bool;
     fn route(&self) -> RouteDescription;
 }
@@ -155,7 +186,7 @@ pub struct StreamHandle {
 }
 
 impl StreamHandle {
-    fn new(inner: impl SystemAudioStreamHandle + 'static) -> Self {
+    pub(crate) fn new(inner: impl SystemAudioStreamHandle + 'static) -> Self {
         Self {
             inner: Box::new(inner),
         }
@@ -849,7 +880,7 @@ mod tests {
     }
 
     #[test]
-    fn capture_backend_parser_accepts_default_and_core_audio_tap_aliases() {
+    fn given_supported_backend_names_when_parsed_then_kind_is_returned() {
         assert_eq!(parse_capture_backend(""), Ok(CaptureBackendKind::Cpal));
         assert_eq!(parse_capture_backend("cpal"), Ok(CaptureBackendKind::Cpal));
         assert_eq!(
@@ -859,6 +890,10 @@ mod tests {
         assert_eq!(
             parse_capture_backend("core_audio_tap"),
             Ok(CaptureBackendKind::CoreAudioTap)
+        );
+        assert_eq!(
+            parse_capture_backend("pocketstation"),
+            Ok(CaptureBackendKind::PocketStation)
         );
         assert!(parse_capture_backend("screencapturekit").is_err());
     }

--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -241,6 +241,7 @@ fn wait_for_settle(path: &Path, delay_ms: u64) -> bool {
     true
 }
 
+#[cfg(any(not(windows), test))]
 fn atomic_noreplace_unavailable(
     source: &Path,
     destination: &Path,

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -151,18 +151,24 @@ session cadence and confidence gates. See
 | `min_disk_space_mb` | `500` | Auto-stop when free disk space drops below this; 0 = off |
 | `auto_call_intent` | `false` | Infer call intent from process detection (high false-positive rate) |
 | `allow_degraded_call_capture` | `false` | Allow call capture when selected input isn't a system-audio route |
-| `capture_backend` | `"cpal"` | System-audio backend: `"cpal"` for loopback devices, or opt-in `"core-audio-tap"` on macOS 14.4+ |
+| `capture_backend` | `"cpal"` | `"cpal"` for loopback devices, `"core-audio-tap"` on macOS 14.4+, or opt-in `"pocketstation"` application capture on Windows and Linux |
 
 ### `[recording.sources]` — multi-source capture
 
 | key | default | meaning |
 |---|---|---|
 | `voice` | unset | Voice (mic) device name, or `"default"` |
-| `call` | unset | Call (system audio) device name, or `"auto"` to detect loopback |
+| `call` | unset | Call audio device, or `"auto"` to detect loopback. PocketStation accepts an application name, application ID, or `pid:<process id>` |
 
 When `capture_backend = "core-audio-tap"`, set `call = "auto"`. The backend
 captures the default macOS system output via Core Audio Process Tap instead of
 opening a named loopback input device.
+
+When `capture_backend = "pocketstation"`, choose the application in `call`.
+Minutes then records that application and the selected microphone as separate
+stems on Windows or Linux. See
+[PocketStation capture](pocketstation-capture.md) for build and configuration
+instructions.
 
 ### `[consent]` — recording disclosure aid
 

--- a/docs/architecture/pocketstation-capture.md
+++ b/docs/architecture/pocketstation-capture.md
@@ -1,0 +1,74 @@
+# PocketStation capture on Windows and Linux
+
+Minutes can use PocketStation to record one desktop application without a
+virtual audio device. The microphone remains a separate source, so Minutes can
+write the mixed recording and both original stems.
+
+This integration is available on Windows and Linux and is off by default.
+macOS recording continues to use Minutes' existing capture code.
+
+## Build Minutes
+
+Enable the `pocketstation-capture` feature:
+
+```bash
+cargo build --release -p minutes-cli --features pocketstation-capture
+```
+
+The feature uses PocketStation 1.1.8 from crates.io. It does not require a
+PocketStation source checkout.
+
+## Choose an application
+
+Add the following settings to `~/.config/minutes/config.toml`:
+
+```toml
+[recording]
+capture_backend = "pocketstation"
+
+[recording.sources]
+voice = "default"
+call = "Zoom"
+```
+
+`voice` selects the microphone. `call` selects the application audio and must
+contain one of these values:
+
+- an exact application name, such as `"Zoom"`;
+- an application ID exposed by the operating system;
+- a process ID written as `"pid:1234"`.
+
+PocketStation rejects a name or ID that matches more than one application.
+Process IDs are useful for automated tests but change whenever an application
+starts. `call = "auto"` is not supported because recording the wrong
+application would be difficult to notice.
+
+Start a recording with the normal Minutes command:
+
+```bash
+minutes record
+```
+
+Minutes writes:
+
+- `meeting.wav`, the mixed recording;
+- `meeting.voice.wav`, the microphone;
+- `meeting.system.wav`, the selected application.
+
+The three files use the same 16 kHz timeline. If either source is briefly late,
+Minutes writes silence for that source instead of shifting the stems out of
+alignment.
+
+## Failure behavior
+
+PocketStation delivers 10 ms audio frames to a dedicated Minutes worker. The
+worker converts 48 kHz application audio to the 16 kHz format used by Minutes
+and groups it into 100 ms chunks.
+
+Minutes keeps 64 call-audio chunks in memory, which is 6.4 seconds at this
+format. If the recording loop cannot keep up, new application chunks are
+dropped and the total is written to the log. Capture errors stop the current
+PocketStation session; Minutes can then use its existing restart handling.
+
+Application capture does not bypass microphone permissions, operating-system
+audio permissions, or Minutes' recording consent settings.

--- a/docs/architecture/pocketstation-capture.md
+++ b/docs/architecture/pocketstation-capture.md
@@ -15,7 +15,7 @@ Enable the `pocketstation-capture` feature:
 cargo build --release -p minutes-cli --features pocketstation-capture
 ```
 
-The feature uses PocketStation 1.1.8 from crates.io. It does not require a
+The feature uses PocketStation 1.1.10 from crates.io. It does not require a
 PocketStation source checkout.
 
 ## Choose an application
@@ -55,9 +55,11 @@ Minutes writes:
 - `meeting.voice.wav`, the microphone;
 - `meeting.system.wav`, the selected application.
 
-The three files use the same 16 kHz timeline. If either source is briefly late,
-Minutes writes silence for that source instead of shifting the stems out of
-alignment.
+Minutes writes all three files at 16 kHz and groups both live sources into
+100 ms chunks. Each source begins with chunk zero when that source starts.
+This experimental backend does not yet measure a common start time between the
+microphone and application capture, so a delayed application start is not
+backfilled with silence from the microphone's start time.
 
 ## Failure behavior
 
@@ -67,8 +69,10 @@ and groups it into 100 ms chunks.
 
 Minutes keeps 64 call-audio chunks in memory, which is 6.4 seconds at this
 format. If the recording loop cannot keep up, new application chunks are
-dropped and the total is written to the log. Capture errors stop the current
-PocketStation session; Minutes can then use its existing restart handling.
+dropped and the total is written to the log. Capture errors cancel the current
+PocketStation Session; Minutes can then use its existing restart handling.
+Stopping a recording also cancels this polled-audio Session before Minutes
+waits for the capture worker, so finalization does not drain pending delivery.
 
 Application capture does not bypass microphone permissions, operating-system
 audio permissions, or Minutes' recording consent settings.

--- a/scripts/check_graph_worker_packaging.mjs
+++ b/scripts/check_graph_worker_packaging.mjs
@@ -19,7 +19,7 @@ const EXPECTED_SOURCE_SHA256 = {
   authority: "2275155b7dd21b47bb0e3a2d79b90ca550d9f27e9997f072cf30e13dde707cf4",
   helperPlist: "543617b03e757520a201bd0a7751cc6aadb48cf0d6b4a44bfc9ef4323a69850f",
   helperEntry: "0efe701412d909021d6ae784eac941e7d9b9d1a0f2ee0f3144bcb15fc2b2ba18",
-  cliCargo: "f913a80d8737c3d4800e75ebe7701585cb771ec4481d714b6b3b0cddc4877936",
+  cliCargo: "67c7e06c6012cfdcbf8e4c1a2fd90af30a1928e4b9221a38fa99f7be172bc9b5",
 };
 
 const sources = {

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -7,6 +7,7 @@ description = "Minutes — menu bar app for conversation memory"
 [features]
 parakeet = ["minutes-core/parakeet", "minutes-core/whisper"]
 engine-sherpa = ["minutes-core/engine-sherpa"]
+pocketstation-capture = ["minutes-core/pocketstation-capture"]
 vad-ort = ["minutes-core/vad-ort"]
 coreml = ["minutes-core/coreml"]
 cuda = ["minutes-core/cuda"]


### PR DESCRIPTION
## Summary

Adds PocketStation as an optional application-audio backend on Windows and Linux.

Minutes continues to own microphone capture, alignment, recording, transcription, and every later processing step. PocketStation supplies only the selected application's audio through the existing `SystemAudioBackend` interface. The current macOS capture code is unchanged.

## Use

Build with the opt-in feature:

```bash
cargo build --release -p minutes-cli --features pocketstation-capture
```

Then configure the application by exact name, application ID, or process ID:

```toml
[recording]
capture_backend = "pocketstation"

[recording.sources]
voice = "default"
call = "Zoom"
```

## Implementation

- resolves `pocketstation 1.1.8` from crates.io with `native-capture` only;
- does not add Opus or Relay dependencies to Minutes;
- requests 10 ms application-audio frames;
- converts PocketStation's 48 kHz frames into Minutes' existing 16 kHz mono chunks;
- keeps application audio and the existing microphone source separate;
- reports full downstream queues and capture failures through existing Minutes diagnostics;
- rejects `call = "auto"` so an ambiguous application is never selected silently.

## Verification

- Linux ARM64: the proof downloaded `pocketstation 1.1.8` from crates.io, captured a selected PipeWire application, and wrote separate application and microphone stems through Minutes' existing recorder. All 80 100 ms slots remained aligned.
- Windows 11 ARM64: selected per-process WASAPI audio and the configured microphone reached the same recorder as separate sources. This VM run proves behavior, not latency.
- A separate Windows check resolves `pocketstation 1.1.8` from crates.io, confirms that the capture-only dependency tree contains neither `opus` nor `audiopus_sys`, and passes all eight focused adapter tests.
- Focused Rust tests, the feature-only CLI build, formatting, and Clippy with warnings denied pass.

The virtual test sources are deterministic fixtures. They do not claim physical-device or latency qualification.
