### PR TITLE
fix: let verified MCP reads finish on slow meeting libraries

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -21,6 +21,7 @@ import { realpath } from "node:fs/promises";
 
 import {
   DEFAULT_CORPUS_READ_BUDGETS,
+  authorizationWorkEnvelopeForTest,
   awaitDeferredCorpusReleasesForTests,
   resolveAuthorizationTimeoutMsForTest,
   withStableCorpusLease,
@@ -170,25 +171,40 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("ignores an ambient authorization override and keeps the production cap", () => {
+  it("derives the production deadline from the complete read envelope", () => {
+    const envelope = authorizationWorkEnvelopeForTest();
+    const physicalBytes =
+      envelope.maxCorpusBytes *
+      envelope.manifestsPerAttempt *
+      envelope.physicalReadsPerManifest *
+      envelope.maxAttempts;
+    expect(envelope.timeoutMs).toBe(
+      Math.ceil(
+        (physicalBytes * 1_000) / envelope.minimumReadBytesPerSecond
+      )
+    );
+    expect(envelope.timeoutMs).toBe(60_000);
+  });
+
+  it("ignores an ambient authorization override and keeps the derived production cap", () => {
     const requested = Number.MAX_SAFE_INTEGER;
     expect(
       resolveAuthorizationTimeoutMsForTest(requested, {
-        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "60000",
+        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
-    ).toBe(15_000);
+    ).toBe(60_000);
     expect(
       resolveAuthorizationTimeoutMsForTest(requested, {
         NODE_ENV: "test",
-        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "60000",
+        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
-    ).toBe(15_000);
+    ).toBe(60_000);
     expect(
       resolveAuthorizationTimeoutMsForTest(requested, {
         MINUTES_TEST_HARNESS: "1",
-        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "60000",
+        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
-    ).toBe(15_000);
+    ).toBe(60_000);
   });
 
   it("applies and clamps the explicitly gated test-harness authorization override", () => {
@@ -730,6 +746,54 @@ describe("stable corpus lease", () => {
         // scheduled diagnostic run before asserting it was attempted.
         await new Promise((resolve) => setImmediate(resolve));
         expect(attempted).toBeGreaterThan(0);
+      } finally {
+        (process.stderr as unknown as { write: unknown }).write = original;
+      }
+    });
+  });
+
+  it("reports elapsed time and the bounded budget only to the operator", async () => {
+    await withCorpus(async (root) => {
+      const privateCanary = "PRIVATE_DIAGNOSTIC_CANARY";
+      writeFileSync(join(root, "meeting.md"), privateCanary);
+      const original = process.stderr.write;
+      let diagnostics = "";
+      (process.stderr as unknown as { write: unknown }).write = (chunk: unknown) => {
+        diagnostics += String(chunk);
+        return true;
+      };
+      try {
+        let forceOperationDeadline!: () => void;
+        const operationDeadline = new Promise<void>((resolve) => {
+          forceOperationDeadline = resolve;
+        });
+        let failure: unknown;
+        try {
+          await withStableCorpusLease(
+            root,
+            (_snapshot, _attempt, signal) =>
+              new Promise((_resolve, reject) => {
+                signal.addEventListener("abort", () => reject(signal.reason), {
+                  once: true,
+                });
+                forceOperationDeadline();
+              }),
+            { timeoutMs: 10_000, operationDeadlineForTest: operationDeadline }
+          );
+        } catch (error) {
+          failure = error;
+        }
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(failure).toBeInstanceOf(Error);
+        expect((failure as Error).message).toBe(
+          "Access denied: stable meeting corpus authorization failed"
+        );
+        expect(diagnostics).toMatch(
+          /\[corpus-lease\] denied: meeting corpus authorization deadline elapsed \(authorization duration \d+ms; 10000ms authorization budget; \d+ms of authorization budget remained\)/
+        );
+        expect(diagnostics).not.toContain(privateCanary);
+        expect(diagnostics).not.toContain(root);
       } finally {
         (process.stderr as unknown as { write: unknown }).write = original;
       }

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -29,7 +29,6 @@ import { nodeChildEnvironment } from "./node-child.js";
 
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
 const DEFAULT_FENCE_TIMEOUT_MS = 5_000;
-const DEFAULT_AUTHORIZATION_TIMEOUT_MS = 15_000;
 const MAX_TEST_HARNESS_AUTHORIZATION_TIMEOUT_MS = 120_000;
 const MAX_ACTIVE_WATCHERS = 64;
 // Snapshot content is retained as JavaScript strings, whose backing storage
@@ -89,6 +88,35 @@ export const DEFAULT_CORPUS_READ_BUDGETS: Readonly<CorpusReadBudgets> =
     maxWatcherCount: 512,
     maxReaderCount: 64,
   });
+
+// One successful attempt materializes a baseline, verifies it before the
+// final fence, then verifies it again at the authorization point. Every
+// manifest reads each file twice to prove the bytes were stable while its
+// descriptor was held. The complete sequence may retry once under the same
+// cumulative deadline.
+const CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT = 3;
+const CORPUS_PHYSICAL_READS_PER_MANIFEST = 2;
+
+// Match the native corpus reader's documented storage floor. Meeting libraries
+// may live on synced folders, external disks, and ordinary spinning disks; a
+// corpus inside every published resource ceiling must not require fast local
+// SSD throughput merely to pass authorization.
+const MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND = 16 * 1024 * 1024;
+
+// This deadline is a backstop, not the primary safety control. File, byte,
+// directory, watcher, reader, retained-memory, and worker-process ceilings
+// still bound what one request may consume. Deriving the wall-clock ceiling
+// from that work envelope keeps those promises consistent when a pass count or
+// byte ceiling changes. At today's limits this is 60 seconds, rather than the
+// old hardcoded 15 seconds that denied valid large or slow corpora (#933).
+const DEFAULT_AUTHORIZATION_TIMEOUT_MS = Math.ceil(
+  (DEFAULT_CORPUS_READ_BUDGETS.maxCorpusBytes *
+    CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT *
+    CORPUS_PHYSICAL_READS_PER_MANIFEST *
+    MAX_AUTHORIZATION_ATTEMPTS *
+    1_000) /
+    MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND
+);
 
 export type CorpusVerificationStats = Readonly<{
   fileCount: number;
@@ -417,12 +445,12 @@ function resolveAuthorizationTimeoutMs(
   environment: Readonly<NodeJS.ProcessEnv> = process.env
 ): number {
   const configuredOverride = environment.MINUTES_CORPUS_AUTH_TIMEOUT_MS;
-  // A longer deadline is test infrastructure, not application configuration.
-  // Requiring both markers keeps an ambient production environment variable
-  // from weakening the fail-closed 15 second cap. Only the repository's test
-  // harness sets this pair; the spawned lease worker inherits it from the
-  // parent. Invalid gated values fail closed instead of silently relaxing or
-  // changing the requested budget.
+  // A deadline beyond the derived production envelope is test infrastructure,
+  // not application configuration. Requiring both markers keeps an ambient
+  // production environment variable from relaxing the fail-closed cap. Only
+  // the repository's test harness sets this pair; the spawned lease worker
+  // inherits it from the parent. Invalid gated values fail closed instead of
+  // silently relaxing or changing the requested budget.
   const testHarnessOverride =
     environment.NODE_ENV === "test" &&
     environment.MINUTES_TEST_HARNESS === "1" &&
@@ -457,11 +485,27 @@ export function resolveAuthorizationTimeoutMsForTest(
   return resolveAuthorizationTimeoutMs(timeoutMs, environment);
 }
 
-function authorizationDeadline(timeoutMs: number | undefined): bigint {
-  return (
-    process.hrtime.bigint() +
-    BigInt(resolveAuthorizationTimeoutMs(timeoutMs)) * 1_000_000n
-  );
+/** @internal Pure policy seam that pins the derived production envelope. */
+export function authorizationWorkEnvelopeForTest() {
+  return Object.freeze({
+    maxCorpusBytes: DEFAULT_CORPUS_READ_BUDGETS.maxCorpusBytes,
+    manifestsPerAttempt: CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT,
+    physicalReadsPerManifest: CORPUS_PHYSICAL_READS_PER_MANIFEST,
+    maxAttempts: MAX_AUTHORIZATION_ATTEMPTS,
+    minimumReadBytesPerSecond: MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND,
+    timeoutMs: DEFAULT_AUTHORIZATION_TIMEOUT_MS,
+  });
+}
+
+function authorizationWindow(timeoutMs: number | undefined): {
+  budgetMs: number;
+  deadline: bigint;
+} {
+  const budgetMs = resolveAuthorizationTimeoutMs(timeoutMs);
+  return {
+    budgetMs,
+    deadline: process.hrtime.bigint() + BigInt(budgetMs) * 1_000_000n,
+  };
 }
 
 function remainingAuthorizationMs(deadline: bigint): number {
@@ -1450,7 +1494,7 @@ async function withStableCorpusLeaseInProcess<T>(
   hooks: CorpusLeaseHooks = {}
 ): Promise<T> {
   const budgets = resolveCorpusReadBudgets(hooks.budgets);
-  const deadline = authorizationDeadline(hooks.timeoutMs);
+  const { deadline } = authorizationWindow(hooks.timeoutMs);
   const fenceTimeoutMs = resolveFenceTimeout(hooks.timeoutMs);
   const memoryReservation = reserveCorpusMemory(budgets);
 
@@ -1948,7 +1992,8 @@ async function dispatchStableCorpusLease<T>(
     );
   }
   const budgets = resolveCorpusReadBudgets(hooks.budgets);
-  const deadline = authorizationDeadline(hooks.timeoutMs);
+  const { budgetMs: authorizationBudgetMs, deadline } =
+    authorizationWindow(hooks.timeoutMs);
   const timeoutMs = remainingAuthorizationMs(deadline);
   const invocation = corpusWorkerInvocation(hooks.workerScriptForTest);
   const reservation = reserveCorpusMemory(budgets);
@@ -2074,14 +2119,22 @@ async function dispatchStableCorpusLease<T>(
             // "0ms remained" rather than an overrun.
             const overran = remainingNs < 0n;
             const magnitudeMs = Number((overran ? -remainingNs : remainingNs) / 1_000_000n);
-            const budget = overran
+            const remainingBudget = overran
               ? `authorization budget overrun by ${magnitudeMs}ms`
               : `${magnitudeMs}ms of authorization budget remained`;
             // Shared with the bound-reader refusal path, because a plain
             // try/catch here never covered an asynchronous EPIPE: that
             // arrives as an 'error' event on a later tick and is fatal
             // without a listener.
-            writeOperatorDiagnostic(`[corpus-lease] denied: ${message} (${budget})\n`);
+            const elapsedMs = overran
+              ? authorizationBudgetMs + magnitudeMs
+              : Math.max(0, authorizationBudgetMs - magnitudeMs);
+            writeOperatorDiagnostic(
+              `[corpus-lease] denied: ${message} (` +
+                `authorization duration ${elapsedMs}ms; ` +
+                `${authorizationBudgetMs}ms authorization budget; ` +
+                `${remainingBudget})\n`
+            );
           } catch {
             // A broken stderr must never turn a clean denial into a crash.
           }

--- a/crates/mcp/test/mcp_tools_test.mjs
+++ b/crates/mcp/test/mcp_tools_test.mjs
@@ -79,9 +79,9 @@ function minutesCli(args) {
   try {
     const result = execFileSync(bin, args, {
       encoding: "utf-8",
-      // Match the production MCP runner. Native corpus authorization has its
-      // own stricter 15-second monotonic deadline; the harness must report
-      // that real exit rather than kill a valid large-corpus command first.
+      // This helper exercises small checked-in fixtures. Keep a bounded but
+      // generous test timeout without claiming to match the native reader's
+      // larger production authorization envelope.
       timeout: 30000,
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, RUST_LOG: "error" },

--- a/crates/mcp/vitest.config.ts
+++ b/crates/mcp/vitest.config.ts
@@ -6,19 +6,20 @@ export default defineConfig({
     include: ["src/**/*.test.ts", "ui/src/**/*.test.ts"],
     // Above every operation deadline the suites exercise, deliberately.
     //
-    // DEFAULT_BOUND_READ_TIMEOUT_MS and DEFAULT_AUTHORIZATION_TIMEOUT_MS are
-    // both 15_000, so at 15_000 here the harness and the operation it measures
-    // shared a deadline and vitest won it, because its clock starts first. A
-    // read or lease that ran to its own limit was killed roughly 10ms short of
-    // reporting why, and the suite printed "Test timed out in 15000ms" with no
-    // cause. 30 of the 49 corpus-lease cases inherited that collision, which is
-    // why the case that failed moved around and never explained itself (#617).
+    // DEFAULT_BOUND_READ_TIMEOUT_MS was 15_000, and the authorization deadline
+    // used to be the same, so at 15_000 here the harness and the operation it
+    // measured shared a deadline and vitest won it because its clock starts
+    // first. A read or lease that ran to its own limit was killed roughly 10ms
+    // short of reporting why, and the suite printed "Test timed out in 15000ms"
+    // with no cause. 30 of the 49 corpus-lease cases inherited that collision,
+    // which is why the case that failed moved around (#617).
     //
     // Demonstrated rather than reasoned about: an operation stalled to its own
     // timeout fails here at 15_000 and passes at 30_000, unchanged otherwise.
     // A harness must outlive what it measures, or it reports itself.
-    // The explicit repository test harness may grant corpus authorization up
-    // to 60 seconds on a loaded runner. Keep Vitest outside that deadline so
+    // Production corpus authorization is now derived as 60 seconds from the
+    // bounded work envelope (#933). The explicit repository test harness grants
+    // the same budget on loaded runners. Keep Vitest outside that deadline so
     // the lease, not the harness, still reports any real timeout.
     testTimeout: 75_000,
   },

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -21,6 +21,7 @@ import { realpath } from "node:fs/promises";
 
 import {
   DEFAULT_CORPUS_READ_BUDGETS,
+  authorizationWorkEnvelopeForTest,
   awaitDeferredCorpusReleasesForTests,
   resolveAuthorizationTimeoutMsForTest,
   withStableCorpusLease,
@@ -170,25 +171,40 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("ignores an ambient authorization override and keeps the production cap", () => {
+  it("derives the production deadline from the complete read envelope", () => {
+    const envelope = authorizationWorkEnvelopeForTest();
+    const physicalBytes =
+      envelope.maxCorpusBytes *
+      envelope.manifestsPerAttempt *
+      envelope.physicalReadsPerManifest *
+      envelope.maxAttempts;
+    expect(envelope.timeoutMs).toBe(
+      Math.ceil(
+        (physicalBytes * 1_000) / envelope.minimumReadBytesPerSecond
+      )
+    );
+    expect(envelope.timeoutMs).toBe(60_000);
+  });
+
+  it("ignores an ambient authorization override and keeps the derived production cap", () => {
     const requested = Number.MAX_SAFE_INTEGER;
     expect(
       resolveAuthorizationTimeoutMsForTest(requested, {
-        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "60000",
+        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
-    ).toBe(15_000);
+    ).toBe(60_000);
     expect(
       resolveAuthorizationTimeoutMsForTest(requested, {
         NODE_ENV: "test",
-        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "60000",
+        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
-    ).toBe(15_000);
+    ).toBe(60_000);
     expect(
       resolveAuthorizationTimeoutMsForTest(requested, {
         MINUTES_TEST_HARNESS: "1",
-        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "60000",
+        MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
-    ).toBe(15_000);
+    ).toBe(60_000);
   });
 
   it("applies and clamps the explicitly gated test-harness authorization override", () => {
@@ -730,6 +746,54 @@ describe("stable corpus lease", () => {
         // scheduled diagnostic run before asserting it was attempted.
         await new Promise((resolve) => setImmediate(resolve));
         expect(attempted).toBeGreaterThan(0);
+      } finally {
+        (process.stderr as unknown as { write: unknown }).write = original;
+      }
+    });
+  });
+
+  it("reports elapsed time and the bounded budget only to the operator", async () => {
+    await withCorpus(async (root) => {
+      const privateCanary = "PRIVATE_DIAGNOSTIC_CANARY";
+      writeFileSync(join(root, "meeting.md"), privateCanary);
+      const original = process.stderr.write;
+      let diagnostics = "";
+      (process.stderr as unknown as { write: unknown }).write = (chunk: unknown) => {
+        diagnostics += String(chunk);
+        return true;
+      };
+      try {
+        let forceOperationDeadline!: () => void;
+        const operationDeadline = new Promise<void>((resolve) => {
+          forceOperationDeadline = resolve;
+        });
+        let failure: unknown;
+        try {
+          await withStableCorpusLease(
+            root,
+            (_snapshot, _attempt, signal) =>
+              new Promise((_resolve, reject) => {
+                signal.addEventListener("abort", () => reject(signal.reason), {
+                  once: true,
+                });
+                forceOperationDeadline();
+              }),
+            { timeoutMs: 10_000, operationDeadlineForTest: operationDeadline }
+          );
+        } catch (error) {
+          failure = error;
+        }
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(failure).toBeInstanceOf(Error);
+        expect((failure as Error).message).toBe(
+          "Access denied: stable meeting corpus authorization failed"
+        );
+        expect(diagnostics).toMatch(
+          /\[corpus-lease\] denied: meeting corpus authorization deadline elapsed \(authorization duration \d+ms; 10000ms authorization budget; \d+ms of authorization budget remained\)/
+        );
+        expect(diagnostics).not.toContain(privateCanary);
+        expect(diagnostics).not.toContain(root);
       } finally {
         (process.stderr as unknown as { write: unknown }).write = original;
       }

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -29,7 +29,6 @@ import { nodeChildEnvironment } from "./node-child.js";
 
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
 const DEFAULT_FENCE_TIMEOUT_MS = 5_000;
-const DEFAULT_AUTHORIZATION_TIMEOUT_MS = 15_000;
 const MAX_TEST_HARNESS_AUTHORIZATION_TIMEOUT_MS = 120_000;
 const MAX_ACTIVE_WATCHERS = 64;
 // Snapshot content is retained as JavaScript strings, whose backing storage
@@ -89,6 +88,35 @@ export const DEFAULT_CORPUS_READ_BUDGETS: Readonly<CorpusReadBudgets> =
     maxWatcherCount: 512,
     maxReaderCount: 64,
   });
+
+// One successful attempt materializes a baseline, verifies it before the
+// final fence, then verifies it again at the authorization point. Every
+// manifest reads each file twice to prove the bytes were stable while its
+// descriptor was held. The complete sequence may retry once under the same
+// cumulative deadline.
+const CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT = 3;
+const CORPUS_PHYSICAL_READS_PER_MANIFEST = 2;
+
+// Match the native corpus reader's documented storage floor. Meeting libraries
+// may live on synced folders, external disks, and ordinary spinning disks; a
+// corpus inside every published resource ceiling must not require fast local
+// SSD throughput merely to pass authorization.
+const MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND = 16 * 1024 * 1024;
+
+// This deadline is a backstop, not the primary safety control. File, byte,
+// directory, watcher, reader, retained-memory, and worker-process ceilings
+// still bound what one request may consume. Deriving the wall-clock ceiling
+// from that work envelope keeps those promises consistent when a pass count or
+// byte ceiling changes. At today's limits this is 60 seconds, rather than the
+// old hardcoded 15 seconds that denied valid large or slow corpora (#933).
+const DEFAULT_AUTHORIZATION_TIMEOUT_MS = Math.ceil(
+  (DEFAULT_CORPUS_READ_BUDGETS.maxCorpusBytes *
+    CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT *
+    CORPUS_PHYSICAL_READS_PER_MANIFEST *
+    MAX_AUTHORIZATION_ATTEMPTS *
+    1_000) /
+    MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND
+);
 
 export type CorpusVerificationStats = Readonly<{
   fileCount: number;
@@ -417,12 +445,12 @@ function resolveAuthorizationTimeoutMs(
   environment: Readonly<NodeJS.ProcessEnv> = process.env
 ): number {
   const configuredOverride = environment.MINUTES_CORPUS_AUTH_TIMEOUT_MS;
-  // A longer deadline is test infrastructure, not application configuration.
-  // Requiring both markers keeps an ambient production environment variable
-  // from weakening the fail-closed 15 second cap. Only the repository's test
-  // harness sets this pair; the spawned lease worker inherits it from the
-  // parent. Invalid gated values fail closed instead of silently relaxing or
-  // changing the requested budget.
+  // A deadline beyond the derived production envelope is test infrastructure,
+  // not application configuration. Requiring both markers keeps an ambient
+  // production environment variable from relaxing the fail-closed cap. Only
+  // the repository's test harness sets this pair; the spawned lease worker
+  // inherits it from the parent. Invalid gated values fail closed instead of
+  // silently relaxing or changing the requested budget.
   const testHarnessOverride =
     environment.NODE_ENV === "test" &&
     environment.MINUTES_TEST_HARNESS === "1" &&
@@ -457,11 +485,27 @@ export function resolveAuthorizationTimeoutMsForTest(
   return resolveAuthorizationTimeoutMs(timeoutMs, environment);
 }
 
-function authorizationDeadline(timeoutMs: number | undefined): bigint {
-  return (
-    process.hrtime.bigint() +
-    BigInt(resolveAuthorizationTimeoutMs(timeoutMs)) * 1_000_000n
-  );
+/** @internal Pure policy seam that pins the derived production envelope. */
+export function authorizationWorkEnvelopeForTest() {
+  return Object.freeze({
+    maxCorpusBytes: DEFAULT_CORPUS_READ_BUDGETS.maxCorpusBytes,
+    manifestsPerAttempt: CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT,
+    physicalReadsPerManifest: CORPUS_PHYSICAL_READS_PER_MANIFEST,
+    maxAttempts: MAX_AUTHORIZATION_ATTEMPTS,
+    minimumReadBytesPerSecond: MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND,
+    timeoutMs: DEFAULT_AUTHORIZATION_TIMEOUT_MS,
+  });
+}
+
+function authorizationWindow(timeoutMs: number | undefined): {
+  budgetMs: number;
+  deadline: bigint;
+} {
+  const budgetMs = resolveAuthorizationTimeoutMs(timeoutMs);
+  return {
+    budgetMs,
+    deadline: process.hrtime.bigint() + BigInt(budgetMs) * 1_000_000n,
+  };
 }
 
 function remainingAuthorizationMs(deadline: bigint): number {
@@ -1450,7 +1494,7 @@ async function withStableCorpusLeaseInProcess<T>(
   hooks: CorpusLeaseHooks = {}
 ): Promise<T> {
   const budgets = resolveCorpusReadBudgets(hooks.budgets);
-  const deadline = authorizationDeadline(hooks.timeoutMs);
+  const { deadline } = authorizationWindow(hooks.timeoutMs);
   const fenceTimeoutMs = resolveFenceTimeout(hooks.timeoutMs);
   const memoryReservation = reserveCorpusMemory(budgets);
 
@@ -1948,7 +1992,8 @@ async function dispatchStableCorpusLease<T>(
     );
   }
   const budgets = resolveCorpusReadBudgets(hooks.budgets);
-  const deadline = authorizationDeadline(hooks.timeoutMs);
+  const { budgetMs: authorizationBudgetMs, deadline } =
+    authorizationWindow(hooks.timeoutMs);
   const timeoutMs = remainingAuthorizationMs(deadline);
   const invocation = corpusWorkerInvocation(hooks.workerScriptForTest);
   const reservation = reserveCorpusMemory(budgets);
@@ -2074,14 +2119,22 @@ async function dispatchStableCorpusLease<T>(
             // "0ms remained" rather than an overrun.
             const overran = remainingNs < 0n;
             const magnitudeMs = Number((overran ? -remainingNs : remainingNs) / 1_000_000n);
-            const budget = overran
+            const remainingBudget = overran
               ? `authorization budget overrun by ${magnitudeMs}ms`
               : `${magnitudeMs}ms of authorization budget remained`;
             // Shared with the bound-reader refusal path, because a plain
             // try/catch here never covered an asynchronous EPIPE: that
             // arrives as an 'error' event on a later tick and is fatal
             // without a listener.
-            writeOperatorDiagnostic(`[corpus-lease] denied: ${message} (${budget})\n`);
+            const elapsedMs = overran
+              ? authorizationBudgetMs + magnitudeMs
+              : Math.max(0, authorizationBudgetMs - magnitudeMs);
+            writeOperatorDiagnostic(
+              `[corpus-lease] denied: ${message} (` +
+                `authorization duration ${elapsedMs}ms; ` +
+                `${authorizationBudgetMs}ms authorization budget; ` +
+                `${remainingBudget})\n`
+            );
           } catch {
             // A broken stderr must never turn a clean denial into a crash.
           }

--- a/crates/sdk/vitest.config.ts
+++ b/crates/sdk/vitest.config.ts
@@ -6,19 +6,20 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     // Above every operation deadline the suites exercise, deliberately.
     //
-    // DEFAULT_BOUND_READ_TIMEOUT_MS and DEFAULT_AUTHORIZATION_TIMEOUT_MS are
-    // both 15_000, so at 15_000 here the harness and the operation it measures
-    // shared a deadline and vitest won it, because its clock starts first. A
-    // read or lease that ran to its own limit was killed roughly 10ms short of
-    // reporting why, and the suite printed "Test timed out in 15000ms" with no
-    // cause. 30 of the 49 corpus-lease cases inherited that collision, which is
-    // why the case that failed moved around and never explained itself (#617).
+    // DEFAULT_BOUND_READ_TIMEOUT_MS was 15_000, and the authorization deadline
+    // used to be the same, so at 15_000 here the harness and the operation it
+    // measured shared a deadline and vitest won it because its clock starts
+    // first. A read or lease that ran to its own limit was killed roughly 10ms
+    // short of reporting why, and the suite printed "Test timed out in 15000ms"
+    // with no cause. 30 of the 49 corpus-lease cases inherited that collision,
+    // which is why the case that failed moved around (#617).
     //
     // Demonstrated rather than reasoned about: an operation stalled to its own
     // timeout fails here at 15_000 and passes at 30_000, unchanged otherwise.
     // A harness must outlive what it measures, or it reports itself.
-    // The explicit repository test harness may grant corpus authorization up
-    // to 60 seconds on a loaded runner. Keep Vitest outside that deadline so
+    // Production corpus authorization is now derived as 60 seconds from the
+    // bounded work envelope (#933). The explicit repository test harness grants
+    // the same budget on loaded runners. Keep Vitest outside that deadline so
     // the lease, not the harness, still reports any real timeout.
     testTimeout: 75_000,
   },

--- a/docs/checklists/pre-commit.md
+++ b/docs/checklists/pre-commit.md
@@ -42,9 +42,13 @@ CI enforces the version-sync and generated-skills checks. The pre-push hooks are
 
 ## Corpus-lease tests need the test-harness budget
 
-The meeting-corpus authorization handshake has a fail-closed 15 s deadline that a
-loaded machine can exceed. The MCP and SDK `npm test` scripts already wrap vitest in
-`scripts/run_corpus_test_harness.mjs`, which sets `NODE_ENV=test`,
-`MINUTES_TEST_HARNESS=1`, and `MINUTES_CORPUS_AUTH_TIMEOUT_MS=60000`. Running vitest
-directly without that wrapper reproduces the CI flake this guards against (#802).
-Both markers are required; the override never applies outside the harness.
+The meeting-corpus authorization handshake has a fail-closed production deadline
+derived from its full bounded read envelope. It is currently 60 s: three manifest
+passes per attempt, two physical reads per manifest, two possible attempts, an
+80 MiB corpus ceiling, and the same 16 MiB/s storage floor used by the native reader
+(#933). The MCP test script wraps vitest in `scripts/run_corpus_test_harness.mjs`,
+and CI sets the same `NODE_ENV=test`, `MINUTES_TEST_HARNESS=1`, and
+`MINUTES_CORPUS_AUTH_TIMEOUT_MS=60000` contract for the focused SDK suite. Running
+vitest directly bypasses that explicit harness contract. Both markers are required;
+the override never applies outside the harness, and the production deadline remains
+bounded by its derived envelope.


### PR DESCRIPTION
Closes #933.

## What changed

The MCP and SDK corpus lease no longer use an arbitrary 15 second production deadline. The deadline is derived from the complete bounded read envelope:

- 80 MiB maximum corpus
- three full manifest passes per attempt
- two physical reads per file and manifest
- two maximum attempts
- 16 MiB/s minimum assumed storage throughput, matching the native corpus reader

That produces a bounded 60 second production deadline at the current limits. If the byte ceiling or pass counts change later, the calculation and its regression test must change together.

Denial diagnostics now report elapsed authorization time and the configured bounded budget to the operator. The assistant-facing error remains uniform and contains no corpus path, content, timing, or failure phase.

## Safety boundary retained

This does not remove or weaken any authorization step. The watcher fences, baseline snapshot, two post-operation manifests, full byte hashes, descriptor and link checks, retry limit, killable worker, cancellation, and all file, byte, directory, watcher, reader, memory, and protocol ceilings remain unchanged.

The ambient environment still cannot raise the production deadline. A longer test-only override requires both repository harness markers and remains capped at 120 seconds.

## Verification

- MCP build: green
- SDK build: green
- MCP full unit suite: 355 passed, 1 platform skip
- SDK full suite: 160 passed, 1 platform skip
- Focused mirrored corpus-lease suites after final edits: 53 passed each
- MCP/SDK mirror guard: all 8 files identical
- Synthetic production-path acceptance with 3,800 Markdown files: 3,800 returned after every worker-backed verification pass, 6.3 seconds
- HTTP transport contract: 13 passed
- surface parity helper: 16 passed
- host compatibility: candidate stdio passed
- MCPB bundle integrity: green
- packaged MCPB handshake: 26 tools, 7 resources, protocol 2025-11-25
- `git diff --check`: green

The local Copilot contract requires a branch-built `target/debug/minutes`. This space-constrained VM has no branch Rust build and otherwise falls back to an unrelated installed 0.18 CLI, so that result is not counted. CI builds the current CLI from this branch and is the authoritative gate for that contract.