### PR TITLE
feat(live): persist sidecar failures and a session summary to minutes.log

### DIFF
--- a/crates/core/src/capture.rs
+++ b/crates/core/src/capture.rs
@@ -1607,6 +1607,16 @@ fn record_to_wav_dual_source(
             dropped_chunks = sidecar_drops,
             "live transcript sidecar: chunks dropped (sidecar channel full, transcript may have gaps)"
         );
+        // Persist as well: the desktop app has no tracing subscriber.
+        crate::logging::append_log(&serde_json::json!({
+            "ts": chrono::Local::now().to_rfc3339(),
+            "level": "warn",
+            "step": "live_sidecar_chunks_dropped",
+            "file": "",
+            "message": "live transcript sidecar dropped audio chunks because it could not keep up; the live transcript may have gaps (the recording is unaffected)",
+            "extra": {"dropped_chunks": sidecar_drops},
+        }))
+        .ok();
     }
 
     let (total_samples, stem_contents) = writers.finalize()?;

--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -255,6 +255,62 @@ fn emit_live_engine_fallback_warning(source: &'static str, detail: &str) {
     .ok();
 }
 
+/// Persist one sidecar diagnostic to `~/.minutes/logs/minutes.log`.
+///
+/// The desktop app installs no tracing subscriber, so every `tracing::warn!`
+/// in this module vanishes there. Anything that explains a missing or thin
+/// live transcript goes through here as well, so a user or a support thread
+/// can read it back after the call instead of reconstructing it from the WAV.
+fn persist_sidecar_log(
+    level: &'static str,
+    step: &'static str,
+    message: &str,
+    extra: serde_json::Value,
+) {
+    crate::logging::append_log(&serde_json::json!({
+        "ts": Local::now().to_rfc3339(),
+        "level": level,
+        "step": step,
+        "file": "",
+        "message": message,
+        "extra": extra,
+    }))
+    .ok();
+}
+
+/// Per-utterance failures repeat at speech cadence. Persist the 1st, 10th,
+/// and 100th, then every 1000th, so a broken engine leaves a clear trail
+/// without flooding the log.
+pub(crate) fn should_persist_repeat(count: u64) -> bool {
+    matches!(count, 1 | 10 | 100) || (count >= 1000 && count.is_multiple_of(1000))
+}
+
+/// Explain a VAD engine that resolved to something other than what the config
+/// asked for. `None` when the request was honored.
+fn vad_downgrade_message(requested: &str, resolved: &str) -> Option<String> {
+    let requested = requested.trim().to_lowercase();
+    let want_ort = matches!(requested.as_str(), "ort-silero" | "ort" | "silero-ort");
+    match resolved {
+        "energy" => Some(format!(
+            "VAD engine \"{requested}\" unavailable; using energy VAD, which segments on volume alone"
+        )),
+        "silero" if want_ort => Some(
+            "VAD engine \"ort-silero\" unavailable (this build lacks the vad-ort feature or silero-vad-v6.2.0.onnx is missing from model_path); using whisper-silero"
+                .into(),
+        ),
+        _ => None,
+    }
+}
+
+/// Utterances the recording sidecar skipped because no whisper model could be
+/// loaded. Reset at sidecar start; reported in the session summary.
+static SIDECAR_SKIPPED_UTTERANCES: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Detected speech below which an empty session is just a quiet room rather
+/// than a silent engine failure (100 ms VAD windows, so 300 is 30 s).
+const SIDECAR_SUMMARY_SPEECH_WINDOWS_FLOOR: usize = 300;
+
 #[cfg(all(feature = "whisper", target_os = "macos"))]
 fn emit_apple_speech_fallback_warning(source: &'static str, detail: &str) {
     eprintln!(
@@ -2319,6 +2375,18 @@ fn transcribe_utterance_for_sidecar(
                     error = %error,
                     "whisper model unavailable for live sidecar — skipping utterance"
                 );
+                let skipped = SIDECAR_SKIPPED_UTTERANCES.fetch_add(1, Ordering::Relaxed) + 1;
+                if should_persist_repeat(skipped) {
+                    persist_sidecar_log(
+                        "warn",
+                        "live_sidecar_utterance_skipped",
+                        "whisper model unavailable for the live sidecar; utterance skipped",
+                        serde_json::json!({
+                            "error": error.to_string(),
+                            "skipped_utterances": skipped,
+                        }),
+                    );
+                }
                 return None;
             }
         },
@@ -3109,6 +3177,26 @@ fn run_sidecar_inner_mpsc(
         current_speech_drafts = partial_publisher.is_some(),
         "live sidecar started (recording mode)"
     );
+    SIDECAR_SKIPPED_UTTERANCES.store(0, Ordering::Relaxed);
+    crate::streaming_whisper::reset_failure_count();
+    let vad_downgrade = vad_downgrade_message(&config.transcription.vad_engine, vad.mode_name());
+    persist_sidecar_log(
+        if vad_downgrade.is_some() {
+            "warn"
+        } else {
+            "info"
+        },
+        "live_sidecar_started",
+        vad_downgrade
+            .as_deref()
+            .unwrap_or("live transcript sidecar started"),
+        serde_json::json!({
+            "vad_requested": config.transcription.vad_engine,
+            "vad_resolved": vad.mode_name(),
+            "backend": sidecar_backend,
+            "current_speech_drafts": partial_publisher.is_some(),
+        }),
+    );
 
     loop {
         if let Some(result) = draft_results.take() {
@@ -3249,6 +3337,35 @@ fn run_sidecar_inner_mpsc(
         draft_jobs_replaced = draft_jobs.replaced.load(Ordering::Relaxed),
         draft_results_replaced = draft_results.replaced.load(Ordering::Relaxed),
         "live sidecar ended (recording mode)"
+    );
+    let dropped_utterances = queue_counters.dropped.load(Ordering::Relaxed);
+    let no_output_despite_speech =
+        lines == 0 && gating_stats.speaking_windows >= SIDECAR_SUMMARY_SPEECH_WINDOWS_FLOOR;
+    persist_sidecar_log(
+        if no_output_despite_speech || dropped_utterances > 0 {
+            "warn"
+        } else {
+            "info"
+        },
+        "live_sidecar_ended",
+        if no_output_despite_speech {
+            "live transcript sidecar ended with no lines despite detected speech"
+        } else if dropped_utterances > 0 {
+            "live transcript sidecar ended; some utterances were dropped because transcription could not keep up"
+        } else {
+            "live transcript sidecar ended"
+        },
+        serde_json::json!({
+            "lines": lines,
+            "duration_secs": format!("{:.1}", duration),
+            "vad_mode": vad.mode_name(),
+            "speaking_windows": gating_stats.speaking_windows,
+            "silence_windows": gating_stats.silence_windows,
+            "speech_secs": gating_stats.speaking_windows / 10,
+            "dropped_utterances": dropped_utterances,
+            "skipped_utterances": SIDECAR_SKIPPED_UTTERANCES.load(Ordering::Relaxed),
+            "whisper_failures": crate::streaming_whisper::failure_count(),
+        }),
     );
 
     if input_disconnected_unexpectedly {
@@ -3940,6 +4057,27 @@ mod tests {
                 .unwrap()
                 .contains("(1 line(s) so far)"));
         });
+    }
+
+    #[test]
+    fn repeated_failures_persist_on_a_log_scale() {
+        let persisted: Vec<u64> = (1..=3000).filter(|n| should_persist_repeat(*n)).collect();
+        assert_eq!(persisted, vec![1, 10, 100, 1000, 2000, 3000]);
+        assert!(!should_persist_repeat(0));
+    }
+
+    #[test]
+    fn vad_downgrade_is_explained_only_when_the_request_was_not_honored() {
+        assert_eq!(vad_downgrade_message("whisper-silero", "silero"), None);
+        assert_eq!(vad_downgrade_message("ort-silero", "ort-silero"), None);
+        assert_eq!(vad_downgrade_message("", "silero"), None);
+
+        let ort_fallback = vad_downgrade_message("ort-silero", "silero").unwrap();
+        assert!(ort_fallback.contains("vad-ort"));
+        assert!(ort_fallback.contains("whisper-silero"));
+
+        let energy = vad_downgrade_message("whisper-silero", "energy").unwrap();
+        assert!(energy.contains("energy VAD"));
     }
 
     #[test]

--- a/crates/core/src/streaming_whisper.rs
+++ b/crates/core/src/streaming_whisper.rs
@@ -1,6 +1,6 @@
 use crate::transcribe::{set_abort_callback, streaming_whisper_params};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
 };
 use whisper_rs::WhisperContext;
@@ -42,6 +42,18 @@ use whisper_rs::WhisperContext;
 //   - Transcription runs on a background thread; audio capture
 //     continues uninterrupted on the main thread.
 // ──────────────────────────────────────────────────────────────
+
+/// Whisper passes that returned an error since the last reset. Read by the
+/// recording sidecar's session summary; reset when a sidecar starts.
+static WHISPER_FAILURES: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn failure_count() -> u64 {
+    WHISPER_FAILURES.load(Ordering::Relaxed)
+}
+
+pub(crate) fn reset_failure_count() {
+    WHISPER_FAILURES.store(0, Ordering::Relaxed);
+}
 
 /// How often to run partial transcription (in audio samples at 16kHz).
 const PARTIAL_INTERVAL_SAMPLES: usize = 16000 * 2; // Every 2 seconds
@@ -218,6 +230,26 @@ impl StreamingWhisper {
         let transcription_audio = &self.audio_buffer[window_start..];
         if let Err(e) = state.full(params, transcription_audio) {
             tracing::warn!("streaming whisper failed: {}", e);
+            // The desktop app has no tracing subscriber; persist a bounded
+            // trail so a whisper pass that fails on every utterance is
+            // visible in minutes.log rather than only as a thin transcript.
+            let failures = WHISPER_FAILURES.fetch_add(1, Ordering::Relaxed) + 1;
+            if crate::live_transcript::should_persist_repeat(failures) {
+                crate::logging::append_log(&serde_json::json!({
+                    "ts": chrono::Local::now().to_rfc3339(),
+                    "level": "warn",
+                    "step": "streaming_whisper_failed",
+                    "file": "",
+                    "message": "streaming whisper pass failed; the utterance produced no text",
+                    "extra": {
+                        "error": e.to_string(),
+                        "failures": failures,
+                        "is_final": is_final,
+                        "audio_secs": format!("{:.1}", transcription_audio.len() as f64 / 16000.0),
+                    },
+                }))
+                .ok();
+            }
             return None;
         }
 


### PR DESCRIPTION
## Why

The desktop app installs no tracing subscriber (deliberately, to silence whisper.cpp's C logs), so every `tracing::warn!` in the live transcript path is dropped there. On Sep 9 the recording sidecar failed every whisper pass for 21 minutes (#951). The only persisted evidence in `~/.minutes/logs/minutes.log` was one backend-downgrade line at startup, because that one site already used `append_log`. The VAD fallback, 85 per-utterance failures, and a session that ended with zero lines despite 3,400 speech windows were all invisible.

## What

Route the sidecar's diagnostics through `crate::logging::append_log`, the pattern the backend downgrade already uses:

| step | when | level |
|---|---|---|
| `live_sidecar_started` | every sidecar start: resolved VAD engine and backend | `warn` when the VAD the config asked for was not honored (this is the ort-silero fallback every shipped build takes), else `info` |
| `streaming_whisper_failed` | a whisper pass returns an error (sidecar, standalone live, dictation) | `warn`, 1st, 10th, 100th, then every 1000th |
| `live_sidecar_utterance_skipped` | no whisper model could be loaded for an utterance | `warn`, same cadence |
| `live_sidecar_chunks_dropped` | capture-side drop counter at stop, previously a tracing warning only | `warn` |
| `live_sidecar_ended` | every sidecar end: lines, detected speech, drops, skips, whisper failures | `warn` when speech was detected and no line was written, or utterances were dropped |

With this in place, today's outage would have left four lines in `minutes.log` for the first affected recording: a VAD downgrade warning, a `streaming_whisper_failed` with `failed to encode`, the 10th and 100th repeats, and an end-of-session warning naming 85 failures and 0 lines.

## Tests

`repeated_failures_persist_on_a_log_scale` and `vad_downgrade_is_explained_only_when_the_request_was_not_honored`. `live_transcript::tests` and `streaming_whisper::tests` green under `--features streaming`. Clippy clean under whisper+streaming, `--all --no-default-features`, and `--features parakeet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpVem3MYXJRfKZgTEbaJws
