### PR TITLE
ci: run the live transcript and streaming whisper tests under their real features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,16 @@ jobs:
         # build above, so this adds little time.
         run: cargo test -p whisper-guard --features whisper --lib -- --test-threads=1
 
+      - name: Test live transcript and streaming whisper (whisper + streaming)
+        # live_transcript.rs and streaming_whisper.rs are gated on
+        # all(streaming, whisper), so the --no-default-features test run
+        # below compiles none of their tests: the whisper-rs abort callback
+        # regression (#951) and the always-healthy status file (#952) both
+        # lived in exactly this code and shipped through three releases with
+        # green CI. No model is required; tests that need one are #[ignore].
+        # whisper-rs is already compiled by the parakeet build above.
+        run: cargo test -p minutes-core --features streaming --lib -- live_transcript:: streaming_whisper:: --test-threads=1
+
       - name: Ensure cmake for sherpa-rs (Linux)
         if: runner.os == 'Linux'
         timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         # lived in exactly this code and shipped through three releases with
         # green CI. No model is required; tests that need one are #[ignore].
         # whisper-rs is already compiled by the parakeet build above.
-        run: cargo test -p minutes-core --features streaming --lib -- live_transcript:: streaming_whisper:: --test-threads=1
+        run: "cargo test -p minutes-core --features streaming --lib -- live_transcript:: streaming_whisper:: --test-threads=1"
 
       - name: Ensure cmake for sherpa-rs (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Why

Every CI test job runs `minutes-core` with `--no-default-features`. `live_transcript.rs` and `streaming_whisper.rs` are gated on `all(streaming, whisper)`, so none of their tests have ever compiled in CI. Both regressions found today lived in exactly this code and shipped through v0.25.4 to v0.26.1 with green CI:

- #951: whisper-rs abort callback failing every live sidecar pass
- #952: status file reporting `healthy` with zero lines

## What

One step in the Test job, after the parakeet build (which already compiles whisper-rs, so the added cost is the `minutes-core` test target):

```
cargo test -p minutes-core --features streaming --lib -- live_transcript:: streaming_whisper:: --test-threads=1
```

Runs on macOS, Windows, and Linux like the other test steps. No model is needed; the tests that require one are `#[ignore]`.

## Verified

Locally with an empty `HOME` and no config, approximating the runner: 52 passed, 0 failed, 2 ignored.

This PR touches only `ci.yml`, which is in the `rust` paths filter, so the Test job runs here and shows the step passing on all three OSes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpVem3MYXJRfKZgTEbaJws
