### PR TITLE
fix(whisper): stop the abort callback from aborting every live sidecar pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,15 @@ jobs:
         # on non-macOS until release.
         run: cargo build -p minutes-core --no-default-features --features parakeet
 
+      - name: Test whisper-guard with the whisper feature (abort callback shim)
+        # The only tests that exercise whisper_guard::params::set_abort_callback.
+        # Every other test job runs --no-default-features, which is how the
+        # whisper-rs set_abort_callback_safe regression (every live sidecar
+        # pass aborted, v0.25.4 through v0.26.1) shipped through three
+        # releases unseen. whisper-rs is already compiled by the parakeet
+        # build above, so this adds little time.
+        run: cargo test -p whisper-guard --features whisper --lib -- --test-threads=1
+
       - name: Ensure cmake for sherpa-rs (Linux)
         if: runner.os == 'Linux'
         timeout-minutes: 20

--- a/crates/core/src/streaming_whisper.rs
+++ b/crates/core/src/streaming_whisper.rs
@@ -1,4 +1,4 @@
-use crate::transcribe::streaming_whisper_params;
+use crate::transcribe::{set_abort_callback, streaming_whisper_params};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -200,8 +200,16 @@ impl StreamingWhisper {
         let mut params = streaming_whisper_params();
         params.set_n_threads(self.n_threads);
         params.set_language(self.language.as_deref());
-        if let Some(abort_signal) = self.abort_signal.as_ref().map(Arc::clone) {
-            params.set_abort_callback_safe(move || abort_signal.load(Ordering::Relaxed));
+        // Stack-owned so it outlives `state.full`; whisper-rs's closure
+        // setter is unsound for capturing closures (see `set_abort_callback`).
+        let abort_signal = self.abort_signal.clone();
+        let abort_when_stopped = move || {
+            abort_signal
+                .as_ref()
+                .is_some_and(|signal| signal.load(Ordering::Relaxed))
+        };
+        if self.abort_signal.is_some() {
+            set_abort_callback(&mut params, &abort_when_stopped);
         }
 
         let start = std::time::Instant::now();

--- a/crates/core/src/transcribe.rs
+++ b/crates/core/src/transcribe.rs
@@ -28,7 +28,9 @@ compile_error!("the parakeet feature requires whisper because Whisper is its run
 // Re-export from whisper-guard for public API compatibility
 pub use whisper_guard::audio::{normalize_audio, resample, strip_silence};
 #[cfg(feature = "whisper")]
-pub use whisper_guard::params::{default_whisper_params, streaming_whisper_params};
+pub use whisper_guard::params::{
+    default_whisper_params, set_abort_callback, streaming_whisper_params,
+};
 pub use whisper_guard::segments::{clean_transcript, CleanStats};
 
 /// Diagnostics from the transcription filtering pipeline.

--- a/crates/whisper-guard/src/params.rs
+++ b/crates/whisper-guard/src/params.rs
@@ -76,3 +76,93 @@ pub fn num_cpus() -> i32 {
         .unwrap_or(4)
         .min(8)
 }
+
+/// Install an abort callback on `params` that polls `callback` from whisper's
+/// compute threads. Returning `true` aborts the in-flight pass.
+///
+/// This exists because whisper-rs 0.16's `FullParams::set_abort_callback_safe`
+/// is unsound. It boxes the closure twice, hands whisper the address of the
+/// outer `Box<Box<dyn FnMut>>`, and then has its trampoline reinterpret that
+/// fat pointer as the caller's concrete closure type. A capturing closure
+/// therefore reads the bytes next to the box instead of its own captures. A
+/// closure that captures an `Arc<AtomicBool>` ends up loading the flag from
+/// garbage and returns `true` on almost every call, so ggml aborts the
+/// encoder before the first token and `full()` fails with "failed to encode"
+/// (whisper.cpp return code -6). Closures whose garbage happens to read as
+/// `false` work by accident, which is why the batch deadline never fired and
+/// never failed either.
+///
+/// The caller keeps `callback` alive until `WhisperState::full` returns. The
+/// `'a` borrow ties `params` to that lifetime so the compiler enforces it.
+pub fn set_abort_callback<'a, 'b, F>(params: &mut whisper_rs::FullParams<'a, 'b>, callback: &'a F)
+where
+    F: Fn() -> bool + Sync,
+{
+    // SAFETY: the trampoline matches `ggml_abort_callback`'s ABI and reads
+    // `callback` back through the user-data pointer installed alongside it.
+    // Both stay valid for `'a`, which covers every use of `params`.
+    unsafe {
+        params.set_abort_callback(Some(abort_trampoline::<F>));
+        params.set_abort_callback_user_data(callback as *const F as *mut std::ffi::c_void);
+    }
+}
+
+/// C-ABI shim whisper calls with the pointer stored by [`set_abort_callback`].
+///
+/// # Safety
+/// `user_data` must be the `&F` installed by [`set_abort_callback`] and must
+/// still be alive.
+unsafe extern "C" fn abort_trampoline<F: Fn() -> bool>(user_data: *mut std::ffi::c_void) -> bool {
+    let callback = &*(user_data as *const F);
+    callback()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::c_void;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    fn call<F: Fn() -> bool>(callback: &F) -> bool {
+        // SAFETY: `callback` outlives the call and matches the trampoline's `F`.
+        unsafe { abort_trampoline::<F>(callback as *const F as *mut c_void) }
+    }
+
+    #[test]
+    fn trampoline_reads_a_capturing_closure_through_its_own_pointer() {
+        // The exact shape that broke the recording sidecar: a closure whose
+        // only capture is an `Arc<AtomicBool>` stop flag.
+        let flag = Arc::new(AtomicBool::new(false));
+        let shared = Arc::clone(&flag);
+        let callback = move || shared.load(Ordering::Relaxed);
+
+        assert!(!call(&callback), "must not abort while the flag is clear");
+        flag.store(true, Ordering::Relaxed);
+        assert!(call(&callback), "must abort once the flag is set");
+    }
+
+    #[test]
+    fn trampoline_sees_state_captured_by_value() {
+        // Batch transcription captures a deadline by value; the helper must
+        // read the real capture, not whatever sits next to a heap box.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3600);
+        let not_yet = move || std::time::Instant::now() > deadline;
+        assert!(!call(&not_yet));
+
+        let past = std::time::Instant::now() - std::time::Duration::from_secs(1);
+        let already = move || std::time::Instant::now() > past;
+        assert!(call(&already));
+    }
+
+    #[test]
+    fn install_on_params_compiles_with_a_stack_callback() {
+        // Compile-time check that the borrow lets the callback live on the
+        // caller's stack for the duration of a `full()` call.
+        let stop = AtomicBool::new(false);
+        let callback = || stop.load(Ordering::Relaxed);
+        let mut params = streaming_whisper_params();
+        set_abort_callback(&mut params, &callback);
+        drop(params);
+    }
+}


### PR DESCRIPTION
## What broke

Since `5ae688bb` (first shipped in **v0.25.4**, Aug 27) the recording sidecar has produced almost no live transcript. Recordings and batch transcripts were unaffected, which is why it went unnoticed: the WAV was fine, the meeting note was fine, only `live-transcript.jsonl` stayed empty while `live-transcript-status.json` reported `healthy`.

Event log evidence (`~/.minutes/events.jsonl`, `live.utterance.final` with `source: recording-sidecar`):

| period | lines per day |
|---|---|
| Aug 3 to Aug 27 12:30 (pre 0.25.4) | 27 to 538 |
| Aug 27 14:35 onward (0.25.4 through 0.26.1) | 0, 0, 3 (75 min call), 1 (21 min call) |

Standalone `minutes live` kept working the whole time because its `StreamingWhisper` never had an abort signal wired in.

## Root cause

`5ae688bb` made the sidecar pass a stop flag to whisper via whisper-rs 0.16's `FullParams::set_abort_callback_safe`. That API is unsound for plain closures: it double-boxes the closure, stores the outer `Box<Box<dyn FnMut>>` pointer as user data, and instantiates its trampoline with the caller's concrete closure type, so the trampoline reinterprets a fat pointer as the closure. The sibling `set_progress_callback_safe` in the same file instantiates its trampoline with `Box<dyn FnMut>` and is correct; the abort one is a copy-paste slip upstream.

A closure capturing `Arc<AtomicBool>` therefore loads the flag from garbage next to the box. On this machine it reads true on almost every poll, ggml aborts the encoder, and `whisper_full` returns -6 (`failed to encode`). Every utterance the VAD finalized was dropped; the rare lines that landed were polls where the garbage happened to read as zero. Because it is undefined behavior, other machines may see anything from "works" to "nothing", which is also why it is nondeterministic run to run.

## Fix

`whisper_guard::params::set_abort_callback` installs the raw ggml callback with a pointer to a stack-owned closure the caller keeps alive across `WhisperState::full`; the `'a` borrow ties `FullParams` to that lifetime so the compiler enforces it. `StreamingWhisper::transcribe` uses it for the sidecar stop flag. Three unit tests exercise the trampoline with the exact closure shapes involved.

Replaying the 21-minute call audio through the production `run_sidecar_mpsc` with the production config:

| build | whisper failures | live lines | words |
|---|---|---|---|
| origin/main | 85 | 4 | 159 |
| abort callback removed (control) | 0 | 21 | 817 |
| this branch, callback wired in | 0 | 18 | 787 |

## Why this is safe elsewhere

- The sidecar change only removes spurious aborts. The callback still reads the same `Arc<AtomicBool>`; recording stop still preempts an in-flight pass, now reliably.
- `extern "C" fn(*mut c_void) -> bool` is `ggml_abort_callback` on every platform; `F: Sync` because ggml polls from compute threads. No new dependencies, no feature changes.
- The batch timeout in `transcribe.rs` uses the same whisper-rs API and has never fired for the same reason (its garbage reads as a far-future deadline on every platform). It is deliberately **not** touched here: wiring it correctly would make the 1-hour cap live for the first time and could abort long recordings on slow CPU-only devices with large models. That needs its own decision.

## How it got past CI

Every CI test job runs `--no-default-features`, so `streaming_whisper.rs`, `live_transcript.rs`, and the whisper-guard params module are never compiled under test and no whisper inference ever runs in CI. This PR adds `cargo test -p whisper-guard --features whisper` to the Test job (whisper-rs is already compiled there by the parakeet build step).

## Follow-ups, separate PRs

- `live-transcript-status.json` reports `healthy` with zero lines for the whole session; `mark_healthy()` is set once at startup and never revisited.
- The sidecar's failure paths (`streaming whisper failed`, model unavailable, VAD fallbacks) are `tracing::warn!` only, and the desktop app installs no subscriber, so they reach neither `minutes.log` nor the unified log.
- `transcription.vad_engine` defaults to `ort-silero`, but the release app is not built with `vad-ort` and `minutes setup` never fetches the ONNX, so every session silently falls back to whisper-silero.
- Batch timeout policy (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpVem3MYXJRfKZgTEbaJws
