### PR TITLE
ci: drop third-party apt sources before installing Linux build deps

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -20,6 +20,16 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
+# GitHub's Ubuntu image ships third-party apt sources (Google Chrome, Microsoft
+# Edge) whose mirrors intermittently answer `apt-get update` with "Hash Sum
+# mismatch" and take the whole update down with them; on 2026-09-09 that
+# failed every Linux job across four pull requests three attempts in a row.
+# Nothing this repo installs comes from those sources, so drop them first.
+sudo rm -f /etc/apt/sources.list.d/google-chrome*.list \
+  /etc/apt/sources.list.d/google-chrome*.sources \
+  /etc/apt/sources.list.d/microsoft-edge*.list \
+  /etc/apt/sources.list.d/microsoft-edge*.sources
+
 # Sized so all three attempts fit inside the twenty minute step backstop:
 # 3 x (120 + 240) seconds of work plus 45 seconds of pauses is 18m45s. Without
 # that the backstop would fire mid-retry and the third attempt would never run,


### PR DESCRIPTION
GitHub's Ubuntu runner image ships Google Chrome and Microsoft Edge apt sources. Their mirrors intermittently answer `apt-get update` with `Hash Sum mismatch`, which fails the whole update. Today that failed the Linux Test job on #953, #959, #960, and #961, three attempts each (`E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz Hash Sum mismatch`).

Nothing this repo installs comes from those sources, so `apt-install.sh` now removes them before `apt-get update`. The retry and timeout logic is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpVem3MYXJRfKZgTEbaJws