### PR TITLE
Report corpus worker exit status without exposing private stderr

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -923,6 +923,45 @@ describe("stable corpus lease", () => {
     });
   });
 
+  it.each([0, 17])("reports worker exit %i without exposing private stderr", async (exitCode) => {
+    await withCorpus(async (root) => {
+      const privateCanary = "PRIVATE_WORKER_STDERR_CANARY";
+      writeFileSync(join(root, "meeting.md"), privateCanary);
+      const fixture = join(root, "exiting-worker.mjs");
+      writeFileSync(
+        fixture,
+        `process.stdin.once("data", () => {\n` +
+          `  process.stderr.write(${JSON.stringify(privateCanary + "\n")}, () => process.exit(${exitCode}));\n` +
+          `});\n`
+      );
+      const original = process.stderr.write;
+      let diagnostics = "";
+      (process.stderr as unknown as { write: unknown }).write = (chunk: unknown) => {
+        diagnostics += String(chunk);
+        return true;
+      };
+      try {
+        let operationRan = false;
+        await expect(
+          withStableCorpusLease(root, () => { operationRan = true; }, {
+            timeoutMs: 10_000,
+            workerScriptForTest: fixture,
+          })
+        ).rejects.toThrow(/^Access denied: stable meeting corpus authorization failed$/);
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(operationRan).toBe(false);
+        expect(diagnostics).toContain(
+          `worker exited before authorization (exit code ${exitCode}; signal none)`
+        );
+        expect(diagnostics).not.toContain(privateCanary);
+        expect(diagnostics).not.toContain(root);
+        await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe("recovered");
+      } finally {
+        (process.stderr as unknown as { write: unknown }).write = original;
+      }
+    });
+  });
+
   it("rejects an out-of-order worker protocol and remains reusable", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "protocol canary");

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -2146,11 +2146,16 @@ async function dispatchStableCorpusLease<T>(
       );
       timer.unref();
       child.once("error", () => fail("meeting corpus worker failed"));
-      child.once("close", (code) => {
+      child.once("close", (code, signal) => {
         clearTimeout(timer);
         if (settled) return;
         if (code !== 0 || !authorized || !operationCompleted) {
-          fail("meeting corpus worker exited before authorization");
+          // Only OS-provided process status belongs in operator diagnostics.
+          // Child stderr can contain corpus data and remains discarded.
+          fail(
+            `meeting corpus worker exited before authorization ` +
+              `(exit code ${code ?? "none"}; signal ${signal ?? "none"})`
+          );
           return;
         }
         settled = true;

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -923,6 +923,45 @@ describe("stable corpus lease", () => {
     });
   });
 
+  it.each([0, 17])("reports worker exit %i without exposing private stderr", async (exitCode) => {
+    await withCorpus(async (root) => {
+      const privateCanary = "PRIVATE_WORKER_STDERR_CANARY";
+      writeFileSync(join(root, "meeting.md"), privateCanary);
+      const fixture = join(root, "exiting-worker.mjs");
+      writeFileSync(
+        fixture,
+        `process.stdin.once("data", () => {\n` +
+          `  process.stderr.write(${JSON.stringify(privateCanary + "\n")}, () => process.exit(${exitCode}));\n` +
+          `});\n`
+      );
+      const original = process.stderr.write;
+      let diagnostics = "";
+      (process.stderr as unknown as { write: unknown }).write = (chunk: unknown) => {
+        diagnostics += String(chunk);
+        return true;
+      };
+      try {
+        let operationRan = false;
+        await expect(
+          withStableCorpusLease(root, () => { operationRan = true; }, {
+            timeoutMs: 10_000,
+            workerScriptForTest: fixture,
+          })
+        ).rejects.toThrow(/^Access denied: stable meeting corpus authorization failed$/);
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(operationRan).toBe(false);
+        expect(diagnostics).toContain(
+          `worker exited before authorization (exit code ${exitCode}; signal none)`
+        );
+        expect(diagnostics).not.toContain(privateCanary);
+        expect(diagnostics).not.toContain(root);
+        await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe("recovered");
+      } finally {
+        (process.stderr as unknown as { write: unknown }).write = original;
+      }
+    });
+  });
+
   it("rejects an out-of-order worker protocol and remains reusable", async () => {
     await withCorpus(async (root) => {
       writeFileSync(join(root, "meeting.md"), "protocol canary");

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -2146,11 +2146,16 @@ async function dispatchStableCorpusLease<T>(
       );
       timer.unref();
       child.once("error", () => fail("meeting corpus worker failed"));
-      child.once("close", (code) => {
+      child.once("close", (code, signal) => {
         clearTimeout(timer);
         if (settled) return;
         if (code !== 0 || !authorized || !operationCompleted) {
-          fail("meeting corpus worker exited before authorization");
+          // Only OS-provided process status belongs in operator diagnostics.
+          // Child stderr can contain corpus data and remains discarded.
+          fail(
+            `meeting corpus worker exited before authorization ` +
+              `(exit code ${code ?? "none"}; signal ${signal ?? "none"})`
+          );
           return;
         }
         settled = true;


### PR DESCRIPTION
When a corpus worker exits before completing authorization, operator logs currently omit its exit status. Include the process exit code and signal while keeping worker stderr discarded and the caller-facing denial unchanged.

Mirrored regressions cover premature exits with codes 0 and 17, verify that neither private stderr nor the corpus path appears in diagnostics, prevent the protected callback from running, and confirm a subsequent lease can succeed.

Validation: SDK build and 55 corpus-lease tests passed; MCP build and 358 unit tests passed (one skipped); the eight-file mirror check, MCPB bundle guard, and packed protocol handshake passed.

Related to #933. This adds diagnostic evidence for the remaining early-exit report; it does not claim to resolve its cause.
