### PR TITLE
Keep audio input streams running after transient overloads

### DIFF
--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -840,7 +840,7 @@ fn build_capture_stream(
     sample_count: &Arc<std::sync::atomic::AtomicU64>,
     err_flag: &Arc<AtomicBool>,
     live_tx: &Option<std::sync::mpsc::SyncSender<Vec<f32>>>,
-) -> Result<cpal::Stream, CaptureError> {
+) -> Result<(cpal::Stream, Arc<crate::resample::InputStreamDiagnostics>), CaptureError> {
     let writer_clone = Arc::clone(writer);
     let sample_count_clone = Arc::clone(sample_count);
     let live_tx_clone = live_tx.clone();
@@ -855,7 +855,7 @@ fn build_capture_stream(
     // based on 16kHz: ~1600 samples for 10 updates/sec.
     let level_interval: u32 = 1600; // 16000 / 10
 
-    let (stream, _device_name, _config) = crate::resample::build_resampled_input_stream(
+    let (stream, _device_name, stream_config) = crate::resample::build_resampled_input_stream(
         device,
         stop_flag,
         err_flag,
@@ -907,7 +907,7 @@ fn build_capture_stream(
         },
     )?;
 
-    Ok(stream)
+    Ok((stream, stream_config.diagnostics))
 }
 
 /// Try to reconnect to the current default audio device.
@@ -920,7 +920,11 @@ fn try_reconnect(
     sample_count: &Arc<std::sync::atomic::AtomicU64>,
     err_flag: &Arc<AtomicBool>,
     live_tx: &Option<std::sync::mpsc::SyncSender<Vec<f32>>>,
-) -> Option<(cpal::Stream, String)> {
+) -> Option<(
+    cpal::Stream,
+    String,
+    Arc<crate::resample::InputStreamDiagnostics>,
+)> {
     use cpal::traits::DeviceTrait;
 
     // Reset error flag for the new stream
@@ -939,9 +943,9 @@ fn try_reconnect(
         .map_or_else(|_| "unknown".to_string(), |d| d.name().to_string());
 
     match build_capture_stream(&device, writer, stop_flag, sample_count, err_flag, live_tx) {
-        Ok(stream) => {
+        Ok((stream, diagnostics)) => {
             tracing::info!(device = %name, "audio stream reconnected");
-            Some((stream, name))
+            Some((stream, name, diagnostics))
         }
         Err(e) => {
             tracing::warn!(device = %name, "reconnect: build stream failed: {}", e);
@@ -1893,6 +1897,10 @@ pub fn record_to_wav_with_lifecycle(
             }
         }
 
+        if let Some((_, diagnostics)) = &stream {
+            diagnostics.report_pending();
+        }
+
         // Check for stream error or device change → attempt reconnection
         let should_reconnect = if err_flag.load(Ordering::Relaxed) {
             tracing::warn!("audio stream error detected — checking for device change");
@@ -1945,11 +1953,11 @@ pub fn record_to_wav_with_lifecycle(
             });
 
             match reconnected {
-                Some((new_stream, new_name)) => {
+                Some((new_stream, new_name, diagnostics)) => {
                     let old_name = current_device_name.clone();
                     current_device_name = new_name;
                     device_monitor.update_device(&current_device_name);
-                    stream = Some(new_stream);
+                    stream = Some((new_stream, diagnostics));
                     safety_guard.extend(); // reset silence timers after reconnect
 
                     eprintln!(
@@ -1972,7 +1980,10 @@ pub fn record_to_wav_with_lifecycle(
         }
     }
 
-    // Stop and finalize
+    // Stop and finalize. Report any final overloads outside the audio callback.
+    if let Some((_, diagnostics)) = &stream {
+        diagnostics.report_pending();
+    }
     drop(stream);
     // Capture is authoritative. Abort optional recognition immediately, then
     // seal the WAV before waiting for the sidecar thread to retire.

--- a/crates/core/src/resample.rs
+++ b/crates/core/src/resample.rs
@@ -1,17 +1,48 @@
 use crate::error::CaptureError;
 use cpal::traits::{DeviceTrait, StreamTrait};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 /// Metadata about the audio device configuration used to build a resampled stream.
 #[allow(dead_code)]
 pub struct StreamConfig {
+    /// Overloads are counted on the audio thread and reported by its owner.
+    pub diagnostics: Arc<InputStreamDiagnostics>,
     /// Native sample rate of the device (e.g., 44100, 48000).
     pub native_sample_rate: u32,
     /// Number of channels on the device.
     pub channels: u16,
     /// Decimation ratio (native_rate / 16000.0).
     pub ratio: f64,
+}
+
+/// Per-stream overload evidence. Reporting belongs on the capture/control thread.
+#[derive(Default)]
+pub struct InputStreamDiagnostics {
+    xruns: AtomicU64,
+}
+
+impl InputStreamDiagnostics {
+    fn handle_error(&self, error: cpal::Error, fatal: &AtomicBool) {
+        if error.kind() == cpal::ErrorKind::Xrun {
+            // CoreAudio delivers overloads from its realtime thread. Do not
+            // format, log, lock, or request a destructive restart here (#940).
+            self.xruns.fetch_add(1, Ordering::Relaxed);
+        } else {
+            tracing::error!("audio stream error: {}", error);
+            fatal.store(true, Ordering::Relaxed);
+        }
+    }
+
+    pub fn report_pending(&self) {
+        let xruns = self.xruns.swap(0, Ordering::Relaxed);
+        if xruns > 0 {
+            tracing::warn!(
+                xruns,
+                "audio input overload: possible audio gaps; continuing the existing stream; review the saved recording"
+            );
+        }
+    }
 }
 
 /// Build a cpal input stream that captures audio, mixes to mono, and resamples
@@ -50,7 +81,9 @@ where
         "audio capture config"
     );
 
+    let diagnostics = Arc::new(InputStreamDiagnostics::default());
     let stream_config = StreamConfig {
+        diagnostics: Arc::clone(&diagnostics),
         native_sample_rate: sample_rate,
         channels,
         ratio,
@@ -73,6 +106,7 @@ where
             let mut resampled: Vec<f32> = Vec::new();
             let stop_clone = Arc::clone(stop_flag);
             let err_flag_clone = Arc::clone(err_flag);
+            let diagnostics = Arc::clone(&diagnostics);
 
             device
                 .build_input_stream(
@@ -110,8 +144,7 @@ where
                         }
                     },
                     move |err| {
-                        tracing::error!("audio stream error: {}", err);
-                        err_flag_clone.store(true, Ordering::Relaxed);
+                        diagnostics.handle_error(err, &err_flag_clone);
                     },
                     None,
                 )
@@ -129,6 +162,7 @@ where
             let mut resampled: Vec<f32> = Vec::new();
             let stop_clone = Arc::clone(stop_flag);
             let err_flag_clone = Arc::clone(err_flag);
+            let diagnostics = Arc::clone(&diagnostics);
 
             device
                 .build_input_stream(
@@ -167,8 +201,7 @@ where
                         }
                     },
                     move |err| {
-                        tracing::error!("audio stream error: {}", err);
-                        err_flag_clone.store(true, Ordering::Relaxed);
+                        diagnostics.handle_error(err, &err_flag_clone);
                     },
                     None,
                 )
@@ -189,4 +222,38 @@ where
         .map_err(|e| CaptureError::Io(std::io::Error::other(format!("stream play: {}", e))))?;
 
     Ok((stream, device_name, stream_config))
+}
+
+#[cfg(test)]
+mod overload_tests {
+    use super::*;
+
+    #[test]
+    fn overloads_do_not_request_reconnect_and_remain_observable() {
+        let diagnostics = InputStreamDiagnostics::default();
+        let fatal = AtomicBool::new(false);
+        for _ in 0..3 {
+            diagnostics.handle_error(cpal::ErrorKind::Xrun.into(), &fatal);
+        }
+        assert!(!fatal.load(Ordering::Relaxed));
+        assert_eq!(diagnostics.xruns.load(Ordering::Relaxed), 3);
+        diagnostics.report_pending();
+        assert_eq!(diagnostics.xruns.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn overload_does_not_clear_a_real_stream_failure() {
+        for kind in [
+            cpal::ErrorKind::DeviceNotAvailable,
+            cpal::ErrorKind::StreamInvalidated,
+            cpal::ErrorKind::BackendError,
+        ] {
+            let diagnostics = InputStreamDiagnostics::default();
+            let fatal = AtomicBool::new(false);
+            diagnostics.handle_error(kind.into(), &fatal);
+            diagnostics.handle_error(cpal::ErrorKind::Xrun.into(), &fatal);
+            assert!(fatal.load(Ordering::Relaxed));
+            assert_eq!(diagnostics.xruns.load(Ordering::Relaxed), 1);
+        }
+    }
 }

--- a/crates/core/src/resample.rs
+++ b/crates/core/src/resample.rs
@@ -35,12 +35,27 @@ impl InputStreamDiagnostics {
     }
 
     pub fn report_pending(&self) {
+        self.report_pending_with(|entry| {
+            // The desktop has no tracing subscriber. Persist content-free
+            // diagnostics here, never from the realtime audio callback.
+            if let Err(error) = crate::logging::append_log(&entry) {
+                tracing::warn!(%error, "failed to write audio overload diagnostic");
+            }
+        });
+    }
+
+    fn report_pending_with(&self, mut report: impl FnMut(serde_json::Value)) {
         let xruns = self.xruns.swap(0, Ordering::Relaxed);
         if xruns > 0 {
-            tracing::warn!(
-                xruns,
-                "audio input overload: possible audio gaps; continuing the existing stream; review the saved recording"
-            );
+            let message = "audio input overload: possible audio gaps; continuing the existing stream; review the saved recording";
+            tracing::warn!(xruns, message);
+            report(serde_json::json!({
+                "ts": chrono::Local::now().to_rfc3339(),
+                "level": "warn",
+                "step": "audio_input_overload",
+                "xruns": xruns,
+                "message": message,
+            }));
         }
     }
 }
@@ -237,8 +252,18 @@ mod overload_tests {
         }
         assert!(!fatal.load(Ordering::Relaxed));
         assert_eq!(diagnostics.xruns.load(Ordering::Relaxed), 3);
-        diagnostics.report_pending();
+        let mut reports = Vec::new();
+        diagnostics.report_pending_with(|entry| reports.push(entry));
         assert_eq!(diagnostics.xruns.load(Ordering::Relaxed), 0);
+        diagnostics.report_pending_with(|entry| reports.push(entry));
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0]["level"], "warn");
+        assert_eq!(reports[0]["step"], "audio_input_overload");
+        assert_eq!(reports[0]["xruns"], 3);
+        assert!(reports[0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("possible audio gaps"));
     }
 
     #[test]

--- a/crates/core/src/streaming.rs
+++ b/crates/core/src/streaming.rs
@@ -246,6 +246,7 @@ pub struct AudioStream {
     _stream: cpal::Stream,
     stop: Arc<AtomicBool>,
     err_flag: Arc<AtomicBool>,
+    diagnostics: Arc<crate::resample::InputStreamDiagnostics>,
     /// Receive audio chunks from this channel.
     pub receiver: Receiver<AudioChunk>,
     /// The sample rate of output chunks (always 16000).
@@ -270,7 +271,7 @@ impl AudioStream {
 
         let mut accumulator = ChunkAccumulator::new();
 
-        let (stream, device_name, _config) = crate::resample::build_resampled_input_stream(
+        let (stream, device_name, config) = crate::resample::build_resampled_input_stream(
             &device,
             &stop,
             &err_flag,
@@ -296,6 +297,7 @@ impl AudioStream {
             _stream: stream,
             stop,
             err_flag,
+            diagnostics: config.diagnostics,
             receiver: rx,
             sample_rate: 16000,
             device_name,
@@ -304,6 +306,7 @@ impl AudioStream {
 
     /// Returns true if the audio stream has encountered an error.
     pub fn has_error(&self) -> bool {
+        self.diagnostics.report_pending();
         self.err_flag.load(Ordering::Relaxed)
     }
 
@@ -316,6 +319,7 @@ impl AudioStream {
 impl Drop for AudioStream {
     fn drop(&mut self) {
         self.stop();
+        self.diagnostics.report_pending();
     }
 }
 


### PR DESCRIPTION
CPAL 0.18.2 reports CoreAudio processor overloads as `ErrorKind::Xrun`. The shared input-stream callback currently sets the fatal error flag for every error, so an overload causes the capture loop to destroy and recreate an otherwise continuing microphone stream. This can produce the same-device restart reported in #940.

Treat Xrun as a possible audio glitch that does not request reconnection. Count these events atomically in the callback and report warnings from the capture/control thread, including the structured diagnostic log because the desktop has no tracing subscriber. Device loss, stream invalidation, and other errors retain the existing fatal recovery path. Single-source recording and streaming consumers retain their per-stream diagnostics.

Regressions cover repeated overloads without a reconnect request, warning aggregation and draining without requiring a tracing subscriber, and an overload arriving after a real stream failure without clearing that failure. Strict workspace Clippy and formatting passed. The full core suite passed 1,819 tests with one ignored.

Signed macOS desktop validation observed seven real CoreAudio overloads, including a controlled 350 ms process stall. All seven produced structured warnings. The system log showed no microphone teardown or reselection between the overloads and pressing Stop. The WAV continued growing and finalized as readable 16 kHz mono audio lasting 45.9 seconds. Bundle seal and native hotkey diagnostics passed.

Related to #940. This prevents an unnecessary restart after an overload; it does not eliminate the original overload, establish lossless capture, or prove the reported transcription and diarization errors share one cause. The short runtime fixture yielded insufficient recognized speech and was correctly preserved for review, so this is capture-recovery evidence, not a transcription-quality benchmark. Callback I/O and per-recording quality metadata need follow-up work.
