### PR TITLE
Describe the 0.26.1 capture fix on the site

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -374,7 +374,7 @@ export default function Home() {
 
         <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
           <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
-          keeps consistency reports in the meeting folder you selected and lets you try sample recall without downloading speech models. On Apple Silicon, automatic transcription can use Parakeet when its plugin and model are ready.{" "}
+          keeps the microphone running after a transient audio overload and records a diagnostic warning. Real device failures still trigger recovery.{" "}
           <a
             href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
             className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -2,9 +2,9 @@
 // step 15) from the GitHub and npm APIs. Coarse on purpose: better slightly
 // stale and reliable than a flaky build-time fetch.
 // Contributors excludes anonymous entries and dependency automation.
-// Last refreshed: 2026-09-05. npm covers 2026-08-06 through 2026-09-04.
+// Last refreshed: 2026-09-07. npm API response covers 2026-07-31 through 2026-08-29.
 
-export const GITHUB_STARS = "1,466";
-export const GITHUB_FORKS = "161";
+export const GITHUB_STARS = "1,468";
+export const GITHUB_FORKS = "160";
 export const GITHUB_CONTRIBUTORS = "30";
-export const NPM_MONTHLY_DOWNLOADS = "3,800";
+export const NPM_MONTHLY_DOWNLOADS = "3,700";

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -2,9 +2,9 @@
 // step 15) from the GitHub and npm APIs. Coarse on purpose: better slightly
 // stale and reliable than a flaky build-time fetch.
 // Contributors excludes anonymous entries and dependency automation.
-// Last refreshed: 2026-09-07. npm API response covers 2026-07-31 through 2026-08-29.
+// GitHub refreshed: 2026-09-07. npm verified: 2026-09-05, covering 2026-08-06 through 2026-09-04.
 
 export const GITHUB_STARS = "1,468";
 export const GITHUB_FORKS = "160";
 export const GITHUB_CONTRIBUTORS = "30";
-export const NPM_MONTHLY_DOWNLOADS = "3,700";
+export const NPM_MONTHLY_DOWNLOADS = "3,800";


### PR DESCRIPTION
Update the release blurb to describe the microphone overload recovery fix in v0.26.1. Refresh the GitHub counts and retain the most recent verified npm download measurement.

Validation: hosted site build and documentation checks passed. Publish after the v0.26.1 assets are available.
