### PR TITLE
Describe the 0.26.2 live transcript fix on the site

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -374,7 +374,7 @@ export default function Home() {
 
         <p className="mx-auto mt-12 max-w-[620px] rounded-[5px] border border-[color:var(--border)] bg-[var(--bg-elevated)] px-4 py-3 font-mono text-[12px] leading-5 text-[var(--text-secondary)]">
           <span className="text-[var(--accent)]">v{MINUTES_RELEASE_VERSION}</span>{" "}
-          keeps the microphone running after a transient audio overload and records a diagnostic warning. Real device failures still trigger recovery.{" "}
+          brings back the live transcript during recordings, which had been empty since 0.25.4, and now reports when transcription stalls instead of calling it healthy.{" "}
           <a
             href={`https://github.com/silverstein/minutes/releases/tag/v${MINUTES_RELEASE_VERSION}`}
             className="text-[var(--text)] underline decoration-[color:var(--border-mid)] underline-offset-2 hover:text-[var(--accent)]"

--- a/site/lib/proof.ts
+++ b/site/lib/proof.ts
@@ -2,9 +2,9 @@
 // step 15) from the GitHub and npm APIs. Coarse on purpose: better slightly
 // stale and reliable than a flaky build-time fetch.
 // Contributors excludes anonymous entries and dependency automation.
-// GitHub refreshed: 2026-09-07. npm verified: 2026-09-05, covering 2026-08-06 through 2026-09-04.
+// GitHub refreshed: 2026-09-09. npm verified: 2026-09-09, covering 2026-08-08 through 2026-09-06.
 
-export const GITHUB_STARS = "1,468";
-export const GITHUB_FORKS = "160";
+export const GITHUB_STARS = "1,471";
+export const GITHUB_FORKS = "162";
 export const GITHUB_CONTRIBUTORS = "30";
-export const NPM_MONTHLY_DOWNLOADS = "3,800";
+export const NPM_MONTHLY_DOWNLOADS = "3,900";


### PR DESCRIPTION
Release checklist step 15 for v0.26.2.

- Homepage release blurb now describes 0.26.2 (live transcript restored during recordings, stalls reported instead of `healthy`) instead of the 0.26.1 overload fix.
- `site/lib/proof.ts`: stars 1,468 → 1,471, forks 160 → 162, contributors unchanged at 30, npm monthly downloads 3,800 → 3,900 (minutes-mcp last-month 3,965 for 2026-08-08 to 2026-09-06, kept coarse on purpose).
- `sync_site_release_version.mjs --check` matches (v0.26.2, 34 tools, 11 resources, 6 prompts, 58 CLI commands, 3020 tests).
- `npm --prefix site ci && run check:llms && run build` pass locally; the built `out/index.html` carries the new blurb.

Cloudflare Pages deploys from `site/` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpVem3MYXJRfKZgTEbaJws