### PR TITLE
fix(recall): give a Terminal session without a selected meeting its meeting directory

### DIFF
--- a/scripts/check_recall_terminal_input_contract.test.mjs
+++ b/scripts/check_recall_terminal_input_contract.test.mjs
@@ -21,10 +21,11 @@ function extractFunction(name) {
   throw new Error(`unterminated ${name} in ${PANEL}`);
 }
 
-function createHarness() {
+function createHarness({ meetingPath = "/meetings/private.md" } = {}) {
   const source = `
     (() => {
-      let pendingRecallTerminalMeetingPath = '/meetings/private.md';
+      let pendingRecallTerminalMeetingPath = ${JSON.stringify(meetingPath)};
+      let recallTerminalContextPending = true;
       let recallTerminalInputDraft = '';
       let recallTerminalInputReliable = true;
       const SESSION_ID = 'recall';
@@ -51,6 +52,7 @@ function createHarness() {
         send: forwardRecallTerminalData,
         state: () => ({
           pending: pendingRecallTerminalMeetingPath,
+          contextPending: recallTerminalContextPending,
           draft: recallTerminalInputDraft,
           reliable: recallTerminalInputReliable,
           calls: structuredClone(calls),
@@ -96,6 +98,31 @@ test("the first plain question prepares the meeting before Return", async () => 
     ["cmd_pty_input", "cmd_prepare_recall_terminal_meeting", "cmd_pty_input"],
   );
   assert.equal(state.calls[2].args.data, "\r");
+});
+
+test("a general question with no selected meeting prepares the meeting directory once", async () => {
+  const harness = createHarness({ meetingPath: null });
+  await harness.send("What did I commit to this week?\r", true);
+  await harness.send("And last week?\r", true);
+
+  const state = harness.state();
+  const prepares = commands(harness, "cmd_prepare_recall_terminal_meeting");
+  assert.equal(prepares.length, 1, "the general context is materialized exactly once");
+  assert.deepEqual(prepares[0].args, { meetingPath: null });
+  assert.equal(state.pending, null);
+  assert.equal(state.contextPending, false);
+  assert.match(state.notices.at(-1).message, /meeting directory is ready/);
+  assert.equal(state.calls.at(-1).args.data, "\r");
+});
+
+test("a general question still cannot bypass the privacy checks", async () => {
+  const harness = createHarness({ meetingPath: null });
+  await harness.send("\r", true);
+
+  const state = harness.state();
+  assert.equal(commands(harness, "cmd_prepare_recall_terminal_meeting").length, 0);
+  assert.equal(state.contextPending, true);
+  assert.match(state.notices.at(-1).message, /complete question or command/);
 });
 
 test("startup terminal replies do not poison the first real question", async () => {

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -14004,8 +14004,13 @@ mod tests {
         assert!(html.contains("let recallTerminalInputReliable = true;"));
         assert!(html.contains("recallTerminalInputReliable = false;"));
         assert!(html.contains(
-            "pendingRecallTerminalMeetingPath && (!question || !recallTerminalInputReliable)"
+            "recallTerminalContextPending && (!question || !recallTerminalInputReliable)"
         ));
+        // General mode has no meeting path but still owes its first question
+        // the same fail-closed input checks before any context is written.
+        assert!(
+            html.contains("await invoke('cmd_prepare_recall_terminal_meeting', { meetingPath });")
+        );
         assert!(html.contains("No meeting context was read"));
     }
 

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -9584,6 +9584,9 @@ fn sync_workspace_for_mode(
 ) -> Result<(), String> {
     // write_assistant_context preserves live transcript markers if present (U2/T3)
     crate::context::write_assistant_context(workspace, config)?;
+    // The general Terminal context is materialized per question, never
+    // carried across mode changes.
+    crate::context::clear_general_assistant_context(workspace)?;
 
     match mode {
         "assistant" => crate::context::clear_active_meeting_context(workspace),
@@ -12168,13 +12171,15 @@ pub fn cmd_recall_chat_clear(state: tauri::State<'_, AppState>) {
     h.clear();
 }
 
-/// Materialize the selected meeting only at the terminal's first real user
-/// question. The PTY must already exist, and Claude subscription auth is
-/// checked before the meeting file is read. Slash commands bypass this command
-/// in the frontend, so `/login` never causes meeting context to be collected.
+/// Materialize the terminal's context only at its first real user question:
+/// the selected meeting when one was chosen, otherwise the general
+/// meeting-directory context. The PTY must already exist, and Claude
+/// subscription auth is checked before anything under the meeting directory
+/// is read. Slash commands bypass this command in the frontend, so `/login`
+/// never causes meeting context to be collected.
 fn prepare_recall_terminal_meeting(
     pty_manager: &Arc<Mutex<crate::pty::PtyManager>>,
-    meeting_path: String,
+    meeting_path: Option<String>,
 ) -> Result<(), String> {
     let (agent_command, agent_cwd) = {
         let manager = pty_manager
@@ -12210,16 +12215,38 @@ fn prepare_recall_terminal_meeting(
     }
 
     let config = Config::load_strict()?;
-    let meeting = PathBuf::from(&meeting_path);
-    minutes_core::notes::validate_meeting_path(&meeting, &config.output_dir)?;
     let workspace = crate::context::workspace_dir();
-    crate::context::write_active_meeting_context(&workspace, &meeting, &config)
+    materialize_recall_terminal_context(&workspace, &config, meeting_path.as_deref())
+}
+
+/// Write exactly one of the two Terminal context files and clear the other, so
+/// a focus left by an earlier session cannot leak into this question. Without
+/// a selected meeting the session used to get nothing at all, and the
+/// instruction stub then had the assistant announce a missing
+/// `CURRENT_MEETING.md` on every general question.
+fn materialize_recall_terminal_context(
+    workspace: &Path,
+    config: &Config,
+    meeting_path: Option<&str>,
+) -> Result<(), String> {
+    match meeting_path {
+        Some(path) => {
+            let meeting = PathBuf::from(path);
+            minutes_core::notes::validate_meeting_path(&meeting, &config.output_dir)?;
+            crate::context::clear_general_assistant_context(workspace)?;
+            crate::context::write_active_meeting_context(workspace, &meeting, config)
+        }
+        None => {
+            crate::context::clear_active_meeting_context(workspace)?;
+            crate::context::write_general_assistant_context(workspace, config)
+        }
+    }
 }
 
 #[tauri::command]
 pub async fn cmd_prepare_recall_terminal_meeting(
     state: tauri::State<'_, AppState>,
-    meeting_path: String,
+    meeting_path: Option<String>,
 ) -> Result<(), String> {
     let pty_manager = state.pty_manager.clone();
     tauri::async_runtime::spawn_blocking(move || {
@@ -15429,15 +15456,57 @@ mod tests {
         )
         .unwrap();
 
+        std::fs::write(
+            workspace
+                .path()
+                .join(crate::context::ASSISTANT_CONTEXT_FILE),
+            "stale general context",
+        )
+        .unwrap();
+
         sync_workspace_for_mode(workspace.path(), &Config::default(), "deferred", None).unwrap();
 
         assert!(!workspace
             .path()
             .join(crate::context::ACTIVE_MEETING_FILE)
             .exists());
+        assert!(!workspace
+            .path()
+            .join(crate::context::ASSISTANT_CONTEXT_FILE)
+            .exists());
         let instructions = std::fs::read_to_string(workspace.path().join("CLAUDE.md")).unwrap();
         assert!(instructions.contains("No meeting context has been loaded yet"));
         assert!(!instructions.contains("stale private context"));
+    }
+
+    #[test]
+    fn general_terminal_question_materializes_the_meeting_directory_not_a_meeting() {
+        let workspace = TempDir::new().unwrap();
+        let corpus = TempDir::new().unwrap();
+        let config = Config {
+            output_dir: corpus.path().to_path_buf(),
+            ..Config::default()
+        };
+        std::fs::write(
+            workspace.path().join(crate::context::ACTIVE_MEETING_FILE),
+            "stale private context",
+        )
+        .unwrap();
+
+        materialize_recall_terminal_context(workspace.path(), &config, None).unwrap();
+
+        assert!(!workspace
+            .path()
+            .join(crate::context::ACTIVE_MEETING_FILE)
+            .exists());
+        let general = std::fs::read_to_string(
+            workspace
+                .path()
+                .join(crate::context::ASSISTANT_CONTEXT_FILE),
+        )
+        .unwrap();
+        assert!(general.contains("## Meeting Directory"));
+        assert!(!general.contains("stale private context"));
     }
 
     #[test]

--- a/tauri/src-tauri/src/context.rs
+++ b/tauri/src-tauri/src/context.rs
@@ -5,6 +5,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 pub const ACTIVE_MEETING_FILE: &str = "CURRENT_MEETING.md";
+/// General meeting-directory context for a Terminal session that opened
+/// without a selected meeting. Written only after the provider is verified
+/// and the user submits a real question, like `CURRENT_MEETING.md`.
+pub const ASSISTANT_CONTEXT_FILE: &str = "ASSISTANT_CONTEXT.md";
 pub const ACTIVE_ARTIFACT_FILE: &str = "CURRENT_ARTIFACT.md";
 pub const ASSISTANT_INSTRUCTION_FILES: &[&str] = &["CLAUDE.md", "AGENTS.md"];
 pub(crate) const LIVE_TRANSCRIPT_GUIDANCE: &str = include_str!("live_transcript_guidance.md");
@@ -579,8 +583,11 @@ pub fn write_deferred_assistant_context(workspace: &Path) -> Result<(), String> 
 You are running inside Minutes Recall. No meeting context has been loaded yet.\n\n\
 ## Deferred meeting context\n\n\
 Before answering every user question, check whether `{ACTIVE_MEETING_FILE}` exists in this directory. \
-If it exists, read it first and treat it as the current stored meeting focus. If it does not exist and \
-there is no `Live Transcript Active` section below, explain that Minutes has not shared stored meeting \
+If it exists, read it first and treat it as the current stored meeting focus. If it does not exist, check \
+whether `{ASSISTANT_CONTEXT_FILE}` exists: that is the general meeting-directory context Minutes writes after \
+verifying the provider, so read it and work in general assistant mode across all meetings without \
+announcing that no meeting is selected. Only when neither file exists, there is no `Live Transcript Active` \
+section below, and the question depends on stored meetings, say that Minutes has not shared meeting \
 context with this session yet.\n\n\
 `{ACTIVE_MEETING_FILE}` gates stored meeting context, not an active live transcript. If a \
 `Live Transcript Active` section exists and the user explicitly asks about the current call, use one \
@@ -639,6 +646,23 @@ pub fn write_active_artifact_context(workspace: &Path, artifact_path: &Path) -> 
     write_atomic(&workspace.join(ACTIVE_ARTIFACT_FILE), &md)
 }
 
+/// Write the general meeting-directory context for a Terminal session that has
+/// no selected meeting. Same gate as `write_active_meeting_context`: the caller
+/// has verified the provider and the user has submitted a real question.
+pub fn write_general_assistant_context(workspace: &Path, config: &Config) -> Result<(), String> {
+    let md = generate_assistant_context(config)?;
+    write_atomic(&workspace.join(ASSISTANT_CONTEXT_FILE), &md)
+}
+
+pub fn clear_general_assistant_context(workspace: &Path) -> Result<(), String> {
+    let path = workspace.join(ASSISTANT_CONTEXT_FILE);
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .map_err(|e| format!("Failed to clear general assistant context: {}", e))?;
+    }
+    Ok(())
+}
+
 pub fn clear_active_meeting_context(workspace: &Path) -> Result<(), String> {
     let active_path = workspace.join(ACTIVE_MEETING_FILE);
     if active_path.exists() {
@@ -661,6 +685,7 @@ pub fn clear_active_artifact_context(workspace: &Path) -> Result<(), String> {
 pub fn cleanup_stale_workspaces() {
     let workspace = workspace_dir();
     clear_active_meeting_context(&workspace).ok();
+    clear_general_assistant_context(&workspace).ok();
     clear_active_artifact_context(&workspace).ok();
 
     if let Ok(entries) = std::fs::read_dir(&workspace) {
@@ -756,6 +781,8 @@ mod tests {
             let content = std::fs::read_to_string(workspace.path().join(file_name)).unwrap();
             assert!(content.contains(ACTIVE_MEETING_FILE));
             assert!(content.contains("No meeting context has been loaded yet"));
+            assert!(content.contains(ASSISTANT_CONTEXT_FILE));
+            assert!(content.contains("without announcing that no meeting is selected"));
             assert!(content.contains("gates stored meeting context, not an active live transcript"));
             assert!(content.contains("it does not mean the live transcript is unavailable"));
             assert!(content.contains("/login"));
@@ -763,6 +790,23 @@ mod tests {
             assert!(!content.contains("## Recent Meetings"));
             assert!(!content.contains("## Open Action Items"));
         }
+    }
+
+    #[test]
+    fn general_assistant_context_is_written_on_request_and_cleared() {
+        let (_corpus, config) = test_config();
+        let workspace = tempfile::tempdir().unwrap();
+
+        write_general_assistant_context(workspace.path(), &config).unwrap();
+        let path = workspace.path().join(ASSISTANT_CONTEXT_FILE);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("## Meeting Directory"));
+        assert!(content.contains(&config.output_dir.display().to_string()));
+
+        clear_general_assistant_context(workspace.path()).unwrap();
+        assert!(!path.exists());
+        // Clearing an absent file is not an error.
+        clear_general_assistant_context(workspace.path()).unwrap();
     }
 
     #[test]

--- a/tauri/src/index.html
+++ b/tauri/src/index.html
@@ -14342,6 +14342,10 @@
     let recallReadiness = null;
     let recallSelectedMeetingPath = null;
     let pendingRecallTerminalMeetingPath = null;
+    // True while a Terminal session still owes its first real question the
+    // context it is allowed to see (the selected meeting, or the general
+    // meeting directory when none was selected). Cleared once materialized.
+    let recallTerminalContextPending = false;
     let recallTerminalInputDraft = '';
     let recallTerminalInputReliable = true;
     let recallTerminalInputQueue = Promise.resolve();
@@ -14438,6 +14442,7 @@
       recallModePreferenceExplicit = true;
       localStorage.setItem('minutes.recallModePreferenceExplicit', 'true');
       pendingRecallTerminalMeetingPath = recallDevMode ? recallSelectedMeetingPath : null;
+      recallTerminalContextPending = recallDevMode;
       recallTerminalInputDraft = '';
       recallTerminalInputReliable = true;
       syncRecallModeControls();
@@ -14479,6 +14484,7 @@
           'error'
         );
         pendingRecallTerminalMeetingPath = mode === 'meeting' ? meetingPath : null;
+        recallTerminalContextPending = true;
         recallTerminalInputDraft = '';
         recallTerminalInputReliable = true;
         return { mode: 'deferred', meetingPath: null };
@@ -14496,6 +14502,7 @@
 
       if (recallDevMode) {
         pendingRecallTerminalMeetingPath = mode === 'meeting' ? meetingPath : null;
+        recallTerminalContextPending = true;
         recallTerminalInputDraft = '';
         recallTerminalInputReliable = true;
         setRecallProviderNotice(
@@ -14506,6 +14513,7 @@
       }
 
       pendingRecallTerminalMeetingPath = null;
+      recallTerminalContextPending = false;
       setRecallProviderNotice(readiness.message);
       return { mode, meetingPath };
     }
@@ -14942,7 +14950,7 @@
         }
 
         const question = recallTerminalInputDraft.trim();
-        if (pendingRecallTerminalMeetingPath && (!question || !recallTerminalInputReliable)) {
+        if (recallTerminalContextPending && (!question || !recallTerminalInputReliable)) {
           setRecallProviderNotice(
             'For privacy, Minutes could not verify a complete question or command. Press Ctrl-U, retype it without cursor editing, and submit again. No meeting context was read.',
             'error'
@@ -14950,14 +14958,18 @@
           return;
         }
         const isAccountCommand = question.startsWith('/');
-        if (pendingRecallTerminalMeetingPath && question && !isAccountCommand) {
+        if (recallTerminalContextPending && question && !isAccountCommand) {
+          // null means "no meeting selected": the backend writes the general
+          // meeting-directory context instead, under the same auth gate.
+          const meetingPath = pendingRecallTerminalMeetingPath;
           try {
-            await invoke('cmd_prepare_recall_terminal_meeting', {
-              meetingPath: pendingRecallTerminalMeetingPath,
-            });
+            await invoke('cmd_prepare_recall_terminal_meeting', { meetingPath });
             pendingRecallTerminalMeetingPath = null;
+            recallTerminalContextPending = false;
             setRecallProviderNotice(
-              'The selected meeting is ready for this question. Terminal chat remains under your agent subscription.'
+              meetingPath
+                ? 'The selected meeting is ready for this question. Terminal chat remains under your agent subscription.'
+                : 'Your meeting directory is ready for this question. Terminal chat remains under your agent subscription.'
             );
           } catch (error) {
             // Do not forward Enter: the question remains in the terminal input,
@@ -15079,6 +15091,7 @@
           // clears any stale CURRENT_MEETING.md before a new question while
           // the backend keeps the already-running terminal session intact.
           await invoke('cmd_spawn_terminal', { mode: 'deferred', themeDark: isEffectiveDarkTheme() });
+          recallTerminalContextPending = true;
           recallPtyAlive = true;
           recallEndBtn.classList.add('active');
         } catch (e) {


### PR DESCRIPTION
## Why

Open Recall in Terminal mode without picking a meeting and every question starts with "Minutes has not shared stored meeting context with this session yet." That was this morning's first bug report.

`chooseRecallExperience` returns `deferred` for both "a meeting was selected" and "nothing was selected." Deferred mode writes a minimal instruction stub (deliberately, so an unverified provider sees no meeting history) and relies on `cmd_prepare_recall_terminal_meeting` to materialize the meeting at the first real question. But that command only ran when `pendingRecallTerminalMeetingPath` was set. With no meeting selected, nothing was ever materialized: the session kept the stub, which instructs the assistant to announce the missing `CURRENT_MEETING.md`, and the assistant never learned where the meeting directory is.

## What

Same gate, correct outcome. The first real question in a Terminal session always materializes context after the provider is verified:

- meeting selected: `CURRENT_MEETING.md`, as before
- nothing selected: `ASSISTANT_CONTEXT.md`, the general meeting-directory context Chat mode already gets (directory path, recent meetings, response style)

The deferred stub tells the assistant to read whichever exists and work in general mode without announcing a missing meeting. The disclaimer survives only for the case where neither file exists and the question depends on stored meetings. Either file is cleared on mode changes and at startup, like `CURRENT_MEETING.md` today.

Privacy contract unchanged: slash commands, empty Return, and cursor-edited lines still never trigger materialization; nothing under the meeting directory is read before the provider is verified.

## Tests

- `scripts/check_recall_terminal_input_contract.test.mjs`: two new cases (general question materializes exactly once with `meetingPath: null`; general mode still cannot bypass the privacy checks). 11/11.
- `minutes-app`: `general_terminal_question_materializes_the_meeting_directory_not_a_meeting`, `general_assistant_context_is_written_on_request_and_cleared`, and the deferred-mode test extended to cover the new file. 15/15 in the touched modules.
- Clippy clean with `--all --no-default-features`.
- UI click-test in the signed dev app pending (see the checklist row); will be done before the 0.26.2 release this rides in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpVem3MYXJRfKZgTEbaJws