### PR TITLE
Add bounded slow-storage profile for corpus verification

### DIFF
--- a/crates/mcp/src/corpus-lease.test.ts
+++ b/crates/mcp/src/corpus-lease.test.ts
@@ -171,7 +171,7 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("derives the production deadline from the complete read envelope", () => {
+  it("derives the standard deadline from the byte read envelope", () => {
     const envelope = authorizationWorkEnvelopeForTest();
     const physicalBytes =
       envelope.maxCorpusBytes *
@@ -205,6 +205,75 @@ describe("stable corpus lease", () => {
         MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
     ).toBe(60_000);
+  });
+
+  it("supports bounded production storage profiles without test markers", () => {
+    const slow = { MINUTES_CORPUS_STORAGE_PROFILE: "slow" };
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, slow)).toBe(240_000);
+    expect(resolveAuthorizationTimeoutMsForTest(Number.MAX_SAFE_INTEGER, slow)).toBe(240_000);
+    expect(resolveAuthorizationTimeoutMsForTest(5_000, slow)).toBe(5_000);
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, {
+      MINUTES_CORPUS_STORAGE_PROFILE: "standard",
+    })).toBe(60_000);
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, {
+      ...slow,
+      MINUTES_CORPUS_AUTH_TIMEOUT_MS: "999999",
+    })).toBe(240_000);
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, {
+      ...slow,
+      NODE_ENV: "test",
+      MINUTES_TEST_HARNESS: "1",
+      MINUTES_CORPUS_AUTH_TIMEOUT_MS: "999999",
+    })).toBe(120_000);
+  });
+
+  it.each(["", "SLOW", "unlimited", "240000", "slow\n"])(
+    "rejects invalid storage profile %j without falling back",
+    (profile) => {
+      expect(() => resolveAuthorizationTimeoutMsForTest(undefined, {
+        MINUTES_CORPUS_STORAGE_PROFILE: profile,
+      })).toThrow("invalid meeting corpus storage profile");
+    }
+  );
+
+  it("keeps resource admission and operation cancellation in the production slow profile", async () => {
+    const keys = ["MINUTES_CORPUS_STORAGE_PROFILE", "NODE_ENV", "MINUTES_TEST_HARNESS", "MINUTES_CORPUS_AUTH_TIMEOUT_MS"];
+    const saved = keys.map((key) => [key, process.env[key]] as const);
+    try {
+      for (const key of keys) delete process.env[key];
+      process.env.MINUTES_CORPUS_STORAGE_PROFILE = "slow";
+      await withCorpus(async (root) => {
+        writeFileSync(join(root, "one.md"), "one");
+        writeFileSync(join(root, "two.md"), "two");
+        let operationRan = false;
+        await expect(withStableCorpusLease(root, () => {
+          operationRan = true;
+        }, { budgets: { maxFileCount: 1 } })).rejects.toThrow("authorization failed");
+        expect(operationRan).toBe(false);
+
+        let forceDeadline!: () => void;
+        const deadline = new Promise<void>((resolve) => { forceDeadline = resolve; });
+        let aborted = false;
+        await expect(withStableCorpusLease(root, (_snapshot, _attempt, signal) => {
+          operationRan = true;
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener("abort", () => {
+              aborted = true;
+              reject(signal.reason);
+            }, { once: true });
+            forceDeadline();
+          });
+        }, { operationDeadlineForTest: deadline })).rejects.toThrow("authorization failed");
+        expect(operationRan).toBe(true);
+        expect(aborted).toBe(true);
+        await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe("recovered");
+      });
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 
   it("applies and clamps the explicitly gated test-harness authorization override", () => {

--- a/crates/mcp/src/corpus-lease.ts
+++ b/crates/mcp/src/corpus-lease.ts
@@ -30,6 +30,10 @@ import { nodeChildEnvironment } from "./node-child.js";
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
 const DEFAULT_FENCE_TIMEOUT_MS = 5_000;
 const MAX_TEST_HARNESS_AUTHORIZATION_TIMEOUT_MS = 120_000;
+// Opt-in bound for seek-heavy storage. The HDD measurements in #933 required
+// more than 120 seconds cold, despite fitting the byte and file ceilings.
+// This is an operator-selected allowance, not a universal disk-speed promise.
+const SLOW_STORAGE_AUTHORIZATION_TIMEOUT_MS = 240_000;
 const MAX_ACTIVE_WATCHERS = 64;
 // Snapshot content is retained as JavaScript strings, whose backing storage
 // may require two bytes per source byte. Reserve that worst case for the full
@@ -97,18 +101,14 @@ export const DEFAULT_CORPUS_READ_BUDGETS: Readonly<CorpusReadBudgets> =
 const CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT = 3;
 const CORPUS_PHYSICAL_READS_PER_MANIFEST = 2;
 
-// Match the native corpus reader's documented storage floor. Meeting libraries
-// may live on synced folders, external disks, and ordinary spinning disks; a
-// corpus inside every published resource ceiling must not require fast local
-// SSD throughput merely to pass authorization.
+// The standard profile matches the native reader's throughput assumption.
+// This byte-based estimate does not model per-file seeks or reader round trips;
+// small-file HDD corpora can exceed it even inside every resource ceiling.
 const MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND = 16 * 1024 * 1024;
 
-// This deadline is a backstop, not the primary safety control. File, byte,
-// directory, watcher, reader, retained-memory, and worker-process ceilings
-// still bound what one request may consume. Deriving the wall-clock ceiling
-// from that work envelope keeps those promises consistent when a pass count or
-// byte ceiling changes. At today's limits this is 60 seconds, rather than the
-// old hardcoded 15 seconds that denied valid large or slow corpora (#933).
+// The standard profile remains 60 seconds. The explicit slow profile allows
+// more wall time without changing passes, watcher fences, cancellation, or any
+// file, byte, directory, reader, watcher, retained-memory or process ceiling.
 const DEFAULT_AUTHORIZATION_TIMEOUT_MS = Math.ceil(
   (DEFAULT_CORPUS_READ_BUDGETS.maxCorpusBytes *
     CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT *
@@ -444,13 +444,17 @@ function resolveAuthorizationTimeoutMs(
   timeoutMs: number | undefined,
   environment: Readonly<NodeJS.ProcessEnv> = process.env
 ): number {
+  const storageProfile = environment.MINUTES_CORPUS_STORAGE_PROFILE ?? "standard";
+  if (storageProfile !== "standard" && storageProfile !== "slow") {
+    throw new Error("Access denied: invalid meeting corpus storage profile");
+  }
+  const productionCap = storageProfile === "slow"
+    ? SLOW_STORAGE_AUTHORIZATION_TIMEOUT_MS
+    : DEFAULT_AUTHORIZATION_TIMEOUT_MS;
   const configuredOverride = environment.MINUTES_CORPUS_AUTH_TIMEOUT_MS;
-  // A deadline beyond the derived production envelope is test infrastructure,
-  // not application configuration. Requiring both markers keeps an ambient
-  // production environment variable from relaxing the fail-closed cap. Only
-  // the repository's test harness sets this pair; the spawned lease worker
-  // inherits it from the parent. Invalid gated values fail closed instead of
-  // silently relaxing or changing the requested budget.
+  // The numeric override remains test-only. Both markers are required, and
+  // its independent cap still applies even with the production slow profile.
+  // Invalid gated values fail closed rather than silently changing policy.
   const testHarnessOverride =
     environment.NODE_ENV === "test" &&
     environment.MINUTES_TEST_HARNESS === "1" &&
@@ -465,7 +469,7 @@ function resolveAuthorizationTimeoutMs(
   }
   const cap =
     testHarnessOverride === undefined
-      ? DEFAULT_AUTHORIZATION_TIMEOUT_MS
+      ? productionCap
       : Math.min(
           Number(testHarnessOverride),
           MAX_TEST_HARNESS_AUTHORIZATION_TIMEOUT_MS

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -27,6 +27,12 @@ const actions = await findOpenActions('~/meetings', 'alex');
 // → [{ path: '...', item: { assignee: 'alex', task: '...', status: 'open' } }]
 ```
 
+## Slow storage
+
+Set `MINUTES_CORPUS_STORAGE_PROFILE=slow` in the SDK process environment to allow up to 240 seconds for corpus verification on seek-heavy storage. The default `standard` profile allows 60 seconds. File and memory limits, full verification, and worker termination remain enforced. Calls return as soon as verification and the operation finish; the setting does not impose a four-minute wait. Other profile values are rejected.
+
+For MCP clients, allow at least 300 seconds per request if the host supports a configurable timeout. The server cannot extend the client's timeout, and a client timeout does not guarantee server cancellation. This setting does not affect native CLI search. See [configuration](https://github.com/silverstein/minutes/blob/main/docs/configuration.md#meeting-libraries-on-slow-storage) for examples and limitations. The numeric `MINUTES_CORPUS_AUTH_TIMEOUT_MS` variable is still test-harness-only.
+
 ## API
 
 ### `listMeetings(dir, limit?, options?)`

--- a/crates/sdk/src/corpus-lease.test.ts
+++ b/crates/sdk/src/corpus-lease.test.ts
@@ -171,7 +171,7 @@ describe("stable corpus lease", () => {
     });
   });
 
-  it("derives the production deadline from the complete read envelope", () => {
+  it("derives the standard deadline from the byte read envelope", () => {
     const envelope = authorizationWorkEnvelopeForTest();
     const physicalBytes =
       envelope.maxCorpusBytes *
@@ -205,6 +205,75 @@ describe("stable corpus lease", () => {
         MINUTES_CORPUS_AUTH_TIMEOUT_MS: "120000",
       })
     ).toBe(60_000);
+  });
+
+  it("supports bounded production storage profiles without test markers", () => {
+    const slow = { MINUTES_CORPUS_STORAGE_PROFILE: "slow" };
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, slow)).toBe(240_000);
+    expect(resolveAuthorizationTimeoutMsForTest(Number.MAX_SAFE_INTEGER, slow)).toBe(240_000);
+    expect(resolveAuthorizationTimeoutMsForTest(5_000, slow)).toBe(5_000);
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, {
+      MINUTES_CORPUS_STORAGE_PROFILE: "standard",
+    })).toBe(60_000);
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, {
+      ...slow,
+      MINUTES_CORPUS_AUTH_TIMEOUT_MS: "999999",
+    })).toBe(240_000);
+    expect(resolveAuthorizationTimeoutMsForTest(undefined, {
+      ...slow,
+      NODE_ENV: "test",
+      MINUTES_TEST_HARNESS: "1",
+      MINUTES_CORPUS_AUTH_TIMEOUT_MS: "999999",
+    })).toBe(120_000);
+  });
+
+  it.each(["", "SLOW", "unlimited", "240000", "slow\n"])(
+    "rejects invalid storage profile %j without falling back",
+    (profile) => {
+      expect(() => resolveAuthorizationTimeoutMsForTest(undefined, {
+        MINUTES_CORPUS_STORAGE_PROFILE: profile,
+      })).toThrow("invalid meeting corpus storage profile");
+    }
+  );
+
+  it("keeps resource admission and operation cancellation in the production slow profile", async () => {
+    const keys = ["MINUTES_CORPUS_STORAGE_PROFILE", "NODE_ENV", "MINUTES_TEST_HARNESS", "MINUTES_CORPUS_AUTH_TIMEOUT_MS"];
+    const saved = keys.map((key) => [key, process.env[key]] as const);
+    try {
+      for (const key of keys) delete process.env[key];
+      process.env.MINUTES_CORPUS_STORAGE_PROFILE = "slow";
+      await withCorpus(async (root) => {
+        writeFileSync(join(root, "one.md"), "one");
+        writeFileSync(join(root, "two.md"), "two");
+        let operationRan = false;
+        await expect(withStableCorpusLease(root, () => {
+          operationRan = true;
+        }, { budgets: { maxFileCount: 1 } })).rejects.toThrow("authorization failed");
+        expect(operationRan).toBe(false);
+
+        let forceDeadline!: () => void;
+        const deadline = new Promise<void>((resolve) => { forceDeadline = resolve; });
+        let aborted = false;
+        await expect(withStableCorpusLease(root, (_snapshot, _attempt, signal) => {
+          operationRan = true;
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener("abort", () => {
+              aborted = true;
+              reject(signal.reason);
+            }, { once: true });
+            forceDeadline();
+          });
+        }, { operationDeadlineForTest: deadline })).rejects.toThrow("authorization failed");
+        expect(operationRan).toBe(true);
+        expect(aborted).toBe(true);
+        await expect(withStableCorpusLease(root, () => "recovered")).resolves.toBe("recovered");
+      });
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 
   it("applies and clamps the explicitly gated test-harness authorization override", () => {

--- a/crates/sdk/src/corpus-lease.ts
+++ b/crates/sdk/src/corpus-lease.ts
@@ -30,6 +30,10 @@ import { nodeChildEnvironment } from "./node-child.js";
 const MAX_AUTHORIZATION_ATTEMPTS = 2;
 const DEFAULT_FENCE_TIMEOUT_MS = 5_000;
 const MAX_TEST_HARNESS_AUTHORIZATION_TIMEOUT_MS = 120_000;
+// Opt-in bound for seek-heavy storage. The HDD measurements in #933 required
+// more than 120 seconds cold, despite fitting the byte and file ceilings.
+// This is an operator-selected allowance, not a universal disk-speed promise.
+const SLOW_STORAGE_AUTHORIZATION_TIMEOUT_MS = 240_000;
 const MAX_ACTIVE_WATCHERS = 64;
 // Snapshot content is retained as JavaScript strings, whose backing storage
 // may require two bytes per source byte. Reserve that worst case for the full
@@ -97,18 +101,14 @@ export const DEFAULT_CORPUS_READ_BUDGETS: Readonly<CorpusReadBudgets> =
 const CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT = 3;
 const CORPUS_PHYSICAL_READS_PER_MANIFEST = 2;
 
-// Match the native corpus reader's documented storage floor. Meeting libraries
-// may live on synced folders, external disks, and ordinary spinning disks; a
-// corpus inside every published resource ceiling must not require fast local
-// SSD throughput merely to pass authorization.
+// The standard profile matches the native reader's throughput assumption.
+// This byte-based estimate does not model per-file seeks or reader round trips;
+// small-file HDD corpora can exceed it even inside every resource ceiling.
 const MIN_ASSUMED_CORPUS_READ_BYTES_PER_SECOND = 16 * 1024 * 1024;
 
-// This deadline is a backstop, not the primary safety control. File, byte,
-// directory, watcher, reader, retained-memory, and worker-process ceilings
-// still bound what one request may consume. Deriving the wall-clock ceiling
-// from that work envelope keeps those promises consistent when a pass count or
-// byte ceiling changes. At today's limits this is 60 seconds, rather than the
-// old hardcoded 15 seconds that denied valid large or slow corpora (#933).
+// The standard profile remains 60 seconds. The explicit slow profile allows
+// more wall time without changing passes, watcher fences, cancellation, or any
+// file, byte, directory, reader, watcher, retained-memory or process ceiling.
 const DEFAULT_AUTHORIZATION_TIMEOUT_MS = Math.ceil(
   (DEFAULT_CORPUS_READ_BUDGETS.maxCorpusBytes *
     CORPUS_MANIFESTS_PER_AUTHORIZATION_ATTEMPT *
@@ -444,13 +444,17 @@ function resolveAuthorizationTimeoutMs(
   timeoutMs: number | undefined,
   environment: Readonly<NodeJS.ProcessEnv> = process.env
 ): number {
+  const storageProfile = environment.MINUTES_CORPUS_STORAGE_PROFILE ?? "standard";
+  if (storageProfile !== "standard" && storageProfile !== "slow") {
+    throw new Error("Access denied: invalid meeting corpus storage profile");
+  }
+  const productionCap = storageProfile === "slow"
+    ? SLOW_STORAGE_AUTHORIZATION_TIMEOUT_MS
+    : DEFAULT_AUTHORIZATION_TIMEOUT_MS;
   const configuredOverride = environment.MINUTES_CORPUS_AUTH_TIMEOUT_MS;
-  // A deadline beyond the derived production envelope is test infrastructure,
-  // not application configuration. Requiring both markers keeps an ambient
-  // production environment variable from relaxing the fail-closed cap. Only
-  // the repository's test harness sets this pair; the spawned lease worker
-  // inherits it from the parent. Invalid gated values fail closed instead of
-  // silently relaxing or changing the requested budget.
+  // The numeric override remains test-only. Both markers are required, and
+  // its independent cap still applies even with the production slow profile.
+  // Invalid gated values fail closed rather than silently changing policy.
   const testHarnessOverride =
     environment.NODE_ENV === "test" &&
     environment.MINUTES_TEST_HARNESS === "1" &&
@@ -465,7 +469,7 @@ function resolveAuthorizationTimeoutMs(
   }
   const cap =
     testHarnessOverride === undefined
-      ? DEFAULT_AUTHORIZATION_TIMEOUT_MS
+      ? productionCap
       : Math.min(
           Number(testHarnessOverride),
           MAX_TEST_HARNESS_AUTHORIZATION_TIMEOUT_MS

--- a/docs/checklists/pre-commit.md
+++ b/docs/checklists/pre-commit.md
@@ -42,13 +42,15 @@ CI enforces the version-sync and generated-skills checks. The pre-push hooks are
 
 ## Corpus-lease tests need the test-harness budget
 
-The meeting-corpus authorization handshake has a fail-closed production deadline
-derived from its full bounded read envelope. It is currently 60 s: three manifest
-passes per attempt, two physical reads per manifest, two possible attempts, an
-80 MiB corpus ceiling, and the same 16 MiB/s storage floor used by the native reader
-(#933). The MCP test script wraps vitest in `scripts/run_corpus_test_harness.mjs`,
-and CI sets the same `NODE_ENV=test`, `MINUTES_TEST_HARNESS=1`, and
+The meeting-corpus authorization handshake uses a bounded production deadline.
+The standard profile is 60 seconds, derived from its byte read envelope. That
+estimate does not include seek and per-file reader overhead. The documented
+`MINUTES_CORPUS_STORAGE_PROFILE=slow` profile permits up to 240 seconds while
+preserving the same verification and resource limits.
+
+The MCP test script wraps vitest in `scripts/run_corpus_test_harness.mjs`, and CI
+sets the same `NODE_ENV=test`, `MINUTES_TEST_HARNESS=1`, and
 `MINUTES_CORPUS_AUTH_TIMEOUT_MS=60000` contract for the focused SDK suite. Running
-vitest directly bypasses that explicit harness contract. Both markers are required;
-the override never applies outside the harness, and the production deadline remains
-bounded by its derived envelope.
+vitest directly bypasses that explicit harness contract. Both markers are required
+for the numeric override; it never applies outside the harness. Its independent
+120-second cap still applies when the production slow profile is selected.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,31 @@
 
 Optional — minutes works out of the box.
 
+## Meeting libraries on slow storage
+
+The MCP server and JavaScript SDK use a bounded verification deadline before returning meeting results. The standard profile allows 60 seconds. A library with thousands of small files on a spinning disk can exceed this even when its total size is small, because file seeks and reader round trips add work beyond byte throughput.
+
+Set `MINUTES_CORPUS_STORAGE_PROFILE=slow` in the environment of the MCP server or SDK process to allow up to 240 seconds. For example, add this entry to the existing MCP server configuration's `env` object, then restart the server:
+
+```json
+{
+  "MINUTES_CORPUS_STORAGE_PROFILE": "slow"
+}
+```
+
+For a direct source build in PowerShell:
+
+```powershell
+$env:MINUTES_CORPUS_STORAGE_PROFILE = "slow"
+node crates/mcp/dist/index.js
+```
+
+Use a client request timeout of at least 300 seconds for this profile, where the client supports configuring it. The verification cap does not extend a client's own timeout. A client timeout also does not guarantee the server has stopped its work; verification retains its own bounded deadline. Calls that complete sooner return immediately. Remove the setting or use `standard` to restore the 60-second profile. Other values are rejected.
+
+The slow profile changes only the time allowance. It preserves all file and memory limits, full rereads, watcher fences, and worker termination. It does not make a library that exceeds resource limits valid, guarantee completion on every disk, or change native CLI search deadlines. The separate numeric `MINUTES_CORPUS_AUTH_TIMEOUT_MS` variable remains test-harness-only and is not a production setting.
+
+## Capture and processing
+
 ```toml
 # By default: ~/.config/minutes/config.toml
 # Or: $XDG_CONFIG_HOME/minutes/config.toml when XDG_CONFIG_HOME is set


### PR DESCRIPTION
On seek-heavy disks, a valid library can exceed the standard 60-second corpus verification budget even when its total byte count is small. Add the explicit production setting `MINUTES_CORPUS_STORAGE_PROFILE=slow` to allow up to 240 seconds. The default remains `standard` at 60 seconds. Unknown profile values fail closed, and the numeric timeout override remains test-harness-only.

The profile changes only the bounded time allowance. Verification passes, watcher fences, worker termination, file and memory limits remain intact. Configuration and SDK documentation explain the setting, native CLI scope, and the need for a client timeout of at least 300 seconds where configurable.

Validation: SDK build and corpus tests, MCP build and unit tests, mirror check, canonical MCPB bundle guard, and packaged protocol handshake. A production-mode probe with no test markers held verification for 62 seconds: standard denied at 60.0 seconds without invoking the operation; slow completed at 62.2 seconds. A production-profile regression verifies resource rejection, operation cancellation, and subsequent recovery. The first MCP suite run hit the existing one-millisecond unconfirmed-worker recovery test; the full rerun passed (363 tests, one skipped). The SDK corpus suite passed 59 tests before the added production regression, which also passed separately.

Related to #933. This implements a documented bounded setting suggested by the new HDD measurements. It does not optimize per-file reads or claim cold-HDD acceptance. The exact branch still needs testing on the reporter's disk before release.
