### PR TITLE
fix(live): detect an active recording on Windows before starting standalone live

### DIFF
--- a/crates/core/src/live_transcript.rs
+++ b/crates/core/src/live_transcript.rs
@@ -881,16 +881,21 @@ fn run_with_partials_internal(
         }
     };
 
-    // Check conflicts: recording must not be active
-    if let Ok(Some(_)) = pid::check_recording() {
+    // Check conflicts: recording must not be active. `inspect_pid_file`, not
+    // `check_recording`: the recorder holds its PID file under a mandatory
+    // exclusive lock on Windows, so a read-based check errors there and
+    // `if let Ok(Some(_))` read that as "no recording" while one was running.
+    // That let a standalone live session start alongside a recording and
+    // write the same live-transcript.jsonl, the #258 hazard in reverse.
+    if pid::inspect_pid_file(&pid::pid_path()).is_active() {
         let error: MinutesError = LiveTranscriptError::RecordingActive.into();
         mark_precreated_session_failed(&error);
         return Err(error);
     }
 
-    // Check conflicts: dictation must not be active
+    // Check conflicts: dictation must not be active (same lock semantics).
     let dict_pid = pid::dictation_pid_path();
-    if let Ok(Some(_)) = pid::check_pid_file(&dict_pid) {
+    if pid::inspect_pid_file(&dict_pid).is_active() {
         let error: MinutesError = LiveTranscriptError::DictationActive.into();
         mark_precreated_session_failed(&error);
         return Err(error);


### PR DESCRIPTION
## Why

Enabling the `live_transcript` tests in CI (#953) failed on windows-latest with:

```
live_transcript::tests::precreated_context_session_is_failed_when_recording_blocks_start
assertion failed: matches!(error, MinutesError::LiveTranscript(LiveTranscriptError::RecordingActive))
```

That is a real bug, not a flaky test. `run()` checks for an active recording with `pid::check_recording()`, which reads the PID file. On Windows the recorder holds that file under a mandatory exclusive lock (`LockFileEx`), so the read errors, and `if let Ok(Some(_))` reads the error as "no recording". A standalone `minutes live` session could start next to a recording and both would write `live-transcript.jsonl`. #258 fixed the same problem in the other direction (sidecar checking for standalone) with `inspect_pid_file`; the standalone side never got the same treatment. The dictation check had the same shape.

## What

Both checks use `pid::inspect_pid_file(..).is_active()`, which reports a lock violation as a live owner. Nine lines.

## Verified

The failing test passes locally (macOS, where the read succeeds either way). The Windows behavior is covered by `pid.rs`'s own tests of `inspect_pid_file` returning `LockedAlive` under a `create_pid_guard` lock, and by #953 once it is rebased on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpVem3MYXJRfKZgTEbaJws